### PR TITLE
Default `CMAKE_BUILD_TYPE` is `Release`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ include(GNUInstallDirs)
 include(CheckTypeSize)
 include(CheckSymbolExists)
 
+set(BuildValues "Release;Debug;RelWithDebInfo;MinSizeRel")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+    message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+endif()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${BuildValues})
+
+
 option(OPENSN_WITH_LUA "Build with lua support" ON)
 
 # dependencies


### PR DESCRIPTION
Also, build type is now an "enum", so when users use `ccmake` they can cycle through all build type by pressing Enter. No need to type the desired value (and possibly make a typo). This is a quality of life improvements.

Closes #84