### PR TITLE
Improved leakage calculations

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -634,7 +634,7 @@ std::vector<uint64_t>
 MeshContinuum::GetDomainUniqueBoundaryIDs() const
 {
   opensn::mpi.Barrier();
-  log.Log() << "Identifying unique boundary-ids.";
+  log.LogAllVerbose1() << "Identifying unique boundary-ids.";
 
   // Develop local bndry-id set
   std::set<uint64_t> local_bndry_ids_set;

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
@@ -1,12 +1,11 @@
 #include "lbs_do_lua_utils.h"
 
-#include "modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h"
-
+#include "framework/runtime.h"
+#include "framework/logging/log.h"
 #include "framework/console/console.h"
 
-#include "framework/runtime.h"
-
-using namespace opensn;
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h"
 
 namespace opensnlua::lbs
 {
@@ -46,6 +45,68 @@ chiLBSComputeLeakage(lua_State* L)
     lua_settable(L, -3);
   }
 
+  return 1;
+}
+
+RegisterLuaFunction(ComputeLeakage, lbs, ComputeLeakage);
+
+int
+ComputeLeakage(lua_State* L)
+{
+  const auto fname = "lbs.ComputeLeakage";
+  const auto num_args = lua_gettop(L);
+
+  // Get the solver
+  LuaCheckNilValue(fname, L, 1);
+  const auto solver_handle = lua_tointeger(L, 1);
+  const auto& solver = opensn::Chi::GetStackItem<opensn::lbs::DiscreteOrdinatesSolver>(
+    opensn::Chi::object_stack, solver_handle, fname);
+
+  // Get the boundaries to parse
+  std::vector<uint64_t> bndry_ids;
+  if (num_args > 1)
+  {
+    LuaCheckTableValue(fname, L, 2);
+
+    // Define mapping from boundary name to id
+    const std::map<std::string, uint64_t> bndry_map = {
+      {"xmax", 0}, {"xmin", 1}, {"ymax", 2}, {"ymin", 3}, {"zmax", 4}, {"zmin", 5}};
+
+    // Get the boundaries
+    const auto n_bndrys = lua_rawlen(L, 2);
+    for (int b = 0; b < n_bndrys; ++b)
+    {
+      lua_pushinteger(L, b + 1);
+      lua_gettable(L, 2);
+      bndry_ids.push_back(bndry_map.at(lua_tostring(L, -1)));
+      lua_pop(L, 1);
+    }
+  }
+  else
+    bndry_ids = solver.Grid().GetDomainUniqueBoundaryIDs();
+
+  // Compute the leakage
+  const auto leakage = solver.ComputeLeakage(bndry_ids);
+
+  // Define mapping from boundary ids to names
+  const std::map<uint64_t, std::string> bndry_map = {
+    {0, "xmax"}, {1, "xmin"}, {2, "ymax"}, {3, "ymin"}, {4, "zmax"}, {5, "zmin"}};
+
+  // Push to lua table
+  lua_newtable(L);
+  for (const auto& [bid, vals] : leakage)
+  {
+    lua_pushstring(L, bndry_map.at(bid).c_str());
+
+    lua_newtable(L);
+    for (int g = 0; g < solver.NumGroups(); ++g)
+    {
+      lua_pushinteger(L, g + 1);
+      lua_pushnumber(L, vals[g]);
+      lua_settable(L, -3);
+    }
+    lua_settable(L, -3);
+  }
   return 1;
 }
 

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h
@@ -4,7 +4,9 @@
 
 namespace opensnlua::lbs
 {
-/**Computes balance tables and prints it to the console.
+
+/**
+ * Computes balance tables and prints it to the console.
  *
  * \param SolverIndex int Handle to the solver for which the list is to be
  * obtained.
@@ -14,7 +16,8 @@ namespace opensnlua::lbs
  */
 int chiLBSComputeBalance(lua_State* L);
 
-/**Computes the leakage for the specified groupset and boundary id.
+/**
+ * Computes the leakage for the specified groupset and boundary id.
  *
  * \param SolverIndex int Handle to the solver.
  * \param GroupSetHandle int Handle to the groupset.
@@ -26,4 +29,20 @@ int chiLBSComputeBalance(lua_State* L);
  * \author Jan
  */
 int chiLBSComputeLeakage(lua_State* L);
+
+/**
+ * Computes the group-wise leakage on all boundaries.
+ *
+ * \param SolverIndex int Handle to the solver.
+ * \param BoundaryNames array List of boundary names. These must be the
+ *      standard boundary names used in OpenSn:
+ *      xmax, xmin, ymax, ymin, zmax, zmin
+ *
+ * \return A table mapping boundary names to group-wise leakage arrays.
+ *
+ * \ingroup LBSLuaFunctions
+ * \author Zachary K. Hardy
+ */
+int ComputeLeakage(lua_State* L);
+
 } // namespace opensnlua::lbs

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -50,6 +50,13 @@ namespace opensn
 {
 namespace lbs
 {
+
+std::map<std::string, uint64_t> LBSSolver::supported_boundary_names = {
+  {"xmax", 0}, {"xmin", 1}, {"ymax", 2}, {"ymin", 3}, {"zmax", 4}, {"zmin", 5}};
+
+std::map<uint64_t, std::string> LBSSolver::supported_boundary_ids = {
+  {0, "xmax"}, {1, "xmin"}, {2, "ymax"}, {3, "ymin"}, {4, "zmax"}, {5, "zmin"}};
+
 // OpenSnRegisterObject(lbs, LBSSolver); Should not be constructible
 
 OpenSnRegisterSyntaxBlock(lbs, OptionsBlock, LBSSolver::OptionsBlock);
@@ -652,9 +659,7 @@ LBSSolver::SetBoundaryOptions(const InputParameters& params)
   const auto boundary_name = user_params.GetParamValue<std::string>("name");
   const auto bndry_type = user_params.GetParamValue<std::string>("type");
 
-  const std::map<std::string, uint64_t> supported_bndry_names = {
-    {"xmin", 1}, {"xmax", 0}, {"ymin", 3}, {"ymax", 2}, {"zmin", 5}, {"zmax", 4}};
-  const auto bid = supported_bndry_names.at(boundary_name);
+  const auto bid = supported_boundary_names.at(boundary_name);
   const std::map<std::string, lbs::BoundaryType> type_list = {
     {"vacuum", BoundaryType::VACUUM},
     {"incident_isotropic", BoundaryType::INCIDENT_ISOTROPIC},

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -562,6 +562,9 @@ protected:
   static void CleanUpTGDSA(LBSGroupset& groupset);
 
 public:
+  static std::map<std::string, uint64_t> supported_boundary_names;
+  static std::map<uint64_t, std::string> supported_boundary_ids;
+
   /**
    * Returns the input parameters for this object.
    */

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -68,11 +68,20 @@ public:
   /**
    * Computes the angular flux based leakage from boundary surfaces.
    * \param groupset_id The groupset for which to compute the leakage.
-   * \param boundary_id uint64_t The boundary-id for which to perform the integration.
+   * \param boundary_id The boundary id for which to perform the integration.
    *
    * \return The leakage as a value.
    */
-  std::vector<double> ComputeLeakage(int groupset_id, uint64_t boundary_id) const;
+  std::vector<double> ComputeLeakage(unsigned int groupset_id, uint64_t boundary_id) const;
+
+  /**
+   * Computes the group-wise angular flux-based leakage from the specified boundaries.
+   *
+   * \param boundary_ids The boundary ids to compute leakages on.
+   * \return A map of boundary ids to group-wise leakages.
+   */
+  std::map<uint64_t, std::vector<double>>
+  ComputeLeakage(const std::vector<uint64_t>& boundary_ids) const;
 
 protected:
   explicit DiscreteOrdinatesSolver(const std::string& text_name);

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -19,6 +19,19 @@
     ]
   },
   {
+    "file": "transport_1d_leakage.lua",
+    "comment": "1D LinearBSolver Test - Leakage",
+    "num_procs": 3,
+    "checks" : [
+      {
+        "type": "KeyValuePair",
+        "key": "[0]  zmax=",
+        "goldvalue": 0.109692,
+        "tol": 0.0001
+      }
+    ]
+  },
+  {
     "file": "transport_1d_3a_dsa_ortho.lua",
     "comment": "1D LinearBSolver test of a block of graphite with an air cavity. DSA and TG",
     "num_procs": 4,

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
@@ -1,0 +1,88 @@
+-- 1D Transport leakage test
+-- Unit angular flux left boundary condition in a pure absorber with unit
+-- length and a unit absorption cross section. The analytic solution is:
+-- j^+ = \int_{0}^{1} \mu e^{-1/\mu} d\mu = 0.10969
+
+-- Check num_procs
+num_procs = 3
+if (check_num_procs == nil and chi_number_of_processes ~= num_procs) then
+    chiLog(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
+    os.exit(false)
+end
+
+-- Setup mesh
+N = 100
+L = 1.0
+nodes = {}
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = (i - 1) * L / N
+end
+
+meshgen = chi_mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
+chi_mesh.MeshGenerator.Execute(meshgen)
+chiVolumeMesherSetMatIDToAll(0)
+
+-- Add materials
+num_groups = 1
+sigma_t = 1.0
+
+materials = {}
+materials[1] = chiPhysicsAddMaterial("Test Material");
+chiPhysicsMaterialAddProperty(materials[1], TRANSPORT_XSECTIONS)
+
+chiPhysicsMaterialSetProperty(materials[1], TRANSPORT_XSECTIONS,
+                              SIMPLEXS0, num_groups, sigma_t)
+
+-- Setup Physics
+pquad = chiCreateProductQuadrature(GAUSS_LEGENDRE, 128)
+lbs_block = {
+    num_groups = num_groups,
+    groupsets = {
+        {
+            groups_from_to = { 0, num_groups - 1 },
+            angular_quadrature_handle = pquad,
+            angle_aggregation_num_subsets = 1,
+            groupset_num_subsets = 1,
+            inner_linear_method = "gmres",
+            l_abs_tol = 1.0e-6,
+            l_max_its = 300,
+            gmres_restart_interval = 100,
+        }
+    }
+}
+
+bsrc = {}
+for g = 1, num_groups do
+    bsrc[g] = 0.0
+end
+bsrc[1] = 1.0
+
+lbs_options = {
+    boundary_conditions = {
+        {
+            name = "zmin",
+            type = "incident_isotropic",
+            group_strength = bsrc
+        }
+    },
+    scattering_order = 0,
+    save_angular_flux =  true
+}
+
+phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys, lbs_options)
+
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys })
+
+-- Solve the problem
+chiSolverInitialize(ss_solver)
+chiSolverExecute(ss_solver)
+
+-- Compute the leakage
+leakage = lbs.ComputeLeakage(phys)
+for k, v in pairs(leakage) do
+    chiLog(LOG_0, string.format("%s=%.5e", k, v[1]))
+end


### PR DESCRIPTION
This PR adds more generalized routines for calculating leakages from boundaries. 

### Highlights 
- Added the `ComputeLeakage` routine to `lbs::DiscreteOrdinatesSolver`. This routine takes a vector of boundary IDs and returns a map of boundary IDs to group-wise leakage values.
- Added the Lua wrapper function `lbs.ComputeLeakage`. The function takes a handle to the solver and optionally an array of boundary names (the standard ones used in OpenSn). The return value in Lua is a table of tables keyed with the boundary names and then the group indices.
- Added a simple leakage test, which gives the correct analytic solution.

### Comments
- While the test is in parallel, the test does not rigorously test the communication carried out in the new routine. This would require a test where a a single boundary is shared among multiple processors, which is more difficult for analytic solutions to compare to.