### PR TITLE
Adjoint Option

### DIFF
--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
@@ -24,7 +24,7 @@ chiLBSInitializeMaterials(lua_State* L)
   auto& lbs_solver =
     opensn::GetStackItem<opensn::lbs::LBSSolver>(opensn::object_stack, solver_handle, fname);
 
-  lbs_solver.InitMaterials();
+  lbs_solver.InitializeMaterials();
 
   return 0;
 }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -18,6 +18,7 @@
 #include "framework/math/time_integrations/time_integration.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h"
 #include "framework/physics/physics_material/physics_material.h"
+#include "framework/physics/physics_material/multi_group_xs/adjoint_mgxs.h"
 #include "framework/physics/field_function/field_function_grid_based.h"
 #include <algorithm>
 #include <iomanip>
@@ -480,6 +481,8 @@ LBSSolver::OptionsBlock()
   "obtained elsewhere.");
   params.AddOptionalParameter("save_angular_flux", false,
   "Flag indicating whether angular fluxes are to be stored or not.");
+  params.AddOptionalParameter("adjoint", false,
+  "Flag for toggling whether the solver is in adjoint mode.");
   params.AddOptionalParameter("verbose_inner_iterations", true,
   "Flag to control verbosity of inner iterations.");
   params.AddOptionalParameter("verbose_outer_iterations", true,
@@ -578,6 +581,38 @@ LBSSolver::SetOptions(const InputParameters& params)
     if (user_params.GetParamValue<bool>("clear_point_sources")) point_sources_.clear();
   if (user_params.Has("clear_distributed_sources"))
     if (user_params.GetParamValue<bool>("clear_distributed_sources")) distributed_sources_.clear();
+  if (user_params.Has("adjoint"))
+  {
+    const bool adjoint = user_params.GetParamValue<bool>("adjoint");
+    if (adjoint != options_.adjoint)
+    {
+      options_.adjoint = adjoint;
+
+      // If a discretization exists, the solver has already been initialized.
+      // Reinitialize the materials to obtain the appropriate xs and clear the
+      // sources to prepare for defining the adjoint problem
+      if (discretization_)
+      {
+        // The materials are reinitialized here to ensure that the proper cross sections
+        // are available to the solver. Because an adjoint solve requires volumetric or
+        // point sources, the material-based sources are not set within the initialize routine.
+        InitializeMaterials();
+
+        // Forward and adjoint sources are fundamentally different, so any existing sources
+        // should be cleared and reset through options upon changing modes.
+        point_sources_.clear();
+        distributed_sources_.clear();
+        boundary_preferences_.clear();
+
+        // Set all solutions to zero.
+        phi_old_local_.assign(phi_old_local_.size(), 0.0);
+        phi_new_local_.assign(phi_new_local_.size(), 0.0);
+        for (auto& psi : psi_new_local_)
+          psi.assign(psi.size(), 0.0);
+        precursor_new_local_.assign(precursor_new_local_.size(), 0.0);
+      }
+    }
+  }
 
   // Handle order insensitive options
   for (size_t p = 0; p < user_params.NumParameters(); ++p)
@@ -748,7 +783,7 @@ LBSSolver::Initialize()
 
   mpi_comm.barrier();
 
-  InitMaterials();                   // c
+  InitializeMaterials();             // c
   InitializeSpatialDiscretization(); // d
   InitializeGroupsets();             // e
   ComputeNumberOfMoments();          // f
@@ -856,14 +891,15 @@ LBSSolver::PrintSimHeader()
 }
 
 void
