### PR TITLE
Removing alias typedef ending with `Ptr`

### DIFF
--- a/framework/math/functions/function.h
+++ b/framework/math/functions/function.h
@@ -17,6 +17,4 @@ protected:
   explicit Function(const InputParameters& params);
 };
 
-typedef std::shared_ptr<Function> FunctionPtr;
-
 } // namespace opensn

--- a/framework/math/linear_solver/linear_solver.cc
+++ b/framework/math/linear_solver/linear_solver.cc
@@ -3,14 +3,15 @@
 namespace opensn
 {
 
-LinearSolver::LinearSolver(const std::string& iterative_method, LinSolveContextPtr context_ptr)
+LinearSolver::LinearSolver(const std::string& iterative_method,
+                           std::shared_ptr<LinearSolverContext> context_ptr)
   : solver_name_(iterative_method), iterative_method_(iterative_method), context_ptr_(context_ptr)
 {
 }
 
 LinearSolver::LinearSolver(const std::string& solver_name,
                            const std::string& iterative_method,
-                           LinSolveContextPtr context_ptr)
+                           std::shared_ptr<LinearSolverContext> context_ptr)
   : solver_name_(solver_name), iterative_method_(iterative_method), context_ptr_(context_ptr)
 {
 }

--- a/framework/math/linear_solver/linear_solver.h
+++ b/framework/math/linear_solver/linear_solver.h
@@ -19,8 +19,6 @@ struct LinearSolverContext;
 class LinearSolver
 {
 public:
-  typedef std::shared_ptr<LinearSolverContext> LinSolveContextPtr;
-
   struct ToleranceOptions
   {
     double residual_relative = 1.0e-50;
@@ -31,18 +29,19 @@ public:
     double gmres_breakdown_tolerance = 1.0e6;
   } tolerance_options_;
 
-  LinearSolver(const std::string& iterative_method, LinSolveContextPtr context_ptr);
+  LinearSolver(const std::string& iterative_method,
+               std::shared_ptr<LinearSolverContext> context_ptr);
 
   LinearSolver(const std::string& solver_name,
                const std::string& iterative_method,
-               LinSolveContextPtr context_ptr);
+               std::shared_ptr<LinearSolverContext> context_ptr);
 
   virtual ~LinearSolver();
 
   ToleranceOptions& ToleranceOptions() { return tolerance_options_; }
   void ApplyToleranceOptions();
 
-  LinSolveContextPtr& GetContext() { return context_ptr_; }
+  std::shared_ptr<LinearSolverContext>& GetContext() { return context_ptr_; }
 
   /**Sets a flag to suppress the KSPSolve() method from being called.*/
   void SetKSPSolveSuppressionFlag(bool flag) { suppress_kspsolve_ = flag; }
@@ -76,7 +75,7 @@ protected:
 
   const std::string solver_name_;
   const std::string iterative_method_;
-  LinSolveContextPtr context_ptr_ = nullptr;
+  std::shared_ptr<LinearSolverContext> context_ptr_ = nullptr;
   Mat A_;
   Vec b_;
   Vec x_;

