### PR TITLE
XS Scaling Factors

### DIFF
--- a/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.cc
+++ b/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.cc
@@ -5,7 +5,7 @@ namespace opensn
 
 AdjointMGXS::AdjointMGXS(const MultiGroupXS& xs) : xs_(xs)
 {
-  // transpose transfer matrices
+  // Transpose transfer matrices
   for (unsigned int ell = 0; ell <= xs_.ScatteringOrder(); ++ell)
   {
     const auto& S_ell = xs_.TransferMatrix(ell);
@@ -22,17 +22,15 @@ AdjointMGXS::AdjointMGXS(const MultiGroupXS& xs) : xs_(xs)
     transposed_transfer_matrices_.push_back(S_ell_transpose);
   } // for ell
 
-  // transpose production matrices
+  // Transpose production matrices
   if (xs_.IsFissionable())
   {
+    transposed_production_matrices_.clear();
+    transposed_production_matrices_.resize(xs_.NumGroups());
     const auto& F = xs_.ProductionMatrix();
     for (size_t g = 0; g < xs_.NumGroups(); ++g)
-    {
-      std::vector<double> F_g_transpose;
       for (size_t gp = 0; gp < xs_.NumGroups(); ++gp)
-        F_g_transpose.emplace_back(F[gp][g]);
-      transposed_production_matrices_.push_back(F_g_transpose);
-    }
+        transposed_production_matrices_[g].push_back(F[gp][g]);
   }
 }
 

--- a/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.h
+++ b/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.h
@@ -37,6 +37,7 @@ public:
   size_t ScatteringOrder() const override { return xs_.ScatteringOrder(); }
   size_t NumPrecursors() const override { return xs_.NumPrecursors(); }
   bool IsFissionable() const override { return xs_.IsFissionable(); }
+  double ScalingFactor() const override { return xs_.ScalingFactor(); }
 
   const std::vector<double>& SigmaTotal() const override { return xs_.SigmaTotal(); }
   const std::vector<double>& SigmaAbsorption() const override { return xs_.SigmaAbsorption(); }

--- a/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.h
+++ b/framework/physics/physics_material/multi_group_xs/adjoint_mgxs.h
@@ -33,58 +33,41 @@ public:
   explicit AdjointMGXS(const MultiGroupXS& xs);
 
   // Accessors
-  const unsigned int NumGroups() const override { return xs_.NumGroups(); }
-
-  const unsigned int ScatteringOrder() const override { return xs_.ScatteringOrder(); }
-
-  const unsigned int NumPrecursors() const override { return xs_.NumPrecursors(); }
-
-  const bool IsFissionable() const override { return xs_.IsFissionable(); }
-
-  const bool DiffusionInitialized() const override { return xs_.DiffusionInitialized(); }
-
-  const bool ScatteringInitialized() const override { return xs_.ScatteringInitialized(); }
+  size_t NumGroups() const override { return xs_.NumGroups(); }
+  size_t ScatteringOrder() const override { return xs_.ScatteringOrder(); }
+  size_t NumPrecursors() const override { return xs_.NumPrecursors(); }
+  bool IsFissionable() const override { return xs_.IsFissionable(); }
 
   const std::vector<double>& SigmaTotal() const override { return xs_.SigmaTotal(); }
-
   const std::vector<double>& SigmaAbsorption() const override { return xs_.SigmaAbsorption(); }
-
-  const std::vector<double>& SigmaFission() const override { return xs_.SigmaFission(); }
-
-  const std::vector<double>& NuSigmaF() const override { return xs_.NuSigmaF(); }
-
-  const std::vector<double>& NuPromptSigmaF() const override { return xs_.NuPromptSigmaF(); }
-
-  const std::vector<double>& NuDelayedSigmaF() const override { return xs_.NuDelayedSigmaF(); }
-
-  const std::vector<double>& InverseVelocity() const override { return xs_.InverseVelocity(); }
-
   const std::vector<SparseMatrix>& TransferMatrices() const override
   {
     return transposed_transfer_matrices_;
   }
-
   const SparseMatrix& TransferMatrix(unsigned int ell) const override
   {
     return transposed_transfer_matrices_.at(ell);
   }
 
-  const std::vector<std::vector<double>> ProductionMatrix() const override
+  const std::vector<double>& SigmaFission() const override { return xs_.SigmaFission(); }
+  const std::vector<double>& NuSigmaF() const override { return xs_.NuSigmaF(); }
+  const std::vector<double>& NuPromptSigmaF() const override { return xs_.NuPromptSigmaF(); }
+  const std::vector<double>& NuDelayedSigmaF() const override { return xs_.NuDelayedSigmaF(); }
+  const std::vector<std::vector<double>>& ProductionMatrix() const override
   {
     return transposed_production_matrices_;
   }
-
   const std::vector<Precursor>& Precursors() const override { return xs_.Precursors(); }
 
+  const std::vector<double>& InverseVelocity() const override { return xs_.InverseVelocity(); }
+
+  bool DiffusionInitialized() const override { return xs_.DiffusionInitialized(); }
+  const std::vector<double>& SigmaTransport() const override { return xs_.SigmaTransport(); }
   const std::vector<double>& DiffusionCoefficient() const override
   {
     return xs_.DiffusionCoefficient();
   }
-
-  std::vector<double> SigmaTransport() const override { return xs_.SigmaTransport(); }
-
   const std::vector<double>& SigmaRemoval() const override { return xs_.SigmaRemoval(); }
-
   const std::vector<double>& SigmaSGtoG() const override { return xs_.SigmaSGtoG(); }
 };
 

--- a/framework/physics/physics_material/multi_group_xs/multi_group_xs.h
+++ b/framework/physics/physics_material/multi_group_xs/multi_group_xs.h
@@ -32,46 +32,29 @@ public:
    */
   void ExportToChiXSFile(const std::string& file_name, const double fission_scaling = 1.0) const;
 
-  virtual const unsigned int NumGroups() const = 0;
-
-  virtual const unsigned int ScatteringOrder() const = 0;
-
-  virtual const unsigned int NumPrecursors() const = 0;
-
-  virtual const bool IsFissionable() const = 0;
-
-  virtual const bool DiffusionInitialized() const = 0;
-
-  virtual const bool ScatteringInitialized() const = 0;
+  virtual size_t NumGroups() const = 0;
+  virtual size_t ScatteringOrder() const = 0;
+  virtual size_t NumPrecursors() const = 0;
+  virtual bool IsFissionable() const = 0;
 
   virtual const std::vector<double>& SigmaTotal() const = 0;
-
   virtual const std::vector<double>& SigmaAbsorption() const = 0;
+  virtual const std::vector<SparseMatrix>& TransferMatrices() const = 0;
+  virtual const SparseMatrix& TransferMatrix(unsigned int ell) const = 0;
 
   virtual const std::vector<double>& SigmaFission() const = 0;
-
   virtual const std::vector<double>& NuSigmaF() const = 0;
-
   virtual const std::vector<double>& NuPromptSigmaF() const = 0;
-
   virtual const std::vector<double>& NuDelayedSigmaF() const = 0;
+  virtual const std::vector<std::vector<double>>& ProductionMatrix() const = 0;
+  virtual const std::vector<Precursor>& Precursors() const = 0;
 
   virtual const std::vector<double>& InverseVelocity() const = 0;
 
-  virtual const std::vector<SparseMatrix>& TransferMatrices() const = 0;
-
-  virtual const SparseMatrix& TransferMatrix(unsigned int ell) const = 0;
-
-  virtual const std::vector<std::vector<double>> ProductionMatrix() const = 0;
-
-  virtual const std::vector<Precursor>& Precursors() const = 0;
-
+  virtual bool DiffusionInitialized() const = 0;
+  virtual const std::vector<double>& SigmaTransport() const = 0;
   virtual const std::vector<double>& DiffusionCoefficient() const = 0;
-
-  virtual std::vector<double> SigmaTransport() const = 0;
-
   virtual const std::vector<double>& SigmaRemoval() const = 0;
-
   virtual const std::vector<double>& SigmaSGtoG() const = 0;
 };
 

--- a/framework/physics/physics_material/multi_group_xs/multi_group_xs.h
+++ b/framework/physics/physics_material/multi_group_xs/multi_group_xs.h
@@ -36,6 +36,7 @@ public:
   virtual size_t ScatteringOrder() const = 0;
   virtual size_t NumPrecursors() const = 0;
   virtual bool IsFissionable() const = 0;
+  virtual double ScalingFactor() const = 0;
 
   virtual const std::vector<double>& SigmaTotal() const = 0;
   virtual const std::vector<double>& SigmaAbsorption() const = 0;

--- a/framework/physics/physics_material/multi_group_xs/single_state_mgxs.cc
+++ b/framework/physics/physics_material/multi_group_xs/single_state_mgxs.cc
@@ -17,24 +17,23 @@ SingleStateMGXS::Clear()
   is_fissionable_ = false;
 
   sigma_t_.clear();
-  sigma_f_.clear();
   sigma_a_.clear();
+  transfer_matrices_.clear();
 
+  sigma_f_.clear();
   nu_sigma_f_.clear();
   nu_prompt_sigma_f_.clear();
   nu_delayed_sigma_f_.clear();
+  production_matrix_.clear();
+  precursors_.clear();
 
   inv_velocity_.clear();
 
-  transfer_matrices_.clear();
-  production_matrix_.clear();
-
-  precursors_.clear();
-
   // Diffusion quantities
   diffusion_initialized_ = false;
+  sigma_tr_.clear();
   diffusion_coeff_.clear();
-  sigma_removal_.clear();
+  sigma_r_.clear();
   sigma_s_gtog_.clear();
 
   // Monte-Carlo quantities
@@ -67,7 +66,6 @@ SingleStateMGXS::MakeSimple1(unsigned int num_groups, double sigma_t, double c)
   // When multi-group, assign half the scattering cross section
   // to within-group scattering. The other half will be used for
   // up/down-scattering.
-
   auto& S = transfer_matrices_.back();
   double scale = (num_groups_ == 1) ? 1.0 : 0.5;
   S.SetDiagonal(std::vector<double>(num_groups, sigma_t * c * scale));
@@ -83,12 +81,12 @@ SingleStateMGXS::MakeSimple1(unsigned int num_groups, double sigma_t, double c)
   //        of the time.
   //     3) The lowest energy group has the same form as 1).
 