-LBSSolver::InitMaterials()
+LBSSolver::InitializeMaterials()
 {
-  const std::string fname = "lbs::SteadyStateSolver::InitMaterials";
   log.Log0Verbose1() << "Initializing Materials";
 
   // Create set of material ids locally relevant
-  std::set<int> unique_material_ids;
+  const size_t num_physics_mats = material_stack.size();
+
   int invalid_mat_cell_count = 0;
+  std::set<int> unique_material_ids;
   for (auto& cell : grid_ptr_->local_cells)
   {
     unique_material_ids.insert(cell.material_id_);
@@ -877,10 +913,10 @@ LBSSolver::InitMaterials()
     if (cell.material_id_ < 0) ++invalid_mat_cell_count;
   }
 
-  if (invalid_mat_cell_count > 0)
-  {
-    log.LogAllWarning() << "Number of invalid material cells: " << invalid_mat_cell_count;
-  }
+  log.Log() << "Invalid cell materials " << invalid_mat_cell_count;
+  ChiLogicalErrorIf(invalid_mat_cell_count > 0,
+                    std::to_string(invalid_mat_cell_count) +
+                      " cells encountered with an invalid material id.");
 
   // Get ready for processing
   std::stringstream materials_list;
@@ -888,75 +924,60 @@ LBSSolver::InitMaterials()
   matid_to_src_map_.clear();
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Process materials found
-  const size_t num_physics_mats = material_stack.size();
 
   for (const int& mat_id : unique_material_ids)
   {
     materials_list << "Material id " << mat_id;
 
-    // Check valid ids
-    if (mat_id < 0)
-      throw std::logic_error(fname + ": Cells encountered with no assigned "
-                                     "material.");
-    if (static_cast<size_t>(mat_id) >= num_physics_mats)
-      throw std::logic_error(fname + ": Cells encountered with material id that"
-                                     " matches no material in physics material "
-                                     "library.");
-
-    auto current_material = GetStackItemPtr(material_stack, mat_id, fname);
+    const auto& current_material = GetStackItemPtr(material_stack, mat_id, __FUNCTION__);
 
     // Extract properties
-    using MatProperty = PropertyType;
     bool found_transport_xs = false;
     for (const auto& property : current_material->properties_)
     {
-      if (property->Type() == MatProperty::TRANSPORT_XSECTIONS)
+      if (property->Type() == PropertyType::TRANSPORT_XSECTIONS)
       {
-        auto transp_xs = std::static_pointer_cast<MultiGroupXS>(property);
-        matid_to_xs_map_[mat_id] = transp_xs;
+        // If forward mode, use the existing xs on stack.
+        // If adjoint mode, create adjoint xs.
+        auto xs = std::static_pointer_cast<MultiGroupXS>(property);
+        matid_to_xs_map_[mat_id] = not options_.adjoint ? xs : std::make_shared<AdjointMGXS>(*xs);
         found_transport_xs = true;
       } // transport xs
-      if (property->Type() == MatProperty::ISOTROPIC_MG_SOURCE)
-      {
-        auto mg_source = std::static_pointer_cast<IsotropicMultiGrpSource>(property);
 
-        if (mg_source->source_value_g_.size() < groups_.size())
+      if (property->Type() == PropertyType::ISOTROPIC_MG_SOURCE)
+      {
+        const auto& src = std::static_pointer_cast<IsotropicMultiGrpSource>(property);
+
+        if (src->source_value_g_.size() < groups_.size())
         {
-          log.LogAllWarning() << fname + ": Isotropic Multigroup source specified in "
+          log.LogAllWarning() << __FUNCTION__ << ": IsotropicMultiGrpSource specified in "
                               << "material \"" << current_material->name_ << "\" has fewer "
                               << "energy groups than called for in the simulation. "
                               << "Source will be ignored.";
         }
-        else { matid_to_src_map_[mat_id] = mg_source; }
+        else { matid_to_src_map_[mat_id] = src; }
       } // P0 source
     }   // for property
 
     // Check valid property
-    if (!found_transport_xs)
-    {
-      log.LogAllError() << fname + ": Found no transport cross-section property for "
-                        << "material \"" << current_material->name_ << "\".";
-      Exit(EXIT_FAILURE);
-    }
+    ChiLogicalErrorIf(not found_transport_xs,
+                      "Material \"" + current_material->name_ + "\" does not contain " +
+                        "transport cross sections.");
+
     // Check number of groups legal
-    if (matid_to_xs_map_[mat_id]->NumGroups() < groups_.size())
-    {
-      log.LogAllError() << fname + ": Found material \"" << current_material->name_ << "\" has "
-                        << matid_to_xs_map_[mat_id]->NumGroups() << " groups and"
-                        << " the simulation has " << groups_.size() << " groups."
-                        << " The material must have a greater or equal amount of groups.";
-      Exit(EXIT_FAILURE);
-    }
+    ChiLogicalErrorIf(matid_to_xs_map_[mat_id]->NumGroups() < groups_.size(),
+                      "Material \"" + current_material->name_ + "\" has fewer groups (" +
+                        std::to_string(matid_to_xs_map_[mat_id]->NumGroups()) + ") than " +
+                        "the simulation (" + std::to_string(groups_.size()) + "). " +
+                        "A material must have at least as many groups as the simulation.");
 
     // Check number of moments
     if (matid_to_xs_map_[mat_id]->ScatteringOrder() < options_.scattering_order)
     {
-      log.Log0Warning() << fname + ": Found material \"" << current_material->name_
-                        << "\" has a scattering order of "
-                        << matid_to_xs_map_[mat_id]->ScatteringOrder()
-                        << " and the simulation has a scattering order of "
-                        << options_.scattering_order
-                        << ". The higher moments will therefore not be used.";
+      log.Log0Warning() << __FUNCTION__ << ": Material \"" << current_material->name_
+                        << "\" has a lower scattering order ("
+                        << matid_to_xs_map_[mat_id]->ScatteringOrder() << ") "
+                        << "than the simulation (" << options_.scattering_order << ").";
     }
 
     materials_list << " number of moments " << matid_to_xs_map_[mat_id]->ScatteringOrder() + 1
@@ -982,14 +1003,13 @@ LBSSolver::InitMaterials()
   // check compatibility when precursors are on
   if (options_.use_precursors)
   {
-    for (const auto& mat_id_xs : matid_to_xs_map_)
+    for (const auto& [mat_id, xs] : matid_to_xs_map_)
     {
-      const auto& xs = mat_id_xs.second;
-      if (xs->IsFissionable() && num_precursors_ == 0)
-        throw std::logic_error("Incompatible cross section data encountered."
-                               "When delayed neutron data is present for one "
-                               "fissionable material, it must be present for "
-                               "all fissionable materials.");
+      ChiLogicalErrorIf(xs->IsFissionable() and num_precursors_ == 0,
+                        "Incompatible cross section data encountered for material ID " +
+                          std::to_string(mat_id) + ". When delayed neutron data is present " +
+                          "for one fissionable matrial, it must be present for all fissionable "
+                          "materials.");
     }
   }
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -2967,7 +2967,9 @@ LBSSolver::ScalePhiVector(PhiSTLOption which_phi, double value)
 }
 
 void
-LBSSolver::SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset, Vec x, PhiSTLOption which_phi)
+LBSSolver::SetGSPETScVecFromPrimarySTLvector(const LBSGroupset& groupset,
+                                             Vec x,
+                                             PhiSTLOption which_phi)
 {
   const std::vector<double>* y_ptr;
   switch (which_phi)
@@ -3012,8 +3014,8 @@ LBSSolver::SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset, Vec x, PhiST
 }
 
 void
-LBSSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset,
-                                             Vec x_src,
+LBSSolver::SetPrimarySTLvectorFromGSPETScVec(const LBSGroupset& groupset,
+                                             Vec x,
                                              PhiSTLOption which_phi)
 {
   std::vector<double>* y_ptr;
@@ -3030,7 +3032,7 @@ LBSSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset,
   }
 
   const double* x_ref;
-  VecGetArrayRead(x_src, &x_ref);
+  VecGetArrayRead(x, &x_ref);
 
   int gsi = groupset.groups_.front().id_;
   int gsf = groupset.groups_.back().id_;
@@ -3055,12 +3057,12 @@ LBSSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset,
     }     // for dof
   }       // for cell
 
