### PR TITLE
No need to rerun cmake when files are renamed/moved/etc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 
 # libopensn
-file(GLOB_RECURSE LIBOPENSN_SRCS
+file(GLOB_RECURSE LIBOPENSN_SRCS CONFIGURE_DEPENDS
     framework/*.cc
     modules/*.cc
 )

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 # libopensnlua
-file(GLOB_RECURSE LIBOPENSN_LUA_SRCS *.cc)
+file(GLOB_RECURSE LIBOPENSN_LUA_SRCS CONFIGURE_DEPENDS framework/*.cc modules/*.cc)
 add_library(libopensnlua SHARED ${LIBOPENSN_LUA_SRCS})
 
 target_include_directories(libopensnlua

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # test binary
-file(GLOB_RECURSE TEST_SRCS *.cc)
+file(GLOB_RECURSE TEST_SRCS CONFIGURE_DEPENDS *.cc)
 
 add_executable(opensn-test ${TEST_SRCS})
 


### PR DESCRIPTION
This creates configure-time dependency on all *.cc files, so when files are moved/renamed, `cmake` figures that out and re-configures the project automatically.