### PR TITLE
Macro tidy up

### DIFF
--- a/framework/math/quadratures/quadrature_gausschebyshev.cc
+++ b/framework/math/quadratures/quadrature_gausschebyshev.cc
@@ -6,9 +6,6 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 
-#define uint unsigned int
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -42,14 +39,14 @@ QuadratureGaussChebyshev::QuadratureGaussChebyshev(const InputParameters& params
 
   if (assigned_params.Has("order"))
   {
-    const uint N = static_cast<uint>(order_);
-    Initialize(N);
+    const auto n = static_cast<unsigned int>(order_);
+    Initialize(n);
   }
   else
   {
-    const uint N = assigned_params.GetParamValue<uint>("N");
-    order_ = static_cast<QuadratureOrder>(std::min(scint(N), 43));
-    Initialize(N);
+    const auto n = assigned_params.GetParamValue<unsigned int>("N");
+    order_ = static_cast<QuadratureOrder>(std::min(n, 43u));
+    Initialize(n);
   }
 }
 

--- a/framework/math/quadratures/quadrature_gausslegendre.cc
+++ b/framework/math/quadratures/quadrature_gausslegendre.cc
@@ -9,9 +9,6 @@
 
 #include <algorithm>
 
-#define uint unsigned int
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -44,19 +41,19 @@ QuadratureGaussLegendre::QuadratureGaussLegendre(const InputParameters& params) 
   const int param_count = int(assigned_params.Has("order")) + int(assigned_params.Has("N"));
   ChiInvalidArgumentIf(param_count == 2, "Either \"order\" or \"N\" must be specified, not both");
 
-  const uint max_iters = params.GetParamValue<uint>("max_root_finding_iters");
+  const auto max_iters = params.GetParamValue<unsigned int>("max_root_finding_iters");
   const double tol = params.GetParamValue<double>("root_finding_tol");
 
   if (assigned_params.Has("order"))
   {
-    const uint N = std::ceil(((int)order_ + 1) / 2.0);
-    Initialize(N, verbose_, max_iters, tol);
+    const unsigned int n = std::ceil((static_cast<int>(order_) + 1) / 2.0);
+    Initialize(n, verbose_, max_iters, tol);
   }
   else
   {
-    const uint N = assigned_params.GetParamValue<uint>("N");
-    order_ = static_cast<QuadratureOrder>(std::min(scint(2 * N + 1), 43));
-    Initialize(N, verbose_, max_iters, tol);
+    const auto n = assigned_params.GetParamValue<unsigned int>("N");
+    order_ = static_cast<QuadratureOrder>(std::min(2 * n + 1, 43u));
+    Initialize(n, verbose_, max_iters, tol);
   }
 }
 

--- a/framework/math/spatial_discretization/finite_element/lagrange/lagrange_continuous.cc
+++ b/framework/math/spatial_discretization/finite_element/lagrange/lagrange_continuous.cc
@@ -8,8 +8,6 @@
 #include "framework/mpi/mpi_utils_map_all2all.h"
 #include <algorithm>
 
-#define sc_int64 static_cast<int64_t>
-
 namespace opensn
 {
 
@@ -217,8 +215,8 @@ LagrangeContinuous::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag
       return locI;
     }
 
-  } dof_handler(sc_int64(local_block_address_),
-                sc_int64(local_block_address_ + local_base_block_size_),
+  } dof_handler(static_cast<int64_t>(local_block_address_),
+                static_cast<int64_t>(local_block_address_ + local_base_block_size_),
                 locJ_block_address_);
 
   // Writes a message on ir error
@@ -357,8 +355,10 @@ LagrangeContinuous::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag
   {
     const int64_t locI = dof_handler.GetLocFromIR(ir_linkage.first);
 
-    locI_serialized[locI].push_back(sc_int64(ir_linkage.second.size())); // row cols amount
-    locI_serialized[locI].push_back(sc_int64(ir_linkage.first));         // row num
+    // row cols amount
+    locI_serialized[locI].push_back(static_cast<int64_t>(ir_linkage.second.size()));
+    // row num
+    locI_serialized[locI].push_back(static_cast<int64_t>(ir_linkage.first));
     for (int64_t jr : ir_linkage.second)
       locI_serialized[locI].push_back(jr); // col num
   }
@@ -533,17 +533,17 @@ LagrangeContinuous::MapDOF(const Cell& cell,
   {
     for (int locJ = 0; locJ < opensn::mpi.process_count; ++locJ)
     {
-      const int64_t local_id = global_id - sc_int64(locJ_block_address_[locJ]);
+      const int64_t local_id = global_id - static_cast<int64_t>(locJ_block_address_[locJ]);
 
       if (local_id < 0 or local_id >= locJ_block_size_[locJ]) continue;
 
-      address = sc_int64(locJ_block_address_[locJ] * num_unknowns) +
-                sc_int64(locJ_block_size_[locJ] * block_id) + local_id;
+      address = static_cast<int64_t>(locJ_block_address_[locJ] * num_unknowns) +
+                static_cast<int64_t>(locJ_block_size_[locJ] * block_id) + local_id;
       break;
     }
   }
   else if (storage == UnknownStorageType::NODAL)
-    address = global_id * sc_int64(num_unknowns) + sc_int64(block_id);
+    address = global_id * static_cast<int64_t>(num_unknowns) + static_cast<int64_t>(block_id);
 
   return address;
 }