-  VecRestoreArrayRead(x_src, &x_ref);
+  VecRestoreArrayRead(x, &x_ref);
 }
 
 void
-LBSSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
-                                         const std::vector<double>& x_src,
+LBSSolver::GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
+                                         const std::vector<double>& x,
                                          std::vector<double>& y)
 {
   int gsi = groupset.groups_.front().id_;
@@ -3077,7 +3079,7 @@ LBSSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
         size_t mapping = transport_view.MapDOF(i, m, gsi);
         for (int g = 0; g < gss; g++)
         {
-          y[mapping + g] = x_src[mapping + g];
+          y[mapping + g] = x[mapping + g];
         } // for g
       }   // for moment
     }     // for dof
@@ -3085,7 +3087,7 @@ LBSSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
 }
 
 void
-LBSSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
+LBSSolver::GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
                                          PhiSTLOption from_which_phi,
                                          PhiSTLOption to_which_phi)
 {
@@ -3174,11 +3176,11 @@ LBSSolver::SetGroupScopedPETScVecFromPrimarySTLvector(int first_group_id,
 void
 LBSSolver::SetPrimarySTLvectorFromGroupScopedPETScVec(int first_group_id,
                                                       int last_group_id,
-                                                      Vec x_src,
+                                                      Vec x,
                                                       std::vector<double>& y)
 {
   const double* x_ref;
-  VecGetArrayRead(x_src, &x_ref);
+  VecGetArrayRead(x, &x_ref);
 
   int gsi = first_group_id;
   int gsf = last_group_id;
@@ -3203,11 +3205,11 @@ LBSSolver::SetPrimarySTLvectorFromGroupScopedPETScVec(int first_group_id,
     }     // for dof
   }       // for cell
 
-  VecRestoreArrayRead(x_src, &x_ref);
+  VecRestoreArrayRead(x, &x_ref);
 }
 
 void
-LBSSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids,
+LBSSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& groupset_ids,
                                                   Vec x,
                                                   PhiSTLOption which_phi)
 {
@@ -3228,7 +3230,7 @@ LBSSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids
   VecGetArray(x, &x_ref);
 
   int64_t index = -1;
-  for (int gs_id : gs_ids)
+  for (int gs_id : groupset_ids)
   {
     const auto& groupset = groupsets_.at(gs_id);
 
@@ -3259,8 +3261,8 @@ LBSSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids
 }
 
 void
-LBSSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs_ids,
-                                                      Vec x_src,
+LBSSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& groupset_ids,
+                                                      Vec x,
                                                       PhiSTLOption which_phi)
 {
   std::vector<double>* y_ptr;
@@ -3277,10 +3279,10 @@ LBSSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs
   }
 
   const double* x_ref;