--- a/framework/math/nonlinear_solver/nonlinear_solver.cc
+++ b/framework/math/nonlinear_solver/nonlinear_solver.cc
@@ -5,7 +5,8 @@
 namespace opensn
 {
 
-NonLinearSolver::NonLinearSolver(NLSolverContextPtr context_ptr, const InputParameters& params)
+NonLinearSolver::NonLinearSolver(std::shared_ptr<NonLinearSolverContext> context_ptr,
+                                 const InputParameters& params)
   : solver_name_(params.GetParamValue<std::string>("name")),
     context_ptr_(context_ptr),
     options_(params)

--- a/framework/math/nonlinear_solver/nonlinear_solver.h
+++ b/framework/math/nonlinear_solver/nonlinear_solver.h
@@ -14,17 +14,15 @@ namespace opensn
 class NonLinearSolver
 {
 public:
-  typedef std::shared_ptr<NonLinearSolverContext> NLSolverContextPtr;
-
   explicit NonLinearSolver(
-    NLSolverContextPtr context_ptr,
+    std::shared_ptr<NonLinearSolverContext> context_ptr,
     const InputParameters& params = NonLinearSolverOptions::GetInputParameters());
   virtual ~NonLinearSolver();
 
   NonLinearSolverOptions& ToleranceOptions() { return options_; }
   void ApplyToleranceOptions();
 
-  NLSolverContextPtr& GetContext() { return context_ptr_; }
+  std::shared_ptr<NonLinearSolverContext>& GetContext() { return context_ptr_; }
 
   bool IsConverged() const { return converged_; }
   std::string GetConvergedReasonString() const;
@@ -56,7 +54,7 @@ protected:
 
   const std::string solver_name_;
 
-  NLSolverContextPtr context_ptr_ = nullptr;
+  std::shared_ptr<NonLinearSolverContext> context_ptr_ = nullptr;
 
   Mat J_;
   Mat P_;

--- a/framework/mesh/field_function_interpolation/ffinterpolation.h
+++ b/framework/mesh/field_function_interpolation/ffinterpolation.h
@@ -6,7 +6,6 @@
 namespace opensn
 {
 class FieldFunctionGridBased;
-typedef std::shared_ptr<FieldFunctionGridBased> FieldFunctionGridBasedPtr;
 
 enum class FieldFunctionInterpolationType : int
 {
@@ -52,12 +51,15 @@ class FieldFunctionInterpolation
 protected:
   FieldFunctionInterpolationType type_;
   unsigned int ref_component_ = 0;
-  std::vector<FieldFunctionGridBasedPtr> field_functions_;
+  std::vector<std::shared_ptr<FieldFunctionGridBased>> field_functions_;
 
 public:
   explicit FieldFunctionInterpolation(FieldFunctionInterpolationType type) : type_(type) {}
 
-  std::vector<FieldFunctionGridBasedPtr>& GetFieldFunctions() { return field_functions_; }
+  std::vector<std::shared_ptr<FieldFunctionGridBased>>& GetFieldFunctions()
+  {
+    return field_functions_;
+  }
 
   FieldFunctionInterpolationType Type() const { return type_; }
 

--- a/framework/mesh/logical_volume/surface_mesh_logical_volume.h
+++ b/framework/mesh/logical_volume/surface_mesh_logical_volume.h
@@ -15,8 +15,7 @@ public:
   bool Inside(const Vector3& point) const override;
 
 private:
-  typedef std::shared_ptr<const SurfaceMesh> SurfaceMeshPtr;
-  const SurfaceMeshPtr surf_mesh = nullptr;
+  const std::shared_ptr<SurfaceMesh> surf_mesh = nullptr;
   std::array<double, 2> xbounds_;
   std::array<double, 2> ybounds_;
   std::array<double, 2> zbounds_;

--- a/framework/mesh/mesh.h
+++ b/framework/mesh/mesh.h
@@ -37,9 +37,6 @@ class FieldFunctionInterpolationVolume;
 class SurfaceMesh;
 class UnpartitionedMesh;
 class MeshContinuum;
-typedef std::shared_ptr<MeshContinuum> MeshContinuumPtr;
-typedef std::shared_ptr<const MeshContinuum> MeshContinuumConstPtr;
-
 // Logical Volumes
 class LogicalVolume;
 class SphereLogicalVolume;

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -24,9 +24,6 @@ class MeshGenerator;
 class MeshContinuum
 {
 private:
-  typedef std::shared_ptr<MPICommunicatorSet> MPILocalCommSetPtr;
-
-private:
   std::vector<std::unique_ptr<Cell>> local_cells_; ///< Actual local cells
   std::vector<std::unique_ptr<Cell>> ghost_cells_; ///< Locally stored ghosts
 
@@ -170,7 +167,7 @@ public:
    * Gets the communicator-set for interprocess communication,
    * associated with this mesh. If not created yet, it will create it.
    */
-  MPILocalCommSetPtr MakeMPILocalCommunicatorSet() const;
+  std::shared_ptr<MPICommunicatorSet> MakeMPILocalCommunicatorSet() const;
 
   /**
    * Returns the total number of global cells.

--- a/framework/mesh/mesh_handler/mesh_handler.cc
+++ b/framework/mesh/mesh_handler/mesh_handler.cc
@@ -7,7 +7,7 @@
 namespace opensn
 {
 
-MeshContinuumPtr&
+std::shared_ptr<MeshContinuum>&
 MeshHandler::GetGrid() const
 {
   if (volume_mesher_ == nullptr)

--- a/framework/mesh/mesh_handler/mesh_handler.h
+++ b/framework/mesh/mesh_handler/mesh_handler.h
@@ -20,7 +20,7 @@ public:
    * get a smart-pointer to a grid object. If a volume-mesher has not
    * been created, or if a grid is not available, this method will
    * throw `std::logic_error`.*/
-  MeshContinuumPtr& GetGrid() const;
+  std::shared_ptr<MeshContinuum>& GetGrid() const;
 
   /**Returns true if the surface mesher has been set.*/
   bool HasSurfaceMesher() const { return surface_mesher_ != nullptr; }

--- a/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
+++ b/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
@@ -13,7 +13,7 @@ AngleAggregation::AngleAggregation(const std::map<uint64_t, SweepBndryPtr>& in_s
                                    size_t in_number_of_groups,
                                    size_t in_number_of_group_subsets,
                                    std::shared_ptr<AngularQuadrature>& in_quadrature,
-                                   MeshContinuumPtr& in_grid)
+                                   std::shared_ptr<MeshContinuum>& in_grid)
 {
   sim_boundaries = in_sim_boundaries;
   number_of_groups = in_number_of_groups;

--- a/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
+++ b/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.cc
@@ -9,11 +9,12 @@
 namespace opensn
 {
 
-AngleAggregation::AngleAggregation(const std::map<uint64_t, SweepBndryPtr>& in_sim_boundaries,
-                                   size_t in_number_of_groups,
-                                   size_t in_number_of_group_subsets,
-                                   std::shared_ptr<AngularQuadrature>& in_quadrature,
-                                   std::shared_ptr<MeshContinuum>& in_grid)
+AngleAggregation::AngleAggregation(
+  const std::map<uint64_t, std::shared_ptr<SweepBndry>>& in_sim_boundaries,
+  size_t in_number_of_groups,
+  size_t in_number_of_group_subsets,
+  std::shared_ptr<AngularQuadrature>& in_quadrature,
+  std::shared_ptr<MeshContinuum>& in_grid)
 {
   sim_boundaries = in_sim_boundaries;
   number_of_groups = in_number_of_groups;

--- a/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.h
+++ b/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.h
@@ -44,14 +44,14 @@ private:
   bool num_ang_unknowns_avail = false;
 
 public:
-  MeshContinuumPtr grid = nullptr;
+  std::shared_ptr<MeshContinuum> grid = nullptr;
 
   /** Sets up the angle-aggregation object. */
   AngleAggregation(const std::map<uint64_t, SweepBndryPtr>& in_sim_boundaries,
                    size_t in_number_of_groups,
                    size_t in_number_of_group_subsets,
                    std::shared_ptr<AngularQuadrature>& in_quadrature,
-                   MeshContinuumPtr& in_grid);
+                   std::shared_ptr<MeshContinuum>& in_grid);
 
   bool IsSetup() const { return is_setup; }
 

--- a/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.h
+++ b/framework/mesh/sweep_utilities/angle_aggregation/angle_aggregation.h
@@ -29,11 +29,8 @@ namespace opensn
 class AngleAggregation
 {
 public:
-  typedef std::shared_ptr<SweepBndry> SweepBndryPtr;
-
-public:
   std::vector<AngleSetGroup> angle_set_groups;
-  std::map<uint64_t, SweepBndryPtr> sim_boundaries;
+  std::map<uint64_t, std::shared_ptr<SweepBndry>> sim_boundaries;
   size_t number_of_groups = 0;
   size_t number_of_group_subsets = 0;
   std::shared_ptr<AngularQuadrature> quadrature = nullptr;
@@ -47,7 +44,7 @@ public:
   std::shared_ptr<MeshContinuum> grid = nullptr;
 
   /** Sets up the angle-aggregation object. */
-  AngleAggregation(const std::map<uint64_t, SweepBndryPtr>& in_sim_boundaries,
+  AngleAggregation(const std::map<uint64_t, std::shared_ptr<SweepBndry>>& in_sim_boundaries,
                    size_t in_number_of_groups,
                    size_t in_number_of_group_subsets,
                    std::shared_ptr<AngularQuadrature>& in_quadrature,

--- a/framework/mesh/sweep_utilities/angle_set/angle_set.cc
+++ b/framework/mesh/sweep_utilities/angle_set/angle_set.cc
@@ -52,7 +52,7 @@ AngleSet::GetAngleIndices() const
   return angles_;
 }
 
-std::map<uint64_t, AngleSet::SweepBndryPtr>&
+std::map<uint64_t, std::shared_ptr<SweepBndry>>&
 AngleSet::GetBoundaries()
 {
   return ref_boundaries_;

--- a/framework/mesh/sweep_utilities/angle_set/angle_set.h
+++ b/framework/mesh/sweep_utilities/angle_set/angle_set.h
@@ -17,15 +17,13 @@ typedef SweepBoundary SweepBndry;
 class AngleSet
 {
 public:
-  typedef std::shared_ptr<SweepBndry> SweepBndryPtr;
-
   /**AngleSet constructor.*/
   AngleSet(size_t id,
            size_t num_groups,
            const SPDS& spds,
            std::shared_ptr<FLUDS>& fluds,
            const std::vector<size_t>& angle_indices,
-           std::map<uint64_t, SweepBndryPtr>& sim_boundaries,
+           std::map<uint64_t, std::shared_ptr<SweepBndry>>& sim_boundaries,
            size_t in_ref_subset);
 
   /**Returns the angleset's unique id.*/
@@ -39,7 +37,7 @@ public:
   /**Returns the angle indices associated with this angleset.*/
   const std::vector<size_t>& GetAngleIndices() const;
   /**Returns the angle indices associated with this angleset.*/
-  std::map<uint64_t, SweepBndryPtr>& GetBoundaries();
+  std::map<uint64_t, std::shared_ptr<SweepBndry>>& GetBoundaries();
 
   size_t GetNumGroups() const;
   size_t GetNumAngles() const;
@@ -91,7 +89,7 @@ protected:
   const SPDS& spds_;
   std::shared_ptr<FLUDS> fluds_;
   const std::vector<size_t> angles_;
-  std::map<uint64_t, SweepBndryPtr>& ref_boundaries_;
+  std::map<uint64_t, std::shared_ptr<SweepBndry>>& ref_boundaries_;
   const size_t ref_group_subset_;
 
   bool executed_ = false;

--- a/framework/mesh/sweep_utilities/print_sweep_ordering.cc
+++ b/framework/mesh/sweep_utilities/print_sweep_ordering.cc
@@ -15,7 +15,7 @@ namespace opensn
 {
 
 void
-PrintSweepOrdering(SPDS* sweep_order, MeshContinuumPtr vol_continuum)
+PrintSweepOrdering(SPDS* sweep_order, std::shared_ptr<MeshContinuum> vol_continuum)
 {
   //  double polar = sweep_order->polar;
   //  double azimuthal = sweep_order->azimuthal;

--- a/framework/mesh/sweep_utilities/sweep_namespace.h
+++ b/framework/mesh/sweep_utilities/sweep_namespace.h
@@ -44,7 +44,7 @@ void CommunicateLocationDependencies(const std::vector<int>& location_dependenci
                                      std::vector<std::vector<int>>& global_dependencies);
 
 /**Print a sweep ordering to file.*/
-void PrintSweepOrdering(SPDS* sweep_order, MeshContinuumPtr vol_continuum);
+void PrintSweepOrdering(SPDS* sweep_order, std::shared_ptr<MeshContinuum> vol_continuum);
 
 enum class AngleSetStatus
 {

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -604,7 +604,6 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
   const std::string fname = "UnpartitionedMesh::CopyUGridCellsAndPoints";
   typedef Vector3 Vec3;
   typedef Vec3* Vec3Ptr;
-  typedef LightWeightCell* CellPtr;
 
   const vtkIdType total_cell_count = ugrid.GetNumberOfCells();
   const vtkIdType total_point_count = ugrid.GetNumberOfPoints();
@@ -625,7 +624,7 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
 
   if (has_global_ids)
   {
-    std::vector<CellPtr> cells(total_cell_count, nullptr);
+    std::vector<LightWeightCell*> cells(total_cell_count, nullptr);
     std::vector<Vec3Ptr> vertices(total_point_count, nullptr);
 
     auto cell_gids_ptr = ugrid.GetCellData()->GetGlobalIds();
@@ -666,7 +665,7 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
 
       if (vtk_celldim != dimension_to_copy) continue;
 
-      CellPtr raw_cell;
+      LightWeightCell* raw_cell;
       if (vtk_celldim == 3) raw_cell = CreateCellFromVTKPolyhedron(vtk_cell);
       else if (vtk_celldim == 2)
         raw_cell = CreateCellFromVTKPolygon(vtk_cell);

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -602,8 +602,6 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
                                            int dimension_to_copy)
 {
   const std::string fname = "UnpartitionedMesh::CopyUGridCellsAndPoints";
-  typedef Vector3 Vec3;
-  typedef Vec3* Vec3Ptr;
 
   const vtkIdType total_cell_count = ugrid.GetNumberOfCells();
   const vtkIdType total_point_count = ugrid.GetNumberOfPoints();
@@ -625,7 +623,7 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
   if (has_global_ids)
   {
     std::vector<LightWeightCell*> cells(total_cell_count, nullptr);
-    std::vector<Vec3Ptr> vertices(total_point_count, nullptr);
+    std::vector<Vector3*> vertices(total_point_count, nullptr);
 
     auto cell_gids_ptr = ugrid.GetCellData()->GetGlobalIds();
     auto pnts_gids_ptr = ugrid.GetPointData()->GetGlobalIds();
@@ -697,7 +695,7 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
       auto point = ugrid.GetPoint(static_cast<vtkIdType>(p));
       const vtkIdType point_gid = pnts_gids->GetValue(p) + pid_offset;
 
-      auto vertex = new Vec3(point[0], point[1], point[2]);
+      auto vertex = new Vector3(point[0], point[1], point[2]);
 
       *vertex *= scale;
 
@@ -745,7 +743,7 @@ UnpartitionedMesh::CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
     {
       auto point = ugrid.GetPoint(static_cast<vtkIdType>(p));
 
-      Vec3 vertex(point[0], point[1], point[2]);
+      Vector3 vertex(point[0], point[1], point[2]);
 
       vertex *= scale;
 

--- a/framework/mesh/volume_mesher/volume_mesher.cc
+++ b/framework/mesh/volume_mesher/volume_mesher.cc
@@ -16,12 +16,12 @@ VolumeMesher::VolumeMesher(VolumeMesherType type) : type_(type)
 }
 
 void
-VolumeMesher::SetContinuum(MeshContinuumPtr& grid)
+VolumeMesher::SetContinuum(std::shared_ptr<MeshContinuum>& grid)
 {
   grid_ptr_ = grid;
 }
 
-MeshContinuumPtr&
+std::shared_ptr<MeshContinuum>&
 VolumeMesher::GetContinuum()
 {
   return grid_ptr_;
@@ -48,7 +48,7 @@ VolumeMesher::SetMatIDFromLogical(const LogicalVolume& log_vol, bool sense, int 
   auto& handler = GetCurrentHandler();
 
   // Get back mesh
-  MeshContinuumPtr vol_cont = handler.GetGrid();
+  std::shared_ptr<MeshContinuum> vol_cont = handler.GetGrid();
 
   int num_cells_modified = 0;
   for (auto& cell : vol_cont->local_cells)
@@ -85,7 +85,7 @@ VolumeMesher::SetBndryIDFromLogical(const LogicalVolume& log_vol,
   auto& handler = GetCurrentHandler();
 
   // Get back mesh
-  MeshContinuumPtr vol_cont = handler.GetGrid();
+  std::shared_ptr<MeshContinuum> vol_cont = handler.GetGrid();
 
   // Check if name already has id
   auto& grid_bndry_id_map = vol_cont->GetBoundaryIDMap();

--- a/framework/mesh/volume_mesher/volume_mesher.h
+++ b/framework/mesh/volume_mesher/volume_mesher.h
@@ -39,7 +39,7 @@ enum VolumeMesherProperty
 class VolumeMesher
 {
 private:
-  MeshContinuumPtr grid_ptr_;
+  std::shared_ptr<MeshContinuum> grid_ptr_;
   const VolumeMesherType type_;
 
 public:
@@ -70,12 +70,12 @@ public:
   /**
    * Sets the grid member of the volume mesher.
    */
-  void SetContinuum(MeshContinuumPtr& grid);
+  void SetContinuum(std::shared_ptr<MeshContinuum>& grid);
 
   /**
    * Gets the smart-pointer for the grid.
    */
-  MeshContinuumPtr& GetContinuum();
+  std::shared_ptr<MeshContinuum>& GetContinuum();
 
   /**
    * Sets grid attributes. This is normally a private member of the grid but this class is a friend.

--- a/framework/parameters/input_parameters.cc
+++ b/framework/parameters/input_parameters.cc
@@ -379,7 +379,7 @@ InputParameters::MarkParamaterRenamed(const std::string& param_name,
 
 void
 InputParameters::ConstrainParameterRange(const std::string& param_name,
-                                         AllowableRangePtr allowable_range)
+                                         std::unique_ptr<AllowableRange> allowable_range)
 {
   if (Has(param_name))
   {

--- a/framework/parameters/input_parameters.h
+++ b/framework/parameters/input_parameters.h
@@ -33,8 +33,7 @@ private:
   std::map<std::string, bool> type_mismatch_allowed_tags_;
   std::map<std::string, std::string> parameter_link_;
 
-  typedef std::unique_ptr<AllowableRange> AllowableRangePtr;
-  std::map<std::string, AllowableRangePtr> constraint_tags_;
+  std::map<std::string, std::unique_ptr<AllowableRange>> constraint_tags_;
 
   std::string general_description_;
 
@@ -171,7 +170,8 @@ public:
    * is specified.*/
   void MarkParamaterRenamed(const std::string& param_name, const std::string& renaming_description);
   /**Creates a range based constraint for a given parameter.*/
-  void ConstrainParameterRange(const std::string& param_name, AllowableRangePtr allowable_range);
+  void ConstrainParameterRange(const std::string& param_name,
+                               std::unique_ptr<AllowableRange> allowable_range);
   /**\brief Sets a tag for the given parameter that will allow its type to be
    * mismatched upon assignment.*/
   void SetParameterTypeMismatchAllowed(const std::string& param_name);

--- a/framework/physics/field_function/field_function_grid_based.cc
+++ b/framework/physics/field_function/field_function_grid_based.cc
@@ -60,9 +60,10 @@ FieldFunctionGridBased::FieldFunctionGridBased(const InputParameters& params)
   ghosted_field_vector_->Set(params.GetParamValue<double>("initial_value"));
 }
 
-FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
-                                               SDMPtr& discretization_ptr,
-                                               opensn::Unknown unknown)
+FieldFunctionGridBased::FieldFunctionGridBased(
+  const std::string& text_name,
+  std::shared_ptr<SpatialDiscretization>& discretization_ptr,
+  opensn::Unknown unknown)
   : FieldFunction(text_name, std::move(unknown)),
     sdm_(discretization_ptr),
     ghosted_field_vector_(MakeFieldVector(*sdm_, GetUnknownManager())),
@@ -71,7 +72,7 @@ FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
 }
 
 FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
-                                               SDMPtr& sdm_ptr,
+                                               std::shared_ptr<SpatialDiscretization>& sdm_ptr,
                                                opensn::Unknown unknown,
                                                const std::vector<double>& field_vector)
   : FieldFunction(text_name, std::move(unknown)),
@@ -86,7 +87,7 @@ FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
 }
 
 FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
-                                               SDMPtr& sdm_ptr,
+                                               std::shared_ptr<SpatialDiscretization>& sdm_ptr,
                                                opensn::Unknown unknown,
                                                double field_value)
   : FieldFunction(text_name, std::move(unknown)),
@@ -115,7 +116,7 @@ FieldFunctionGridBased::FieldVector()
   return ghosted_field_vector_->LocalSTLData();
 }
 
-SDMPtr
+std::shared_ptr<SpatialDiscretization>
 FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
 {
   const auto& user_params = params.ParametersAtAssignment();

--- a/framework/physics/field_function/field_function_grid_based.h
+++ b/framework/physics/field_function/field_function_grid_based.h
@@ -15,7 +15,6 @@
 namespace opensn
 {
 class SpatialDiscretization;
-typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class GhostedParallelSTLVector;
 
 /***/
@@ -32,20 +31,20 @@ public:
 
   /**Creates a field function, filling it with zeros.*/
   FieldFunctionGridBased(const std::string& text_name,
-                         SDMPtr& discretization_ptr,
+                         std::shared_ptr<SpatialDiscretization>& discretization_ptr,
                          opensn::Unknown unknown);
 
   /**Creates a field function with an associated field vector.
    * The field's data vector is set to the incoming field vector.*/
   FieldFunctionGridBased(const std::string& text_name,
-                         SDMPtr& sdm_ptr,
+                         std::shared_ptr<SpatialDiscretization>& sdm_ptr,
                          opensn::Unknown unknown,
                          const std::vector<double>& field_vector);
 
   /**Creates a field function where all the values are assigned to
    * the single supplied value.*/
   FieldFunctionGridBased(const std::string& text_name,
-                         SDMPtr& sdm_ptr,
+                         std::shared_ptr<SpatialDiscretization>& sdm_ptr,
                          opensn::Unknown unknown,
                          double field_value);
 
@@ -100,14 +99,15 @@ public:
   double Evaluate(const Cell& cell, const Vector3& position, unsigned int component) const override;
 
 protected:
-  SDMPtr sdm_;
+  std::shared_ptr<SpatialDiscretization> sdm_;
   std::unique_ptr<GhostedParallelSTLVector> ghosted_field_vector_;
 
 private:
   /**
    * Static method for making the GetSpatialDiscretization for the constructors.
    */
-  static SDMPtr MakeSpatialDiscretization(const InputParameters& params);
+  static std::shared_ptr<SpatialDiscretization>
+  MakeSpatialDiscretization(const InputParameters& params);
 
   /**
    * Static method for making the ghosted vector for the constructors.

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -28,7 +28,7 @@ Logger& log = Logger::GetInstance();
 MPI_Info& mpi = MPI_Info::GetInstance();
 Timer program_timer;
 
-std::vector<MeshHandlerPtr> meshhandler_stack;
+std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 int current_mesh_handler = -1;
 
 std::vector<SurfaceMeshPtr> surface_mesh_stack;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -43,7 +43,7 @@ std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 std::vector<std::shared_ptr<Object>> object_stack;
 std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
-std::vector<PostProcessorPtr> postprocessor_stack;
+std::vector<std::shared_ptr<PostProcessor>> postprocessor_stack;
 std::vector<std::shared_ptr<Function>> function_stack;
 
 bool suppress_color = false;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -39,7 +39,7 @@ std::vector<std::shared_ptr<Material>> material_stack;
 std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
 std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 
-std::vector<AngularQuadraturePtr> angular_quadrature_stack;
+std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 std::vector<std::shared_ptr<Object>> object_stack;
 std::vector<SpatialDiscretizationPtr> sdm_stack;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -42,7 +42,7 @@ std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 std::vector<std::shared_ptr<Object>> object_stack;
-std::vector<SpatialDiscretizationPtr> sdm_stack;
+std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
 std::vector<PostProcessorPtr> postprocessor_stack;
 std::vector<std::shared_ptr<Function>> function_stack;
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -32,7 +32,7 @@ std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 int current_mesh_handler = -1;
 
 std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
-std::vector<FFInterpPtr> field_func_interpolation_stack;
+std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
 std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
 
 std::vector<MaterialPtr> material_stack;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -31,7 +31,7 @@ Timer program_timer;
 std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 int current_mesh_handler = -1;
 
-std::vector<SurfaceMeshPtr> surface_mesh_stack;
+std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 std::vector<FFInterpPtr> field_func_interpolation_stack;
 std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -41,7 +41,7 @@ std::vector<FieldFunctionPtr> field_function_stack;
 
 std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 
-std::vector<ChiObjectPtr> object_stack;
+std::vector<std::shared_ptr<Object>> object_stack;
 std::vector<SpatialDiscretizationPtr> sdm_stack;
 std::vector<PostProcessorPtr> postprocessor_stack;
 std::vector<FunctionPtr> function_stack;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -35,7 +35,7 @@ std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
 std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
-std::vector<MaterialPtr> material_stack;
+std::vector<std::shared_ptr<Material>> material_stack;
 std::vector<MultiGroupXSPtr> multigroup_xs_stack;
 std::vector<FieldFunctionPtr> field_function_stack;
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -36,7 +36,7 @@ std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolatio
 std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 std::vector<std::shared_ptr<Material>> material_stack;
-std::vector<MultiGroupXSPtr> multigroup_xs_stack;
+std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
 std::vector<FieldFunctionPtr> field_function_stack;
 
 std::vector<AngularQuadraturePtr> angular_quadrature_stack;

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -44,7 +44,7 @@ std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 std::vector<std::shared_ptr<Object>> object_stack;
 std::vector<SpatialDiscretizationPtr> sdm_stack;
 std::vector<PostProcessorPtr> postprocessor_stack;
-std::vector<FunctionPtr> function_stack;
+std::vector<std::shared_ptr<Function>> function_stack;
 
 bool suppress_color = false;
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -37,7 +37,7 @@ std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 std::vector<std::shared_ptr<Material>> material_stack;
 std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
-std::vector<FieldFunctionPtr> field_function_stack;
+std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 
 std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -33,7 +33,7 @@ int current_mesh_handler = -1;
 
 std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
-std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
+std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 std::vector<MaterialPtr> material_stack;
 std::vector<MultiGroupXSPtr> multigroup_xs_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -26,7 +26,6 @@ class MultiGroupXS;
 class FieldFunction;
 class Function;
 
-typedef std::shared_ptr<FieldFunction> FieldFunctionPtr;
 typedef std::shared_ptr<Function> FunctionPtr;
 
 class AngularQuadrature;
@@ -58,7 +57,7 @@ extern std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 extern std::vector<std::shared_ptr<Material>> material_stack;
 extern std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
-extern std::vector<FieldFunctionPtr> field_function_stack;
+extern std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 
 extern std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -16,7 +16,6 @@ const std::string name = "OpenSn";
 class MeshHandler;
 
 class SurfaceMesh;
-typedef std::shared_ptr<SurfaceMesh> SurfaceMeshPtr;
 
 class FieldFunctionInterpolation;
 typedef FieldFunctionInterpolation FFInterp;
@@ -60,7 +59,7 @@ extern Timer program_timer;
 extern std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 extern int current_mesh_handler;
 
-extern std::vector<SurfaceMeshPtr> surface_mesh_stack;
+extern std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 extern std::vector<FFInterpPtr> field_func_interpolation_stack;
 extern std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
 

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -16,10 +16,7 @@ const std::string name = "OpenSn";
 class MeshHandler;
 
 class SurfaceMesh;
-
 class FieldFunctionInterpolation;
-typedef FieldFunctionInterpolation FFInterp;
-typedef std::shared_ptr<FFInterp> FFInterpPtr;
 
 class UnpartitionedMesh;
 typedef std::shared_ptr<UnpartitionedMesh> UnpartitionedMeshPtr;
@@ -60,7 +57,7 @@ extern std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 extern int current_mesh_handler;
 
 extern std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
-extern std::vector<FFInterpPtr> field_func_interpolation_stack;
+extern std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
 extern std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
 
 extern std::vector<MaterialPtr> material_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -14,7 +14,6 @@ namespace opensn
 const std::string name = "OpenSn";
 
 class MeshHandler;
-typedef std::shared_ptr<MeshHandler> MeshHandlerPtr;
 
 class SurfaceMesh;
 typedef std::shared_ptr<SurfaceMesh> SurfaceMeshPtr;
@@ -59,7 +58,7 @@ extern Logger& log;
 extern Timer program_timer;
 
 /** Global stack of handlers */
-extern std::vector<MeshHandlerPtr> meshhandler_stack;
+extern std::vector<std::shared_ptr<MeshHandler>> meshhandler_stack;
 extern int current_mesh_handler;
 
 extern std::vector<SurfaceMeshPtr> surface_mesh_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -14,27 +14,20 @@ namespace opensn
 const std::string name = "OpenSn";
 
 class MeshHandler;
-
 class SurfaceMesh;
 class FieldFunctionInterpolation;
-
 class UnpartitionedMesh;
-
 class Solver;
 class Material;
 class MultiGroupXS;
 class FieldFunction;
 class Function;
-
 class AngularQuadrature;
 class SpatialDiscretization;
-
 class UnknownManager;
-
 class Timer;
 class Logger;
 class PostProcessor;
-
 class Object;
 
 extern MPI_Info& mpi;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -34,7 +34,6 @@ class UnknownManager;
 class Timer;
 class Logger;
 class PostProcessor;
-typedef std::shared_ptr<PostProcessor> PostProcessorPtr;
 
 class Object;
 
@@ -58,7 +57,7 @@ extern std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 extern std::vector<std::shared_ptr<Object>> object_stack;
 extern std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
-extern std::vector<PostProcessorPtr> postprocessor_stack;
+extern std::vector<std::shared_ptr<PostProcessor>> postprocessor_stack;
 extern std::vector<std::shared_ptr<Function>> function_stack;
 
 const size_t SIZE_T_INVALID = ((size_t)-1);

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -29,7 +29,6 @@ class Function;
 class AngularQuadrature;
 class SpatialDiscretization;
 
-typedef std::shared_ptr<AngularQuadrature> AngularQuadraturePtr;
 typedef std::shared_ptr<SpatialDiscretization> SpatialDiscretizationPtr;
 
 class UnknownManager;
@@ -57,7 +56,7 @@ extern std::vector<std::shared_ptr<Material>> material_stack;
 extern std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
 extern std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 
-extern std::vector<AngularQuadraturePtr> angular_quadrature_stack;
+extern std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 extern std::vector<std::shared_ptr<Object>> object_stack;
 extern std::vector<SpatialDiscretizationPtr> sdm_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -51,7 +51,6 @@ class PostProcessor;
 typedef std::shared_ptr<PostProcessor> PostProcessorPtr;
 
 class Object;
-typedef std::shared_ptr<Object> ChiObjectPtr;
 
 extern MPI_Info& mpi;
 extern Logger& log;
@@ -71,7 +70,7 @@ extern std::vector<FieldFunctionPtr> field_function_stack;
 
 extern std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 
-extern std::vector<ChiObjectPtr> object_stack;
+extern std::vector<std::shared_ptr<Object>> object_stack;
 extern std::vector<SpatialDiscretizationPtr> sdm_stack;
 extern std::vector<PostProcessorPtr> postprocessor_stack;
 extern std::vector<FunctionPtr> function_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -19,8 +19,6 @@ class SurfaceMesh;
 class FieldFunctionInterpolation;
 
 class UnpartitionedMesh;
-typedef std::shared_ptr<UnpartitionedMesh> UnpartitionedMeshPtr;
-typedef UnpartitionedMeshPtr UnpartMeshPtr;
 
 class Solver;
 class Material;
@@ -58,7 +56,7 @@ extern int current_mesh_handler;
 
 extern std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 extern std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
-extern std::vector<UnpartMeshPtr> unpartitionedmesh_stack;
+extern std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 extern std::vector<MaterialPtr> material_stack;
 extern std::vector<MultiGroupXSPtr> multigroup_xs_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -26,8 +26,6 @@ class MultiGroupXS;
 class FieldFunction;
 class Function;
 
-typedef std::shared_ptr<Function> FunctionPtr;
-
 class AngularQuadrature;
 class SpatialDiscretization;
 
@@ -64,7 +62,7 @@ extern std::vector<AngularQuadraturePtr> angular_quadrature_stack;
 extern std::vector<std::shared_ptr<Object>> object_stack;
 extern std::vector<SpatialDiscretizationPtr> sdm_stack;
 extern std::vector<PostProcessorPtr> postprocessor_stack;
-extern std::vector<FunctionPtr> function_stack;
+extern std::vector<std::shared_ptr<Function>> function_stack;
 
 const size_t SIZE_T_INVALID = ((size_t)-1);
 

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -29,8 +29,6 @@ class Function;
 class AngularQuadrature;
 class SpatialDiscretization;
 
-typedef std::shared_ptr<SpatialDiscretization> SpatialDiscretizationPtr;
-
 class UnknownManager;
 
 class Timer;
@@ -59,7 +57,7 @@ extern std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 extern std::vector<std::shared_ptr<AngularQuadrature>> angular_quadrature_stack;
 
 extern std::vector<std::shared_ptr<Object>> object_stack;
-extern std::vector<SpatialDiscretizationPtr> sdm_stack;
+extern std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
 extern std::vector<PostProcessorPtr> postprocessor_stack;
 extern std::vector<std::shared_ptr<Function>> function_stack;
 

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -26,7 +26,6 @@ class MultiGroupXS;
 class FieldFunction;
 class Function;
 
-typedef std::shared_ptr<MultiGroupXS> MultiGroupXSPtr;
 typedef std::shared_ptr<FieldFunction> FieldFunctionPtr;
 typedef std::shared_ptr<Function> FunctionPtr;
 
@@ -58,7 +57,7 @@ extern std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_inter
 extern std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
 extern std::vector<std::shared_ptr<Material>> material_stack;
-extern std::vector<MultiGroupXSPtr> multigroup_xs_stack;
+extern std::vector<std::shared_ptr<MultiGroupXS>> multigroup_xs_stack;
 extern std::vector<FieldFunctionPtr> field_function_stack;
 
 extern std::vector<AngularQuadraturePtr> angular_quadrature_stack;

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -26,7 +26,6 @@ class MultiGroupXS;
 class FieldFunction;
 class Function;
 
-typedef std::shared_ptr<Material> MaterialPtr;
 typedef std::shared_ptr<MultiGroupXS> MultiGroupXSPtr;
 typedef std::shared_ptr<FieldFunction> FieldFunctionPtr;
 typedef std::shared_ptr<Function> FunctionPtr;
@@ -58,7 +57,7 @@ extern std::vector<std::shared_ptr<SurfaceMesh>> surface_mesh_stack;
 extern std::vector<std::shared_ptr<FieldFunctionInterpolation>> field_func_interpolation_stack;
 extern std::vector<std::shared_ptr<UnpartitionedMesh>> unpartitionedmesh_stack;
 
-extern std::vector<MaterialPtr> material_stack;
+extern std::vector<std::shared_ptr<Material>> material_stack;
 extern std::vector<MultiGroupXSPtr> multigroup_xs_stack;
 extern std::vector<FieldFunctionPtr> field_function_stack;
 

--- a/modules/cfem_diffusion/cfem_diffusion_solver.h
+++ b/modules/cfem_diffusion/cfem_diffusion_solver.h
@@ -13,7 +13,6 @@ namespace opensn
 {
 class MeshContinuum;
 class SpatialDiscretization;
-typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
 
 namespace cfem_diffusion
@@ -28,7 +27,7 @@ class Solver : public opensn::Solver
 public:
   std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
-  SDMPtr sdm_ptr_ = nullptr;
+  std::shared_ptr<SpatialDiscretization> sdm_ptr_ = nullptr;
 
   size_t num_local_dofs_ = 0;
   size_t num_globl_dofs_ = 0;

--- a/modules/cfem_diffusion/cfem_diffusion_solver.h
+++ b/modules/cfem_diffusion/cfem_diffusion_solver.h
@@ -12,7 +12,6 @@
 namespace opensn
 {
 class MeshContinuum;
-typedef std::shared_ptr<MeshContinuum> MeshContinuumPtr;
 class SpatialDiscretization;
 typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
@@ -27,7 +26,7 @@ namespace cfem_diffusion
 class Solver : public opensn::Solver
 {
 public:
-  MeshContinuumPtr grid_ptr_ = nullptr;
+  std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
   SDMPtr sdm_ptr_ = nullptr;
 

--- a/modules/dfem_diffusion/dfem_diffusion_solver.h
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.h
@@ -12,7 +12,6 @@ namespace opensn
 {
 class MeshContinuum;
 class SpatialDiscretization;
-typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
 
 namespace dfem_diffusion
@@ -26,7 +25,7 @@ class Solver : public opensn::Solver
 public:
   std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
-  SDMPtr sdm_ptr_ = nullptr;
+  std::shared_ptr<SpatialDiscretization> sdm_ptr_ = nullptr;
 
   size_t num_local_dofs_ = 0;
   size_t num_globl_dofs_ = 0;

--- a/modules/dfem_diffusion/dfem_diffusion_solver.h
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.h
@@ -11,7 +11,6 @@
 namespace opensn
 {
 class MeshContinuum;
-typedef std::shared_ptr<MeshContinuum> MeshContinuumPtr;
 class SpatialDiscretization;
 typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
@@ -25,7 +24,7 @@ namespace dfem_diffusion
 class Solver : public opensn::Solver
 {
 public:
-  MeshContinuumPtr grid_ptr_ = nullptr;
+  std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
   SDMPtr sdm_ptr_ = nullptr;
 

--- a/modules/diffusion_solver/diffusion_solver.h
+++ b/modules/diffusion_solver/diffusion_solver.h
@@ -50,7 +50,7 @@ public:
 public:
   BoundaryPreferences boundary_preferences_;
   std::map<uint64_t, Boundary*> boundaries_;
-  MeshContinuumPtr grid_ptr_ = nullptr;
+  std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
   std::shared_ptr<SpatialDiscretization> discretization_;
 

--- a/modules/fv_diffusion/fv_diffusion_solver.h
+++ b/modules/fv_diffusion/fv_diffusion_solver.h
@@ -13,7 +13,6 @@
 namespace opensn
 {
 class MeshContinuum;
-typedef std::shared_ptr<MeshContinuum> MeshContinuumPtr;
 class SpatialDiscretization;
 typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
@@ -27,7 +26,7 @@ namespace fv_diffusion
 class Solver : public opensn::Solver
 {
 public:
-  MeshContinuumPtr grid_ptr_ = nullptr;
+  std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
   SDMPtr sdm_ptr_ = nullptr;
 

--- a/modules/fv_diffusion/fv_diffusion_solver.h
+++ b/modules/fv_diffusion/fv_diffusion_solver.h
@@ -14,7 +14,6 @@ namespace opensn
 {
 class MeshContinuum;
 class SpatialDiscretization;
-typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 class ScalarSpatialMaterialFunction;
 
 namespace fv_diffusion
@@ -28,7 +27,7 @@ class Solver : public opensn::Solver
 public:
   std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
-  SDMPtr sdm_ptr_ = nullptr;
+  std::shared_ptr<SpatialDiscretization> sdm_ptr_ = nullptr;
 
   size_t num_local_dofs_ = 0;
   size_t num_globl_dofs_ = 0;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.cc
@@ -35,7 +35,7 @@ TranslateBCs(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& sweep_bou
 }
 
 std::map<int, Multigroup_D_and_sigR>
-PackGroupsetXS(const std::map<int, MGXSPtr>& matid_to_xs_map,
+PackGroupsetXS(const std::map<int, std::shared_ptr<MultiGroupXS>>& matid_to_xs_map,
                int first_grp_index,
                int last_group_index)
 {

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.cc
@@ -12,7 +12,8 @@ namespace lbs
 {
 
 std::map<uint64_t, BoundaryCondition>
-TranslateBCs(const std::map<uint64_t, SwpBndryPtr>& sweep_boundaries, bool vaccum_bcs_are_dirichlet)
+TranslateBCs(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& sweep_boundaries,
+             bool vaccum_bcs_are_dirichlet)
 {
   typedef BoundaryType SwpBndryType;
   typedef BoundaryCondition BC;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.h
@@ -64,12 +64,10 @@ struct TwoGridCollapsedInfo
 
 TwoGridCollapsedInfo MakeTwoGridCollapsedInfo(const MultiGroupXS& xs, EnergyCollapseScheme scheme);
 
-typedef std::shared_ptr<SweepBoundary> SwpBndryPtr;
-
 /**Translates sweep boundary conditions to that used in diffusion acceleration
  * methods.*/
 std::map<uint64_t, BoundaryCondition>
-TranslateBCs(const std::map<uint64_t, SwpBndryPtr>& sweep_boundaries,
+TranslateBCs(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& sweep_boundaries,
              bool vaccum_bcs_are_dirichlet = true);
 
 typedef std::shared_ptr<MultiGroupXS> MGXSPtr;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/acceleration.h
@@ -70,13 +70,12 @@ std::map<uint64_t, BoundaryCondition>
 TranslateBCs(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& sweep_boundaries,
              bool vaccum_bcs_are_dirichlet = true);
 
-typedef std::shared_ptr<MultiGroupXS> MGXSPtr;
-
 /**Makes a packaged set of XSs, suitable for diffusion, for a particular
  * set of groups.*/
-std::map<int, Multigroup_D_and_sigR> PackGroupsetXS(const std::map<int, MGXSPtr>& matid_to_xs_map,
-                                                    int first_grp_index,
-                                                    int last_group_index);
+std::map<int, Multigroup_D_and_sigR>
+PackGroupsetXS(const std::map<int, std::shared_ptr<MultiGroupXS>>& matid_to_xs_map,
+               int first_grp_index,
+               int last_group_index);
 
 } // namespace lbs
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.cc
@@ -20,7 +20,7 @@ namespace
 {
 
 std::shared_ptr<NLKEigenDiffContext>
-GetNLKDiffContextPtr(const NonLinearSolver::NLSolverContextPtr& context,
+GetNLKDiffContextPtr(const std::shared_ptr<NonLinearSolverContext>& context,
                      const std::string& func_name)
 {
   auto nlk_eigen_diff_context = std::dynamic_pointer_cast<NLKEigenDiffContext>(context);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/nl_keigen_acc_solver.h
@@ -14,9 +14,7 @@ namespace lbs
 class NLKEigenDiffSolver : public NonLinearSolver
 {
 public:
-  typedef std::shared_ptr<NLKEigenDiffContext> NLKEigenDiffContextPtr;
-
-  explicit NLKEigenDiffSolver(NLKEigenDiffContextPtr nlk_diff_context_ptr)
+  explicit NLKEigenDiffSolver(std::shared_ptr<NLKEigenDiffContext> nlk_diff_context_ptr)
     : NonLinearSolver(nlk_diff_context_ptr)
   {
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/groupset/lbs_groupset.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/groupset/lbs_groupset.h
@@ -29,14 +29,11 @@ class LBSSolver;
 /**Group set functioning as a collection of groups*/
 class LBSGroupset : public Object
 {
-protected:
-  typedef std::shared_ptr<AngleAggregation> AngleAggPtr;
-
 public:
   int id_;
   std::vector<LBSGroup> groups_;
   std::shared_ptr<AngularQuadrature> quadrature_ = nullptr;
-  AngleAggPtr angle_agg_;
+  std::shared_ptr<AngleAggregation> angle_agg_;
   UniqueSOGroupings unique_so_groupings_;
   DirIDToSOMap dir_id_to_so_map_;
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_context.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_context.h
@@ -14,11 +14,10 @@ class LBSSolver;
 
 struct AGSContext : public LinearSolverContext
 {
-  typedef std::shared_ptr<LinearSolver> LinSolveBaseTypePtr;
   LBSSolver& lbs_solver_;
-  std::vector<LinSolveBaseTypePtr> sub_solvers_list_;
+  std::vector<std::shared_ptr<LinearSolver>> sub_solvers_list_;
 
-  AGSContext(LBSSolver& lbs_solver, std::vector<LinSolveBaseTypePtr> sub_solvers_list)
+  AGSContext(LBSSolver& lbs_solver, std::vector<std::shared_ptr<LinearSolver>> sub_solvers_list)
     : lbs_solver_(lbs_solver), sub_solvers_list_(std::move(sub_solvers_list))
   {
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_linear_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/ags_linear_solver.h
@@ -12,8 +12,6 @@ namespace lbs
 class AGSLinearSolver : public LinearSolver
 {
 public:
-  typedef std::shared_ptr<AGSContext> AGSContextPtr;
-
   /**Constructor.
    * \param iterative_method string Across Groupset iterative method.
    * \param ags_context_ptr Pointer Pointer to the context to use.
@@ -21,7 +19,7 @@ public:
    * \param groupspan_last_id int Last group index.
    * \param verbose bool Flag to enable verbose output.*/
   AGSLinearSolver(std::string iterative_method,
-                  AGSContextPtr ags_context_ptr,
+                  std::shared_ptr<AGSContext> ags_context_ptr,
                   int groupspan_first_id,
                   int groupspan_last_id,
                   bool verbose = true)

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
@@ -22,7 +22,7 @@ namespace
 {
 
 std::shared_ptr<NLKEigenAGSContext>
-GetNLKAGSContextPtr(const NonLinearSolver::NLSolverContextPtr& context,
+GetNLKAGSContextPtr(const std::shared_ptr<NonLinearSolverContext>& context,
                     const std::string& func_name)
 {
   auto nlk_ags_context = std::dynamic_pointer_cast<NLKEigenAGSContext>(context);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_solver.h
@@ -11,9 +11,7 @@ namespace lbs
 class NLKEigenvalueAGSSolver : public NonLinearSolver
 {
 public:
-  typedef std::shared_ptr<NLKEigenAGSContext> NLKAGSContextPtr;
-
-  explicit NLKEigenvalueAGSSolver(NLKAGSContextPtr nlk_ags_context_ptr)
+  explicit NLKEigenvalueAGSSolver(std::shared_ptr<NLKEigenAGSContext> nlk_ags_context_ptr)
     : NonLinearSolver(nlk_ags_context_ptr)
   {
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
@@ -20,7 +20,7 @@ namespace opensn
 namespace lbs
 {
 
-WGSLinearSolver::WGSLinearSolver(WGSContextPtr gs_context_ptr)
+WGSLinearSolver::WGSLinearSolver(std::shared_ptr<WGSContext> gs_context_ptr)
   : LinearSolver(IterativeMethodPETScName(gs_context_ptr->groupset_.iterative_method_),
                  gs_context_ptr)
 {

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.h
@@ -17,13 +17,11 @@ namespace lbs
 class WGSLinearSolver : public LinearSolver
 {
 public:
-  typedef std::shared_ptr<WGSContext> WGSContextPtr;
-
   /**
    * Constructor.
    * \param gs_context_ptr Context Pointer to abstract context.
    */
-  explicit WGSLinearSolver(WGSContextPtr gs_context_ptr);
+  explicit WGSLinearSolver(std::shared_ptr<WGSContext> gs_context_ptr);
   ~WGSLinearSolver() override;
 
 protected:

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -227,7 +227,7 @@ LBSSolver::DistributedSources() const
   return distributed_sources_;
 }
 
-const std::map<int, XSPtr>&
+const std::map<int, std::shared_ptr<MultiGroupXS>>&
 LBSSolver::GetMatID2XSMap() const
 {
   return matid_to_xs_map_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -233,7 +233,7 @@ LBSSolver::GetMatID2XSMap() const
   return matid_to_xs_map_;
 }
 
-const std::map<int, IsotropicSrcPtr>&
+const std::map<int, std::shared_ptr<IsotropicMultiGrpSource>>&
 LBSSolver::GetMatID2IsoSrcMap() const
 {
   return matid_to_src_map_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -377,7 +377,7 @@ LBSSolver::GetPrimaryAGSSolver()
   return primary_ags_solver_;
 }
 
-std::vector<LBSSolver::LinSolvePtr>&
+std::vector<std::shared_ptr<LinearSolver>>&
 LBSSolver::GetWGSSolvers()
 {
   return wgs_solvers_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -371,7 +371,7 @@ LBSSolver::GetActiveSetSourceFunction() const
   return active_set_source_function_;
 }
 
-LBSSolver::AGSLinSolverPtr
+std::shared_ptr<AGSLinearSolver>
 LBSSolver::GetPrimaryAGSSolver()
 {
   return primary_ags_solver_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -148,7 +148,7 @@ public:
   /**
    * Returns a reference to the map of material ids to Isotropic Srcs.
    */
-  const std::map<int, IsotropicSrcPtr>& GetMatID2IsoSrcMap() const;
+  const std::map<int, std::shared_ptr<IsotropicMultiGrpSource>>& GetMatID2IsoSrcMap() const;
 
   /**
    * Obtains a reference to the grid.
@@ -525,7 +525,7 @@ protected:
   std::vector<LBSGroupset> groupsets_;
 
   std::map<int, std::shared_ptr<MultiGroupXS>> matid_to_xs_map_;
-  std::map<int, IsotropicSrcPtr> matid_to_src_map_;
+  std::map<int, std::shared_ptr<IsotropicMultiGrpSource>> matid_to_src_map_;
 
   std::vector<PointSource> point_sources_;
   std::vector<DistributedSource> distributed_sources_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -535,7 +535,7 @@ protected:
   std::vector<PointSource> point_sources_;
   std::vector<DistributedSource> distributed_sources_;
 
-  MeshContinuumPtr grid_ptr_;
+  std::shared_ptr<MeshContinuum> grid_ptr_;
   std::shared_ptr<opensn::SpatialDiscretization> discretization_ = nullptr;
 
   std::vector<CellFaceNodalMapping> grid_nodal_mappings_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -19,7 +19,6 @@ namespace opensn
 
 class MPICommunicatorSet;
 class GridFaceHistogram;
-typedef std::shared_ptr<GridFaceHistogram> GridFaceHistogramPtr;
 
 class TimeIntegration;
 
@@ -540,7 +539,7 @@ protected:
 
   std::vector<CellFaceNodalMapping> grid_nodal_mappings_;
   std::shared_ptr<MPICommunicatorSet> grid_local_comm_set_ = nullptr;
-  GridFaceHistogramPtr grid_face_histogram_ = nullptr;
+  std::shared_ptr<GridFaceHistogram> grid_face_histogram_ = nullptr;
 
   std::vector<UnitCellMatrices> unit_cell_matrices_;
   std::map<uint64_t, UnitCellMatrices> unit_ghost_cell_matrices_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -148,7 +148,7 @@ public:
   /**
    * Returns a reference to the map of material ids to XSs.
    */
-  const std::map<int, XSPtr>& GetMatID2XSMap() const;
+  const std::map<int, std::shared_ptr<MultiGroupXS>>& GetMatID2XSMap() const;
 
   /**
    * Returns a reference to the map of material ids to Isotropic Srcs.
@@ -529,7 +529,7 @@ protected:
   std::vector<LBSGroup> groups_;
   std::vector<LBSGroupset> groupsets_;
 
-  std::map<int, XSPtr> matid_to_xs_map_;
+  std::map<int, std::shared_ptr<MultiGroupXS>> matid_to_xs_map_;
   std::map<int, IsotropicSrcPtr> matid_to_src_map_;
 
   std::vector<PointSource> point_sources_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -18,8 +18,6 @@ namespace opensn
 {
 
 class MPICommunicatorSet;
-typedef std::shared_ptr<MPICommunicatorSet> MPILocalCommSetPtr;
-
 class GridFaceHistogram;
 typedef std::shared_ptr<GridFaceHistogram> GridFaceHistogramPtr;
 
@@ -541,7 +539,7 @@ protected:
   std::shared_ptr<opensn::SpatialDiscretization> discretization_ = nullptr;
 
   std::vector<CellFaceNodalMapping> grid_nodal_mappings_;
-  MPILocalCommSetPtr grid_local_comm_set_ = nullptr;
+  std::shared_ptr<MPICommunicatorSet> grid_local_comm_set_ = nullptr;
   GridFaceHistogramPtr grid_face_histogram_ = nullptr;
 
   std::vector<UnitCellMatrices> unit_cell_matrices_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -33,7 +33,6 @@ class LBSSolver : public opensn::Solver
 {
 public:
   typedef std::shared_ptr<AGSLinearSolver> AGSLinSolverPtr;
-  typedef std::shared_ptr<LinearSolver> LinSolvePtr;
 
 public:
   explicit LBSSolver(const std::string& text_name);
@@ -268,7 +267,7 @@ public:
 
   AGSLinSolverPtr GetPrimaryAGSSolver();
 
-  std::vector<LinSolvePtr>& GetWGSSolvers();
+  std::vector<std::shared_ptr<LinearSolver>>& GetWGSSolvers();
 
   WGSContext& GetWGSContext(int groupset_id);
 
@@ -562,7 +561,7 @@ protected:
   SetSourceFunction active_set_source_function_;
 
   std::vector<AGSLinSolverPtr> ags_solvers_;
-  std::vector<LinSolvePtr> wgs_solvers_;
+  std::vector<std::shared_ptr<LinearSolver>> wgs_solvers_;
   AGSLinSolverPtr primary_ags_solver_;
 
   std::map<std::pair<size_t, size_t>, size_t> phi_field_functions_local_map_;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -32,9 +32,6 @@ struct WGSContext;
 class LBSSolver : public opensn::Solver
 {
 public:
-  typedef std::shared_ptr<AGSLinearSolver> AGSLinSolverPtr;
-
-public:
   explicit LBSSolver(const std::string& text_name);
   /**
    * Input parameters based construction.
@@ -265,7 +262,7 @@ public:
 
   SetSourceFunction GetActiveSetSourceFunction() const;
 
-  AGSLinSolverPtr GetPrimaryAGSSolver();
+  std::shared_ptr<AGSLinearSolver> GetPrimaryAGSSolver();
 
   std::vector<std::shared_ptr<LinearSolver>>& GetWGSSolvers();
 
@@ -560,9 +557,9 @@ protected:
 
   SetSourceFunction active_set_source_function_;
 
-  std::vector<AGSLinSolverPtr> ags_solvers_;
+  std::vector<std::shared_ptr<AGSLinearSolver>> ags_solvers_;
   std::vector<std::shared_ptr<LinearSolver>> wgs_solvers_;
-  AGSLinSolverPtr primary_ags_solver_;
+  std::shared_ptr<AGSLinearSolver> primary_ags_solver_;
 
   std::map<std::pair<size_t, size_t>, size_t> phi_field_functions_local_map_;
   size_t power_gen_fieldfunc_local_handle_ = 0;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
@@ -21,8 +21,6 @@ typedef std::vector<VecDbl> MatDbl;
 typedef std::vector<Vector3> VecVec3;
 typedef std::vector<VecVec3> MatVec3;
 
-typedef std::shared_ptr<IsotropicMultiGrpSource> IsotropicSrcPtr;
-
 enum class SolverType
 {
   DISCRETE_ORDINATES = 1,

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
@@ -21,7 +21,6 @@ typedef std::vector<VecDbl> MatDbl;
 typedef std::vector<Vector3> VecVec3;
 typedef std::vector<VecVec3> MatVec3;
 
-typedef std::shared_ptr<MultiGroupXS> XSPtr;
 typedef std::shared_ptr<IsotropicMultiGrpSource> IsotropicSrcPtr;
 
 enum class SolverType

--- a/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/lbs_mip_solver.h
+++ b/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/lbs_mip_solver.h
@@ -9,11 +9,8 @@ namespace lbs
 
 class DiffusionDFEMSolver : public LBSSolver
 {
-protected:
-  typedef std::shared_ptr<DiffusionMIPSolver> MIPSolverPtr;
-
 public:
-  std::vector<MIPSolverPtr> gs_mip_solvers_;
+  std::vector<std::shared_ptr<DiffusionMIPSolver>> gs_mip_solvers_;
 
 public:
   explicit DiffusionDFEMSolver(const InputParameters& params);

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -828,7 +828,7 @@ DiscreteOrdinatesSolver::InitializeSweepDataStructures()
 
   // Define sweep ordering groups
   quadrature_unq_so_grouping_map_.clear();
-  std::map<AngQuadPtr, bool> quadrature_allow_cycles_map_;
+  std::map<std::shared_ptr<AngularQuadrature>, bool> quadrature_allow_cycles_map_;
   for (auto& groupset : groupsets_)
   {
     if (quadrature_unq_so_grouping_map_.count(groupset.quadrature_) == 0)

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -19,8 +19,6 @@ class DiscreteOrdinatesSolver : public LBSSolver
 protected:
   typedef std::pair<UniqueSOGroupings, DirIDToSOMap> SwpOrderGroupingInfo;
 
-  typedef std::vector<std::shared_ptr<SPDS>> SPDS_ptrs;
-
   typedef std::vector<std::unique_ptr<FLUDSCommonData>> FLUDSCommonDataPtrs;
 
 public:
@@ -121,7 +119,8 @@ protected:
 
   std::map<std::shared_ptr<AngularQuadrature>, SwpOrderGroupingInfo>
     quadrature_unq_so_grouping_map_;
-  std::map<std::shared_ptr<AngularQuadrature>, SPDS_ptrs> quadrature_spds_map_;
+  std::map<std::shared_ptr<AngularQuadrature>, std::vector<std::shared_ptr<SPDS>>>
+    quadrature_spds_map_;
   std::map<std::shared_ptr<AngularQuadrature>, FLUDSCommonDataPtrs>
     quadrature_fluds_commondata_map_;
 

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -17,8 +17,6 @@ class CBC_ASynchronousCommunicator;
 class DiscreteOrdinatesSolver : public LBSSolver
 {
 protected:
-  typedef std::shared_ptr<AngularQuadrature> AngQuadPtr;
-
   typedef std::pair<UniqueSOGroupings, DirIDToSOMap> SwpOrderGroupingInfo;
 
   typedef std::shared_ptr<SPDS> SPDS_ptr;
@@ -123,9 +121,11 @@ protected:
    */
   virtual std::shared_ptr<SweepChunk> SetSweepChunk(LBSGroupset& groupset);
 
-  std::map<AngQuadPtr, SwpOrderGroupingInfo> quadrature_unq_so_grouping_map_;
-  std::map<AngQuadPtr, SPDS_ptrs> quadrature_spds_map_;
-  std::map<AngQuadPtr, FLUDSCommonDataPtrs> quadrature_fluds_commondata_map_;
+  std::map<std::shared_ptr<AngularQuadrature>, SwpOrderGroupingInfo>
+    quadrature_unq_so_grouping_map_;
+  std::map<std::shared_ptr<AngularQuadrature>, SPDS_ptrs> quadrature_spds_map_;
+  std::map<std::shared_ptr<AngularQuadrature>, FLUDSCommonDataPtrs>
+    quadrature_fluds_commondata_map_;
 
   std::vector<size_t> verbose_sweep_angles_;
   const std::string sweep_type_;

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -19,8 +19,7 @@ class DiscreteOrdinatesSolver : public LBSSolver
 protected:
   typedef std::pair<UniqueSOGroupings, DirIDToSOMap> SwpOrderGroupingInfo;
 
-  typedef std::shared_ptr<SPDS> SPDS_ptr;
-  typedef std::vector<SPDS_ptr> SPDS_ptrs;
+  typedef std::vector<std::shared_ptr<SPDS>> SPDS_ptrs;
 
   typedef std::vector<std::unique_ptr<FLUDSCommonData>> FLUDSCommonDataPtrs;
 

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -22,8 +22,7 @@ protected:
   typedef std::shared_ptr<SPDS> SPDS_ptr;
   typedef std::vector<SPDS_ptr> SPDS_ptrs;
 
-  typedef std::unique_ptr<FLUDSCommonData> FLUDSCommonDataPtr;
-  typedef std::vector<FLUDSCommonDataPtr> FLUDSCommonDataPtrs;
+  typedef std::vector<std::unique_ptr<FLUDSCommonData>> FLUDSCommonDataPtrs;
 
 public:
   /**

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -19,8 +19,6 @@ class DiscreteOrdinatesSolver : public LBSSolver
 protected:
   typedef std::pair<UniqueSOGroupings, DirIDToSOMap> SwpOrderGroupingInfo;
 
-  typedef std::vector<std::unique_ptr<FLUDSCommonData>> FLUDSCommonDataPtrs;
-
 public:
   /**
    * Static registration based constructor.
@@ -121,7 +119,7 @@ protected:
     quadrature_unq_so_grouping_map_;
   std::map<std::shared_ptr<AngularQuadrature>, std::vector<std::shared_ptr<SPDS>>>
     quadrature_spds_map_;
-  std::map<std::shared_ptr<AngularQuadrature>, FLUDSCommonDataPtrs>
+  std::map<std::shared_ptr<AngularQuadrature>, std::vector<std::unique_ptr<FLUDSCommonData>>>
     quadrature_fluds_commondata_map_;
 
   std::vector<size_t> verbose_sweep_angles_;

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
@@ -16,7 +16,7 @@ AAH_SweepChunk::AAH_SweepChunk(const MeshContinuum& grid,
                                std::vector<double>& destination_psi,
                                const std::vector<double>& source_moments,
                                const LBSGroupset& groupset,
-                               const std::map<int, XSPtr>& xs,
+                               const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                                int num_moments,
                                int max_num_cell_dofs)
   : SweepChunk(destination_phi,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.h
@@ -39,7 +39,7 @@ public:
                  std::vector<double>& destination_psi,
                  const std::vector<double>& source_moments,
                  const LBSGroupset& groupset,
-                 const std::map<int, XSPtr>& xs,
+                 const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                  int num_moments,
                  int max_num_cell_dofs);
 

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
@@ -19,7 +19,7 @@ CBC_SweepChunk::CBC_SweepChunk(std::vector<double>& destination_phi,
                                std::vector<lbs::CellLBSView>& cell_transport_views,
                                const std::vector<double>& source_moments,
                                const LBSGroupset& groupset,
-                               const std::map<int, XSPtr>& xs,
+                               const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                                int num_moments,
                                int max_num_cell_dofs)
   : SweepChunk(destination_phi,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.h
@@ -55,7 +55,7 @@ public:
                  std::vector<lbs::CellLBSView>& cell_transport_views,
                  const std::vector<double>& source_moments,
                  const LBSGroupset& groupset,
-                 const std::map<int, XSPtr>& xs,
+                 const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                  int num_moments,
                  int max_num_cell_dofs);
 

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
@@ -20,7 +20,7 @@ SweepChunk::SweepChunk(std::vector<double>& destination_phi,
                        std::vector<lbs::CellLBSView>& cell_transport_views,
                        const std::vector<double>& source_moments,
                        const LBSGroupset& groupset,
-                       const std::map<int, XSPtr>& xs,
+                       const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                        int num_moments,
                        int max_num_cell_dofs,
                        std::unique_ptr<SweepDependencyInterface> sweep_dependency_interface_ptr)

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -70,7 +70,7 @@ public:
              std::vector<lbs::CellLBSView>& cell_transport_views,
              const std::vector<double>& source_moments,
              const LBSGroupset& groupset,
-             const std::map<int, XSPtr>& xs,
+             const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
              int num_moments,
              int max_num_cell_dofs,
              std::unique_ptr<SweepDependencyInterface> sweep_dependency_interface_ptr);
@@ -84,7 +84,7 @@ protected:
   std::vector<lbs::CellLBSView>& grid_transport_view_;
   const std::vector<double>& q_moments_;
   const LBSGroupset& groupset_;
-  const std::map<int, XSPtr>& xs_;
+  const std::map<int, std::shared_ptr<MultiGroupXS>>& xs_;
   const int num_moments_;
   const bool save_angular_flux_;
 

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_angle_set.cc
@@ -19,7 +19,7 @@ CBC_AngleSet::CBC_AngleSet(size_t id,
                            const SPDS& spds,
                            std::shared_ptr<FLUDS>& fluds,
                            const std::vector<size_t>& angle_indices,
-                           std::map<uint64_t, SweepBndryPtr>& sim_boundaries,
+                           std::map<uint64_t, std::shared_ptr<SweepBndry>>& sim_boundaries,
                            size_t in_ref_subset,
                            const MPICommunicatorSet& comm_set)
   : AngleSet(id, num_groups, spds, fluds, angle_indices, sim_boundaries, in_ref_subset),

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_angle_set.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweepers/cbc_angle_set.h
@@ -19,7 +19,7 @@ public:
                const SPDS& spds,
                std::shared_ptr<FLUDS>& fluds,
                const std::vector<size_t>& angle_indices,
-               std::map<uint64_t, SweepBndryPtr>& sim_boundaries,
+               std::map<uint64_t, std::shared_ptr<SweepBndry>>& sim_boundaries,
                size_t in_ref_subset,
                const MPICommunicatorSet& comm_set);
 

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
@@ -20,7 +20,7 @@ SweepChunkPWLRZ::SweepChunkPWLRZ(
   std::vector<double>& destination_psi,
   const std::vector<double>& source_moments,
   lbs::LBSGroupset& groupset,
-  const std::map<int, lbs::XSPtr>& xs,
+  const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
   int num_moments,
   int max_num_cell_dofs)
   : AAH_SweepChunk(grid,

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.h
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.h
@@ -43,7 +43,7 @@ public:
                   std::vector<double>& destination_psi,
                   const std::vector<double>& source_moments,
                   lbs::LBSGroupset& groupset,
-                  const std::map<int, lbs::XSPtr>& xs,
+                  const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                   int num_moments,
                   int max_num_cell_dofs);
 

--- a/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.cc
@@ -19,7 +19,7 @@ lbs::SweepChunkPWLTransientTheta::SweepChunkPWLTransientTheta(
   const double time_step,
   const std::vector<double>& source_moments,
   LBSGroupset& groupset,
-  const std::map<int, XSPtr>& xs,
+  const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
   const int num_moments,
   const int max_num_cell_dofs)
   : SweepChunk(destination_phi, destination_psi),

--- a/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.h
+++ b/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.h
@@ -23,7 +23,7 @@ protected:
   std::vector<lbs::CellLBSView>& grid_transport_view_;
   const std::vector<double>& q_moments_;
   LBSGroupset& groupset_;
-  const std::map<int, XSPtr>& xs_;
+  const std::map<int, std::shared_ptr<MultiGroupXS>>& xs_;
   const int num_moments_;
   const size_t num_groups_;
   const int max_num_cell_dofs_;
@@ -53,7 +53,7 @@ public:
                               double time_step,
                               const std::vector<double>& source_moments,
                               LBSGroupset& groupset,
-                              const std::map<int, XSPtr>& xs,
+                              const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
                               int num_moments,
                               int max_num_cell_dofs);
 

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
@@ -12,8 +12,6 @@ namespace lbs
 
 class XXPowerIterationKEigenSCDSA : public XXPowerIterationKEigen
 {
-  typedef std::shared_ptr<VectorGhostCommunicator> VecGhostCommPtr;
-
 protected:
   int accel_pi_max_its_;
   double accel_pi_k_tol_;
@@ -26,7 +24,7 @@ protected:
   bool requires_ghosts_ = false;
   struct GhostInfo
   {
-    VecGhostCommPtr vector_ghost_communicator = nullptr;
+    std::shared_ptr<VectorGhostCommunicator> vector_ghost_communicator = nullptr;
     std::map<int64_t, int64_t> ghost_global_id_2_local_map;
   };
   GhostInfo lbs_pwld_ghost_info_;

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
@@ -12,14 +12,13 @@ namespace lbs
 
 class XXPowerIterationKEigenSCDSA : public XXPowerIterationKEigen
 {
-  typedef std::shared_ptr<DiffusionSolver> DiffusionSolverPtr;
   typedef std::shared_ptr<VectorGhostCommunicator> VecGhostCommPtr;
 
 protected:
   int accel_pi_max_its_;
   double accel_pi_k_tol_;
   bool accel_pi_verbose_;
-  DiffusionSolverPtr diffusion_solver_ = nullptr;
+  std::shared_ptr<DiffusionSolver> diffusion_solver_ = nullptr;
 
   const std::string diffusion_solver_sdm_;
 

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.h
@@ -14,7 +14,6 @@ class XXPowerIterationKEigenSCDSA : public XXPowerIterationKEigen
 {
   typedef std::shared_ptr<DiffusionSolver> DiffusionSolverPtr;
   typedef std::shared_ptr<VectorGhostCommunicator> VecGhostCommPtr;
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 
 protected:
   int accel_pi_max_its_;
@@ -24,7 +23,7 @@ protected:
 
   const std::string diffusion_solver_sdm_;
 
-  SDMPtr continuous_sdm_ptr_ = nullptr;
+  std::shared_ptr<SpatialDiscretization> continuous_sdm_ptr_ = nullptr;
   bool requires_ghosts_ = false;
   struct GhostInfo
   {

--- a/modules/mg_diffusion/mg_diffusion_solver.h
+++ b/modules/mg_diffusion/mg_diffusion_solver.h
@@ -14,7 +14,6 @@ namespace opensn
 {
 class MeshContinuum;
 class SpatialDiscretization;
-typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 
 namespace mg_diffusion
 {
@@ -45,7 +44,7 @@ class Solver : public opensn::Solver
 public:
   std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
-  SDMPtr sdm_ptr_ = nullptr;
+  std::shared_ptr<SpatialDiscretization> sdm_ptr_ = nullptr;
 
   uint num_groups_ = 0;
   uint last_fast_group_ = 0;

--- a/modules/mg_diffusion/mg_diffusion_solver.h
+++ b/modules/mg_diffusion/mg_diffusion_solver.h
@@ -13,7 +13,6 @@
 namespace opensn
 {
 class MeshContinuum;
-typedef std::shared_ptr<MeshContinuum> MeshContinuumPtr;
 class SpatialDiscretization;
 typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
 
@@ -44,7 +43,7 @@ struct TwoGridCollapsedInfo
 class Solver : public opensn::Solver
 {
 public:
-  MeshContinuumPtr grid_ptr_ = nullptr;
+  std::shared_ptr<MeshContinuum> grid_ptr_ = nullptr;
 
   SDMPtr sdm_ptr_ = nullptr;
 

--- a/test/framework/tutorials/fv_test1.cc
+++ b/test/framework/tutorials/fv_test1.cc
@@ -35,8 +35,7 @@ chiSimTest01_FV(const InputParameters&)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = FiniteVolume::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = FiniteVolume::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/fv_test2.cc
+++ b/test/framework/tutorials/fv_test2.cc
@@ -37,8 +37,7 @@ chiSimTest02_FV(const InputParameters&)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = FiniteVolume::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = FiniteVolume::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/pwlc_test1.cc
+++ b/test/framework/tutorials/pwlc_test1.cc
@@ -34,8 +34,7 @@ chiSimTest03_PWLC(const InputParameters&)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearContinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearContinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/pwlc_test2.cc
+++ b/test/framework/tutorials/pwlc_test2.cc
@@ -36,8 +36,7 @@ chiSimTest04_PWLC(const InputParameters& params)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearContinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearContinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/tutorial_06_wdd.cc
+++ b/test/framework/tutorials/tutorial_06_wdd.cc
@@ -76,8 +76,7 @@ chiSimTest06_WDD(const InputParameters&)
   if (grid.Attributes() & Dim3) dimension = 3;
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = FiniteVolume::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = FiniteVolume::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/framework/tutorials/tutorial_91a_pwld.cc
@@ -61,8 +61,7 @@ chiSimTest91_PWLD(const InputParameters&)
   if (grid.Attributes() & Dim3) dimension = 3;
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/framework/tutorials/tutorial_93_raytracing.cc
+++ b/test/framework/tutorials/tutorial_93_raytracing.cc
@@ -64,8 +64,7 @@ chiSimTest93_RayTracing(const InputParameters&)
         m_to_ell_em_map.emplace_back(ell, m);
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   UnknownManager phi_uk_man;

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
@@ -39,8 +39,7 @@ acceleration_Diffusion_CFEM(const InputParameters&)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearContinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearContinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
@@ -56,8 +56,7 @@ acceleration_Diffusion_DFEM(const InputParameters&)
   opensn::log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // Make SDM
-  typedef std::shared_ptr<SpatialDiscretization> SDMPtr;
-  SDMPtr sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
+  std::shared_ptr<SpatialDiscretization> sdm_ptr = PieceWiseLinearDiscontinuous::New(grid);
   const auto& sdm = *sdm_ptr;
 
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;


### PR DESCRIPTION
This removes custom defined types like `typedef std::shared_ptr<SomeType> SomeTypePtr`.