@@ -564,7 +564,7 @@ LagrangeContinuous::MapDOFLocal(const Cell& cell,
   size_t block_id = unknown_manager.MapUnknown(unknown_id, component);
   auto storage = unknown_manager.dof_storage_type_;
 
-  const int64_t local_id = node_global_id - sc_int64(local_block_address_);
+  const int64_t local_id = node_global_id - static_cast<int64_t>(local_block_address_);
   const bool is_local = not(local_id < 0 or local_id >= local_base_block_size_);
 
   int64_t address = -1;
@@ -572,10 +572,10 @@ LagrangeContinuous::MapDOFLocal(const Cell& cell,
   {
     if (storage == UnknownStorageType::BLOCK)
     {
-      address = sc_int64(local_base_block_size_ * block_id) + local_id;
+      address = static_cast<int64_t>(local_base_block_size_ * block_id) + local_id;
     }
     else if (storage == UnknownStorageType::NODAL)
-      address = local_id * sc_int64(num_unknowns) + sc_int64(block_id);
+      address = local_id * static_cast<int64_t>(num_unknowns) + static_cast<int64_t>(block_id);
   } // if is_local
   else
   {
@@ -593,12 +593,13 @@ LagrangeContinuous::MapDOFLocal(const Cell& cell,
     }
     if (storage == UnknownStorageType::BLOCK)
     {
-      address = sc_int64(ghost_node_mapping_.size() * block_id) + ghost_local_node_id;
+      address = static_cast<int64_t>(ghost_node_mapping_.size() * block_id) + ghost_local_node_id;
     }
     else if (storage == UnknownStorageType::NODAL)
-      address = ghost_local_node_id * sc_int64(num_unknowns) + sc_int64(block_id);
+      address =
+        ghost_local_node_id * static_cast<int64_t>(num_unknowns) + static_cast<int64_t>(block_id);
 
-    address += sc_int64(num_local_dofs);
+    address += static_cast<int64_t>(num_local_dofs);
   }
 
   return address;
@@ -638,17 +639,18 @@ LagrangeContinuous::GetGhostDOFIndices(const UnknownManager& unknown_manager) co
         {
           for (int locJ = 0; locJ < opensn::mpi.process_count; ++locJ)
           {
-            const int64_t local_id = global_id - sc_int64(locJ_block_address_[locJ]);
+            const int64_t local_id = global_id - static_cast<int64_t>(locJ_block_address_[locJ]);
 
             if (local_id < 0 or local_id >= locJ_block_size_[locJ]) continue;
 
-            address = sc_int64(locJ_block_address_[locJ] * num_unknown_comps) +
-                      sc_int64(locJ_block_size_[locJ] * block_id) + local_id;
+            address = static_cast<int64_t>(locJ_block_address_[locJ] * num_unknown_comps) +
+                      static_cast<int64_t>(locJ_block_size_[locJ] * block_id) + local_id;
             break;
           }
         }
         else if (storage == UnknownStorageType::NODAL)
-          address = global_id * sc_int64(num_unknown_comps) + sc_int64(block_id);
+          address =
+            global_id * static_cast<int64_t>(num_unknown_comps) + static_cast<int64_t>(block_id);
 
         dof_ids.push_back(address);
       } // for c

--- a/framework/math/spatial_discretization/finite_element/lagrange/lagrange_discontinuous.cc
+++ b/framework/math/spatial_discretization/finite_element/lagrange/lagrange_discontinuous.cc
@@ -7,8 +7,6 @@
 #include "framework/mpi/mpi.h"
 #include "framework/mpi/mpi_utils.h"
 
-#define sc_int64 static_cast<int64_t>
-
 namespace opensn
 {
 
@@ -285,14 +283,14 @@ LagrangeDiscontinuous::MapDOF(const Cell& cell,
   {
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(local_block_address_ * num_unknowns) +
+      int64_t address = static_cast<int64_t>(local_block_address_ * num_unknowns) +
                         cell_local_block_address_[cell.local_id_] +
                         local_base_block_size_ * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(local_block_address_ * num_unknowns) +
+      int64_t address = static_cast<int64_t>(local_block_address_ * num_unknowns) +
                         cell_local_block_address_[cell.local_id_] * num_unknowns +
                         node * num_unknowns + block_id;
       return address;
@@ -322,14 +320,15 @@ LagrangeDiscontinuous::MapDOF(const Cell& cell,
 
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second) +
+      int64_t address = static_cast<int64_t>(neighbor_cell_block_address_[index].second) +
                         locJ_block_size_[cell.partition_id_] * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(neighbor_cell_block_address_[index].second * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }
@@ -353,14 +352,15 @@ LagrangeDiscontinuous::MapDOFLocal(const Cell& cell,
   {
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(cell_local_block_address_[cell.local_id_]) +
+      int64_t address = static_cast<int64_t>(cell_local_block_address_[cell.local_id_]) +
                         local_base_block_size_ * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(cell_local_block_address_[cell.local_id_] * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(cell_local_block_address_[cell.local_id_] * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }
@@ -388,14 +388,15 @@ LagrangeDiscontinuous::MapDOFLocal(const Cell& cell,
 
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second) +
+      int64_t address = static_cast<int64_t>(neighbor_cell_block_address_[index].second) +
                         locJ_block_size_[cell.partition_id_] * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(neighbor_cell_block_address_[index].second * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
@@ -6,10 +6,6 @@
 #include "framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_polygon_mapping.h"
 #include "framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_polyhedron_mapping.h"
 
-#define UnsupportedCellType(fname)                                                                 \
-  std::invalid_argument((fname) + ": Unsupported cell type encountered. type_id=" +                \
-                        std::to_string(static_cast<int>(cell.Type())));
-
 namespace opensn
 {
 
@@ -66,7 +62,9 @@ PieceWiseLinearBase::CreateCellMappings()
         break;
       }
       default:
-        throw UnsupportedCellType(std::string(fname))
+        throw std::invalid_argument(std::string(fname) +
+                                    ": Unsupported cell type encountered. type_id=" +
+                                    std::to_string(static_cast<int>(cell.Type())));
     }
     return mapping;
   };

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
@@ -7,8 +7,6 @@
 #include "framework/mpi/mpi.h"
 #include "framework/mpi/mpi_utils.h"
 
-#define sc_int64 static_cast<int64_t>
-
 namespace opensn
 {
 
@@ -285,14 +283,14 @@ PieceWiseLinearDiscontinuous::MapDOF(const Cell& cell,
   {
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(local_block_address_ * num_unknowns) +
+      int64_t address = static_cast<int64_t>(local_block_address_ * num_unknowns) +
                         cell_local_block_address_[cell.local_id_] +
                         local_base_block_size_ * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(local_block_address_ * num_unknowns) +
+      int64_t address = static_cast<int64_t>(local_block_address_ * num_unknowns) +
                         cell_local_block_address_[cell.local_id_] * num_unknowns +
                         node * num_unknowns + block_id;
       return address;
@@ -322,14 +320,15 @@ PieceWiseLinearDiscontinuous::MapDOF(const Cell& cell,
 
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second) +
+      int64_t address = static_cast<int64_t>(neighbor_cell_block_address_[index].second) +
                         locJ_block_size_[cell.partition_id_] * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(neighbor_cell_block_address_[index].second * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }
@@ -353,14 +352,15 @@ PieceWiseLinearDiscontinuous::MapDOFLocal(const Cell& cell,
   {
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(cell_local_block_address_[cell.local_id_]) +
+      int64_t address = static_cast<int64_t>(cell_local_block_address_[cell.local_id_]) +
                         local_base_block_size_ * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(cell_local_block_address_[cell.local_id_] * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(cell_local_block_address_[cell.local_id_] * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }
@@ -388,14 +388,15 @@ PieceWiseLinearDiscontinuous::MapDOFLocal(const Cell& cell,
 
     if (storage == UnknownStorageType::BLOCK)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second) +
+      int64_t address = static_cast<int64_t>(neighbor_cell_block_address_[index].second) +
                         locJ_block_size_[cell.partition_id_] * block_id + node;
       return address;
     }
     else if (storage == UnknownStorageType::NODAL)
     {
-      int64_t address = sc_int64(neighbor_cell_block_address_[index].second * num_unknowns) +
-                        node * num_unknowns + block_id;
+      int64_t address =
+        static_cast<int64_t>(neighbor_cell_block_address_[index].second * num_unknowns) +
+        node * num_unknowns + block_id;
       return address;
     }
   }

--- a/framework/math/time_integrations/crank_nicolson_time_intgr.cc
+++ b/framework/math/time_integrations/crank_nicolson_time_intgr.cc
@@ -2,8 +2,6 @@
 
 #include "framework/object_factory.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -19,7 +17,7 @@ CrankNicolsonTimeIntegration::GetInputParameters()
   params.SetDocGroup("DocTimeIntegrations");
   // clang-format on
 
-  params.ChangeExistingParamToOptional("method", scint(SteppingMethod::CRANK_NICOLSON));
+  params.ChangeExistingParamToOptional("method", static_cast<int>(SteppingMethod::CRANK_NICOLSON));
   params.ChangeExistingParamToOptional("theta", 0.5);
 
   return params;

--- a/framework/math/time_integrations/implicit_euler_time_intgr.cc
+++ b/framework/math/time_integrations/implicit_euler_time_intgr.cc
@@ -2,8 +2,6 @@
 
 #include "framework/object_factory.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -19,7 +17,7 @@ ImplicitEulerTimeIntegration::GetInputParameters()
   params.SetDocGroup("DocTimeIntegrations");
   // clang-format on
 
-  params.ChangeExistingParamToOptional("method", scint(SteppingMethod::IMPLICIT_EULER));
+  params.ChangeExistingParamToOptional("method", static_cast<int>(SteppingMethod::IMPLICIT_EULER));
   params.ChangeExistingParamToOptional("theta", 1.0);
 
   return params;

--- a/framework/math/time_integrations/theta_scheme_time_intgr.cc
+++ b/framework/math/time_integrations/theta_scheme_time_intgr.cc
@@ -2,8 +2,6 @@
 
 #include "framework/object_factory.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -19,7 +17,7 @@ ThetaSchemeTimeIntegration::GetInputParameters()
   params.SetDocGroup("DocTimeIntegrations");
   // clang-format on
 
-  params.ChangeExistingParamToOptional("method", scint(SteppingMethod::THETA_SCHEME));
+  params.ChangeExistingParamToOptional("method", static_cast<int>(SteppingMethod::THETA_SCHEME));
 
   params.AddRequiredParameter<double>("theta", "The theta parameter for a theta scheme");
 

--- a/framework/math/time_integrations/time_integration.cc
+++ b/framework/math/time_integrations/time_integration.cc
@@ -2,8 +2,6 @@
 
 #include "framework/logging/log_exceptions.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -20,13 +18,13 @@ TimeIntegration::GetInputParameters()
 TimeIntegration::TimeIntegration(const InputParameters& params) : Object(params)
 {
   const int method_option = params.GetParamValue<int>("method");
-  if (method_option == scint(SteppingMethod::EXPLICIT_EULER))
+  if (method_option == static_cast<int>(SteppingMethod::EXPLICIT_EULER))
     method_ = SteppingMethod::EXPLICIT_EULER;
-  else if (method_option == scint(SteppingMethod::IMPLICIT_EULER))
+  else if (method_option == static_cast<int>(SteppingMethod::IMPLICIT_EULER))
     method_ = SteppingMethod::IMPLICIT_EULER;
-  else if (method_option == scint(SteppingMethod::CRANK_NICOLSON))
+  else if (method_option == static_cast<int>(SteppingMethod::CRANK_NICOLSON))
     method_ = SteppingMethod::CRANK_NICOLSON;
-  else if (method_option == scint(SteppingMethod::THETA_SCHEME))
+  else if (method_option == static_cast<int>(SteppingMethod::THETA_SCHEME))
     method_ = SteppingMethod::THETA_SCHEME;
   else
     ChiInvalidArgument("Unsupported Time Integration scheme");

--- a/framework/math/vector_ghost_communicator/vector_ghost_communicator.cc
+++ b/framework/math/vector_ghost_communicator/vector_ghost_communicator.cc
@@ -8,8 +8,6 @@
 #include <string>
 #include <algorithm>
 
-#define scint64_t static_cast<int64_t>
-
 namespace opensn
 {
 
@@ -95,7 +93,7 @@ VectorGhostCommunicator::MakeCachedParallelData()
                           std::to_string(location_id_) + " needs to communicate global id " +
                           std::to_string(gid) + " to it, but this id is not locally owned.");
 
-      local_ids_to_send.push_back(gid - scint64_t(extents_[location_id_]));
+      local_ids_to_send.push_back(gid - static_cast<int64_t>(extents_[location_id_]));
     }
 
   // Finally, the communication pattern for the data being sent
@@ -152,7 +150,7 @@ VectorGhostCommunicator::MapGhostToLocal(const int64_t ghost_id) const
   const auto k = std::find(ghost_ids_.begin(), ghost_ids_.end(), ghost_id) - ghost_ids_.begin();
 
   // Local index is local size plus the position in the ghost id vector
-  return scint64_t(local_size_) + k;
+  return static_cast<int64_t>(local_size_) + k;
 }
 
 void

--- a/framework/mesh/logical_volume/rpp_logical_volume.cc
+++ b/framework/mesh/logical_volume/rpp_logical_volume.cc
@@ -42,13 +42,6 @@ RPPLogicalVolume::RPPLogicalVolume(const InputParameters& params)
 {
 }
 
-#define XMAX 0
-#define XMIN 1
-#define YMAX 2
-#define YMIN 3
-#define ZMAX 4
-#define ZMIN 5
-
 bool
 RPPLogicalVolume::Inside(const Vector3& point) const
 {

--- a/framework/mesh/logical_volume/rpp_logical_volume.h
+++ b/framework/mesh/logical_volume/rpp_logical_volume.h
@@ -8,6 +8,16 @@ namespace opensn
 /**Rectangular Parallel Piped (RPP) logical volume*/
 class RPPLogicalVolume : public LogicalVolume
 {
+  enum CornerName
+  {
+    XMAX = 0,
+    XMIN = 1,
+    YMAX = 2,
+    YMIN = 3,
+    ZMAX = 4,
+    ZMIN = 5
+  };
+
 public:
   static InputParameters GetInputParameters();
   explicit RPPLogicalVolume(const InputParameters& params);

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -19,8 +19,6 @@
 #include <vtkCellData.h>
 #include <algorithm>
 
-#define scvtkid static_cast<vtkIdType>
-
 namespace opensn
 {
 
@@ -175,7 +173,7 @@ MeshContinuum::ExportCellsToExodus(const std::string& file_base_name,
 
       // Exodus node- and cell indices are 1-based
       // therefore we add a 1 here.
-      global_node_id_list->InsertNextValue(scvtkid(v + 1));
+      global_node_id_list->InsertNextValue(static_cast<vtkIdType>(v + 1));
     }
 
     // Load cells
@@ -191,7 +189,7 @@ MeshContinuum::ExportCellsToExodus(const std::string& file_base_name,
 
       // Exodus node- and cell indices are 1-based
       // therefore we add a 1 here.
-      global_elem_id_list->InsertNextValue(scvtkid(cell.global_id_ + 1));
+      global_elem_id_list->InsertNextValue(static_cast<vtkIdType>(cell.global_id_ + 1));
     } // for local cells
 
     // Set arrays
@@ -293,14 +291,14 @@ MeshContinuum::ExportCellsToExodus(const std::string& file_base_name,
 
         // Exodus node- and cell indices are 1-based
         // therefore we add a 1 here.
-        node_global_ids->InsertNextValue(scvtkid(vid + 1));
+        node_global_ids->InsertNextValue(static_cast<vtkIdType>(vid + 1));
       }
 
       // Load cells
       for (uint64_t vid : vid_set)
       {
-        std::vector<vtkIdType> cell_vids = {scvtkid(vertex_map[vid])};
-        ugrid->InsertNextCell(VTK_VERTEX, scvtkid(1), cell_vids.data());
+        std::vector<vtkIdType> cell_vids = {static_cast<vtkIdType>(vertex_map[vid])};
+        ugrid->InsertNextCell(VTK_VERTEX, static_cast<vtkIdType>(1), cell_vids.data());
       }
 
       ugrid->SetPoints(points);
@@ -353,7 +351,7 @@ MeshContinuum::ExportCellsToExodus(const std::string& file_base_name,
       for (const auto& face_info : face_list)
       {
         UploadFaceGeometry(*face_info.face_ptr, vertex_map, ugrid);
-        src_cell_global_ids->InsertNextValue(scvtkid(face_info.source_cell_id));
+        src_cell_global_ids->InsertNextValue(static_cast<vtkIdType>(face_info.source_cell_id));
         src_cell_face_id->InsertNextValue(face_info.source_face_id);
       }
 

--- a/framework/mesh/mesh_face.h
+++ b/framework/mesh/mesh_face.h
@@ -65,8 +65,6 @@ struct Face
   }
 };
 
-#define NEIGHBOR 0
-
 // ######################################################### Struct
 /**Data structure for a polygon face.
 

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -14,8 +14,6 @@
 
 #include <filesystem>
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 
@@ -211,10 +209,10 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
 
     WriteBinaryValue(ofile, num_parts); // int
 
-    WriteBinaryValue(ofile, scint(umesh.GetMeshAttributes())); // int
-    WriteBinaryValue(ofile, mesh_options.ortho_Nx);            // size_t
-    WriteBinaryValue(ofile, mesh_options.ortho_Ny);            // size_t
-    WriteBinaryValue(ofile, mesh_options.ortho_Nz);            // size_t
+    WriteBinaryValue(ofile, static_cast<int>(umesh.GetMeshAttributes())); // int
+    WriteBinaryValue(ofile, mesh_options.ortho_Nx);                       // size_t
+    WriteBinaryValue(ofile, mesh_options.ortho_Ny);                       // size_t
+    WriteBinaryValue(ofile, mesh_options.ortho_Nz);                       // size_t
 
     WriteBinaryValue(ofile, raw_vertices.size()); // size_t
 
@@ -225,8 +223,8 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
     {
       WriteBinaryValue(ofile, bid); // uint64_t
       const size_t num_chars = bname.size();
-      WriteBinaryValue(ofile, num_chars);          // size_t
-      ofile.write(bname.data(), scint(num_chars)); // characters
+      WriteBinaryValue(ofile, num_chars);                     // size_t
+      ofile.write(bname.data(), static_cast<int>(num_chars)); // characters
     }
 
     // Write how many cells and vertices in file
@@ -248,7 +246,7 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
       t_serialize.TimeSectionEnd();
       if (serial_data.Size() > BUFFER_SIZE)
       {
-        ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+        ofile.write((char*)serial_data.Data().data(), static_cast<int>(serial_data.Size()));
         const size_t cap = serial_data.Data().capacity();
         serial_data.Clear();
         serial_data.Data().reserve(cap);
@@ -257,7 +255,7 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
     }
     if (serial_data.Size() > 0)
     {
-      ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+      ofile.write((char*)serial_data.Data().data(), static_cast<int>(serial_data.Size()));
       serial_data.Clear();
     }
 
@@ -269,13 +267,13 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
       serial_data.Write(raw_vertices[vid]);
       if (serial_data.Size() > BUFFER_SIZE)
       {
-        ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+        ofile.write((char*)serial_data.Data().data(), static_cast<int>(serial_data.Size()));
         serial_data.Clear();
       }
     }
     if (serial_data.Size() > 0)
     {
-      ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+      ofile.write((char*)serial_data.Data().data(), static_cast<int>(serial_data.Size()));
       serial_data.Clear();
     }
     t_verts.TimeSectionEnd();

--- a/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
+++ b/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
@@ -6,14 +6,6 @@
 #include "framework/logging/log.h"
 #include "framework/mpi/mpi.h"
 
-#define ExceptionReflectedAngleError                                                               \
-  std::logic_error(fname + "Reflected angle not found for angle " + std::to_string(n) +            \
-                   " with direction " + quadrature->omegas_[n].PrintStr() +                        \
-                   ". This can happen for two reasons: i) A quadrature is used"                    \
-                   " that is not symmetric about the axis associated with the "                    \
-                   "reflected boundary, or ii) the reflecting boundary is not "                    \
-                   "aligned with any reflecting axis of the quadrature.")
-
 namespace opensn
 {
 
@@ -150,7 +142,13 @@ AngleAggregation::InitializeReflectingBCs()
             break;
           }
 
-        if (index_map[n] < 0) throw ExceptionReflectedAngleError;
+        if (index_map[n] < 0)
+          throw std::logic_error(
+            fname + ": Reflected angle not found for angle " + std::to_string(n) +
+            " with direction " + quadrature->omegas_[n].PrintStr() +
+            ". This can happen for two reasons: i) A quadrature is used that is not symmetric "
+            "about the axis associated with the reflected boundary, or ii) the reflecting boundary "
+            "is not aligned with any reflecting axis of the quadrature.");
       }
 
       // Initialize storage for all outbound directions

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -23,11 +23,19 @@
 #include <fstream>
 #include <map>
 
-#define ErrorReadingFile(fname)                                                                    \
-  std::runtime_error("Failed to open file: " + options.file_name + " in call to " + #fname + ".")
-
 namespace opensn
 {
+
+namespace
+{
+
+std::string
+ErrorReadingFileStr(const std::string& file_name, const std::string& function_name)
+{
+  return std::string("Failed to open file: " + file_name + " in call to " + function_name + ".");
+}
+
+} // namespace
 
 UnpartitionedMesh::~UnpartitionedMesh()
 {
@@ -885,7 +893,8 @@ UnpartitionedMesh::ReadFromVTU(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open()) throw ErrorReadingFile(ReadFromVTU);
+  if (!file.is_open())
+    throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromVTU"));
   file.close();
 
   // Read the file
@@ -956,7 +965,8 @@ UnpartitionedMesh::ReadFromPVTU(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open()) throw ErrorReadingFile(ReadFromVTU);
+  if (!file.is_open())
+    throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromPVTU"));
   file.close();
 
   // Read the file
@@ -1027,7 +1037,8 @@ UnpartitionedMesh::ReadFromEnsightGold(const UnpartitionedMesh::Options& options
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open()) throw ErrorReadingFile(ReadFromEnsightGold);
+  if (!file.is_open())
+    throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromEnsightGold"));
   file.close();
 
   // Read the file
@@ -1848,7 +1859,8 @@ UnpartitionedMesh::ReadFromExodus(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open()) throw ErrorReadingFile(ReadFromExodus);
+  if (!file.is_open())
+    throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromExodus"));
   file.close();
 
   // Read the file

--- a/framework/parameters/input_parameters.h
+++ b/framework/parameters/input_parameters.h
@@ -5,8 +5,6 @@
 
 #include <map>
 
-#define MakeInpParamsForObj(x, y) InputParameters::MakeForObject<x>(y)
-
 namespace opensn
 {
 

--- a/framework/utils/utils.cc
+++ b/framework/utils/utils.cc
@@ -5,8 +5,6 @@
 #include <iomanip>
 #include <sstream>
 
-#define scdouble static_cast<double>
-
 namespace opensn
 {
 
@@ -122,7 +120,8 @@ std::vector<SubSetInfo>
 MakeSubSets(size_t num_items, size_t desired_num_subsets)
 {
   std::vector<SubSetInfo> ss_infos;
-  const std::size_t div = std::floor(scdouble(num_items) / scdouble(desired_num_subsets));
+  const std::size_t div =
+    std::floor(static_cast<double>(num_items) / static_cast<double>(desired_num_subsets));
   const std::size_t rem = num_items % desired_num_subsets;
 
   for (size_t i = 0; i < desired_num_subsets; ++i)

--- a/modules/dfem_diffusion/dfem_diffusion_solver.cc
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.cc
@@ -9,17 +9,6 @@
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h"
 #include "framework/math/functions/scalar_spatial_material_function.h"
 
-#define scdouble static_cast<double>
-
-#define DefaultBCDirichlet                                                                         \
-  BoundaryCondition                                                                                \
-  {                                                                                                \
-    BCType::DIRICHLET,                                                                             \
-    {                                                                                              \
-      0, 0, 0                                                                                      \
-    }                                                                                              \
-  }
-
 namespace opensn
 {
 namespace dfem_diffusion
@@ -544,7 +533,9 @@ Solver::HPerpendicular(const Cell& cell, unsigned int f)
       else
       {
         hp = 2.0 * volume / surface_area;
-        hp += sqrt(2.0 * volume / (scdouble(num_faces) * sin(2.0 * M_PI / scdouble(num_faces))));
+        hp +=
+          sqrt(2.0 * volume /
+               (static_cast<double>(num_faces) * sin(2.0 * M_PI / static_cast<double>(num_faces))));
       }
     }
   }

--- a/modules/diffusion_solver/diffusion_solver.cc
+++ b/modules/diffusion_solver/diffusion_solver.cc
@@ -74,7 +74,7 @@ Solver::GetMaterialProperties(const Cell& cell,
   sigmaa.resize(cell_dofs, 0.0);
 
   // REGULAR MATERIAL
-  if (material_mode_ == DIFFUSION_MATERIALS_REGULAR)
+  if (material_mode_ == REGULAR)
   {
     // We absolutely need the diffusion coefficient so process error
     if ((property_map_D < 0) || (property_map_D >= material->properties_.size()))
@@ -126,7 +126,7 @@ Solver::GetMaterialProperties(const Cell& cell,
   // TRANSPORT XS D
   // TRANSPORT XS SIGA
   // SCALAR       Q
-  else if (material_mode_ == DIFFUSION_MATERIALS_FROM_TRANSPORTXS_TTR)
+  else if (material_mode_ == FROM_TRANSPORTXS_TTR)
   {
     // Setting D and Sigma_a
     bool transportxs_found = false;

--- a/modules/diffusion_solver/diffusion_solver.h
+++ b/modules/diffusion_solver/diffusion_solver.h
@@ -12,12 +12,6 @@
 #include "framework/utils/timer.h"
 #include <petscksp.h>
 
-#define DIFFUSION_MATERIALS_REGULAR 10
-#define DIFFUSION_MATERIALS_FROM_TRANSPORTXS_TTR 11
-#define DIFFUSION_MATERIALS_FROM_TRANSPORTXS_TTF 12
-#define DIFFUSION_MATERIALS_FROM_TRANSPORTXS_TTF_JPART 13
-#define DIFFUSION_MATERIALS_FROM_TRANSPORTXS_TTF_JFULL 14
-
 namespace opensn
 {
 namespace diffusion
@@ -39,6 +33,15 @@ private:
   double time_solve_ = 0.0;
   bool verbose_info_ = true;
 
+  enum MaterialMode
+  {
+    REGULAR = 10,
+    FROM_TRANSPORTXS_TTR = 11,
+    FROM_TRANSPORTXS_TTF = 12,
+    FROM_TRANSPORTXS_TTF_JPART = 13,
+    FROM_TRANSPORTXS_TTF_JFULL = 14
+  };
+
 public:
   typedef unsigned int uint;
   typedef std::pair<BoundaryType, std::vector<double>> BoundaryInfo;
@@ -53,7 +56,7 @@ public:
 
   UnknownManager unknown_manager_;
 
-  int material_mode_ = DIFFUSION_MATERIALS_REGULAR;
+  MaterialMode material_mode_ = REGULAR;
 
   bool common_items_initialized_ = false;
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_mip_solver.cc
@@ -10,17 +10,6 @@
 #include "framework/utils/timer.h"
 #include <utility>
 
-#define DefaultBCDirichlet                                                                         \
-  BoundaryCondition                                                                                \
-  {                                                                                                \
-    BCType::DIRICHLET,                                                                             \
-    {                                                                                              \
-      0, 0, 0                                                                                      \
-    }                                                                                              \
-  }
-
-#define scdouble static_cast<double>
-
 namespace opensn
 {
 namespace lbs
@@ -242,7 +231,7 @@ DiffusionMIPSolver::AssembleAand_b_wQpoints(const std::vector<double>& q_vector)
         } // internal face
         else
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -463,7 +452,7 @@ DiffusionMIPSolver::Assemble_b_wQpoints(const std::vector<double>& q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -742,7 +731,7 @@ DiffusionMIPSolver::AssembleAand_b(const std::vector<double>& q_vector)
         } // internal face
         else
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -930,7 +919,7 @@ DiffusionMIPSolver::Assemble_b(const std::vector<double>& q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -1074,7 +1063,7 @@ DiffusionMIPSolver::Assemble_b(Vec petsc_q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -1195,7 +1184,9 @@ DiffusionMIPSolver::HPerpendicular(const Cell& cell, unsigned int f)
       else
       {
         hp = 2.0 * volume / surface_area;
-        hp += sqrt(2.0 * volume / (scdouble(num_faces) * sin(2.0 * M_PI / scdouble(num_faces))));
+        hp +=
+          sqrt(2.0 * volume /
+               (static_cast<double>(num_faces) * sin(2.0 * M_PI / static_cast<double>(num_faces))));
       }
     }
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_pwlc_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_pwlc_solver.cc
@@ -8,15 +8,6 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 
-#define DefaultBCDirichlet                                                                         \
-  BoundaryCondition                                                                                \
-  {                                                                                                \
-    BCType::DIRICHLET,                                                                             \
-    {                                                                                              \
-      0, 0, 0                                                                                      \
-    }                                                                                              \
-  }
-
 namespace opensn
 {
 namespace lbs
@@ -86,7 +77,7 @@ DiffusionPWLCSolver::AssembleAand_b(const std::vector<double>& q_vector)
       const auto& face = cell.faces_[f];
       if (not face.has_neighbor_)
       {
-        auto bc = DefaultBCDirichlet;
+        BoundaryCondition bc;
         if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
         if (bc.type != BCType::DIRICHLET) continue;
@@ -143,7 +134,7 @@ DiffusionPWLCSolver::AssembleAand_b(const std::vector<double>& q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -274,7 +265,7 @@ DiffusionPWLCSolver::Assemble_b(const std::vector<double>& q_vector)
       const auto& face = cell.faces_[f];
       if (not face.has_neighbor_)
       {
-        auto bc = DefaultBCDirichlet;
+        BoundaryCondition bc;
         if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
         if (bc.type != BCType::DIRICHLET) continue;
@@ -327,7 +318,7 @@ DiffusionPWLCSolver::Assemble_b(const std::vector<double>& q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)
@@ -410,7 +401,7 @@ DiffusionPWLCSolver::Assemble_b(Vec petsc_q_vector)
       const auto& face = cell.faces_[f];
       if (not face.has_neighbor_)
       {
-        auto bc = DefaultBCDirichlet;
+        BoundaryCondition bc;
         if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
         if (bc.type != BCType::DIRICHLET) continue;
@@ -450,7 +441,7 @@ DiffusionPWLCSolver::Assemble_b(Vec petsc_q_vector)
 
         if (not face.has_neighbor_)
         {
-          auto bc = DefaultBCDirichlet;
+          BoundaryCondition bc;
           if (bcs_.count(face.neighbor_id_) > 0) bc = bcs_.at(face.neighbor_id_);
 
           if (bc.type == BCType::DIRICHLET)

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.cc
@@ -11,22 +11,30 @@
 
 #include <iomanip>
 
-#define CheckContext(x)                                                                            \
-  if (not x)                                                                                       \
-  throw std::runtime_error(std::string(__PRETTY_FUNCTION__) + ": context casting failure")
-#define GetNLKDiffContextPtr(x)                                                                    \
-  std::dynamic_pointer_cast<NLKEigenDiffContext>(x);                                               \
-  CheckContext(x)
-
 namespace opensn
 {
 namespace lbs
 {
 
+namespace
+{
+
+std::shared_ptr<NLKEigenDiffContext>
+GetNLKDiffContextPtr(const NonLinearSolver::NLSolverContextPtr& context,
+                     const std::string& func_name)
+{
+  auto nlk_eigen_diff_context = std::dynamic_pointer_cast<NLKEigenDiffContext>(context);
+  if (not nlk_eigen_diff_context)
+    throw std::runtime_error(std::string(func_name) + ": context casting failure");
+  return nlk_eigen_diff_context;
+}
+
+} // namespace
+
 void
 NLKEigenDiffSolver::SetMonitor()
 {
-  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   if (nl_context_ptr->verbosity_level_ >= 1)
     SNESMonitorSet(
@@ -43,7 +51,7 @@ NLKEigenDiffSolver::SetMonitor()
 void
 NLKEigenDiffSolver::SetSystemSize()
 {
-  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& diff_solver = nl_context_ptr->diff_solver_;
   auto sizes = diff_solver.GetNumPhiIterativeUnknowns();
@@ -63,7 +71,7 @@ NLKEigenDiffSolver::SetSystem()
 void
 NLKEigenDiffSolver::SetFunction()
 {
-  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   SNESSetFunction(
     nl_solver_, r_, NLKEigenAccResidualFunction, &nl_context_ptr->kresid_func_context_);
@@ -85,7 +93,7 @@ NLKEigenDiffSolver::SetInitialGuess()
 void
 NLKEigenDiffSolver::PostSolveCallback()
 {
-  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   auto& groupsets = lbs_solver.Groupsets();

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_context.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_context.cc
@@ -2,8 +2,6 @@
 #include "modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h"
 #include "modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_context.h"
 
-#define GetGSContextPtr(x) std::dynamic_pointer_cast<WGSContext>(x)
-
 namespace opensn
 {
 namespace lbs
@@ -18,7 +16,7 @@ AGSContext::SystemSize()
   std::set<int> groupset_list_group_ids;
   for (auto& wgs_solver : sub_solvers_list_)
   {
-    auto gs_context_ptr = GetGSContextPtr(wgs_solver->GetContext());
+    auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(wgs_solver->GetContext());
     for (const auto& group : gs_context_ptr->groupset_.groups_)
       groupset_list_group_ids.insert(group.id_);
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_linear_solver.cc
@@ -12,10 +12,6 @@
 
 #include <iomanip>
 
-#define sc_int64_t static_cast<int64_t>
-
-#define GetAGSContextPtr(x) std::dynamic_pointer_cast<AGSContext>(x)
-
 namespace opensn
 {
 namespace lbs
@@ -24,7 +20,7 @@ namespace lbs
 void
 AGSLinearSolver::SetSystemSize()
 {
-  auto ags_context_ptr = GetAGSContextPtr(context_ptr_);
+  auto ags_context_ptr = std::dynamic_pointer_cast<AGSContext>(context_ptr_);
 
   const auto sizes = ags_context_ptr->SystemSize();
 
@@ -35,17 +31,17 @@ AGSLinearSolver::SetSystemSize()
 void
 AGSLinearSolver::SetSystem()
 {
-  x_ = CreateVector(sc_int64_t(num_local_dofs_), sc_int64_t(num_global_dofs_));
+  x_ = CreateVector(static_cast<int64_t>(num_local_dofs_), static_cast<int64_t>(num_global_dofs_));
 
   VecSet(x_, 0.0);
   VecDuplicate(x_, &b_);
 
   // Create the matrix-shell
   MatCreateShell(PETSC_COMM_WORLD,
-                 sc_int64_t(num_local_dofs_),
-                 sc_int64_t(num_local_dofs_),
-                 sc_int64_t(num_global_dofs_),
-                 sc_int64_t(num_global_dofs_),
+                 static_cast<int64_t>(num_local_dofs_),
+                 static_cast<int64_t>(num_local_dofs_),
+                 static_cast<int64_t>(num_global_dofs_),
+                 static_cast<int64_t>(num_global_dofs_),
                  &(*context_ptr_),
                  &A_);
 
@@ -60,7 +56,7 @@ AGSLinearSolver::SetSystem()
 void
 AGSLinearSolver::SetPreconditioner()
 {
-  auto ags_context_ptr = GetAGSContextPtr(context_ptr_);
+  auto ags_context_ptr = std::dynamic_pointer_cast<AGSContext>(context_ptr_);
 
   ags_context_ptr->SetPreconditioner(ksp_);
 }
@@ -78,7 +74,7 @@ AGSLinearSolver::SetInitialGuess()
 void
 AGSLinearSolver::Solve()
 {
-  auto ags_context_ptr = GetAGSContextPtr(context_ptr_);
+  auto ags_context_ptr = std::dynamic_pointer_cast<AGSContext>(context_ptr_);
   auto& lbs_solver = ags_context_ptr->lbs_solver_;
 
   const int gid_i = GroupSpanFirstID();

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
@@ -13,22 +13,29 @@
 
 #include <iomanip>
 
-#define CheckContext(x)                                                                            \
-  if (not x)                                                                                       \
-  throw std::runtime_error(std::string(__PRETTY_FUNCTION__) + ": context casting failure")
-#define GetNLKAGSContextPtr(x)                                                                     \
-  std::dynamic_pointer_cast<NLKEigenAGSContext>(x);                                                \
-  CheckContext(x)
-
 namespace opensn
 {
 namespace lbs
 {
 
+namespace
+{
+
+std::shared_ptr<NLKEigenAGSContext>
+GetNLKAGSContextPtr(const NonLinearSolver::NLSolverContextPtr& context,
+                    const std::string& func_name)
+{
+  auto nlk_ags_context = std::dynamic_pointer_cast<NLKEigenAGSContext>(context);
+  if (not nlk_ags_context) throw std::runtime_error(func_name + ": context casting failure");
+  return nlk_ags_context;
+}
+
+} // namespace
+
 void
 NLKEigenvalueAGSSolver::PreSetupCallback()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   for (auto& groupset : lbs_solver.Groupsets())
@@ -38,7 +45,7 @@ NLKEigenvalueAGSSolver::PreSetupCallback()
 void
 NLKEigenvalueAGSSolver::SetMonitor()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   if (lbs_solver.Options().verbose_outer_iterations)
@@ -55,7 +62,7 @@ NLKEigenvalueAGSSolver::SetMonitor()
 void
 NLKEigenvalueAGSSolver::SetSystemSize()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   auto sizes = lbs_solver.GetNumPhiIterativeUnknowns();
@@ -75,7 +82,7 @@ NLKEigenvalueAGSSolver::SetSystem()
 void
 NLKEigenvalueAGSSolver::SetFunction()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   SNESSetFunction(nl_solver_, r_, NLKEigenResidualFunction, &nl_context_ptr->kresid_func_context_);
 }
@@ -90,7 +97,7 @@ NLKEigenvalueAGSSolver::SetJacobian()
 void
 NLKEigenvalueAGSSolver::SetInitialGuess()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   const auto& groupset_ids = nl_context_ptr->groupset_ids;
@@ -101,7 +108,7 @@ NLKEigenvalueAGSSolver::SetInitialGuess()
 void
 NLKEigenvalueAGSSolver::PostSolveCallback()
 {
-  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_);
+  auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
@@ -15,11 +15,6 @@
 #include <memory>
 #include <iomanip>
 
-#define sc_double static_cast<double>
-#define sc_int64_t static_cast<int64_t>
-
-#define GetGSContextPtr(x) std::dynamic_pointer_cast<WGSContext>(x)
-
 namespace opensn
 {
 namespace lbs
@@ -44,7 +39,7 @@ WGSLinearSolver::~WGSLinearSolver()
 void
 WGSLinearSolver::PreSetupCallback()
 {
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   gs_context_ptr->PreSetupCallback();
 }
@@ -58,7 +53,7 @@ WGSLinearSolver::SetConvergenceTest()
 void
 WGSLinearSolver::SetSystemSize()
 {
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   const auto sizes = gs_context_ptr->SystemSize();
 
   num_local_dofs_ = sizes.first;
@@ -70,17 +65,17 @@ WGSLinearSolver::SetSystem()
 {
   if (IsSystemSet()) return;
 
-  x_ = CreateVector(sc_int64_t(num_local_dofs_), sc_int64_t(num_global_dofs_));
+  x_ = CreateVector(static_cast<int64_t>(num_local_dofs_), static_cast<int64_t>(num_global_dofs_));
 
   VecSet(x_, 0.0);
   VecDuplicate(x_, &b_);
 
   // Create the matrix-shell
   MatCreateShell(PETSC_COMM_WORLD,
-                 sc_int64_t(num_local_dofs_),
-                 sc_int64_t(num_local_dofs_),
-                 sc_int64_t(num_global_dofs_),
-                 sc_int64_t(num_global_dofs_),
+                 static_cast<int64_t>(num_local_dofs_),
+                 static_cast<int64_t>(num_local_dofs_),
+                 static_cast<int64_t>(num_global_dofs_),
+                 static_cast<int64_t>(num_global_dofs_),
                  &(*context_ptr_),
                  &A_);
 
@@ -96,7 +91,7 @@ void
 WGSLinearSolver::SetPreconditioner()
 {
   if (IsSystemSet()) return;
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   gs_context_ptr->SetPreconditioner(ksp_);
 }
@@ -104,7 +99,7 @@ WGSLinearSolver::SetPreconditioner()
 void
 WGSLinearSolver::PostSetupCallback()
 {
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   gs_context_ptr->PostSetupCallback();
 }
@@ -112,7 +107,7 @@ WGSLinearSolver::PostSetupCallback()
 void
 WGSLinearSolver::PreSolveCallback()
 {
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   gs_context_ptr->PreSolveCallback();
 }
@@ -123,7 +118,7 @@ WGSLinearSolver::SetInitialGuess()
   // If the norm of the initial guess is large enough, the initial guess will be used, otherwise it
   // is assumed to be zero.
 
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   auto& groupset = gs_context_ptr->groupset_;
   auto& lbs_solver = gs_context_ptr->lbs_solver_;
@@ -143,7 +138,7 @@ WGSLinearSolver::SetInitialGuess()
 void
 WGSLinearSolver::SetRHS()
 {
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   auto& groupset = gs_context_ptr->groupset_;
   auto& lbs_solver = gs_context_ptr->lbs_solver_;
@@ -228,7 +223,7 @@ WGSLinearSolver::PostSolveCallback()
   }
 
   // Copy x to local solution
-  auto gs_context_ptr = GetGSContextPtr(context_ptr_);
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
 
   auto& groupset = gs_context_ptr->groupset_;
   auto& lbs_solver = gs_context_ptr->lbs_solver_;

--- a/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/iterative_methods/mip_wgs_context2.cc
+++ b/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/iterative_methods/mip_wgs_context2.cc
@@ -12,13 +12,12 @@
 
 #include <iomanip>
 
-#define sc_double static_cast<double>
-#define PCShellPtr PetscErrorCode (*)(PC, Vec, Vec)
-
 namespace opensn
 {
 namespace lbs
 {
+
+typedef PetscErrorCode (*PCShellPtr)(PC, Vec, Vec);
 
 MIPWGSContext2::MIPWGSContext2(DiffusionDFEMSolver& lbs_mip_ss_solver,
                                LBSGroupset& groupset,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -10,13 +10,12 @@
 
 #include <iomanip>
 
-#define sc_double static_cast<double>
-#define PCShellPtr PetscErrorCode (*)(PC, Vec, Vec)
-
 namespace opensn
 {
 namespace lbs
 {
+
+typedef PetscErrorCode (*PCShellPtr)(PC, Vec, Vec);
 
 SweepWGSContext::SweepWGSContext(DiscreteOrdinatesSolver& lbs_solver,
                                  LBSGroupset& groupset,
@@ -105,7 +104,9 @@ SweepWGSContext::SystemSize()
     log.Log() << "Total number of angular unknowns: " << num_psi_global << "\n"
               << "Number of lagged angular unknowns: " << num_delayed_psi_globl << "("
               << std::setprecision(2)
-              << sc_double(num_delayed_psi_globl) * 100 / sc_double(num_psi_global) << "%)";
+              << static_cast<double>(num_delayed_psi_globl) * 100 /
+                   static_cast<double>(num_psi_global)
+              << "%)";
   }
 
   return {static_cast<int64_t>(local_size), static_cast<int64_t>(globl_size)};

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
@@ -3,8 +3,6 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/mesh/sweep_utilities/fluds/aah_fluds.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 namespace lbs
@@ -181,7 +179,7 @@ AAH_SweepChunk::Sweep(AngleSet& angle_set)
         ExecuteKernels(mass_term_kernels_);
 
         // Solve system
-        GaussElimination(Atemp_, b_[gsg], scint(cell_num_nodes_));
+        GaussElimination(Atemp_, b_[gsg], static_cast<int>(cell_num_nodes_));
       }
 
       // Flux updates

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
@@ -6,8 +6,6 @@
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_fluds.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 namespace lbs
@@ -173,7 +171,7 @@ CBC_SweepChunk::Sweep(AngleSet& angle_set)
       ExecuteKernels(mass_term_kernels_);
 
       // Solve system
-      GaussElimination(Atemp_, b_[gsg], scint(cell_num_nodes_));
+      GaussElimination(Atemp_, b_[gsg], static_cast<int>(cell_num_nodes_));
     }
 
     // Flux updates

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
@@ -7,8 +7,6 @@
 #include "framework/logging/log.h"
 #include "framework/logging/log_exceptions.h"
 
-#define scint static_cast<int>
-
 namespace opensn
 {
 namespace lbs
@@ -154,7 +152,7 @@ SweepChunk::KernelFEMSTDMassTerms()
     double temp_src = 0.0;
     for (int m = 0; m < num_moments_; ++m)
     {
-      const size_t ir = cell_transport_view_->MapDOF(i, m, scint(g_));
+      const size_t ir = cell_transport_view_->MapDOF(i, m, static_cast<int>(g_));
       temp_src += m2d_op[m][direction_num_] * q_moments_[ir];
     } // for m
     source_[i] = temp_src;

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_async_comm.cc
@@ -10,8 +10,6 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 
-#define uint unsigned int
-
 namespace opensn
 {
 namespace lbs
@@ -57,7 +55,7 @@ CBC_ASynchronousCommunicator::SendData()
     {
       const MPIRank locI = std::get<0>(msg_key);
       const uint64_t cell_global_id = std::get<1>(msg_key);
-      const uint face_id = std::get<2>(msg_key);
+      const unsigned int face_id = std::get<2>(msg_key);
       const size_t data_size = data.size();
 
       BufferItem& buffer_item = locI_buffer_map[locI];
@@ -112,7 +110,7 @@ CBC_ASynchronousCommunicator::SendData()
 std::vector<uint64_t>
 CBC_ASynchronousCommunicator::ReceiveData()
 {
-  typedef std::pair<uint64_t, uint> CellFaceKey; // cell_gid + face_id
+  typedef std::pair<uint64_t, unsigned int> CellFaceKey; // cell_gid + face_id
 
   std::map<CellFaceKey, std::vector<double>> received_messages;
   std::vector<uint64_t> cells_who_received_data;
@@ -145,7 +143,7 @@ CBC_ASynchronousCommunicator::ReceiveData()
       while (not data_array.EndOfBuffer())
       {
         const uint64_t cell_global_id = data_array.Read<uint64_t>();
-        const uint face_id = data_array.Read<uint>();
+        const auto face_id = data_array.Read<unsigned int>();
         const size_t data_size = data_array.Read<size_t>();
 
         std::vector<double> psi_data;

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
@@ -12,8 +12,6 @@
 
 #include "lua/framework/console/console.h"
 
-#define scdouble static_cast<double>
-
 using namespace opensn;
 
 namespace unit_tests

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -12,8 +12,6 @@
 
 #include "lua/framework/console/console.h"
 
-#define scdouble static_cast<double>
-
 using namespace opensn;
 
 namespace unit_tests
@@ -478,7 +476,9 @@ HPerpendicular(const CellMapping& cell_mapping, unsigned int f)
       else
       {
         hp = 2.0 * volume / surface_area;
-        hp += sqrt(2.0 * volume / (scdouble(num_faces) * sin(2.0 * M_PI / scdouble(num_faces))));
+        hp +=
+          sqrt(2.0 * volume /
+               (static_cast<double>(num_faces) * sin(2.0 * M_PI / static_cast<double>(num_faces))));
       }
     }
   }

--- a/test/framework/parameters/params_test_01.cc
+++ b/test/framework/parameters/params_test_01.cc
@@ -59,8 +59,8 @@ TestObject::GetInputParameters()
 
 TestObject::TestObject(const InputParameters& params)
   : solver_type_(params.GetParamValue<std::string>("solver_type")),
-    sub_obj1_(MakeInpParamsForObj(TestSubObject, params.GetParam("sub_obj1"))),
-    sub_obj2_(MakeInpParamsForObj(TestSubObject, params.GetParam("sub_obj2")))
+    sub_obj1_(InputParameters::MakeForObject<TestSubObject>(params.GetParam("sub_obj1"))),
+    sub_obj2_(InputParameters::MakeForObject<TestSubObject>(params.GetParam("sub_obj2")))
 {
   opensn::log.Log() << "TestObject created "
                     << "solver_type=" << solver_type_;


### PR DESCRIPTION
Things that are done:
- change macros into enums when they are used in an enum sense
- remove macros that obfuscate the code
- properly define types via `typedef` instead of macro