-  VecGetArrayRead(x_src, &x_ref);
+  VecGetArrayRead(x, &x_ref);
 
   int64_t index = -1;
-  for (int gs_id : gs_ids)
+  for (int gs_id : groupset_ids)
   {
     const auto& groupset = groupsets_.at(gs_id);
 
@@ -3307,7 +3309,7 @@ LBSSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs
     }       // for cell
   }         // for groupset id
 
-  VecRestoreArrayRead(x_src, &x_ref);
+  VecRestoreArrayRead(x, &x_ref);
 }
 
 } // namespace lbs

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -289,7 +289,7 @@ public:
   /**
    * Initializes default materials and physics materials.
    */
-  void InitMaterials();
+  void InitializeMaterials();
 
   /**Initializes the Within-Group DSA solver. */
   void InitWGDSA(LBSGroupset& groupset, bool vaccum_bcs_are_dirichlet = true);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -422,25 +422,25 @@ public:
    * Assembles a vector for a given groupset from a source vector.
    */
   virtual void
-  SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset, Vec x, PhiSTLOption which_phi);
+  SetGSPETScVecFromPrimarySTLvector(const LBSGroupset& groupset, Vec x, PhiSTLOption which_phi);
 
   /**
    * Assembles a vector for a given groupset from a source vector.
    */
   virtual void
-  SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset, Vec x_src, PhiSTLOption which_phi);
+  SetPrimarySTLvectorFromGSPETScVec(const LBSGroupset& groupset, Vec x, PhiSTLOption which_phi);
 
   /**
    * Assembles a vector for a given groupset from a source vector.
    */
-  virtual void GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
-                                             const std::vector<double>& x_src,
+  virtual void GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
+                                             const std::vector<double>& x,
                                              std::vector<double>& y);
 
   /**
    * Assembles a vector for a given groupset from a source vector.
    */
-  virtual void GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
+  virtual void GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
                                              PhiSTLOption from_which_phi,
                                              PhiSTLOption to_which_phi);
 
@@ -457,21 +457,21 @@ public:
    */
   virtual void SetPrimarySTLvectorFromGroupScopedPETScVec(int first_group_id,
                                                           int last_group_id,
-                                                          Vec x_src,
+                                                          Vec x,
                                                           std::vector<double>& y);
 
   /**
    * Assembles a PETSc vector from multiple groupsets.
    */
-  virtual void SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids,
+  virtual void SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& groupset_ids,
                                                       Vec x,
                                                       PhiSTLOption which_phi);
 
   /**
    * Disassembles a multiple Groupset PETSc vector STL vectors.
    */
