### PR TITLE
Add option to run_tests to allow user to specify job launch command

### DIFF
--- a/test/run_tests
+++ b/test/run_tests
@@ -70,7 +70,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-   "--mpicmd", default="mpiexec -n ", type=str, required=False,
+   "--mpi-cmd", default="mpiexec -n ", type=str, required=False,
    help="MPI application launcher command"
 )
 

--- a/test/run_tests
+++ b/test/run_tests
@@ -69,6 +69,11 @@ parser.add_argument(
     help="Controls verbose failure"
 )
 
+parser.add_argument(
+   "--mpicmd", default="mpiexec -n ", type=str, required=False,
+   help="MPI application launcher command"
+)
+
 parser.add_argument("-w", "--weights", default=3, type=int, required=False,
                     help="Test weight configuration. Single numeric value < 7,"
                          " converted to binary gives the long, intermediate, "

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -27,7 +27,7 @@ class TestSlot:
         if test.skip != "":
             return
 
-        cmd =  self.argv.mpicmd + " " + str(test.num_procs) + " "
+        cmd =  self.argv.mpi_cmd + " " + str(test.num_procs) + " "
         cmd += self.argv.exe + " "
         cmd += test.filename + " "
         cmd += "--suppress_color "

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -27,8 +27,7 @@ class TestSlot:
         if test.skip != "":
             return
 
-        cmd = "mpiexec "
-        cmd += "-np " + str(test.num_procs) + " "
+        cmd =  self.argv.mpicmd + " " + str(test.num_procs) + " "
         cmd += self.argv.exe + " "
         cmd += test.filename + " "
         cmd += "--suppress_color "


### PR DESCRIPTION
I think the test scripts could use a bit of refactoring, but this at least gives the user the ability to specify the launch command in situations where mpirun/mpiexec is not used.