-  for (unsigned int g = 0; g < num_groups_; ++g)
+  for (size_t g = 0; g < num_groups_; ++g)
   {
-    // downscattering
+    // Down-scattering
     if (g > 0) S.Insert(g, g - 1, sigma_t * c * 0.5);
 
-    // upscattering
+    // Up-scattering
     if (g > num_groups_ / 2)
     {
       if (g < num_groups_ - 1)
@@ -110,37 +108,35 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
 {
   Clear();
 
-  // pickup all xs and make sure valid
+  // Pickup all xs and make sure valid
   std::vector<std::shared_ptr<MultiGroupXS>> xsecs;
   xsecs.reserve(combinations.size());
 
   unsigned int n_grps = 0;
   unsigned int n_precs = 0;
-  double Nf_total = 0.0; // total density of fissile materials
+  double Nf_total = 0.0; // Total density of fissile materials
 
-  // loop over cross sections
+  // Loop over cross sections
   for (auto combo : combinations)
   {
-    // get the cross section from the lua stack
+    // Get the cross section from the stack
     std::shared_ptr<MultiGroupXS> xs;
     xs = Chi::GetStackItemPtr(Chi::multigroup_xs_stack, combo.first, std::string(__FUNCTION__));
     xsecs.push_back(xs);
 
-    // increment densities
+    // Increment densities
     if (xs->IsFissionable())
     {
       is_fissionable_ = true;
       Nf_total += combo.second;
     }
 
-    // define and check number of groups
+    // Define and check number of groups
     if (xsecs.size() == 1) n_grps = xs->NumGroups();
-    else if (xs->NumGroups() != n_grps)
-      throw std::logic_error("Incompatible cross sections encountered.\n"
-                             "All cross sections being combined must have the "
-                             "same number of energy groups.");
+    ChiLogicalErrorIf(xs->NumGroups() != n_grps,
+                      "All cross sections being combined must have the same group structure.");
 
-    // increment number of precursors
+    // Increment number of precursors
     n_precs += xs->NumPrecursors();
   } // for cross section
 
@@ -153,38 +149,36 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
   // prompt/delayed fission data or total fission data
   if (n_precs > 0)
     for (const auto& xs : xsecs)
-      if (xs->IsFissionable() and xs->NumPrecursors() == 0)
-        throw std::logic_error("Incompatible cross sections encountered.\n"
-                               "If any fissionable cross sections specify delayed neutron "
-                               "data, all fissionable cross sections must specify delayed "
-                               "neutron data.");
+      ChiLogicalErrorIf(xs->IsFissionable() and xs->NumPrecursors() == 0,
+                        "If precursors are specified, all fissionable cross sections must "
+                        "specify precursors.");
 
   // Initialize the data
   num_groups_ = n_grps;
-  num_precursors_ = n_precs;
   scattering_order_ = 0;
+  num_precursors_ = n_precs;
   for (const auto& xs : xsecs)
     scattering_order_ = std::max(scattering_order_, xs->ScatteringOrder());
 
-  // mandatory cross sections
+  // Init mandatory cross sections
   sigma_t_.assign(n_grps, 0.0);
   sigma_a_.assign(n_grps, 0.0);
 
-  // init transfer matrices only if at least one exists
-  using XSPtr = MultiGroupXSPtr;
+  // Init transfer matrices only if at least one exists
   if (std::any_of(xsecs.begin(),
                   xsecs.end(),
-                  [](const XSPtr& x) { return not x->TransferMatrices().empty(); }))
+                  [](const std::shared_ptr<MultiGroupXS>& x)
+                  { return not x->TransferMatrices().empty(); }))
     transfer_matrices_.assign(scattering_order_ + 1, SparseMatrix(num_groups_, num_groups_));
 
-  // init fission data
+  // Init fission data
   if (is_fissionable_)
   {
     sigma_f_.assign(n_grps, 0.0);
     nu_sigma_f_.assign(n_grps, 0.0);
     production_matrix_.assign(num_groups_, std::vector<double>(num_groups_, 0.0));
 
-    // init prompt/delayed fission data
+    // Init prompt/delayed fission data
     if (n_precs > 0)
     {
       nu_prompt_sigma_f_.assign(n_grps, 0.0);
@@ -194,13 +188,13 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
   }
 
   // Combine the data
-  unsigned int precursor_count = 0;
+  size_t precursor_count = 0;
   for (size_t x = 0; x < xsecs.size(); ++x)
   {
-    // atom density
-    double N_i = combinations[x].second;
+    // Atom density
+    const auto N_i = combinations[x].second;
 
-    // fraction of fissile density
+    // Fraction of fissile density
     double ff_i = 0.0;
     if (xsecs[x]->IsFissionable()) ff_i = N_i / Nf_total;
 
@@ -214,43 +208,40 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
 
     // Here, raw cross sections are scaled by densities and spectra by
     // fractional densities. The latter is done to preserve a unit spectra.
-    for (unsigned int g = 0; g < n_grps; ++g)
+    for (size_t g = 0; g < n_grps; ++g)
     {
-      sigma_t_[g] += sig_t[g] * N_i;
-      sigma_a_[g] += sig_a[g] * N_i;
+      sigma_t_[g] += N_i * sig_t[g];
+      sigma_a_[g] += N_i * sig_a[g];
 
       if (xsecs[x]->IsFissionable())
       {
-        sigma_f_[g] += sig_f[g] * N_i;
-        nu_sigma_f_[g] += sig_f[g] * N_i;
-        for (unsigned int gp = 0; gp < num_groups_; ++gp)
-          production_matrix_[g][gp] += F[g][gp] * N_i;
+        sigma_f_[g] += N_i * sig_f[g];
+        nu_sigma_f_[g] += N_i * sig_f[g];
+        for (size_t gp = 0; gp < num_groups_; ++gp)
+          production_matrix_[g][gp] += N_i * F[g][gp];
 
         if (n_precs > 0)
         {
-          nu_prompt_sigma_f_[g] += nu_p_sig_f[g] * N_i;
-          nu_delayed_sigma_f_[g] += nu_d_sig_f[g] * N_i;
+          nu_prompt_sigma_f_[g] += N_i * nu_p_sig_f[g];
+          nu_delayed_sigma_f_[g] += N_i * nu_d_sig_f[g];
         }
       }
     } // for g
 
     // Combine precursor data
-
-    // Here, all precursors across all materials are stored. The decay
-    // constants and delayed spectrum are what they are, however, some
-    // special treatment must be given to the yields. Because the yield
-    // tells us what fraction of delayed neutrons are produced from a
-    // given family, the sum over all families must yield unity. To
-    // achieve this end, we must scale all precursor yields based on
-    // the fraction of the total density of materials with precursors
-    // they make up.
+    // Here, all precursors across all materials are stored. The decay constants and delayed
+    // spectrum are what they are, however, some special treatment must be given to the yields.
+    // Because the yield dictates what fraction of delayed neutrons are produced from a
+    // given family, the sum over all families must yield unity. To achieve this end, all
+    // precursor yields must be scaled based on the fraction of the total density of materials
+    // with precursors they make up.
 
     if (xsecs[x]->NumPrecursors() > 0)
     {
       const auto& precursors = xsecs[x]->Precursors();
-      for (unsigned int j = 0; j < xsecs[x]->NumPrecursors(); ++j)
+      for (size_t j = 0; j < xsecs[x]->NumPrecursors(); ++j)
       {
-        unsigned int count = precursor_count + j;
+        size_t count = precursor_count + j;
         const auto& precursor = precursors[j];
         precursors_[count].decay_constant = precursor.decay_constant;
         precursors_[count].fractional_yield = precursor.fractional_yield * ff_i;
@@ -261,12 +252,10 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
     }
 
     // Set inverse velocity data
-    if (x == 0 && !xsecs[x]->InverseVelocity().empty()) inv_velocity_ = xsecs[x]->InverseVelocity();
-    else if (xsecs[x]->InverseVelocity() != inv_velocity_)
-      throw std::logic_error("Invalid cross sections encountered.\n"
-                             "All cross sections being combined must share a group "
-                             "structure. This implies that the inverse speeds for "
-                             "each of the cross sections must be equivalent.");
+    if (x == 0 and xsecs[x]->InverseVelocity().empty()) inv_velocity_ = xsecs[x]->InverseVelocity();
+    ChiLogicalErrorIf(
+      xsecs[x]->InverseVelocity() != inv_velocity_,
+      "All cross sections being combined must have the same group-wise velocities.");
 
     // Combine transfer matrices
 
@@ -277,11 +266,11 @@ SingleStateMGXS::MakeCombined(std::vector<std::pair<int, double>>& combinations)
 
     if (not xsecs[x]->TransferMatrices().empty())
     {
-      for (unsigned int m = 0; m < xsecs[x]->ScatteringOrder() + 1; ++m)
+      for (size_t m = 0; m < xsecs[x]->ScatteringOrder() + 1; ++m)
       {
         auto& Sm = transfer_matrices_[m];
         const auto& Sm_other = xsecs[x]->TransferMatrix(m);
-        for (unsigned int g = 0; g < num_groups_; ++g)
+        for (size_t g = 0; g < num_groups_; ++g)
         {
           const auto& cols = Sm_other.rowI_indices_[g];
           const auto& vals = Sm_other.rowI_values_[g];
@@ -301,80 +290,64 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
   Clear();
 
   // Open Chi XS file
-
-  log.Log() << "Reading Chi cross section file \"" << file_name << "\"\n";
-
-  // opens and checks if open
   std::ifstream file;
   file.open(file_name);
-  if (not file.is_open())
-    throw std::runtime_error("Failed to open Chi cross section file "
-                             "\"" +
-                             file_name + "\" in call to " + std::string(__FUNCTION__));
+  ChiLogicalErrorIf(not file.is_open(), "Failed to open cross section file " + file_name + ".");
+  log.Log() << "Reading Chi cross section file \"" << file_name << "\"\n";
 
-  // Define utility functions for parsing
-
-  /// Lambda for reading group structure data.
-  ///
-  /// \param G Number of groups
+  // Lambda for reading group structure data.
   auto ReadGroupStructure = [](const std::string& keyword,
                                std::vector<std::vector<double>>& destination,
-                               const unsigned int G,
+                               const size_t n_grps,
                                std::ifstream& file,
                                std::istringstream& line_stream,
-                               unsigned int& line_number)
+                               size_t& line_number)
   {
-    // init storage
-    destination.assign(G, std::vector<double>(2, 0.0));
+    destination.assign(n_grps, std::vector<double>(2, 0.0));
 
-    // bookkeeping
     std::string line;
     int group;
-    double high;
-    double low;
-    unsigned int count = 0;
+    double high, low;
+    size_t count = 0;
 
-    // read the block
+    // Read the block
     std::getline(file, line);
     line_stream = std::istringstream(line);
     ++line_number;
     while (line != keyword + "_END")
     {
-      // get data from current line
+      // Get data from current line
       line_stream >> group >> high >> low;
       destination.at(group).at(0) = high;
       destination.at(group).at(1) = low;
-      if (count++ >= G)
-        throw std::runtime_error("Too many entries encountered when parsing "
-                                 "group structure.\nThe expected number of entries "
-                                 "is " +
-                                 std::to_string(G) + ".");
+      ChiLogicalErrorIf(count++ >= n_grps,
+                        "Too many entries encountered when parsing group structure.\n"
+                        "The expected number of entries is " +
+                          std::to_string(n_grps) + ".");
 
-      // go to next line
+      // Go to next line
       std::getline(file, line);
       line_stream = std::istringstream(line);
       ++line_number;
     }
   };
 
-  /// Lambda for reading vector data.
+  // Lambda for reading vector data.
   auto Read1DData = [](const std::string& keyword,
                        std::vector<double>& destination,
-                       const unsigned int N,
+                       const size_t n_entries,
                        std::ifstream& file,
                        std::istringstream& line_stream,
-                       unsigned int& line_number)
+                       size_t& line_number)
   {
-    // init storage
-    destination.assign(N, 0.0);
+    destination.assign(n_entries, 0.0);
 
-    // bookkeeping
     std::string line;
     int i;
     double value;
-    unsigned int count = 0;
+    size_t count = 0;
 
-    // read the bloc
+    // Read the bloc
     std::getline(file, line);
     line_stream = std::istringstream(line);
     ++line_number;
@@ -383,110 +356,96 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
       // get data from current line
       line_stream >> i >> value;
       destination.at(i) = value;
-      if (count++ >= N)
-        throw std::runtime_error("To many entries encountered when parsing "
-                                 "1D data.\nThe expected number of entries is " +
-                                 std::to_string(N));
+      ChiLogicalErrorIf(count++ >= n_entries,
+                        "Too many entries encountered when parsing 1D data.\n"
+                        "The expected number of entries is " +
+                          std::to_string(n_entries) + ".");
 
-      // go to next line
+      // Go to next line
       std::getline(file, line);
       line_stream = std::istringstream(line);
       ++line_number;
     }
   };
 
-  /// Lambda for reading 2D data
+  // Lambda for reading 2D data
   auto Read2DData = [](const std::string& keyword,
                        const std::string& entry_prefix,
                        std::vector<std::vector<double>>& destination,
-                       const unsigned int n_rows,
-                       const unsigned int n_cols,
+                       const size_t n_rows,
+                       const size_t n_cols,
                        std::ifstream& file,
                        std::istringstream& line_stream,
-                       unsigned int& line_number)
+                       size_t& line_number)
   {
-    // init storage
-    destination.clear();
-    for (unsigned int i = 0; i < n_rows; ++i)
-      destination.emplace_back(n_cols, 0.0);
+    destination.assign(n_rows, std::vector<double>(n_cols, 0.0));
 
-    // bookkeeping
     std::string word, line;
     double value;
-    unsigned int i;
-    unsigned int j;
+    size_t i, j;
 
-    // read the block
+    // Read the block
     std::getline(file, line);
     line_stream = std::istringstream(line);
     ++line_number;
     while (line != keyword + "_END")
     {
-      // check that this line contains an entry
+      // Check that this line contains an entry
       line_stream >> word;
       if (word == entry_prefix)
       {
-        // get data from current line
+        // Get data from current line
         line_stream >> i >> j >> value;
         if (entry_prefix == "G_PRECURSOR_VAL") destination.at(j).at(i) = value; // hack
         else
           destination.at(i).at(j) = value;
       }
 
-      // go to next line
+      // Go to next line
       std::getline(file, line);
       line_stream = std::istringstream(line);
       ++line_number;
     }
   };
 
-  /// Lambda for reading transfer matrix data.
-  ///
-  /// \param M Number of moments
-  /// \param G Number of groups
+  // Lambda for reading transfer matrix data.
   auto ReadTransferMatrices = [](const std::string& keyword,
                                  std::vector<SparseMatrix>& destination,
-                                 const unsigned int M,
-                                 const unsigned int G,
+                                 const size_t n_moms,
+                                 const size_t n_grps,
                                  std::ifstream& file,
                                  std::istringstream& line_stream,
-                                 unsigned int& line_number)
+                                 size_t& line_number)
   {
-    // init storage
-    destination.clear();
-    for (unsigned int i = 0; i < M; ++i)
-      destination.emplace_back(G, G);
+    destination.assign(n_moms, SparseMatrix(n_grps, n_grps));
 
-    // bookkeeping
     std::string word, line;
     double value;
-    unsigned int ell;
-    unsigned int group;
-    unsigned int gprime;
+    size_t ell, group, gprime;
 
-    // read the block
+    // Read the block
     std::getline(file, line);
     line_stream = std::istringstream(line);
     ++line_number;
     while (line != keyword + "_END")
     {
-      // check that this line contains an entry
+      // Check that this line contains an entry
       line_stream >> word;
       if (word == "M_GPRIME_G_VAL")
       {
-        // get data from current line
+        // Get data from current line
         line_stream >> ell >> gprime >> group >> value;
         destination.at(ell).Insert(group, gprime, value);
       }
 
-      // go to next line
+      // Go to next line
       std::getline(file, line);
       line_stream = std::istringstream(line);
       ++line_number;
     }
   };
 
-  /// Lambda for checking for all non-negative values.
+  // Lambda for checking for all non-negative values.
   auto IsNonNegative = [](const std::vector<double>& vec)
   { return not std::any_of(vec.begin(), vec.end(), [](double x) { return x < 0.0; }); };
 
@@ -499,7 +458,6 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
   { return std::any_of(vec.begin(), vec.end(), [](double x) { return x > 0.0; }); };
 
   // Read the Chi XS file
-
   // TODO: Determine whether or not to allow specification of a
   //       data block without any data. Currently, if a data block
   //       is specified and no values are present, the std::any_of
@@ -512,47 +470,42 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
   std::vector<double> chi, chi_prompt;
 
   std::string word, line;
-  unsigned int line_number = 0;
+  size_t line_number = 0;
   while (std::getline(file, line))
   {
     std::istringstream line_stream(line);
     line_stream >> word;
 
-    // parse number of groups
+    // Parse number of groups
     if (word == "NUM_GROUPS")
     {
-      int G;
-      line_stream >> G;
-      if (G <= 0)
-        throw std::logic_error("The specified number of energy groups "
-                               "must be strictly positive.");
-      num_groups_ = G;
+      int n_groups;
+      line_stream >> n_groups;
+      ChiLogicalErrorIf(n_groups <= 0, "The number of energy groups must be positive.");
+      num_groups_ = n_groups;
     }
 
-    // parse the number of scattering moments
+    // Parse the number of scattering moments
     if (word == "NUM_MOMENTS")
     {
-      int M;
-      line_stream >> M;
-      if (M < 0)
-        throw std::logic_error("The specified number of scattering moments "
-                               "must be non-negative.");
-      scattering_order_ = std::max(0, M - 1);
+      int n_moments;
+      line_stream >> n_moments;
+      ChiLogicalErrorIf(n_moments < 0, "The number of scattering moments must be non-negative.");
+      scattering_order_ = std::max(0, n_moments - 1);
     }
 
-    // parse the number of precursors species
+    // Parse the number of precursors species
     if (word == "NUM_PRECURSORS")
     {
-      int J;
-      line_stream >> J;
-      if (J < 0)
-        throw std::logic_error("The specified number of delayed neutron "
-                               "precursors must be non-negative.");
-      num_precursors_ = J;
+      int n_prec;
+      line_stream >> n_prec;
+      ChiLogicalErrorIf(n_prec < 0,
+                        "The number of delayed neutron precursors must be non-negative.");
+      num_precursors_ = n_prec;
       precursors_.resize(num_precursors_);
     }
 
-    // parse nuclear data
+    // Parse nuclear data
     try
     {
       auto& ln = line_number;
@@ -560,110 +513,98 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
       auto& f = file;
       auto& fw = word;
 
+      //
       // Group Structure Data
+      //
 
       if (fw == "GROUP_STRUCTURE_BEGIN")
         ReadGroupStructure("GROUP_STRUCTURE", e_bounds_, num_groups_, f, ls, ln);
-
       if (fw == "INV_VELOCITY_BEGIN")
       {
         Read1DData("INV_VELOCITY", inv_velocity_, num_groups_, f, ls, ln);
-
-        if (not IsPositive(inv_velocity_))
-          throw std::logic_error("Invalid inverse velocity value encountered.\n"
-                                 "Only strictly positive values are permitted.");
+        ChiLogicalErrorIf(not IsPositive(inv_velocity_),
+                          "Only positive inverse velocity values are permitted.");
       }
       if (fw == "VELOCITY_BEGIN" and inv_velocity_.empty())
       {
         Read1DData("VELOCITY", inv_velocity_, num_groups_, f, ls, ln);
+        ChiLogicalErrorIf(not IsPositive(inv_velocity_),
+                          "Only positive velocity values are permitted.");
 
-        if (not IsPositive(inv_velocity_))
-          throw std::logic_error("Invalid velocity value encountered.\n"
-                                 "Only strictly positive values are permitted.");
-
-        // compute inverse
-        for (unsigned int g = 0; g < num_groups_; ++g)
+        // Compute inverse velocity
+        for (size_t g = 0; g < num_groups_; ++g)
           inv_velocity_[g] = 1.0 / inv_velocity_[g];
       }
 
-      // Cross Section Data
+      //
+      // Read cross section data
+      //
 
       if (fw == "SIGMA_T_BEGIN")
       {
         Read1DData("SIGMA_T", sigma_t_, num_groups_, f, ls, ln);
-
-        if (not IsNonNegative(sigma_t_))
-          throw std::logic_error("Invalid total cross section value encountered.\n"
-                                 "Negative values are not permitted.");
+        ChiLogicalErrorIf(not IsNonNegative(sigma_t_),
+                          "Only non-negative total cross section values are permitted.");
       } // if sigma_t
 
       if (fw == "SIGMA_A_BEGIN")
       {
         Read1DData("SIGMA_A", sigma_a_, num_groups_, f, ls, ln);
-
-        if (not IsNonNegative(sigma_a_))
-          throw std::logic_error("Invalid absorption cross section value encountered.\n"
-                                 "Negative values are not permitted.");
+        ChiLogicalErrorIf(not IsNonNegative(sigma_a_),
+                          "Only non-negative absorption cross section values are permitted.");
       } // if sigma_a
 
       if (fw == "SIGMA_F_BEGIN")
       {
         Read1DData("SIGMA_F", sigma_f_, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(not IsNonNegative(sigma_f_),
+                          "Only non-negative fission cross section values are permitted.");
         if (not HasNonZero(sigma_f_))
         {
           log.Log0Warning() << "The fission cross section specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           sigma_f_.clear();
         }
-        else if (not IsNonNegative(sigma_f_))
-          throw std::logic_error("Invalid fission cross section value encountered.\n"
-                                 "Negative values are not permitted.");
       } // if sigma_f
 
       if (fw == "NU_SIGMA_F_BEGIN")
       {
         Read1DData("NU_SIGMA_F", nu_sigma_f_, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(
+          not IsNonNegative(nu_sigma_f_),
+          "Only non-negative total fission multiplication cross section values are permitted.");
         if (not HasNonZero(nu_sigma_f_))
         {
           log.Log0Warning() << "The production cross-section specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           nu_sigma_f_.clear();
         }
-        else if (not IsNonNegative(nu_sigma_f_))
-          throw std::logic_error("Invalid production cross section value encountered.\n"
-                                 "Negative values are not permitted.");
       } // if nu_sigma_f
 
-      // Neutrons Per Fission
+      //
+      // Read neutrons per fission data
+      //
 
       if (fw == "NU_BEGIN")
       {
         Read1DData("NU", nu, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(
+          not std::all_of(nu.begin(), nu.end(), [](double x) { return x == 0.0 or x > 1.0; }),
+          "Total fission neutron yield values must be either zero, or greater than one.");
         if (not HasNonZero(nu))
         {
           log.Log0Warning() << "The total fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           nu.clear();
         }
-        else if (std::any_of(
-                   nu.begin(), nu.end(), [](double x) { return not(x == 0.0 or x > 1.0); }))
-          throw std::logic_error("Invalid total fission neutron yield value encountered.\n"
-                                 "Only values strictly greater than one, or zero, are "
-                                 "permitted.");
 
-        // compute prompt/delayed nu, if needed
+        // Compute prompt/delayed nu, if needed
         if (num_precursors_ > 0 and not nu.empty() and not beta.empty() and nu_prompt.empty() and
             nu_delayed.empty())
         {
           nu_prompt.assign(num_groups_, 0.0);
           nu_delayed.assign(num_groups_, 0.0);
-          for (unsigned int g = 0; g < num_groups_; ++g)
+          for (size_t g = 0; g < num_groups_; ++g)
           {
             nu_prompt[g] = (1.0 - beta[g]) * nu[g];
             nu_delayed[g] = beta[g] * nu[g];
@@ -674,55 +615,47 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
       if (fw == "NU_PROMPT_BEGIN")
       {
         Read1DData("NU_PROMPT", nu_prompt, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(not std::all_of(nu_prompt.begin(),
+                                          nu_prompt.end(),
+                                          [](double x) { return x == 0.0 or x > 1.0; }),
+                          "Average prompt fission neutron yield values must be either zero, "
+                          "or greater than one.");
         if (not HasNonZero(nu_prompt))
         {
           log.Log0Warning() << "The prompt fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           nu_prompt.clear();
         }
-        else if (std::any_of(nu_prompt.begin(),
-                             nu_prompt.end(),
-                             [](double x) { return not(x == 0.0 or x > 1.0); }))
-          throw std::logic_error("Invalid prompt fission neutron yield value encountered.\n"
-                                 "Only values strictly greater than one, or zero, are "
-                                 "permitted.");
-      }
+      } // if nu_prompt
 
       if (fw == "NU_DELAYED_BEGIN")
       {
         Read1DData("NU_DELAYED", nu_delayed, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(not IsNonNegative(nu_delayed),
+                          "Average delayed fission neutron yield values "
+                          "must be non-negative.");
         if (not HasNonZero(nu_delayed))
         {
           log.Log0Warning() << "The delayed fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           nu_prompt.clear();
         }
-        else if (not IsNonNegative(nu_delayed))
-          throw std::logic_error("Invalid delayed fission neutron yield value encountered.\n"
-                                 "Only non-negative values are permitted.");
-      }
+      } // if nu_delayed
 
       if (fw == "BETA_BEGIN")
       {
         Read1DData("BETA", beta, num_groups_, f, ls, ln);
-
+        ChiLogicalErrorIf(
+          not std::all_of(beta.begin(), beta.end(), [](double x) { return x >= 0.0 and x <= 1.0; }),
+          "Delayed neutron fraction values must be in the range [0.0, 1.0].");
         if (not HasNonZero(beta))
         {
           log.Log0Warning() << "The delayed neutron fraction specified in "
-                            << "\"" << file_name << "\" is uniformly zero..."
-                            << "Clearing it.";
+                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
           beta.clear();
         }
-        else if (std::any_of(
-                   beta.begin(), beta.end(), [](double x) { return not(x >= 0.0 and x <= 1.0); }))
-          throw std::logic_error("Invalid delayed neutron fraction value encountered.\n"
-                                 "Only values in the range [0.0, 1.0] are permitted.");
 
-        // compute prompt/delayed nu, if needed
+        // Compute prompt/delayed nu, if needed
         if (num_precursors_ > 0 and not nu.empty() and not beta.empty() and nu_prompt.empty() and
             nu_delayed.empty())
         {
@@ -736,37 +669,34 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
         }
       } // if beta
 
-      // Fission/Emission Spectra
+      //
+      // Read fission/emission spectra
+      //
 
       if (fw == "CHI_BEGIN")
       {
         Read1DData("CHI", chi, num_groups_, f, ls, ln);
+        ChiLogicalErrorIf(
+          not HasNonZero(chi),
+          "The steady-state fission spectrum must have at least one non-zero value.");
+        ChiLogicalErrorIf(not IsNonNegative(chi),
+                          "The steady-state fission spectrum must be non-negative.");
 
-        if (not HasNonZero(chi))
-          throw std::logic_error("Invalid steady-state fission spectrum encountered.\n"
-                                 "No non-zero values found.");
-        if (not IsNonNegative(chi))
-          throw std::logic_error("Invalid steady-state fission spectrum value encountered.\n"
-                                 "Only non-negative values are permitted.");
-
-        // normalizing
-        double sum = std::accumulate(chi.begin(), chi.end(), 0.0);
+        // Normalizing
+        const auto sum = std::accumulate(chi.begin(), chi.end(), 0.0);
         std::transform(chi.begin(), chi.end(), chi.begin(), [sum](double& x) { return x / sum; });
       } // if chi
 
       if (fw == "CHI_PROMPT_BEGIN")
       {
         Read1DData("CHI_PROMPT", chi_prompt, num_groups_, f, ls, ln);
+        ChiLogicalErrorIf(not HasNonZero(chi_prompt),
+                          "The prompt fission spectrum must have at least one non-zero value.");
+        ChiLogicalErrorIf(not IsNonNegative(chi_prompt),
+                          "The prompt fission spectrum must be non-negative.");
 
-        if (not HasNonZero(chi_prompt))
-          throw std::logic_error("Invalid prompt fission spectrum encountered.\n"
-                                 "No non-zero values found.");
-        if (not IsNonNegative(chi_prompt))
-          throw std::logic_error("Invalid prompt fission spectrum value encountered.\n"
-                                 "Only non-negative values are permitted.");
-
-        // normalizing
-        double sum = std::accumulate(chi_prompt.begin(), chi_prompt.end(), 0.0);
+        // Normalizing
+        const auto sum = std::accumulate(chi_prompt.begin(), chi_prompt.end(), 0.0);
         std::transform(chi_prompt.begin(),
                        chi_prompt.end(),
                        chi_prompt.begin(),
@@ -786,20 +716,18 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
                    ls,
                    ln);
 
-        for (unsigned int j = 0; j < num_precursors_; ++j)
+        for (size_t j = 0; j < num_precursors_; ++j)
         {
-          if (not HasNonZero(emission_spectra[j]))
-            throw std::logic_error("Invalid delayed emission spectrum encountered for "
-                                   "precursor species " +
-                                   std::to_string(j) + ".\n" + "No non-zero values found.");
-          if (not IsNonNegative(emission_spectra[j]))
-            throw std::logic_error("Invalid delayed emission spectrum value encountered "
-                                   "for precursor species " +
-                                   std::to_string(j) + ".\n" +
-                                   "Only non-negative values are permitted.");
+          ChiLogicalErrorIf(not HasNonZero(emission_spectra[j]),
+                            "Delayed emission spectrum for precursor " + std::to_string(j) +
+                              " must have at least one non-zero value.");
+          ChiLogicalErrorIf(not IsNonNegative(emission_spectra[j]),
+                            "Delayed emission spectrum for precursor " + std::to_string(j) +
+                              " must be non-negative.");
 
           // normalizing
-          double sum = std::accumulate(emission_spectra[j].begin(), emission_spectra[j].end(), 0.0);
+          const auto sum =
+            std::accumulate(emission_spectra[j].begin(), emission_spectra[j].end(), 0.0);
           std::transform(emission_spectra[j].begin(),
                          emission_spectra[j].end(),
                          emission_spectra[j].begin(),
@@ -807,42 +735,43 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
         }
       } // if delayed chi
 
-      // Delayed Neutron Precursor Data
+      //
+      // Read delayed neutron precursor data
+      //
 
       if (num_precursors_ > 0)
       {
         if (fw == "PRECURSOR_DECAY_CONSTANTS_BEGIN")
         {
           Read1DData("PRECURSOR_DECAY_CONSTANTS", decay_constants, num_precursors_, f, ls, ln);
-
-          if (not IsPositive(decay_constants))
-            throw std::logic_error("Invalid precursor decay constant value encountered.\n"
-                                   "Only strictly positive values are permitted.");
+          ChiLogicalErrorIf(not IsPositive(decay_constants),
+                            "Delayed neutron precursor decay constants must be positive.");
         } // if decay constants
 
         if (fw == "PRECURSOR_FRACTIONAL_YIELDS_BEGIN")
         {
           Read1DData("PRECURSOR_FRACTIONAL_YIELDS", fractional_yields, num_precursors_, f, ls, ln);
+          ChiLogicalErrorIf(
+            not HasNonZero(fractional_yields),
+            "Delayed neutron precursor fractional yields must contain at least one non-zero.");
+          ChiLogicalErrorIf(
+            not std::all_of(fractional_yields.begin(),
+                            fractional_yields.end(),
+                            [](double x) { return x >= 0.0 and x <= 1.0; }),
+            "Delayed neutron precursor fractional yields must be in the range [0.0, 1.0].");
 
-          if (not HasNonZero(fractional_yields))
-            throw std::logic_error("Invalid precursor fractional yields encountered.\n"
-                                   "No non-zero values found.");
-          if (std::any_of(fractional_yields.begin(),
-                          fractional_yields.end(),
-                          [](double x) { return not(x >= 0.0 and x <= 1.0); }))
-            throw std::logic_error("Invalid precursor fractional yield value encountered.\n"
-                                   "Only values in the range [0.0, 1.0] are permitted.");
-
-          // normalizing
-          double sum = std::accumulate(fractional_yields.begin(), fractional_yields.end(), 0.0);
+          // Normalizing
+          const auto sum = std::accumulate(fractional_yields.begin(), fractional_yields.end(), 0.0);
           std::transform(fractional_yields.begin(),
                          fractional_yields.end(),
                          fractional_yields.begin(),
                          [sum](double& x) { return x / sum; });
-        }
+        } // if precursor yield
       }
 
-      // Transfer Data
+      //
+      // Read transfer data
+      //
 
       if (fw == "TRANSFER_MOMENTS_BEGIN")
         ReadTransferMatrices(
@@ -877,7 +806,7 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
 
     catch (...)
     {
-      throw std::runtime_error("Unknown error encountered in " + std::string(__FUNCTION__));
+      throw std::runtime_error("Unknown error encountered.");
     }
 
     word = "";
@@ -887,94 +816,77 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
   if (sigma_a_.empty()) ComputeAbsorption();
   ComputeDiffusionParameters();
 
+  //
   // Compute and check fission data
+  //
 
-  // determine if the material is fissionable
+  // Determine if the material is fissionable
   is_fissionable_ =
     not sigma_f_.empty() or not nu_sigma_f_.empty() or not production_matrix_.empty();
 
-  // clear fission data if not fissionable
-  if (not is_fissionable_)
+  // Check and set the fission data
+  if (is_fissionable_)
   {
-    sigma_f_.clear();
-    nu_sigma_f_.clear();
-    nu_prompt_sigma_f_.clear();
-    nu_delayed_sigma_f_.clear();
-    precursors_.clear();
-  } // if not fissionable
-
-  // otherwise, check and set the fission data
-  else
-  {
-    // check vector data inputs
+    // Check vector data inputs
     if (production_matrix_.empty())
     {
-      // check for non-delayed fission neutron yield data
-      if (nu.empty() and nu_prompt.empty())
-        throw std::logic_error("Invalid fission neutron yield specification encountered.\n"
-                               "Either the total or prompt fission neutron yield must be "
-                               "specified.");
+      // Check for non-delayed fission neutron yield data
+      ChiLogicalErrorIf(nu.empty() and nu_prompt.empty(),
+                        "Either the total or prompt fission neutron yield must be specified "
+                        "for fissionable materials.");
+      ChiLogicalErrorIf(not nu.empty() and not nu_prompt.empty(),
+                        "Ambiguous fission neutron yield. Only one of the total and prompt "
+                        "fission neutron yield should be specified.");
 
-      if (not nu.empty() and not nu_prompt.empty())
-        throw std::logic_error("Ambiguous fission neutron yield data specified.\n"
-                               "Either the total or prompt fission neutron yield "
-                               "must be specified, not both.");
+      // Check for fission spectrum data
+      ChiLogicalErrorIf(chi.empty() and chi_prompt.empty(),
+                        "Either the steady-state or prompt fission spectrum must be specified "
+                        "for fissionable materials.");
+      ChiLogicalErrorIf(not chi.empty() and not chi_prompt.empty(),
+                        "Ambiguous fission spectrum data. Only one of the steady-state and "
+                        "prompt fission spectrum should be specified.");
 
-      // check for fission spectrum data
-      if (chi.empty() and chi_prompt.empty())
-        throw std::logic_error("Invalid fission spectrum specification encountered.\n"
-                               "Either the steady-state or prompt fission spectrum must be "
-                               "specified.");
-
-      if (not chi.empty() and not chi_prompt.empty())
-        throw std::logic_error("Ambiguous fission spectrum data specified.\n"
-                               "Either the steady-state or prompt fission spectrum "
-                               "must be specified, not both.");
-
-      // check for compatibility
+      // Check for compatibility
       if ((not nu.empty() and chi.empty()) or (nu.empty() and not chi.empty()) or
           (not nu_prompt.empty() and chi_prompt.empty()) or
           (nu_prompt.empty() and not chi_prompt.empty()))
-        throw std::logic_error("Ambiguous fission data specified.\n"
-                               "Either the total fission neutron yield and steady-state "
-                               "fission spectrum or the prompt fission neutron yield and "
-                               "prompt fission spectrum must be specified.");
+        ChiLogicalError("Ambiguous fission data. Either the total fission neutron yield with the "
+                        "steady-state fission spectrum or the prompt fission neutron yield with "
+                        "the prompt fission spectrum should be specified.");
 
-      // initialize total fission neutron yield
-      // do this only when prompt is specified
-      if (not nu_prompt.empty())
-      {
-        nu.assign(num_groups_, 0.0);
-        for (unsigned int g = 0; g < num_groups_; ++g)
-          nu[g] = nu_prompt[g];
-      }
+      // Initialize total fission neutron yield from prompt
+      if (not nu_prompt.empty()) nu = nu_prompt;
 
-      // check delayed neutron data
+      // Check delayed neutron data
       if (num_precursors_ > 0)
       {
-        // check that prompt data was specified
-        if (chi_prompt.empty() or nu_prompt.empty())
-          throw std::logic_error("Invalid fission data specification encountered.\n"
-                                 "When delayed neutron precursors are present, "
-                                 "prompt fission data must be specified.");
+        // Check that decay data was specified
+        ChiLogicalErrorIf(decay_constants.empty(),
+                          "Precursor decay constants are required when precursors are specified.");
 
-        // check that delayed fission neutron yield was specified
-        if (nu_delayed.empty() or decay_constants.empty() or fractional_yields.empty() or
-            std::any_of(emission_spectra.begin(),
-                        emission_spectra.end(),
-                        [](const std::vector<double>& x) { return x.empty(); }))
-          throw std::logic_error("Invalid fission data specification encountered.\n"
-                                 "When delayed neutron precursors are present, "
-                                 "the delayed fission neutron yield, delayed neutron "
-                                 "precursor decay constants, fractional yields, and "
-                                 "emission spectra must all be specified.");
+        // Check that yield data was specified
+        ChiLogicalErrorIf(fractional_yields.empty(),
+                          "Precursor yields are required when precursors are specified.");
 
-        // add delayed fission neutron yield to total
-        for (unsigned int g = 0; g < num_groups_; ++g)
+        // Check that prompt data was specified
+        ChiLogicalErrorIf(chi_prompt.empty() or nu_prompt.empty(),
+                          "Both the prompt fission spectrum and prompt fission neutron yield "
+                          "must be specified when delayed neutron precursors are specified.");
+
+        // Check that delayed neutron production and emission spectra were specified
+        ChiLogicalErrorIf(nu_delayed.empty() or
+                            std::any_of(emission_spectra.begin(),
+                                        emission_spectra.end(),
+                                        [](const std::vector<double>& x) { return x.empty(); }),
+                          "Both the delay emission spectra and delayed fission neutron yield "
+                          "must be specified when precursors are specified.");
+
+        // Add delayed fission neutron yield to total
+        for (size_t g = 0; g < num_groups_; ++g)
           nu[g] += nu_delayed[g];
 
-        // add data to precursor structs
-        for (unsigned int j = 0; j < num_precursors_; ++j)
+        // Add data to precursor structs
+        for (size_t j = 0; j < num_precursors_; ++j)
         {
           precursors_[j].decay_constant = decay_constants[j];
           precursors_[j].fractional_yield = fractional_yields[j];
@@ -982,89 +894,98 @@ SingleStateMGXS::MakeFromChiXSFile(const std::string& file_name)
         }
       }
 
-      // compute fission cross section
+      // Compute fission cross section
       if (sigma_f_.empty() and not nu_sigma_f_.empty())
       {
-        sigma_f_.assign(num_groups_, 0.0);
-        for (unsigned int g = 0; g < num_groups_; ++g)
-          if (nu_sigma_f_[g] > 0.0) sigma_f_[g] = nu_sigma_f_[g] / nu[g];
+        sigma_f_ = nu_sigma_f_;
+        for (size_t g = 0; g < num_groups_; ++g)
+          if (nu_sigma_f_[g] > 0.0) sigma_f_[g] /= nu[g];
       }
 
-      // compute total production cross section
-      nu_sigma_f_.assign(num_groups_, 0.0);
-      for (unsigned int g = 0; g < num_groups_; ++g)
-        nu_sigma_f_[g] = nu[g] * sigma_f_[g];
+      // Compute total production cross section
+      nu_sigma_f_ = sigma_f_;
+      for (size_t g = 0; g < num_groups_; ++g)
+        nu_sigma_f_[g] *= nu[g];
 
-      // compute prompt production cross section
+      // Compute prompt production cross section
       if (not nu_prompt.empty())
       {
-        nu_prompt_sigma_f_.assign(num_groups_, 0.0);
-        for (unsigned int g = 0; g < num_groups_; ++g)
-          nu_prompt_sigma_f_[g] = nu_prompt[g] * sigma_f_[g];
+        nu_prompt_sigma_f_ = sigma_f_;
+        for (size_t g = 0; g < num_groups_; ++g)
+          nu_prompt_sigma_f_[g] *= nu_prompt[g];
       }
 
-      // compute delayed production cross section
+      // Compute delayed production cross section
       if (not nu_delayed.empty())
       {
-        nu_delayed_sigma_f_.assign(num_groups_, 0.0);
-        for (unsigned int g = 0; g < num_groups_; ++g)
-          nu_delayed_sigma_f_[g] = nu_delayed[g] * sigma_f_[g];
+        nu_delayed_sigma_f_ = sigma_f_;
+        for (size_t g = 0; g < num_groups_; ++g)
+          nu_delayed_sigma_f_[g] *= nu_delayed[g];
       }
 
-      // compute production matrix
-      const auto chi_ = not chi_prompt.empty() ? chi_prompt : chi;
+      // Compute production matrix
+      const auto fis_spec = not chi_prompt.empty() ? chi_prompt : chi;
       const auto nu_sigma_f = not nu_prompt.empty() ? nu_prompt_sigma_f_ : nu_sigma_f_;
 
-      for (unsigned int g = 0; g < num_groups_; ++g)
-      {
-        std::vector<double> prod;
-        for (unsigned int gp = 0.0; gp < num_groups_; ++gp)
-          prod.push_back(chi_[g] * nu_sigma_f[gp]);
-        production_matrix_.push_back(prod);
-      }
+      production_matrix_.resize(num_groups_);
+      for (size_t g = 0; g < num_groups_; ++g)
+        for (size_t gp = 0.0; gp < num_groups_; ++gp)
+          production_matrix_[g].push_back(fis_spec[g] * nu_sigma_f[gp]);
     } // if production_matrix empty
 
     else
     {
-      // TODO: Develop an implementation for multi-particle delayed
-      //       neutron data. The primary challenge in this is that
-      //       different precursor species exist for neutron-induced
-      //       fission than for photo-fission.
+      // TODO: Develop an implementation for multi-particle delayed neutron data.
+      //       The primary challenge in this is that different precursor species exist for
+      //       neutron-induced fission than for photo-fission.
 
-      // throw error if precursors are present
-      if (num_precursors_ > 0)
-        throw std::runtime_error("This setup has not been implemented.\n"
-                                 "Currently, when a production matrix is specified, "
-                                 "no delayed neutron precursors are allowed.");
+      ChiLogicalErrorIf(num_precursors_ > 0,
+                        "Currently, production matrix specification is not allowed when "
+                        "delayed neutrons are present.");
 
-      // check for fission cross sections
-      if (sigma_f_.empty())
-        throw std::logic_error("Invalid fission data specification encountered.\n"
-                               "When a production matrix is specified, the fission "
-                               "cross sections must also be specified.");
+      // Check for fission cross sections
+      ChiLogicalErrorIf(sigma_f_.empty(),
+                        "When a production matrix is specified, it must "
+                        "be accompanied with a fission cross section.");
 
-      // compute production cross section
+      // Compute production cross section
       nu_sigma_f_.assign(num_groups_, 0.0);
-      for (unsigned int g = 0; g < num_groups_; ++g)
-        for (unsigned int gp = 0; gp < num_groups_; ++gp)
+      for (size_t g = 0; g < num_groups_; ++g)
+        for (size_t gp = 0; gp < num_groups_; ++gp)
           nu_sigma_f_[gp] += production_matrix_[g][gp];
 
-      // check for reasonable fission neutron yield
-      nu.assign(num_groups_, 0.0);
-      for (unsigned int g = 0; g < num_groups_; ++g)
-        if (sigma_f_[g] > 0.0) nu[g] = nu_sigma_f_[g] / sigma_f_[g];
+      // Check for reasonable fission neutron yield
+      nu = nu_sigma_f_;
+      for (size_t g = 0; g < num_groups_; ++g)
+        if (sigma_f_[g] > 0.0) nu[g] /= sigma_f_[g];
 
-      if (std::any_of(
-            nu.begin(), nu.end(), [](double x) { return not(x == 0.0 or (x > 1.0 and x < 10.0)); }))
-        throw std::logic_error("Incompatible fission data encountered.\n"
-                               "The estimated fission neutron yield must be either zero "
-                               "or in the range (1.0, 10.0).");
+      ChiLogicalErrorIf(
+        not IsNonNegative(nu),
+        "The production matrix implies an invalid negative average fission neutron yield.");
+      ChiLogicalErrorIf(
+        not std::all_of(nu.begin(), nu.end(), [](double x) { return x == 0.0 and x > 1.0; }),
+        "Incompatible fission data encountered. The computed nu is not either zero or "
+        "greater than one.");
+
+      if (std::any_of(nu.begin(), nu.end(), [](double x) { return x > 8.0; }))
+        log.Log0Warning() << "A computed nu of greater than 8.0 was encountered. ";
     }
 
-    ChiLogicalErrorIf(sigma_f_.empty(),
-                      "After reading xs, a fissionable "
-                      "material's sigma_f is not defined");
+    ChiLogicalErrorIf(
+      sigma_f_.empty(),
+      "Fissionable materials are required to have a defined fission cross section.");
   } // if fissionable
+
+  // Clear fission data if not fissionable
+  else
+  {
+    sigma_f_.clear();
+    nu_sigma_f_.clear();
+    nu_prompt_sigma_f_.clear();
+    nu_delayed_sigma_f_.clear();
+    production_matrix_.clear();
+    precursors_.clear();
+  } // if not fissionable
 }
 
 void
@@ -1072,21 +993,21 @@ SingleStateMGXS::ComputeAbsorption()
 {
   sigma_a_.assign(num_groups_, 0.0);
 
-  // compute for a pure absorber
+  // Compute for a pure absorber
   if (transfer_matrices_.empty())
     for (size_t g = 0; g < num_groups_; ++g)
       sigma_a_[g] = sigma_t_[g];
 
-  // estimate from a transfer matrix
+  // Estimate from a transfer matrix
   else
   {
     log.Log0Warning() << "Estimating absorption from the transfer matrices.";
 
-    const auto& S0 = transfer_matrices_[0];
+    const auto& S0 = transfer_matrices_.front();
     for (size_t g = 0; g < num_groups_; ++g)
     {
-      // estimate the scattering cross section
-      double sig_s = 0.0;
+      // Estimate the scattering cross section
+      double sigma_s = 0.0;
       for (size_t row = 0; row < S0.NumRows(); ++row)
       {
         const auto& cols = S0.rowI_indices_[row];
@@ -1094,18 +1015,16 @@ SingleStateMGXS::ComputeAbsorption()
         for (size_t t = 0; t < cols.size(); ++t)
           if (cols[t] == g)
           {
-            sig_s += vals[t];
+            sigma_s += vals[t];
             break;
           }
       }
-
-      sigma_a_[g] = sigma_t_[g] - sig_s;
+      sigma_a_[g] = sigma_t_[g] - sigma_s;
 
       // TODO: Should negative absorption be allowed?
       if (sigma_a_[g] < 0.0)
-        log.Log0Warning() << "Negative absorption cross section encountered "
-                          << "in group " << g << " when estimating from the "
-                          << "transfer matrices";
+        log.Log0Warning() << "Negative absorption cross section encountered in group " << g
+                          << " when estimating from the transfer matrices";
     } // for g
   }   // if scattering present
 }
@@ -1115,51 +1034,50 @@ SingleStateMGXS::ComputeDiffusionParameters()
 {
   if (diffusion_initialized_) return;
 
-  // initialize diffusion data
+  // Initialize diffusion data
+  sigma_tr_.resize(num_groups_, 0.0);
   diffusion_coeff_.resize(num_groups_, 1.0);
   sigma_s_gtog_.resize(num_groups_, 0.0);
-  sigma_removal_.resize(num_groups_, 0.1);
+  sigma_r_.resize(num_groups_, 0.0);
 
-  // perfom computations group-wise
+  // Perform computations group-wise
   const auto& S = transfer_matrices_;
-  for (unsigned int g = 0; g < num_groups_; ++g)
+  for (size_t g = 0; g < num_groups_; ++g)
   {
     // Determine transport correction
-
-    double sig_1 = 0.0;
+    double sigma_1 = 0.0;
     if (S.size() > 1)
     {
-      for (unsigned int gp = 0; gp < num_groups_; ++gp)
+      for (size_t gp = 0; gp < num_groups_; ++gp)
       {
         const auto& cols = S[1].rowI_indices_[gp];
         const auto& vals = S[1].rowI_values_[gp];
         for (size_t t = 0; t < cols.size(); ++t)
           if (cols[t] == g)
           {
-            sig_1 += vals[t];
+            sigma_1 += vals[t];
             break;
           }
       } // for gp
     }   // if moment 1 available
 
-    // Compute diffusion coefficient
-
-    if (sig_1 >= sigma_t_[g])
+    // Compute transport cross section
+    if (sigma_1 >= sigma_t_[g])
     {
-      sig_1 = 0.0;
       log.Log0Warning() << "Transport corrected diffusion coefficient failed for group " << g
                         << " in call to " << __FUNCTION__ << ". "
-                        << "sigma_t=" << sigma_t_[g] << " sigs_g_(m=1)=" << sig_1
-                        << ". Setting sigs_g_(m=1) to zero for this group.";
+                        << "sigma_t=" << sigma_t_[g] << " sigma_1=" << sigma_1 << ". "
+                        << "Setting sigma_1 to zero for group " << g << ".";
+      sigma_1 = 0.0;
     }
+    sigma_tr_[g] = sigma_t_[g] - sigma_1;
 
-    // compute the diffusion coefficient
-    // cap the value for when sig_t - sig_1 is near zero
-    diffusion_coeff_[g] = std::fmin(1.0e12, 1.0 / 3.0 / (sigma_t_[g] - sig_1));
+    // Compute the diffusion coefficient
+    // Cap the value for when sigma_t - sigma_1 is near zero
+    diffusion_coeff_[g] = std::fmin(1.0e12, 1.0 / 3.0 / (sigma_t_[g] - sigma_1));
 
     // Determine within group scattering
-
-    if (!S.empty())
+    if (not S.empty())
     {
       const auto& cols = S[0].rowI_indices_[g];
       const auto& vals = S[0].rowI_values_[g];
@@ -1172,8 +1090,7 @@ SingleStateMGXS::ComputeDiffusionParameters()
     }
 
     // Compute removal cross section
-
-    sigma_removal_[g] = std::max(0.0, sigma_t_[g] - sigma_s_gtog_[g]);
+    sigma_r_[g] = std::max(0.0, sigma_t_[g] - sigma_s_gtog_[g]);
   } // for g
 
   diffusion_initialized_ = true;

--- a/framework/physics/physics_material/multi_group_xs/single_state_mgxs.h
+++ b/framework/physics/physics_material/multi_group_xs/single_state_mgxs.h
@@ -42,6 +42,14 @@ public:
    */
   void MakeCombined(std::vector<std::pair<int, double>>& combinations);
 
+  /**
+   * Scale the cross sections by the specified factor.
+   *
+   * @note Scaling factors do not compound. Each time this routine is called, the cross sections
+   *       are scaled by the ratio of the argument and the existing scaling factor.
+   */
+  void SetScalingFactor(const double factor);
+
 private:
   void Clear();
 
@@ -61,6 +69,7 @@ public:
   size_t ScatteringOrder() const override { return scattering_order_; }
   size_t NumPrecursors() const override { return num_precursors_; }
   bool IsFissionable() const override { return is_fissionable_; }
+  double ScalingFactor() const override { return scaling_factor_; }
 
   const std::vector<double>& SigmaTotal() const override { return sigma_t_; }
   const std::vector<double>& SigmaAbsorption() const override { return sigma_a_; }
@@ -94,6 +103,8 @@ protected:
   size_t num_precursors_ = 0;   ///< Number of precursors
   bool is_fissionable_ = false;
   std::vector<std::vector<double>> e_bounds_; ///< Energy bin boundaries in MeV
+
+  double scaling_factor_ = 1.0; ///< An arbitrary scaling factor
 
   std::vector<double> sigma_t_; ///< Total cross section
   std::vector<double> sigma_a_; ///< Absorption cross section

--- a/framework/physics/physics_material/multi_group_xs/single_state_mgxs.h
+++ b/framework/physics/physics_material/multi_group_xs/single_state_mgxs.h
@@ -15,44 +15,6 @@ class SingleStateMGXS : public MultiGroupXS
 protected:
   typedef std::vector<std::pair<double, double>> AnglePairs;
 
-protected:
-  unsigned int num_groups_ = 0;       ///< Total number of groups
-  unsigned int scattering_order_ = 0; ///< Legendre scattering order
-  unsigned int num_precursors_ = 0;   ///< Number of precursors
-
-  bool is_fissionable_ = false;
-
-  std::vector<std::vector<double>> e_bounds_; ///< Energy bin boundaries in MeV
-
-  std::vector<double> sigma_t_; ///< Total cross section
-  std::vector<double> sigma_a_; ///< Absorption cross section
-  std::vector<double> sigma_f_; ///< Fission cross section
-
-  std::vector<double> nu_sigma_f_;
-  std::vector<double> nu_prompt_sigma_f_;
-  std::vector<double> nu_delayed_sigma_f_;
-
-  std::vector<double> inv_velocity_;
-
-  std::vector<SparseMatrix> transfer_matrices_;
-  std::vector<std::vector<double>> production_matrix_;
-
-  std::vector<Precursor> precursors_;
-
-  // Diffusion quantities
-  bool diffusion_initialized_ = false;
-  std::vector<double> diffusion_coeff_; ///< Transport corrected diffusion coeff
-  std::vector<double> sigma_removal_;   ///< Removal cross section
-  std::vector<double> sigma_s_gtog_;    ///< Within-group scattering xs
-
-  // Monte-Carlo quantities
-protected:
-  bool scattering_initialized_ = false;
-
-private:
-  std::vector<std::vector<double>> cdf_gprime_g_;
-  std::vector<std::vector<AnglePairs>> scat_angles_gprime_g_;
-
 public:
   SingleStateMGXS()
     : MultiGroupXS(),
@@ -95,58 +57,69 @@ private:
 
 public:
   // Accessors
-  const unsigned int NumGroups() const override { return num_groups_; }
-
-  const unsigned int ScatteringOrder() const override { return scattering_order_; }
-
-  const unsigned int NumPrecursors() const override { return num_precursors_; }
-
-  const bool IsFissionable() const override { return is_fissionable_; }
-
-  const bool DiffusionInitialized() const override { return diffusion_initialized_; }
-
-  const bool ScatteringInitialized() const override { return scattering_initialized_; }
+  size_t NumGroups() const override { return num_groups_; }
+  size_t ScatteringOrder() const override { return scattering_order_; }
+  size_t NumPrecursors() const override { return num_precursors_; }
+  bool IsFissionable() const override { return is_fissionable_; }
 
   const std::vector<double>& SigmaTotal() const override { return sigma_t_; }
   const std::vector<double>& SigmaAbsorption() const override { return sigma_a_; }
-  const std::vector<double>& SigmaFission() const override { return sigma_f_; }
-
-  const std::vector<double>& NuSigmaF() const override { return nu_sigma_f_; }
-
-  const std::vector<double>& NuPromptSigmaF() const override { return nu_prompt_sigma_f_; }
-
-  const std::vector<double>& NuDelayedSigmaF() const override { return nu_delayed_sigma_f_; }
-
-  const std::vector<double>& InverseVelocity() const override { return inv_velocity_; }
-
   const std::vector<SparseMatrix>& TransferMatrices() const override { return transfer_matrices_; }
-
   const SparseMatrix& TransferMatrix(unsigned int ell) const override
   {
     return transfer_matrices_.at(ell);
   }
 
-  const std::vector<std::vector<double>> ProductionMatrix() const override
+  const std::vector<double>& SigmaFission() const override { return sigma_f_; }
+  const std::vector<double>& NuSigmaF() const override { return nu_sigma_f_; }
+  const std::vector<double>& NuPromptSigmaF() const override { return nu_prompt_sigma_f_; }
+  const std::vector<double>& NuDelayedSigmaF() const override { return nu_delayed_sigma_f_; }
+  const std::vector<std::vector<double>>& ProductionMatrix() const override
   {
     return production_matrix_;
   }
-
   const std::vector<Precursor>& Precursors() const override { return precursors_; }
 
+  const std::vector<double>& InverseVelocity() const override { return inv_velocity_; }
+
+  bool DiffusionInitialized() const override { return diffusion_initialized_; }
+  const std::vector<double>& SigmaTransport() const override { return sigma_tr_; }
   const std::vector<double>& DiffusionCoefficient() const override { return diffusion_coeff_; }
-
-  std::vector<double> SigmaTransport() const override
-  {
-    std::vector<double> sigma_tr(num_groups_, 0.0);
-    for (size_t g = 0; g < num_groups_; ++g)
-      sigma_tr[g] = (1.0 / diffusion_coeff_[g]) / 3.0;
-
-    return sigma_tr;
-  }
-
-  const std::vector<double>& SigmaRemoval() const override { return sigma_removal_; }
-
+  const std::vector<double>& SigmaRemoval() const override { return sigma_r_; }
   const std::vector<double>& SigmaSGtoG() const override { return sigma_s_gtog_; }
+
+protected:
+  size_t num_groups_ = 0;       ///< Total number of groups
+  size_t scattering_order_ = 0; ///< Legendre scattering order
+  size_t num_precursors_ = 0;   ///< Number of precursors
+  bool is_fissionable_ = false;
+  std::vector<std::vector<double>> e_bounds_; ///< Energy bin boundaries in MeV
+
+  std::vector<double> sigma_t_; ///< Total cross section
+  std::vector<double> sigma_a_; ///< Absorption cross section
+  std::vector<SparseMatrix> transfer_matrices_;
+
+  std::vector<double> sigma_f_; ///< Fission cross section
+  std::vector<double> nu_sigma_f_;
+  std::vector<double> nu_prompt_sigma_f_;
+  std::vector<double> nu_delayed_sigma_f_;
+  std::vector<std::vector<double>> production_matrix_;
+  std::vector<Precursor> precursors_;
+
+  std::vector<double> inv_velocity_;
+
+  // Diffusion quantities
+  bool diffusion_initialized_ = false;
+  std::vector<double> sigma_tr_;        ///< Transport cross section
+  std::vector<double> diffusion_coeff_; ///< Transport corrected diffusion coefficient
+  std::vector<double> sigma_r_;         ///< Removal cross section
+  std::vector<double> sigma_s_gtog_;    ///< Within-group scattering cross section
+
+  // Monte-Carlo quantities
+private:
+  bool scattering_initialized_ = false;
+  std::vector<std::vector<double>> cdf_gprime_g_;
+  std::vector<std::vector<AnglePairs>> scat_angles_gprime_g_;
 };
 
 } // namespace opensn

--- a/lua/framework/physics/physics_material/multi_group_xs/multi_group_xs_lua_utils.cc
+++ b/lua/framework/physics/physics_material/multi_group_xs/multi_group_xs_lua_utils.cc
@@ -206,11 +206,9 @@ int
 chiPhysicsTransportXSCreate(lua_State* L)
 {
   auto xs = std::make_shared<SingleStateMGXS>();
-
   opensn::Chi::multigroup_xs_stack.push_back(xs);
 
   const size_t index = opensn::Chi::multigroup_xs_stack.size() - 1;
-
   lua_pushinteger(L, static_cast<lua_Integer>(index));
   return 1;
 }
@@ -218,19 +216,18 @@ chiPhysicsTransportXSCreate(lua_State* L)
 int
 chiPhysicsTransportXSSet(lua_State* L)
 {
-  int num_args = lua_gettop(L);
+  const auto fname = std::string(__FUNCTION__);
+  const int num_args = lua_gettop(L);
 
-  if (num_args < 3)
-  {
-    LuaPostArgAmountError("chiPhysicsTransportXSSet", 3, num_args);
-    opensn::Exit(EXIT_FAILURE);
-  }
+  if (num_args < 3) LuaPostArgAmountError(fname, 3, num_args);
 
-  LuaCheckNilValue("chiPhysicsTransportXSSet", L, 1);
-  LuaCheckNilValue("chiPhysicsTransportXSSet", L, 2);
+  // Process xs handle
+  LuaCheckIntegerValue(fname, L, 1);
+  const int handle = lua_tointeger(L, 1);
 
-  int handle = lua_tonumber(L, 1);
-  int operation_index = lua_tonumber(L, 2);
+  // Process operation id
+  LuaCheckIntegerValue(fname, L, 2);
+  const int operation_index = lua_tointeger(L, 2);
 
   std::shared_ptr<SingleStateMGXS> xs;
   try
@@ -240,8 +237,7 @@ chiPhysicsTransportXSSet(lua_State* L)
   }
   catch (const std::out_of_range& o)
   {
-    opensn::log.LogAllError() << "ERROR: Invalid cross section handle"
-                              << " in call to chiPhysicsTransportXSSet." << std::endl;
+    opensn::log.LogAllError() << "ERROR: Invalid cross section handle in call to " << fname << ".";
     opensn::Exit(EXIT_FAILURE);
   }
 
@@ -249,26 +245,26 @@ chiPhysicsTransportXSSet(lua_State* L)
   using OpType = OperationType;
   if (operation_index == static_cast<int>(OpType::SIMPLEXS0))
   {
-    if (num_args != 4) LuaPostArgAmountError("chiPhysicsTransportXSSet", 4, num_args);
+    if (num_args != 4) LuaPostArgAmountError(fname, 4, num_args);
 
-    int G = lua_tonumber(L, 3);
-    double sigma_t = lua_tonumber(L, 4);
+    const int n_grps = lua_tointeger(L, 3);
+    const double sigma_t = lua_tonumber(L, 4);
 
-    xs->MakeSimple0(G, sigma_t);
+    xs->MakeSimple0(n_grps, sigma_t);
   }
   else if (operation_index == static_cast<int>(OpType::SIMPLEXS1))
   {
-    if (num_args != 5) LuaPostArgAmountError("chiPhysicsTransportXSSet", 5, num_args);
+    if (num_args != 5) LuaPostArgAmountError(fname, 5, num_args);
 
-    int G = lua_tonumber(L, 3);
-    double sigma_t = lua_tonumber(L, 4);
-    double c = lua_tonumber(L, 5);
+    const int n_grps = lua_tointeger(L, 3);
+    const double sigma_t = lua_tonumber(L, 4);
+    const double c = lua_tonumber(L, 5);
 
-    xs->MakeSimple1(G, sigma_t, c);
+    xs->MakeSimple1(n_grps, sigma_t, c);
   }
   else if (operation_index == static_cast<int>(OpType::CHI_XSFILE))
   {
-    if (num_args != 3) LuaPostArgAmountError("chiPhysicsTransportXSSet", 3, num_args);
+    if (num_args != 3) LuaPostArgAmountError(fname, 3, num_args);
 
     const char* file_name_c = lua_tostring(L, 3);
 
@@ -276,8 +272,7 @@ chiPhysicsTransportXSSet(lua_State* L)
   }
   else
   {
-    opensn::log.LogAllError() << "Unsupported operation in "
-                              << "chiPhysicsTransportXSSet. " << operation_index << std::endl;
+    opensn::log.LogAllError() << "Unsupported operation in " << fname << ". " << operation_index;
     opensn::Exit(EXIT_FAILURE);
   }
   return 0;
@@ -286,17 +281,14 @@ chiPhysicsTransportXSSet(lua_State* L)
 int
 chiPhysicsTransportXSGet(lua_State* L)
 {
-  int num_args = lua_gettop(L);
+  const auto fname = std::string(__FUNCTION__);
+  const int num_args = lua_gettop(L);
 
-  if (num_args < 1)
-  {
-    LuaPostArgAmountError(__FUNCTION__, 1, num_args);
-    opensn::Exit(EXIT_FAILURE);
-  }
+  if (num_args < 1) LuaPostArgAmountError(fname, 1, num_args);
 
-  LuaCheckNilValue(__FUNCTION__, L, 1);
-
-  int handle = lua_tonumber(L, 1);
+  // Process xs handle
+  LuaCheckNilValue(fname, L, 1);
+  const int handle = lua_tointeger(L, 1);
 
   std::shared_ptr<SingleStateMGXS> xs;
   try
@@ -306,8 +298,7 @@ chiPhysicsTransportXSGet(lua_State* L)
   }
   catch (const std::out_of_range& o)
   {
-    opensn::log.LogAllError() << "ERROR: Invalid cross section handle"
-                              << " in call to " << __FUNCTION__ << "." << std::endl;
+    opensn::log.LogAllError() << "ERROR: Invalid cross section handle in call to " << fname << ".";
     opensn::Exit(EXIT_FAILURE);
   }
 
@@ -319,47 +310,35 @@ chiPhysicsTransportXSGet(lua_State* L)
 int
 chiPhysicsTransportXSMakeCombined(lua_State* L)
 {
-  int num_args = lua_gettop(L);
-  if (num_args != 1) LuaPostArgAmountError("chiPhysicsMakeCombinedTransportXS", 1, num_args);
+  const auto fname = std::string(__FUNCTION__);
+  const int num_args = lua_gettop(L);
 
-  if (!lua_istable(L, 1))
-  {
-    opensn::log.LogAllError() << "In call to chiPhysicsMakeCombinedTransportXS: "
-                              << "Argument must be a lua table.";
-    opensn::Exit(EXIT_FAILURE);
-  }
-
-  size_t table_len = lua_rawlen(L, 1);
-
-  std::vector<std::pair<int, double>> combinations;
-  combinations.reserve(table_len);
+  if (num_args != 1) LuaPostArgAmountError(fname, 1, num_args);
 
   // Process table
-  for (int v = 0; v < table_len; ++v)
+  LuaCheckTableValue(fname, L, 1);
+  std::vector<std::pair<int, double>> combinations;
+  for (int v = 0; v < lua_rawlen(L, 1); ++v)
   {
     lua_pushnumber(L, v + 1);
     lua_gettable(L, 1);
 
-    if (!lua_istable(L, -1))
-    {
-      opensn::log.LogAllError() << "In call to chiPhysicsMakeCombinedTransportXS: "
-                                << "The elements of the supplied table must themselves also"
-                                   "be lua tables of the xs handle and its scalar multiplier.";
-      opensn::Exit(EXIT_FAILURE);
-    }
+    ChiInvalidArgumentIf(not lua_istable(L, -1),
+                         "The elements of the supplied Lua array must themselves also be "
+                         "Lua array containing a xs handle and scalar multiplier.");
 
+    // Process xs handle
     lua_pushinteger(L, 1);
     lua_gettable(L, -2);
-    LuaCheckNilValue("chiPhysicsMakeCombinedTransportXS:A1:E1", L, -1);
-
-    int handle = lua_tonumber(L, -1);
+    LuaCheckIntegerValue(fname + "A1:E1", L, -1);
+    const int handle = lua_tointeger(L, -1);
     lua_pop(L, 1);
 
+    // Process scalar multiplier
     lua_pushinteger(L, 2);
     lua_gettable(L, -2);
-    LuaCheckNilValue("chiPhysicsMakeCombinedTransportXS:A1:E2", L, -1);
-
-    double scalar = lua_tonumber(L, -1);
+    LuaCheckNumberValue(fname + ":A1:E2", L, -1);
+    const double scalar = lua_tonumber(L, -1);
     lua_pop(L, 1);
 
     combinations.emplace_back(handle, scalar);
@@ -369,7 +348,7 @@ chiPhysicsTransportXSMakeCombined(lua_State* L)
   // Print out table
   opensn::log.Log() << "Generating XS with following combination:";
   for (auto& elem : combinations)
-    opensn::log.Log() << "  Element handle: " << elem.first << " scalar value: " << elem.second;
+    opensn::log.Log() << " Element handle: " << elem.first << " scalar value: " << elem.second;
 
   // Make the new cross section
   auto new_xs = std::make_shared<SingleStateMGXS>();
@@ -377,7 +356,8 @@ chiPhysicsTransportXSMakeCombined(lua_State* L)
   new_xs->MakeCombined(combinations);
 
   opensn::Chi::multigroup_xs_stack.push_back(new_xs);
-  lua_pushinteger(L, static_cast<lua_Integer>(opensn::Chi::multigroup_xs_stack.size()) - 1);
+  const lua_Integer num_xs = opensn::Chi::multigroup_xs_stack.size();
+  lua_pushinteger(L, num_xs - 1);
 
   return 1;
 }
@@ -385,20 +365,14 @@ chiPhysicsTransportXSMakeCombined(lua_State* L)
 int
 chiPhysicsTransportXSSetCombined(lua_State* L)
 {
+  const auto fname = std::string(__FUNCTION__);
   int num_args = lua_gettop(L);
 
-  if (num_args < 2)
-  {
-    LuaPostArgAmountError(__FUNCTION__, 2, num_args);
-    opensn::Exit(EXIT_FAILURE);
-  }
+  if (num_args < 2) LuaPostArgAmountError(fname, 2, num_args);
 
-  LuaCheckNilValue(__FUNCTION__, L, 1);
-  LuaCheckNilValue(__FUNCTION__, L, 2);
-  LuaCheckTableValue(__FUNCTION__, L, 2);
-
-  // Process handle
-  int xs_handle = lua_tonumber(L, 1);
+  // Process xs handle
+  LuaCheckIntegerValue(fname, L, 1);
+  const int xs_handle = lua_tointeger(L, 1);
 
   std::shared_ptr<SingleStateMGXS> xs;
   try
@@ -408,42 +382,34 @@ chiPhysicsTransportXSSetCombined(lua_State* L)
   }
   catch (const std::out_of_range& o)
   {
-    opensn::log.LogAllError() << "ERROR: Invalid cross section handle"
-                              << " in call to " << __FUNCTION__ << "." << std::endl;
+    opensn::log.LogAllError() << "ERROR: Invalid cross section handle in call to " << fname << ".";
     opensn::Exit(EXIT_FAILURE);
   }
 
   // Process table
-  size_t table_len = lua_rawlen(L, 2);
-
+  LuaCheckTableValue(fname, L, 2);
   std::vector<std::pair<int, double>> combinations;
-  combinations.reserve(table_len);
-
-  for (int v = 0; v < table_len; ++v)
+  for (int v = 0; v < lua_rawlen(L, 2); ++v)
   {
     lua_pushnumber(L, v + 1);
     lua_gettable(L, 1);
 
-    if (!lua_istable(L, -1))
-    {
-      opensn::log.LogAllError() << "In call to " << __FUNCTION__ << ": "
-                                << "The elements of the supplied table must themselves also"
-                                   "be lua tables of the xs handle and its scalar multiplier.";
-      opensn::Exit(EXIT_FAILURE);
-    }
+    ChiInvalidArgumentIf(not lua_istable(L, -1),
+                         "The elements of the supplied Lua array must themselves also be "
+                         "Lua array containing a xs handle and scalar multiplier.");
 
+    // Process xs handle
     lua_pushinteger(L, 1);
     lua_gettable(L, -2);
-    LuaCheckNilValue((std::string(__FUNCTION__) + ":A1:E1").c_str(), L, -1);
-
-    int handle = lua_tonumber(L, -1);
+    LuaCheckIntegerValue(fname + ":A1:E1", L, -1);
+    const int handle = lua_tonumber(L, -1);
     lua_pop(L, 1);
 
+    // Process scalar multiplier
     lua_pushinteger(L, 2);
     lua_gettable(L, -2);
-    LuaCheckNilValue((std::string(__FUNCTION__) + ":A1:E2").c_str(), L, -1);
-
-    double scalar = lua_tonumber(L, -1);
+    LuaCheckNumberValue(fname + ":A1:E2", L, -1);
+    const double scalar = lua_tonumber(L, -1);
     lua_pop(L, 1);
 
     combinations.emplace_back(handle, scalar);
@@ -463,15 +429,14 @@ chiPhysicsTransportXSSetCombined(lua_State* L)
 int
 chiPhysicsTransportXSExportToChiTechFormat(lua_State* L)
 {
-  int num_args = lua_gettop(L);
+  const auto fname = std::string(__FUNCTION__);
+  const int num_args = lua_gettop(L);
 
-  if (num_args != 2) LuaPostArgAmountError(__FUNCTION__, 2, num_args);
+  if (num_args != 2) LuaPostArgAmountError(fname, 2, num_args);
 
-  LuaCheckNilValue(__FUNCTION__, L, 1);
-  LuaCheckNilValue(__FUNCTION__, L, 2);
-
-  // Process handle
-  int handle = lua_tonumber(L, 1);
+  // Process xs handle
+  LuaCheckIntegerValue(fname, L, 1);
+  const int handle = lua_tointeger(L, 1);
 
   std::shared_ptr<MultiGroupXS> xs;
   try
@@ -480,11 +445,12 @@ chiPhysicsTransportXSExportToChiTechFormat(lua_State* L)
   }
   catch (const std::out_of_range& o)
   {
-    opensn::log.LogAllError() << "ERROR: Invalid cross section handle"
-                              << " in call to " << __FUNCTION__ << "." << std::endl;
+    opensn::log.LogAllError() << "ERROR: Invalid cross section handle in call to " << fname << ".";
     opensn::Exit(EXIT_FAILURE);
   }
 
+  // Process file name
+  LuaCheckNilValue(fname, L, 2);
   std::string file_name = lua_tostring(L, 2);
 
   xs->ExportToChiXSFile(file_name);


### PR DESCRIPTION
This PR introduces scaling factors for cross sections. Existing code capabilities does not store any information about the scalings that are applied. In effect, the `MakeCombined` routine is used to generate macroscopic cross sections that remain fixed throughout a simulation. Subsequent calls to `MakeCombined` compound the scaling factors, which is not the desired behavior when trying to change something like the density applied to a microscopic cross section. To obtain the correct behavior, a number of things were implemented:

- `scaling_factor_` member added to cross sections with accessor.
- `SetScalingFactor` multiplies cross sections by the ratio of the new scaling factor to the old and sets `scaling_factor_` to the new value.
- `MakeCombined` calls `SetScalingFactor` with the specified factor and combines accordingly
    - The resulting XS set from `MakeCombined` will have a scaling factor of 1. For a single cross section set, one must use the original XS set that gets the scaling factor applied, not the one returned. 
    - For homogenizing isotopes and applying a bulk density, one must call `MakeCombined` to combine isotopes and second time to scale by the bulk density. The same principle applies to the previous bullet point.
    - This system needs improvement, and `MakeCombined` sneakily uses Lua information and should be moved in the future.