-  virtual void SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs_ids,
-                                                          Vec x_src,
+  virtual void SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& groupset_ids,
+                                                          Vec x,
                                                           PhiSTLOption which_phi);
 
   /**

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -474,6 +474,13 @@ public:
                                                           Vec x_src,
                                                           PhiSTLOption which_phi);
 
+  /**
+   * A method for post-processing an adjoint solution.
+   *
+   * @note This does nothing for diffusion-based solvers.
+   */
+  virtual void ReorientAdjointSolution(){};
+
 protected:
   /**
    * Performs general input checks before initialization continues.

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
@@ -229,6 +229,8 @@ struct Options
 
   bool save_angular_flux = false;
 
+  bool adjoint = false;
+
   bool verbose_inner_iterations = true;
   bool verbose_ags_iterations = false;
   bool verbose_outer_iterations = true;

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -191,7 +191,7 @@ DiscreteOrdinatesSolver::ScalePhiVector(PhiSTLOption which_phi, double value)
 }
 
 void
-DiscreteOrdinatesSolver::SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset,
+DiscreteOrdinatesSolver::SetGSPETScVecFromPrimarySTLvector(const LBSGroupset& groupset,
                                                            Vec x,
                                                            PhiSTLOption which_phi)
 {
@@ -248,8 +248,8 @@ DiscreteOrdinatesSolver::SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset
 }
 
 void
-DiscreteOrdinatesSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset,
-                                                           Vec x_src,
+DiscreteOrdinatesSolver::SetPrimarySTLvectorFromGSPETScVec(const LBSGroupset& groupset,
+                                                           Vec x,
                                                            PhiSTLOption which_phi)
 {
   std::vector<double>* y_ptr;
@@ -266,7 +266,7 @@ DiscreteOrdinatesSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset
   }
 
   const double* x_ref;
-  VecGetArrayRead(x_src, &x_ref);
+  VecGetArrayRead(x, &x_ref);
 
   int gsi = groupset.groups_.front().id_;
   int gsf = groupset.groups_.back().id_;
@@ -300,11 +300,11 @@ DiscreteOrdinatesSolver::SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset
       groupset.angle_agg_->SetOldDelayedAngularDOFsFromArray(index, x_ref);
   }
 
-  VecRestoreArrayRead(x_src, &x_ref);
+  VecRestoreArrayRead(x, &x_ref);
 }
 
 void
-DiscreteOrdinatesSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
+DiscreteOrdinatesSolver::GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
                                                        PhiSTLOption from_which_phi,
                                                        PhiSTLOption to_which_phi)
 {
@@ -361,9 +361,8 @@ DiscreteOrdinatesSolver::GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
 }
 
 void
-DiscreteOrdinatesSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids,
-                                                                Vec x,
-                                                                PhiSTLOption which_phi)
+DiscreteOrdinatesSolver::SetMultiGSPETScVecFromPrimarySTLvector(
+  const std::vector<int>& groupset_ids, Vec x, PhiSTLOption which_phi)
 {
   const std::vector<double>* y_ptr;
   switch (which_phi)
@@ -382,7 +381,7 @@ DiscreteOrdinatesSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vecto
   VecGetArray(x, &x_ref);
 
   int64_t index = -1;
-  for (int gs_id : gs_ids)
+  for (int gs_id : groupset_ids)
   {
     auto& groupset = groupsets_.at(gs_id);
 
@@ -423,9 +422,8 @@ DiscreteOrdinatesSolver::SetMultiGSPETScVecFromPrimarySTLvector(const std::vecto
 }
 
 void
-DiscreteOrdinatesSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs_ids,
-                                                                    Vec x_src,
-                                                                    PhiSTLOption which_phi)
+DiscreteOrdinatesSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(
+  const std::vector<int>& groupset_ids, Vec x, PhiSTLOption which_phi)
 {
   std::vector<double>* y_ptr;
   switch (which_phi)
@@ -441,10 +439,10 @@ DiscreteOrdinatesSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::v
   }
 
   const double* x_ref;
-  VecGetArrayRead(x_src, &x_ref);
+  VecGetArrayRead(x, &x_ref);
 
   int64_t index = -1;
-  for (int gs_id : gs_ids)
+  for (int gs_id : groupset_ids)
   {
     auto& groupset = groupsets_.at(gs_id);
 
@@ -480,7 +478,7 @@ DiscreteOrdinatesSolver::SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::v
     }
   } // for groupset id
 
-  VecRestoreArrayRead(x_src, &x_ref);
+  VecRestoreArrayRead(x, &x_ref);
 }
 
 void

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -45,6 +45,10 @@ public:
   void SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs_ids,
                                                   Vec x_src,
                                                   PhiSTLOption which_phi) override;
+  /**
+   * Reorient an adjoint solution to account for backwards streaming.
+   */
+  void ReorientAdjointSolution() override;
 
   /**
    * Zeroes all the outflow data-structures required to compute

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -31,19 +31,20 @@ public:
   std::pair<size_t, size_t> GetNumPhiIterativeUnknowns() override;
   void Initialize() override;
   void ScalePhiVector(PhiSTLOption which_phi, double value) override;
-  void
-  SetGSPETScVecFromPrimarySTLvector(LBSGroupset& groupset, Vec x, PhiSTLOption which_phi) override;
-  void SetPrimarySTLvectorFromGSPETScVec(LBSGroupset& groupset,
-                                         Vec x_src,
+  void SetGSPETScVecFromPrimarySTLvector(const LBSGroupset& groupset,
+                                         Vec x,
                                          PhiSTLOption which_phi) override;
-  void GSScopedCopyPrimarySTLvectors(LBSGroupset& groupset,
+  void SetPrimarySTLvectorFromGSPETScVec(const LBSGroupset& groupset,
+                                         Vec x,
+                                         PhiSTLOption which_phi) override;
+  void GSScopedCopyPrimarySTLvectors(const LBSGroupset& groupset,
                                      PhiSTLOption from_which_phi,
                                      PhiSTLOption to_which_phi) override;
-  void SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& gs_ids,
+  void SetMultiGSPETScVecFromPrimarySTLvector(const std::vector<int>& groupset_ids,
                                               Vec x,
                                               PhiSTLOption which_phi) override;
-  void SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& gs_ids,
-                                                  Vec x_src,
+  void SetPrimarySTLvectorFromMultiGSPETScVecFrom(const std::vector<int>& groupset_ids,
+                                                  Vec x,
                                                   PhiSTLOption which_phi) override;
   /**
    * Reorient an adjoint solution to account for backwards streaming.

--- a/modules/linear_boltzmann_solvers/executors/lbs_steady_state.cc
+++ b/modules/linear_boltzmann_solvers/executors/lbs_steady_state.cc
@@ -51,6 +51,8 @@ SteadyStateSolver::Execute()
 
   if (lbs_solver_.Options().use_precursors) lbs_solver_.ComputePrecursors();
 
+  if (lbs_solver_.Options().adjoint) lbs_solver_.ReorientAdjointSolution();
+
   lbs_solver_.UpdateFieldFunctions();
 }
 

--- a/modules/mg_diffusion/mg_diffusion_solver.cc
+++ b/modules/mg_diffusion/mg_diffusion_solver.cc
@@ -209,11 +209,12 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
     // Check valid ids
     if (mat_id < 0)
     {
-      throw std::logic_error("MG-diff-InitMaterials: Cells encountered with no assigned material.");
+      throw std::logic_error(
+        "MG-diff-InitializeMaterials: Cells encountered with no assigned material.");
     }
     if (static_cast<size_t>(mat_id) >= num_physics_mats)
     {
-      throw std::logic_error("MG-diff-InitMaterials: Cells encountered with "
+      throw std::logic_error("MG-diff-InitializeMaterials: Cells encountered with "
                              "material id that matches no material in physics material library.");
     }
 
@@ -236,11 +237,12 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
 
         if (mg_source->source_value_g_.size() < num_groups_)
         {
-          log.LogAllWarning() << "MG-Diff-InitMaterials: Isotropic Multigroup source specified "
-                                 "in "
-                              << "material \"" << current_material->name_ << "\" has fewer "
-                              << "energy groups than called for in the simulation. "
-                              << "Source will be ignored.";
+          log.LogAllWarning()
+            << "MG-Diff-InitializeMaterials: Isotropic Multigroup source specified "
+               "in "
+            << "material \"" << current_material->name_ << "\" has fewer "
+            << "energy groups than called for in the simulation. "
+            << "Source will be ignored.";
         }
         else { matid_to_src_map[mat_id] = mg_source; }
       } // P0 source
@@ -249,7 +251,7 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
     // Check valid property
     if (!found_transport_xs)
     {
-      log.LogAllError() << "MG-Diff-InitMaterials: Found no transport cross-section property "
+      log.LogAllError() << "MG-Diff-InitializeMaterials: Found no transport cross-section property "
                            "for "
                         << "material \"" << current_material->name_ << "\".";
       Exit(EXIT_FAILURE);
@@ -257,8 +259,9 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
     // Check number of groups legal
     if (matid_to_xs_map[mat_id]->NumGroups() != num_groups_)
     {
-      log.LogAllError() << "MG-Diff-InitMaterials: Found material \"" << current_material->name_
-                        << "\" has " << matid_to_xs_map[mat_id]->NumGroups() << " groups and "
+      log.LogAllError() << "MG-Diff-InitializeMaterials: Found material \""
+                        << current_material->name_ << "\" has "
+                        << matid_to_xs_map[mat_id]->NumGroups() << " groups and "
                         << "the simulation has " << num_groups_ << " groups. The material "
                         << "must have the same number of groups.";
       Exit(EXIT_FAILURE);
@@ -267,8 +270,8 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
     // Check number of moments
     if (matid_to_xs_map[mat_id]->ScatteringOrder() > 1)
     {
-      log.Log0Warning() << "MG-Diff-InitMaterials: Found material \"" << current_material->name_
-                        << "\" has a scattering order of "
+      log.Log0Warning() << "MG-Diff-InitializeMaterials: Found material \""
+                        << current_material->name_ << "\" has a scattering order of "
                         << matid_to_xs_map[mat_id]->ScatteringOrder() << " and"
                         << " the simulation has a scattering order of One (MG-Diff)"
                         << " The higher moments will therefore not be used.";

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_1b_adjoint.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_1b_adjoint.lua
@@ -114,10 +114,11 @@ lbs_block = {
 
 lbs_options = {
     scattering_order = 1,
-    distributed_sources = { dsrc }
+    adjoint = true,
+    distributed_sources = { dsrc },
 }
 
-phys = lbs.DiscreteOrdinatesAdjointSolver.Create(lbs_block)
+phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
 --############################################### Initialize and Execute Solver

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_2b_adjoint.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_2b_adjoint.lua
@@ -100,10 +100,11 @@ lbs_block = {
 
 lbs_options = {
     scattering_order = 1,
+    adjoint = true,
     distributed_sources = { dsrc }
 }
 
-phys = lbs.DiscreteOrdinatesAdjointSolver.Create(lbs_block)
+phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
 --############################################### Initialize and Execute Solver

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_3b_adjoint.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/adjoint_2d_3b_adjoint.lua
@@ -115,10 +115,11 @@ lbs_block = {
 
 lbs_options = {
     scattering_order = 1,
+    adjoint = true,
     distributed_sources = { dsrc }
 }
 
-phys = lbs.DiscreteOrdinatesAdjointSolver.Create(lbs_block)
+phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
 --############################################### Initialize and Execute Solver


### PR DESCRIPTION
This PR introduces an adjoint option into the `LBSSolver`. This is primarily done as a first step towards separating response evaluations from the actual solver. The adjoint option was added to the `Options` struct, and to `LBSSolver::InputParameters` as well as routines for reorienting angles.

### Highlights

- Within `InitializeMaterials` a check is performed to determine if adjoint mode is on or off. This dictates whether `matid_to_xs_map` gets set with `SingleStateMGXS` or `AdjointMGXS`.
- When the `adjoint` option is specified via `SetOptions`, the routine explicitly looks it before going through other parameters because it is order sensitive. 
    - If the new flag is the same as the already set flag, nothing is done
    - If the flags are different and a discretization is not present, the solver has not been initialized and will be initialized in the appropriate form for an adjoint solve upon a call to the main `Initialize` routine.
    - If the flags are different and a discretization is present, the materials must be reinitialized, sources and boundary conditions cleared, and solutions zeroed out. This occurs within the `SetOptions` routine. The user is expected to pass the necessary source and boundary conditions with the adjoint option after initialization (as they are before). There is no good way to remove material sources, so one must be careful there.
- Tests updated to use the adjoint option.

### Notes

The previous adjoint solver pre-dated the executioner system. Its routine to reorient angles lived within its own execute routine. Since the executioner system, however, the `LBSSolver` have not implemented such a routine, which implies that the reorientation did not occur in the pre-existing adjoint solver. The tests passed because they were all scalar flux based, which does not get modified as a result of angle reorientation. The adjoint option implementation adds the reorientation routine to the base `LBSSolver`, where it does nothing, and then overrides it in the `DiscreteOrdinatesSolver` class. This allows for it to be called within the executioner system.