### PR TITLE
Using operators `and`, `or`, and `not` in boolean operations

### DIFF
--- a/framework/event_system/event.cc
+++ b/framework/event_system/event.cc
@@ -34,7 +34,7 @@ Event::Parameters() const
 bool
 Event::IsSolverEvent() const
 {
-  return (code_ >= SolverPreInitialize) && (code_ <= SolverAdvanced);
+  return (code_ >= SolverPreInitialize) and (code_ <= SolverAdvanced);
 }
 
 Event::EventCode

--- a/framework/field_functions/interpolation/ffinter_line.cc
+++ b/framework/field_functions/interpolation/ffinter_line.cc
@@ -163,7 +163,7 @@ FieldFunctionInterpolationLine::ExportPython(std::string base_name)
     }
     for (int p = 0; p < interpolation_points_.size(); p++)
     {
-      if ((not ff_ctx.interpolation_points_has_ass_cell[p]) && (opensn::mpi_comm.rank() != 0))
+      if ((not ff_ctx.interpolation_points_has_ass_cell[p]) and (opensn::mpi_comm.rank() != 0))
       {
         continue;
       }
@@ -181,7 +181,8 @@ FieldFunctionInterpolationLine::ExportPython(std::string base_name)
 
     ofile << offset << "done=True\n";
     ofile << "\n\n";
-    if ((opensn::mpi_comm.size() > 1) && (opensn::mpi_comm.rank() != (opensn::mpi_comm.size() - 1)))
+    if ((opensn::mpi_comm.size() > 1) and
+        (opensn::mpi_comm.rank() != (opensn::mpi_comm.size() - 1)))
     {
       ofile << offset << submod_name << ".AddData" << ff << "(data" << ff << ")\n";
     }
@@ -217,7 +218,8 @@ FieldFunctionInterpolationLine::ExportPython(std::string base_name)
     }
     ofile << offset << "done=True\n";
     ofile << "\n\n";
-    if ((opensn::mpi_comm.size() > 1) && (opensn::mpi_comm.rank() != (opensn::mpi_comm.size() - 1)))
+    if ((opensn::mpi_comm.size() > 1) and
+        (opensn::mpi_comm.rank() != (opensn::mpi_comm.size() - 1)))
     {
       ofile << offset << submod_name << ".AddData" << ff << "(data" << ff << ")\n";
     }

--- a/framework/field_functions/interpolation/ffinter_slice.cc
+++ b/framework/field_functions/interpolation/ffinter_slice.cc
@@ -156,7 +156,7 @@ FieldFunctionInterpolationSlice::Initialize()
             }
 
             // No duplicate
-            if (!duplicate_found)
+            if (not duplicate_found)
             {
               FFIFaceEdgeIntersection face_isds;
 
@@ -214,7 +214,7 @@ FieldFunctionInterpolationSlice::Initialize()
       cell_isds.intersections.push_back(unsorted_points[0]);
       unsorted_points.erase(unsorted_points.begin());
 
-      while (!unsorted_points.empty())
+      while (not unsorted_points.empty())
       {
         for (int p = 0; p < unsorted_points.size(); p++)
         {
@@ -235,7 +235,7 @@ FieldFunctionInterpolationSlice::Initialize()
             } // if not p
           }   // for pr
 
-          if (!illegal_value)
+          if (not illegal_value)
           {
             cell_isds.intersections.push_back(unsorted_points[p]);
             unsorted_points.erase(unsorted_points.begin() + p);

--- a/framework/logging/log.cc
+++ b/framework/logging/log.cc
@@ -78,7 +78,7 @@ Logger::Log(LOG_LVL level)
 
     case LOG_0VERBOSE_1:
     {
-      if ((opensn::mpi_comm.rank() == 0) && (verbosity_ >= 1))
+      if ((opensn::mpi_comm.rank() == 0) and (verbosity_ >= 1))
       {
         std::string header = "[" + std::to_string(opensn::mpi_comm.rank()) + "]  ";
         header += StringStreamColor(FG_CYAN);
@@ -92,7 +92,7 @@ Logger::Log(LOG_LVL level)
     }
     case Logger::LOG_LVL::LOG_0VERBOSE_2:
     {
-      if ((opensn::mpi_comm.rank() == 0) && (verbosity_ >= 2))
+      if ((opensn::mpi_comm.rank() == 0) and (verbosity_ >= 2))
       {
         std::string header = "[" + std::to_string(opensn::mpi_comm.rank()) + "]  ";
         header += StringStreamColor(FG_MAGENTA);

--- a/framework/logging/log_stream.cc
+++ b/framework/logging/log_stream.cc
@@ -13,7 +13,7 @@ LogStream::~LogStream()
   while (std::getline(*this, line))
     oline += log_header_ + line + '\n' + StringStreamColor(RESET);
 
-  if (!oline.empty()) *log_stream_ << oline << std::flush;
+  if (not oline.empty()) *log_stream_ << oline << std::flush;
 }
 
 } // namespace opensn

--- a/framework/math/math.cc
+++ b/framework/math/math.cc
@@ -103,7 +103,7 @@ SwapRow(size_t r1, size_t r2, MatDbl& A)
   size_t AC = 0;
   if (AR) AC = A[0].size();
 
-  assert(r1 >= 0 && r1 < AR && r2 >= 0 && r2 < AR);
+  assert(r1 >= 0 and r1 < AR and r2 >= 0 and r2 < AR);
 
   for (size_t j = 0; j < AC; j++)
     std::swap(A[r1][j], A[r2][j]);
@@ -116,7 +116,7 @@ SwapColumn(size_t c1, size_t c2, MatDbl& A)
   assert(A[0].size());
   size_t AR = A.size();
 
-  if (A.size()) assert(c1 >= 0 && c1 < A[0].size() && c2 >= 0 && c2 < A[0].size());
+  if (A.size()) assert(c1 >= 0 and c1 < A[0].size() and c2 >= 0 and c2 < A[0].size());
 
   for (size_t i = 0; i < AR; i++)
     std::swap(A[i][c1], A[i][c2]);
@@ -163,12 +163,12 @@ MatMul(const MatDbl& A, const MatDbl& B)
 {
   size_t AR = A.size();
 
-  assert(AR != 0 && B.size() != 0);
+  assert(AR != 0 and B.size() != 0);
 
   size_t AC = A[0].size();
   size_t BC = B[0].size();
 
-  assert(AC != 0 && BC != 0 && AC == B.size());
+  assert(AC != 0 and BC != 0 and AC == B.size());
 
   size_t CR = AR;
   size_t CC = BC;
@@ -190,13 +190,13 @@ MatAdd(const MatDbl& A, const MatDbl& B)
   size_t AR = A.size();
   size_t BR = A.size();
 
-  assert(AR != 0 && B.size() != 0);
+  assert(AR != 0 and B.size() != 0);
   assert(AR == BR);
 
   size_t AC = A[0].size();
   size_t BC = B[0].size();
 
-  assert(AC != 0 && BC != 0);
+  assert(AC != 0 and BC != 0);
   assert(AC == BC);
 
   MatDbl C(AR, VecDbl(AC, 0.0));
@@ -214,13 +214,13 @@ MatSubtract(const MatDbl& A, const MatDbl& B)
   size_t AR = A.size();
   size_t BR = A.size();
 
-  assert(AR != 0 && B.size() != 0);
+  assert(AR != 0 and B.size() != 0);
   assert(AR == BR);
 
   size_t AC = A[0].size();
   size_t BC = B[0].size();
 
-  assert(AC != 0 && BC != 0);
+  assert(AC != 0 and BC != 0);
   assert(AC == BC);
 
   MatDbl C(AR, VecDbl(AC, 0.0));
@@ -280,7 +280,7 @@ SubMatrix(const size_t r, const size_t c, const MatDbl& A)
   size_t C = 0;
   if (R) C = A[0].size();
 
-  assert((r >= 0) && (r < R) && (c >= 0) && (c < C));
+  assert((r >= 0) and (r < R) and (c >= 0) and (c < C));
 
   MatDbl B(R - 1, VecDbl(C - 1));
   for (size_t i = 0, ii = 0; i < R; ++i)
@@ -508,7 +508,7 @@ PowerIteration(const MatDbl& A, VecDbl& e_vec, int max_it, double tol)
 
   // Perform convergence loop
   bool converged = false;
-  while (!converged && it_counter < max_it)
+  while (!converged and it_counter < max_it)
   {
     // Update old eigenvalue
     lambda0 = std::fabs(lambda);

--- a/framework/math/math.cc
+++ b/framework/math/math.cc
@@ -508,7 +508,7 @@ PowerIteration(const MatDbl& A, VecDbl& e_vec, int max_it, double tol)
 
   // Perform convergence loop
   bool converged = false;
-  while (!converged and it_counter < max_it)
+  while (not converged and it_counter < max_it)
   {
     // Update old eigenvalue
     lambda0 = std::fabs(lambda);

--- a/framework/math/quadratures/cylindrical_angular_quadrature.cc
+++ b/framework/math/quadratures/cylindrical_angular_quadrature.cc
@@ -120,13 +120,13 @@ CylindricalAngularQuadrature::Initialize(const Quadrature& quad_polar,
 
     //  existence of zero-weight abscissae at the start and at the end of the
     //  interval
-    if (std::abs(azimu_quad.weights_.front()) > eps &&
+    if (std::abs(azimu_quad.weights_.front()) > eps and
         std::abs(azimu_quad.qpoints_.front()[0] - azimu_quad_span.first) > eps)
     {
       azimu_quad.weights_.emplace(azimu_quad.weights_.begin(), 0);
       azimu_quad.qpoints_.emplace(azimu_quad.qpoints_.begin(), azimu_quad_span.first);
     }
-    if (std::abs(azimu_quad.weights_.back()) > eps &&
+    if (std::abs(azimu_quad.weights_.back()) > eps and
         std::abs(azimu_quad.qpoints_.back()[0] - azimu_quad_span.second) > eps)
     {
       azimu_quad.weights_.emplace(azimu_quad.weights_.end(), 0);

--- a/framework/math/quadratures/cylindrical_angular_quadrature.cc
+++ b/framework/math/quadratures/cylindrical_angular_quadrature.cc
@@ -80,7 +80,7 @@ CylindricalAngularQuadrature::Initialize(const Quadrature& quad_polar,
                                 "polar quadrature weights sum to zero.");
 
   //  defined on range [-1;+1]
-  if (std::abs(polar_quad.GetRange().first - polar_quad_span.first) > eps ||
+  if (std::abs(polar_quad.GetRange().first - polar_quad_span.first) > eps or
       std::abs(polar_quad.GetRange().second - polar_quad_span.second) > eps)
     polar_quad.SetRange(polar_quad_span);
 
@@ -107,7 +107,7 @@ CylindricalAngularQuadrature::Initialize(const Quadrature& quad_polar,
                                   "azimuthal quadrature weights sum to zero.");
 
     //  defined on range [-1;+1]
-    if (std::abs(azimu_quad.GetRange().first - azimu_quad_span.first) > eps ||
+    if (std::abs(azimu_quad.GetRange().first - azimu_quad_span.first) > eps or
         std::abs(azimu_quad.GetRange().second - azimu_quad_span.second) > eps)
       azimu_quad.SetRange(azimu_quad_span);
 

--- a/framework/math/quadratures/jacobi/quadrature_jacobi.cc
+++ b/framework/math/quadratures/jacobi/quadrature_jacobi.cc
@@ -9,7 +9,7 @@ namespace opensn
 void
 QuadratureJacobi::Initialize(QuadratureOrder order)
 {
-  if ((m_alpha_ == 1) && (m_beta_ == 0))
+  if ((m_alpha_ == 1) and (m_beta_ == 0))
   {
     switch (order)
     {
@@ -755,9 +755,9 @@ QuadratureJacobi::Initialize(QuadratureOrder order)
         throw std::invalid_argument("Quadrature rule " + std::to_string((int)order) +
                                     " not supported!");
     } // end switch(_order + 2*p)
-  }   // end if ((_alpha == 1) && (_beta == 0))
+  }   // end if ((_alpha == 1) and (_beta == 0))
 
-  else if ((m_alpha_ == 2) && (m_beta_ == 0))
+  else if ((m_alpha_ == 2) and (m_beta_ == 0))
   {
 
     switch (order)

--- a/framework/math/quadratures/spherical_angular_quadrature.cc
+++ b/framework/math/quadratures/spherical_angular_quadrature.cc
@@ -67,13 +67,13 @@ SphericalAngularQuadrature::Initialize(const Quadrature& quad_polar, const bool 
 
   //  existence of zero-weight abscissae at the start and at the end of the
   //  interval
-  if (std::abs(polar_quad.weights_.front()) > eps &&
+  if (std::abs(polar_quad.weights_.front()) > eps and
       std::abs(polar_quad.qpoints_.front()[0] - polar_quad_span.first) > eps)
   {
     polar_quad.weights_.emplace(polar_quad.weights_.begin(), 0);
     polar_quad.qpoints_.emplace(polar_quad.qpoints_.begin(), polar_quad_span.first);
   }
-  if (std::abs(polar_quad.weights_.back()) > eps &&
+  if (std::abs(polar_quad.weights_.back()) > eps and
       std::abs(polar_quad.qpoints_.back()[0] - polar_quad_span.second) > eps)
   {
     polar_quad.weights_.emplace(polar_quad.weights_.end(), 0);

--- a/framework/math/quadratures/spherical_angular_quadrature.cc
+++ b/framework/math/quadratures/spherical_angular_quadrature.cc
@@ -54,7 +54,7 @@ SphericalAngularQuadrature::Initialize(const Quadrature& quad_polar, const bool 
                                 "polar quadrature weights sum to zero.");
 
   //  defined on range [-1;+1]
-  if (std::abs(polar_quad.GetRange().first - polar_quad_span.first) > eps ||
+  if (std::abs(polar_quad.GetRange().first - polar_quad_span.first) > eps or
       std::abs(polar_quad.GetRange().second - polar_quad_span.second) > eps)
     polar_quad.SetRange(polar_quad_span);
 

--- a/framework/math/quadratures/spherical_angular_quadrature.cc
+++ b/framework/math/quadratures/spherical_angular_quadrature.cc
@@ -61,7 +61,7 @@ SphericalAngularQuadrature::Initialize(const Quadrature& quad_polar, const bool 
   //  abscissae sorted in ascending order
   auto lt_qp = [](const QuadraturePointXYZ& qp0, const QuadraturePointXYZ& qp1)
   { return qp0[0] < qp1[0]; };
-  if (!std::is_sorted(polar_quad.qpoints_.begin(), polar_quad.qpoints_.end(), lt_qp))
+  if (not std::is_sorted(polar_quad.qpoints_.begin(), polar_quad.qpoints_.end(), lt_qp))
     throw std::invalid_argument("SphericalAngularQuadrature::Initialize : "
                                 "polar quadrature abscissae not in ascending order.");
 

--- a/framework/math/sparse_matrix/math_sparse_matrix.cc
+++ b/framework/math/sparse_matrix/math_sparse_matrix.cc
@@ -34,7 +34,7 @@ SparseMatrix::Insert(size_t i, size_t j, double value)
 {
   CheckInitialized();
 
-  if ((i < 0) || (i >= row_size_) || (j < 0) || (j >= col_size_))
+  if ((i < 0) or (i >= row_size_) or (j < 0) or (j >= col_size_))
   {
     log.LogAllError() << "SparseMatrix::Insert encountered out of bounds,"
                       << " i=" << i << " j=" << j << " bounds(" << row_size_ << "," << col_size_
@@ -62,7 +62,7 @@ SparseMatrix::InsertAdd(size_t i, size_t j, double value)
 {
   CheckInitialized();
 
-  if ((i < 0) || (i >= row_size_) || (j < 0) || (j >= col_size_))
+  if ((i < 0) or (i >= row_size_) or (j < 0) or (j >= col_size_))
   {
     log.LogAllError() << "SparseMatrix::Insert encountered out of bounds,"
                       << " i=" << i << " j=" << j << " bounds(" << row_size_ << "," << col_size_
@@ -122,7 +122,7 @@ double
 SparseMatrix::ValueIJ(size_t i, size_t j) const
 {
   double retval = 0.0;
-  if ((i < 0) || (i >= rowI_indices_.size()))
+  if ((i < 0) or (i >= rowI_indices_.size()))
   {
     log.LogAllError() << "Index i out of bounds"
                       << " in call to SparseMatrix::ValueIJ"

--- a/framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_polygon_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_polygon_mapping.cc
@@ -94,7 +94,7 @@ PieceWiseLinearPolygonMapping::TriShape(uint32_t index, const Vector3& qpoint, b
 {
   double xi;
   double eta;
-  if (!on_surface)
+  if (not on_surface)
   {
     xi = qpoint.x;
     eta = qpoint.y;

--- a/framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_slab_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/piecewise_linear/piecewise_linear_slab_mapping.cc
@@ -31,7 +31,7 @@ PieceWiseLinearSlabMapping::SlabShape(uint32_t index,
                                       uint32_t edge) const
 {
   double xi = 0.0;
-  if (!on_surface) xi = qpoint.x;
+  if (not on_surface) xi = qpoint.x;
   else
     xi = static_cast<double>(edge);
 

--- a/framework/math/spatial_discretization/finite_element/lagrange/lagrange_discontinuous.cc
+++ b/framework/math/spatial_discretization/finite_element/lagrange/lagrange_discontinuous.cc
@@ -302,7 +302,7 @@ LagrangeDiscontinuous::MapDOF(const Cell& cell,
       ++index;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "SpatialDiscretization_PWL::MapDFEMDOF. Mapping failed for cell "
                         << "with global index " << cell.global_id_ << " and partition-ID "
@@ -370,7 +370,7 @@ LagrangeDiscontinuous::MapDOFLocal(const Cell& cell,
       ++index;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "SpatialDiscretization_PWL::MapDFEMDOF. Mapping failed for cell "
                         << "with global index " << cell.global_id_ << " and partition-ID "

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
@@ -302,7 +302,7 @@ PieceWiseLinearDiscontinuous::MapDOF(const Cell& cell,
       ++index;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "SpatialDiscretization_PWL::MapDFEMDOF. Mapping failed for cell "
                         << "with global index " << cell.global_id_ << " and partition-ID "
@@ -370,7 +370,7 @@ PieceWiseLinearDiscontinuous::MapDOFLocal(const Cell& cell,
       ++index;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "SpatialDiscretization_PWL::MapDFEMDOF. Mapping failed for cell "
                         << "with global index " << cell.global_id_ << " and partition-ID "

--- a/framework/math/statistics/cdfsampler.cc
+++ b/framework/math/statistics/cdfsampler.cc
@@ -23,7 +23,7 @@ CDFSampler::SubIntvl::SubIntvl(std::string offset,
   cbin_i = ibin;
   cbin_f = fbin;
 
-  if (!inhibited)
+  if (not inhibited)
   {
     size_t cdf_size = cbin_f - cbin_i + 1;
     size_t intvl_size = ceil(cdf_size / (double)subdiv_factor);
@@ -220,7 +220,7 @@ SampleCDF(double x, std::vector<double> cdf_bin)
   //  refine_limit_reached = true;
   // Recursively refine
   int refine_count = 0;
-  while (!refine_limit_reached)
+  while (not refine_limit_reached)
   {
     int intvl_size = 0;
     if (x <= cdf_bin[indA]) refine_limit_reached = true;

--- a/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
+++ b/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
@@ -186,7 +186,7 @@ SurfaceMeshLogicalVolume::Inside(const Vector3& point) const
       } // for inner iter face
     }   // if sense negative
 
-    if ((closest_distance < distance_to_face) && closest_sense_pos) good_to_go = true;
+    if ((closest_distance < distance_to_face) and closest_sense_pos) good_to_go = true;
 
     if (!good_to_go) return false;
   } // for f

--- a/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
+++ b/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
@@ -136,7 +136,7 @@ SurfaceMeshLogicalVolume::Inside(const Vector3& point) const
         std::pair<double, double> weights;
         bool intersects_plane = CheckPlaneLineIntersect(
           surf_mesh->GetTriangles()[fi].geometric_normal, v0, point, fc, intp, &weights);
-        if (!intersects_plane) continue;
+        if (not intersects_plane) continue;
 
         // Check if the line intersects the triangle
         bool intersects_triangle = true;
@@ -168,7 +168,7 @@ SurfaceMeshLogicalVolume::Inside(const Vector3& point) const
         if (x1p.Dot(face_norm) < 0.0) intersects_triangle = false;
         if (x2p.Dot(face_norm) < 0.0) intersects_triangle = false;
 
-        if (!intersects_triangle) continue;
+        if (not intersects_triangle) continue;
 
         // Determine the sense with the triangle
         double sense_with_this_tri = p_to_fc.Dot(surf_mesh->GetTriangles()[fi].geometric_normal);
@@ -188,7 +188,7 @@ SurfaceMeshLogicalVolume::Inside(const Vector3& point) const
 
     if ((closest_distance < distance_to_face) and closest_sense_pos) good_to_go = true;
 
-    if (!good_to_go) return false;
+    if (not good_to_go) return false;
   } // for f
 
   return true;

--- a/framework/mesh/mesh_continuum/grid_vtk_utils.cc
+++ b/framework/mesh/mesh_continuum/grid_vtk_utils.cc
@@ -456,7 +456,7 @@ BuildCellMaterialIDsFromField(vtkUGridPtr& ugrid,
     auto cell_data = ugrid->GetCellData();
     const auto vtk_abstract_array_ptr = cell_data->GetAbstractArray(field_name.c_str());
 
-    if (!vtk_abstract_array_ptr)
+    if (not vtk_abstract_array_ptr)
     {
       log.Log0Warning() << "The VTU file : \"" << file_name << "\" "
                         << "does not contain a vtkCellData field of name : \"" << field_name
@@ -465,7 +465,7 @@ BuildCellMaterialIDsFromField(vtkUGridPtr& ugrid,
     }
 
     cell_id_array_ptr = vtkArrayDownCast<vtkDataArray>(vtk_abstract_array_ptr);
-    if (!cell_id_array_ptr)
+    if (not cell_id_array_ptr)
     {
       log.Log0Warning() << "The VTU file : \"" << file_name << "\" "
                         << "with vtkCellData field of name : \"" << field_name << "\" "

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -418,7 +418,7 @@ MeshContinuum::ExportCellsToExodus(const std::string& file_base_name,
 void
 MeshContinuum::ExportCellsToObj(const char* fileName, bool per_material, int options) const
 {
-  if (!per_material)
+  if (not per_material)
   {
     FILE* of = fopen(fileName, "w");
 
@@ -787,7 +787,7 @@ MeshContinuum::FindAssociatedVertices(const CellFace& cur_face,
       afv++;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "Face DOF mapping failed in call to "
                         << "MeshContinuum::FindAssociatedVertices. Could not find a matching"
@@ -827,7 +827,7 @@ MeshContinuum::FindAssociatedCellVertices(const CellFace& cur_face,
       ++acv;
     }
 
-    if (!found)
+    if (not found)
     {
       log.LogAllError() << "Face DOF mapping failed in call to "
                         << "MeshContinuum::FindAssociatedVertices. Could not find a matching"

--- a/framework/mesh/raytrace/raytracer.cc
+++ b/framework/mesh/raytrace/raytracer.cc
@@ -33,7 +33,7 @@ RayTracer::TraceRay(const Cell& cell, Vector3& pos_i, Vector3& omega_i, int func
     throw std::logic_error("Unsupported cell type encountered in call to "
                            "RayTrace.");
 
-  if (!intersection_found)
+  if (not intersection_found)
   {
     if (function_depth < 5)
     {
@@ -429,7 +429,7 @@ CheckLineIntersectStrip(const Vector3& strip_point0,
   bool intersects_plane = CheckPlaneLineIntersect(
     strip_normal, strip_point0, line_point0, line_point1, plane_intersection_point, &weights);
 
-  if (!intersects_plane) return false;
+  if (not intersects_plane) return false;
 
   Vector3 edge_vec = strip_point1 - strip_point0;
   Vector3 ints_vec1 = plane_intersection_point - strip_point0;

--- a/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/framework/mesh/surface_mesh/surface_mesh.cc
@@ -169,7 +169,7 @@ SurfaceMesh::UpdateInternalConnectivity()
 
         for (size_t e2 = 0; e2 < 3; e2++)
         {
-          if ((curface_edge[0] == other_face.e_index[e2][1]) &&
+          if ((curface_edge[0] == other_face.e_index[e2][1]) and
               (curface_edge[1] == other_face.e_index[e2][0]))
           {
             curface_edge[2] = ofi; // cell index
@@ -185,7 +185,7 @@ SurfaceMesh::UpdateInternalConnectivity()
 
         for (size_t e2 = 0; e2 < 3; e2++)
         {
-          if ((curface_edge[0] == other_face.e_index[e2][1]) &&
+          if ((curface_edge[0] == other_face.e_index[e2][1]) and
               (curface_edge[1] == other_face.e_index[e2][0]))
           {
             curface_edge[2] = ofi; // cell index
@@ -212,7 +212,7 @@ SurfaceMesh::UpdateInternalConnectivity()
 
         for (size_t e2 = 0; e2 < other_face->edges.size(); e2++)
         {
-          if ((curface_edge[0] == other_face->edges[e2][1]) &&
+          if ((curface_edge[0] == other_face->edges[e2][1]) and
               (curface_edge[1] == other_face->edges[e2][0]))
           {
             curface_edge[2] = ofi; // cell index
@@ -228,7 +228,7 @@ SurfaceMesh::UpdateInternalConnectivity()
 
         for (size_t e2 = 0; e2 < other_face->edges.size(); e2++)
         {
-          if ((curface_edge[0] == other_face->edges[e2][1]) &&
+          if ((curface_edge[0] == other_face->edges[e2][1]) and
               (curface_edge[1] == other_face->edges[e2][0]))
           {
             curface_edge[2] = ofi; // cell index
@@ -376,7 +376,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     if (first_word.compare("f") == 0)
     {
       int number_of_verts = std::count(file_line.begin(), file_line.end(), '/') / 2;
-      if ((number_of_verts == 3) && (!as_poly))
+      if ((number_of_verts == 3) and (!as_poly))
       {
         Face* newFace = new Face;
 

--- a/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/framework/mesh/surface_mesh/surface_mesh.cc
@@ -95,7 +95,7 @@ SurfaceMesh::ExtractOpenEdgesToObj(const char* fileName)
   std::ofstream outfile;
   outfile.open(fileName);
 
-  if (!outfile.is_open())
+  if (not outfile.is_open())
   {
     log.LogAllError() << "In call to SurfaceMesh::ExtractOpenEdgesToObj. Failed"
                       << " to open file: " << std::string(fileName);
@@ -247,7 +247,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
   // Opening the file
   std::ifstream file;
   file.open(fileName);
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << fileName << " in call "
                       << "to ImportFromOBJFile \n";
@@ -376,7 +376,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     if (first_word.compare("f") == 0)
     {
       int number_of_verts = std::count(file_line.begin(), file_line.end(), '/') / 2;
-      if ((number_of_verts == 3) and (!as_poly))
+      if ((number_of_verts == 3) and (not as_poly))
       {
         Face* newFace = new Face;
 
@@ -639,7 +639,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   // Opening the node file
   std::ifstream file;
   file.open(node_filename);
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << node_filename << " in call "
                       << "to ImportFromOBJFile \n";
@@ -664,7 +664,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
 
   // Opening the ele file
   file.open(tria_filename);
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << tria_filename << " in call "
                       << "to ImportFromOBJFile \n";
@@ -887,7 +887,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
   std::ifstream file;
   file.open(std::string(fileName));
 
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << fileName << " in call "
                       << "to ImportFromMshFiles \n";
@@ -903,7 +903,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
   std::getline(file, line);
   iss = std::istringstream(line);
   int num_nodes;
-  if (!(iss >> num_nodes))
+  if (not(iss >> num_nodes))
   {
     log.LogAllError() << "Failed while trying to read the number of nodes.\n";
     Exit(EXIT_FAILURE);
@@ -918,13 +918,13 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
 
     Vertex vertex;
     int vert_index;
-    if (!(iss >> vert_index))
+    if (not(iss >> vert_index))
     {
       log.LogAllError() << "Failed to read vertex index.\n";
       Exit(EXIT_FAILURE);
     }
 
-    if (!(iss >> vertex.x >> vertex.y >> vertex.z))
+    if (not(iss >> vertex.x >> vertex.y >> vertex.z))
     {
       log.LogAllError() << "Failed while reading the vertex coordinates.\n";
       Exit(EXIT_FAILURE);
@@ -943,7 +943,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
   std::getline(file, line);
   iss = std::istringstream(line);
   int num_elems;
-  if (!(iss >> num_elems))
+  if (not(iss >> num_elems))
   {
     log.LogAllError() << "Failed to read number of elements.\n";
     Exit(EXIT_FAILURE);
@@ -956,21 +956,21 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
     std::getline(file, line);
     iss = std::istringstream(line);
 
-    if (!(iss >> element_index >> elem_type >> num_tags))
+    if (not(iss >> element_index >> elem_type >> num_tags))
     {
       log.LogAllError() << "Failed while reading element index, element "
                            "type, and number of tags.\n";
       Exit(EXIT_FAILURE);
     }
 
-    if (!(iss >> physical_reg))
+    if (not(iss >> physical_reg))
     {
       log.LogAllError() << "Failed while reading physical region.\n";
       Exit(EXIT_FAILURE);
     }
 
     for (int i = 1; i < num_tags; i++)
-      if (!(iss >> tag))
+      if (not(iss >> tag))
       {
         log.LogAllError() << "Failed when reading tags.\n";
         Exit(EXIT_FAILURE);
@@ -982,7 +982,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
 
       int nodes[num_nodes];
       for (int i = 0; i < num_nodes; i++)
-        if (!(iss >> nodes[i]))
+        if (not(iss >> nodes[i]))
         {
           log.LogAllError() << "Failed when reading element node index.\n";
           Exit(EXIT_FAILURE);
@@ -998,7 +998,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
 
       int nodes[num_nodes];
       for (int& node : nodes)
-        if (!(iss >> node))
+        if (not(iss >> node))
         {
           log.LogAllError() << "Failed when reading element node index.\n";
           Exit(EXIT_FAILURE);
@@ -1089,7 +1089,7 @@ SurfaceMesh::ExportToOBJFile(const char* fileName)
     fprintf(outputFile, "l %d %d \n", lines_[ell].v_index[0] + 1, lines_[ell].v_index[1] + 1);
   }
 
-  if (!faces_.empty())
+  if (not faces_.empty())
   {
     Face first_face = this->faces_.front();
     fprintf(outputFile,
@@ -1109,7 +1109,7 @@ SurfaceMesh::ExportToOBJFile(const char* fileName)
               cur_face->v_index[2] + 1);
     }
   }
-  if (!poly_faces_.empty())
+  if (not poly_faces_.empty())
   {
     PolyFace* first_face = this->poly_faces_.front();
     fprintf(outputFile,
@@ -1445,7 +1445,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
     }
 
     // If no match found, create new list
-    if (!matchFound)
+    if (not matchFound)
     {
       printf("New list created\n");
       FaceList* new_list = new FaceList;
@@ -1522,7 +1522,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
         if (updateMade) { break; }
       }
 
-      if (!updateMade)
+      if (not updateMade)
       {
         FaceList* new_patch_list = new FaceList;
         inner_patch_list_collection.push_back(new_patch_list);

--- a/framework/mesh/sweep_utilities/angle_set/aah_angle_set.cc
+++ b/framework/mesh/sweep_utilities/angle_set/aah_angle_set.cc
@@ -37,7 +37,7 @@ AAH_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk,
 
   if (executed_)
   {
-    if (!async_comm_.DoneSending()) async_comm_.ClearDownstreamBuffers();
+    if (not async_comm_.DoneSending()) async_comm_.ClearDownstreamBuffers();
     return AngleSetStatus::FINISHED;
   }
 
@@ -79,7 +79,7 @@ AAH_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk,
 AngleSetStatus
 AAH_AngleSet::FlushSendBuffers()
 {
-  if (!async_comm_.DoneSending()) async_comm_.ClearDownstreamBuffers();
+  if (not async_comm_.DoneSending()) async_comm_.ClearDownstreamBuffers();
 
   if (async_comm_.DoneSending()) return AngleSetStatus::MESSAGES_SENT;
 

--- a/framework/mesh/sweep_utilities/communicators/aah_asyn_comm.cc
+++ b/framework/mesh/sweep_utilities/communicators/aah_asyn_comm.cc
@@ -293,7 +293,7 @@ AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
 
   // Resize FLUDS non-local incoming Data
   const size_t num_loc_deps = spds.GetLocationDependencies().size();
-  if (!upstream_data_initialized)
+  if (not upstream_data_initialized)
   {
     fluds_.AllocatePrelocIOutgoingPsi(num_groups_, num_angles_, num_loc_deps);
 
@@ -309,7 +309,7 @@ AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
     size_t num_mess = prelocI_message_count[prelocI];
     for (int m = 0; m < num_mess; m++)
     {
-      if (!prelocI_message_received[prelocI][m])
+      if (not prelocI_message_received[prelocI][m])
       {
         auto& comm = comm_set_.LocICommunicator(opensn::mpi_comm.rank());
         auto source = comm_set_.MapIonJ(locJ, opensn::mpi_comm.rank());
@@ -331,10 +331,10 @@ AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
       } // if not message already received
     }   // for message
 
-    if (!ready_to_execute) break;
+    if (not ready_to_execute) break;
   } // for predecessor
 
-  if (!ready_to_execute) return AngleSetStatus::RECEIVING;
+  if (not ready_to_execute) return AngleSetStatus::RECEIVING;
   else
     return AngleSetStatus::READY_TO_EXECUTE;
 }
@@ -371,7 +371,7 @@ AAH_ASynchronousCommunicator::SendDownstreamPsi(int angle_set_num)
 void
 AAH_ASynchronousCommunicator::InitializeLocalAndDownstreamBuffers()
 {
-  if (!data_initialized)
+  if (not data_initialized)
   {
     const auto& spds = fluds_.GetSPDS();
 

--- a/framework/mesh/sweep_utilities/fluds/aah_fluds.cc
+++ b/framework/mesh/sweep_utilities/fluds/aah_fluds.cc
@@ -60,7 +60,7 @@ AAH_FLUDS::NLOutgoingPsi(int outb_face_counter, int face_dof, int n)
   int index =
     nonlocal_psi_Gn_blockstride * num_groups_ * n + slot * num_groups_ + face_dof * num_groups_;
 
-  if ((index < 0) || (index > deplocI_outgoing_psi_[depLocI].size()))
+  if ((index < 0) or (index > deplocI_outgoing_psi_[depLocI].size()))
   {
     log.LogAllError() << "Invalid index " << index << " encountered in non-local outgoing Psi"
                       << " max allowed " << deplocI_outgoing_psi_[depLocI].size();

--- a/framework/mesh/sweep_utilities/fluds/aah_fluds_common_data.cc
+++ b/framework/mesh/sweep_utilities/fluds/aah_fluds_common_data.cc
@@ -194,7 +194,7 @@ AAH_FLUDSCommonData::SlotDynamics(const Cell& cell,
             break;
           }
         }
-        if (!found)
+        if (not found)
         {
           log.LogAllError() << "Lock-box location not found in call to "
                             << "InitializeAlphaElements. Local Cell " << cell.local_id_ << " face "
@@ -299,7 +299,7 @@ AAH_FLUDSCommonData::SlotDynamics(const Cell& cell,
       }
 
       // If an open slot was not found push a new one
-      if (!slot_found)
+      if (not slot_found)
       {
         outb_face_slot_indices.push_back(lock_box.size());
         lock_box.push_back(std::pair<int, short>(cell_g_index, f));
@@ -356,7 +356,7 @@ AAH_FLUDSCommonData::AddFaceViewToDepLocI(int deplocI,
   }
 
   // If the cell is not there yet
-  if (!cell_already_there)
+  if (not cell_already_there)
   {
     CompactCellView new_cell_view;
     new_cell_view.first = cell_g_index;
@@ -746,7 +746,7 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
               }
             }
 
-            if (!match_found)
+            if (not match_found)
             {
               log.LogAll() << "Associated vertex not found in call to "
                               "InitializeBetaElements";
@@ -805,7 +805,7 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
                 }
               }
 
-              if (!match_found)
+              if (not match_found)
               {
                 face_matches = false;
                 break;
@@ -841,7 +841,7 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
               }
             }
 
-            if (!match_found)
+            if (not match_found)
             {
               log.LogAll() << "Associated vertex not found in call to "
                               "InitializeBetaElements";

--- a/framework/mesh/sweep_utilities/fluds/aah_fluds_common_data.cc
+++ b/framework/mesh/sweep_utilities/fluds/aah_fluds_common_data.cc
@@ -163,14 +163,14 @@ AAH_FLUDSCommonData::SlotDynamics(const Cell& cell,
           int c = cell.local_id_;
           int d = face.GetNeighborLocalID(grid);
 
-          if ((a == c) && (b == d))
+          if ((a == c) and (b == d))
           {
             is_cyclic = true;
             inco_face_face_category.back() *= -1;
             inco_face_face_category.back() -= 1;
           }
 
-          if ((a == d) && (b == c))
+          if ((a == d) and (b == c))
           {
             is_cyclic = true;
             inco_face_face_category.back() *= -1;
@@ -186,7 +186,7 @@ AAH_FLUDSCommonData::SlotDynamics(const Cell& cell,
         bool found = false;
         for (auto& lock_box_slot : lock_box)
         {
-          if ((lock_box_slot.first == face.neighbor_id_) && (lock_box_slot.second == ass_face))
+          if ((lock_box_slot.first == face.neighbor_id_) and (lock_box_slot.second == ass_face))
           {
             lock_box_slot.first = -1;
             lock_box_slot.second = -1;
@@ -263,14 +263,14 @@ AAH_FLUDSCommonData::SlotDynamics(const Cell& cell,
           int c = cell.local_id_;
           int d = face.GetNeighborLocalID(grid);
 
-          if ((a == c) && (b == d))
+          if ((a == c) and (b == d))
           {
             temp_lock_box = &delayed_lock_box;
             outb_face_face_category.back() *= -1;
             outb_face_face_category.back() -= 1;
           }
 
-          if ((a == d) && (b == c))
+          if ((a == d) and (b == c))
           {
             temp_lock_box = &delayed_lock_box;
             outb_face_face_category.back() *= -1;

--- a/framework/mesh/sweep_utilities/sweep_boundary/boundary_reflecting.cc
+++ b/framework/mesh/sweep_utilities/sweep_boundary/boundary_reflecting.cc
@@ -51,7 +51,7 @@ BoundaryReflecting::CheckAnglesReadyStatus(const std::vector<size_t>& angles, si
   if (opposing_reflected_) return true;
   bool ready_flag = true;
   for (auto& n : angles)
-    if (!hetero_boundary_flux_[reflected_anglenum_[n]].empty())
+    if (not hetero_boundary_flux_[reflected_anglenum_[n]].empty())
       if (not angle_readyflags_[n][gs_ss]) return false;
 
   return ready_flag;

--- a/framework/mesh/sweep_utilities/sweep_scheduler/sweep_scheduler.cc
+++ b/framework/mesh/sweep_utilities/sweep_scheduler/sweep_scheduler.cc
@@ -163,7 +163,7 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
   // Loop till done
   bool finished = false;
   size_t scheduled_angleset = 0;
-  while (!finished)
+  while (not finished)
   {
     finished = true;
     for (auto& rule_value : rule_values_)

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -889,7 +889,7 @@ UnpartitionedMesh::ReadFromVTU(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
     throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromVTU"));
   file.close();
 
@@ -961,7 +961,7 @@ UnpartitionedMesh::ReadFromPVTU(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
     throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromPVTU"));
   file.close();
 
@@ -1033,7 +1033,7 @@ UnpartitionedMesh::ReadFromEnsightGold(const UnpartitionedMesh::Options& options
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
     throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromEnsightGold"));
   file.close();
 
@@ -1126,7 +1126,7 @@ UnpartitionedMesh::ReadFromWavefrontOBJ(const Options& options)
   // Opening the file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << options.file_name << " in call "
                       << "to ImportFromOBJFile \n";
@@ -1486,7 +1486,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
   // Opening the file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
   {
     log.LogAllError() << "Failed to open file: " << options.file_name << " in call "
                       << "to ReadFromMsh \n";
@@ -1511,7 +1511,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
   std::getline(file, file_line);
   iss = std::istringstream(file_line);
   double format;
-  if (!(iss >> format)) throw std::logic_error(fname + ": Failed to read the file format.");
+  if (not(iss >> format)) throw std::logic_error(fname + ": Failed to read the file format.");
   else if (format != 2.2)
     throw std::logic_error(fname + ": Currently, only msh format 2.2 is supported.");
 
@@ -1523,7 +1523,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
   std::getline(file, file_line);
   iss = std::istringstream(file_line);
   int num_nodes;
-  if (!(iss >> num_nodes))
+  if (not(iss >> num_nodes))
     throw std::logic_error(fname + ": Failed while trying to read "
                                    "the number of nodes.");
 
@@ -1536,10 +1536,10 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
     iss = std::istringstream(file_line);
 
     int vert_index;
-    if (!(iss >> vert_index)) throw std::logic_error(fname + ": Failed to read vertex index.");
+    if (not(iss >> vert_index)) throw std::logic_error(fname + ": Failed to read vertex index.");
 
-    if (!(iss >> vertices_[vert_index - 1].x >> vertices_[vert_index - 1].y >>
-          vertices_[vert_index - 1].z))
+    if (not(iss >> vertices_[vert_index - 1].x >> vertices_[vert_index - 1].y >>
+            vertices_[vert_index - 1].z))
       throw std::logic_error(fname + ": Failed while reading the vertex "
                                      "coordinates.");
   }
@@ -1550,7 +1550,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
   {
     std::vector<int> raw_nodes(num_nodes, 0);
     for (int i = 0; i < num_nodes; ++i)
-      if (!(iss >> raw_nodes[i]))
+      if (not(iss >> raw_nodes[i]))
         throw std::logic_error(fname + ": Failed when reading element "
                                        "node index.");
 
@@ -1628,7 +1628,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
   std::getline(file, file_line);
   iss = std::istringstream(file_line);
   int num_elems;
-  if (!(iss >> num_elems)) throw std::logic_error(fname + ": Failed to read number of elements.");
+  if (not(iss >> num_elems)) throw std::logic_error(fname + ": Failed to read number of elements.");
 
   for (int n = 0; n < num_elems; n++)
   {
@@ -1637,15 +1637,15 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
     std::getline(file, file_line);
     iss = std::istringstream(file_line);
 
-    if (!(iss >> element_index >> elem_type >> num_tags))
+    if (not(iss >> element_index >> elem_type >> num_tags))
       throw std::logic_error(fname + ": Failed while reading element index, "
                                      "element type, and number of tags.");
 
-    if (!(iss >> physical_reg))
+    if (not(iss >> physical_reg))
       throw std::logic_error(fname + ": Failed while reading physical region.");
 
     for (int i = 1; i < num_tags; i++)
-      if (!(iss >> tag)) throw std::logic_error(fname + ": Failed when reading tags.");
+      if (not(iss >> tag)) throw std::logic_error(fname + ": Failed when reading tags.");
 
     if (IsElementType3D(elem_type))
     {
@@ -1669,7 +1669,7 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
 
   std::getline(file, file_line);
   iss = std::istringstream(file_line);
-  if (!(iss >> num_elems)) throw std::logic_error(fname + ": Failed to read number of elements.");
+  if (not(iss >> num_elems)) throw std::logic_error(fname + ": Failed to read number of elements.");
 
   for (int n = 0; n < num_elems; n++)
   {
@@ -1678,15 +1678,15 @@ UnpartitionedMesh::ReadFromMsh(const Options& options)
     std::getline(file, file_line);
     iss = std::istringstream(file_line);
 
-    if (!(iss >> element_index >> elem_type >> num_tags))
+    if (not(iss >> element_index >> elem_type >> num_tags))
       throw std::logic_error(fname + ": Failed while reading element index, "
                                      "element type, and number of tags.");
 
-    if (!(iss >> physical_reg))
+    if (not(iss >> physical_reg))
       throw std::logic_error(fname + ": Failed while reading physical region.");
 
     for (int i = 1; i < num_tags; i++)
-      if (!(iss >> tag)) throw std::logic_error(fname + ": Failed when reading tags.");
+      if (not(iss >> tag)) throw std::logic_error(fname + ": Failed when reading tags.");
 
     if (elem_type == 15) // skip point type elements
       continue;
@@ -1855,7 +1855,7 @@ UnpartitionedMesh::ReadFromExodus(const UnpartitionedMesh::Options& options)
   // Attempt to open file
   std::ifstream file;
   file.open(options.file_name);
-  if (!file.is_open())
+  if (not file.is_open())
     throw std::runtime_error(ErrorReadingFileStr(options.file_name, "ReadFromExodus"));
   file.close();
 

--- a/framework/mesh/volume_mesher/volume_mesher.cc
+++ b/framework/mesh/volume_mesher/volume_mesher.cc
@@ -52,7 +52,7 @@ VolumeMesher::SetMatIDFromLogical(const LogicalVolume& log_vol, bool sense, int 
   int num_cells_modified = 0;
   for (auto& cell : vol_cont->local_cells)
   {
-    if (log_vol.Inside(cell.centroid_) && sense)
+    if (log_vol.Inside(cell.centroid_) and sense)
     {
       cell.material_id_ = mat_id;
       ++num_cells_modified;
@@ -63,7 +63,7 @@ VolumeMesher::SetMatIDFromLogical(const LogicalVolume& log_vol, bool sense, int 
   for (uint64_t ghost_id : ghost_ids)
   {
     auto& cell = vol_cont->cells[ghost_id];
-    if (log_vol.Inside(cell.centroid_) && sense) cell.material_id_ = mat_id;
+    if (log_vol.Inside(cell.centroid_) and sense) cell.material_id_ = mat_id;
   }
 
   int global_num_cells_modified;
@@ -97,7 +97,7 @@ VolumeMesher::SetBndryIDFromLogical(const LogicalVolume& log_vol,
     for (auto& face : cell.faces_)
     {
       if (face.has_neighbor_) continue;
-      if (log_vol.Inside(face.centroid_) && sense)
+      if (log_vol.Inside(face.centroid_) and sense)
       {
         face.neighbor_id_ = bndry_id;
         ++num_faces_modified;

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -239,7 +239,7 @@ FFInterpolationSetProperty(lua_State* L)
     int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);
     int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
 
-    if (!((op_type >= OP_SUM) and (op_type <= OP_MAX_FUNC)))
+    if (not((op_type >= OP_SUM) and (op_type <= OP_MAX_FUNC)))
     {
       opensn::log.LogAllError() << "Volume property FFI_PROP_OPERATION"
                                 << " used in FFInterpolationSetProperty. Unsupported OPERATON."

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -72,14 +72,14 @@ FFInterpolationSetProperty(lua_State* L)
                              " used in FFInterpolationSetProperty but FFI is not a point-probe.");
 
   // Check slice properties
-  if ((property >= FieldFunctionInterpolationProperty::SLICEPOINT) &&
+  if ((property >= FieldFunctionInterpolationProperty::SLICEPOINT) and
       (property <= FieldFunctionInterpolationProperty::SLICEBINORM))
     if (p_ffi->Type() != FieldFunctionInterpolationType::SLICE)
       throw std::logic_error("Slice property" + std::to_string(static_cast<int>(property)) +
                              " used in FFInterpolationSetProperty but FFI is not a slice.");
 
   // Check Line properties
-  if ((property >= FieldFunctionInterpolationProperty::FIRSTPOINT) &&
+  if ((property >= FieldFunctionInterpolationProperty::FIRSTPOINT) and
       (property <= FieldFunctionInterpolationProperty::NUMBEROFPOINTS))
     if (p_ffi->Type() != FieldFunctionInterpolationType::LINE)
       throw std::logic_error("Line property " + std::to_string(static_cast<int>(property)) +

--- a/lua/framework/mesh/surface_mesh/surface_mesh_check_cycles.cc
+++ b/lua/framework/mesh/surface_mesh/surface_mesh_check_cycles.cc
@@ -46,7 +46,7 @@ ComputeLoadBalancing(lua_State* L)
     opensn::GetStackItem<SurfaceMesh>(opensn::surface_mesh_stack, surf_handle, __FUNCTION__);
 
   // Extract x-cuts
-  if (!lua_istable(L, 2))
+  if (not lua_istable(L, 2))
   {
     opensn::log.LogAllError() << "In call to ComputeLoadBalancing: "
                               << " expected table for argument 2. Incompatible value supplied.";
@@ -65,7 +65,7 @@ ComputeLoadBalancing(lua_State* L)
   }
 
   // Extract y-cuts
-  if (!lua_istable(L, 3))
+  if (not lua_istable(L, 3))
   {
     opensn::log.LogAllError() << "In call to ComputeLoadBalancing: "
                               << " expected table for argument 3. Incompatible value supplied.";

--- a/lua/framework/mesh/volume_mesher/volume_mesher_set_property.cc
+++ b/lua/framework/mesh/volume_mesher/volume_mesher_set_property.cc
@@ -333,7 +333,7 @@ VolumeMesherSetProperty(lua_State* L)
 
   else if (property_index == VMP::MATID_FROMLOGICAL)
   {
-    if (!((num_args == 3) || (num_args == 4)))
+    if (!((num_args == 3) or (num_args == 4)))
     {
       opensn::log.LogAllError() << "Invalid amount of arguments used for "
                                    "VolumeMesherSetProperty("
@@ -353,7 +353,7 @@ VolumeMesherSetProperty(lua_State* L)
 
   else if (property_index == VMP::BNDRYID_FROMLOGICAL)
   {
-    if (!((num_args == 3) || (num_args == 4)))
+    if (!((num_args == 3) or (num_args == 4)))
     {
       opensn::log.LogAllError() << "Invalid amount of arguments used for "
                                    "VolumeMesherSetProperty("

--- a/lua/framework/mesh/volume_mesher/volume_mesher_set_property.cc
+++ b/lua/framework/mesh/volume_mesher/volume_mesher_set_property.cc
@@ -333,7 +333,7 @@ VolumeMesherSetProperty(lua_State* L)
 
   else if (property_index == VMP::MATID_FROMLOGICAL)
   {
-    if (!((num_args == 3) or (num_args == 4)))
+    if (not((num_args == 3) or (num_args == 4)))
     {
       opensn::log.LogAllError() << "Invalid amount of arguments used for "
                                    "VolumeMesherSetProperty("
@@ -353,7 +353,7 @@ VolumeMesherSetProperty(lua_State* L)
 
   else if (property_index == VMP::BNDRYID_FROMLOGICAL)
   {
-    if (!((num_args == 3) or (num_args == 4)))
+    if (not((num_args == 3) or (num_args == 4)))
     {
       opensn::log.LogAllError() << "Invalid amount of arguments used for "
                                    "VolumeMesherSetProperty("

--- a/lua/framework/physics/physics_material_properties.cc
+++ b/lua/framework/physics/physics_material_properties.cc
@@ -91,7 +91,7 @@ PhysicsMaterialAddProperty(lua_State* L)
   const std::string fname = __FUNCTION__;
   const int numArgs = lua_gettop(L);
 
-  if (!((numArgs >= 2) and (numArgs <= 3)))
+  if (not((numArgs >= 2) and (numArgs <= 3)))
   {
     opensn::log.Log0Error() << "Incorrect amount of arguments "
                                "in PhysicsMaterialAddProperty";
@@ -228,7 +228,7 @@ PhysicsMaterialSetProperty(lua_State* L)
   auto cur_material = opensn::GetStackItemPtr(opensn::material_stack, material_index, fname);
 
   // If user supplied name then find property index
-  if (!lua_isnumber(L, 2))
+  if (not lua_isnumber(L, 2))
   {
     for (auto& property : cur_material->properties_)
       if (property->property_name == property_index_name)
@@ -436,7 +436,7 @@ PhysicsMaterialSetProperty(lua_State* L)
       {
         if (numArgs != 4) LuaPostArgAmountError("PhysicsMaterialSetProperty", 4, numArgs);
 
-        if (!lua_istable(L, 4))
+        if (not lua_istable(L, 4))
         {
           opensn::log.LogAllError() << "In call to PhysicsMaterialSetProperty: "
                                     << "Material \"" << cur_material->name_ << "\", when setting "
@@ -510,7 +510,7 @@ PhysicsMaterialGetProperty(lua_State* L)
   auto cur_material = opensn::GetStackItemPtr(opensn::material_stack, material_index, fname);
 
   // If user supplied name then find property index
-  if (!lua_isnumber(L, 2))
+  if (not lua_isnumber(L, 2))
   {
     for (auto& property : cur_material->properties_)
       if (property->property_name == property_index_name)

--- a/lua/framework/physics/physics_material_properties.cc
+++ b/lua/framework/physics/physics_material_properties.cc
@@ -91,7 +91,7 @@ PhysicsMaterialAddProperty(lua_State* L)
   const std::string fname = __FUNCTION__;
   const int numArgs = lua_gettop(L);
 
-  if (!((numArgs >= 2) && (numArgs <= 3)))
+  if (!((numArgs >= 2) and (numArgs <= 3)))
   {
     opensn::log.Log0Error() << "Incorrect amount of arguments "
                                "in PhysicsMaterialAddProperty";

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_set_property.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_set_property.cc
@@ -76,7 +76,7 @@ LBSSetProperty(lua_State* L)
     const int bident = lua_tonumber(L, 3);
     const int btype = lua_tonumber(L, 4);
 
-    if (!((bident >= static_cast<int>(PropertyCode::XMAX)) &&
+    if (!((bident >= static_cast<int>(PropertyCode::XMAX)) and
           (bident <= static_cast<int>(PropertyCode::ZMIN))))
     {
       opensn::log.LogAllError() << "Unknown boundary identifier encountered "

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_set_property.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_set_property.cc
@@ -76,8 +76,8 @@ LBSSetProperty(lua_State* L)
     const int bident = lua_tonumber(L, 3);
     const int btype = lua_tonumber(L, 4);
 
-    if (!((bident >= static_cast<int>(PropertyCode::XMAX)) and
-          (bident <= static_cast<int>(PropertyCode::ZMIN))))
+    if (not((bident >= static_cast<int>(PropertyCode::XMAX)) and
+            (bident <= static_cast<int>(PropertyCode::ZMIN))))
     {
       opensn::log.LogAllError() << "Unknown boundary identifier encountered "
                                    "in call to LBSSetProperty";
@@ -104,7 +104,7 @@ LBSSetProperty(lua_State* L)
         opensn::Exit(EXIT_FAILURE);
       }
 
-      if (!lua_istable(L, 5))
+      if (not lua_istable(L, 5))
       {
         opensn::log.LogAllError() << "In call to LBSSetProperty, setting "
                                   << "incident isotropic flux boundary type,"

--- a/modules/dfem_diffusion/dfem_diffusion_solver.cc
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.cc
@@ -546,7 +546,7 @@ Solver::HPerpendicular(const Cell& cell, unsigned int f)
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;
-    else if (num_faces == 6 && num_vertices == 8) // Hex
+    else if (num_faces == 6 and num_vertices == 8) // Hex
       hp = volume / surface_area;
     else // Polyhedron
       hp = 6 * volume / surface_area;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion_mip_solver.cc
@@ -1201,7 +1201,7 @@ DiffusionMIPSolver::HPerpendicular(const Cell& cell, unsigned int f)
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;
-    else if (num_faces == 6 && num_vertices == 8) // Hex
+    else if (num_faces == 6 and num_vertices == 8) // Hex
       hp = volume / surface_area;
     else // Polyhedron
       hp = 6 * volume / surface_area;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/groupset/lbs_groupset.cc
@@ -205,13 +205,13 @@ void
 lbs::LBSGroupset::BuildDiscMomOperator(unsigned int scattering_order,
                                        lbs::GeometryType geometry_type)
 {
-  if (geometry_type == lbs::GeometryType::ONED_SLAB ||
-      geometry_type == lbs::GeometryType::ONED_CYLINDRICAL ||
+  if (geometry_type == lbs::GeometryType::ONED_SLAB or
+      geometry_type == lbs::GeometryType::ONED_CYLINDRICAL or
       geometry_type == lbs::GeometryType::ONED_SPHERICAL)
   {
     quadrature_->BuildDiscreteToMomentOperator(scattering_order, 1);
   }
-  else if (geometry_type == lbs::GeometryType::TWOD_CARTESIAN ||
+  else if (geometry_type == lbs::GeometryType::TWOD_CARTESIAN or
            geometry_type == lbs::GeometryType::TWOD_CYLINDRICAL)
   {
     quadrature_->BuildDiscreteToMomentOperator(scattering_order, 2);
@@ -226,13 +226,13 @@ void
 lbs::LBSGroupset::BuildMomDiscOperator(unsigned int scattering_order,
                                        lbs::GeometryType geometry_type)
 {
-  if (geometry_type == lbs::GeometryType::ONED_SLAB ||
-      geometry_type == lbs::GeometryType::ONED_CYLINDRICAL ||
+  if (geometry_type == lbs::GeometryType::ONED_SLAB or
+      geometry_type == lbs::GeometryType::ONED_CYLINDRICAL or
       geometry_type == lbs::GeometryType::ONED_SPHERICAL)
   {
     quadrature_->BuildMomentToDiscreteOperator(scattering_order, 1);
   }
-  else if (geometry_type == lbs::GeometryType::TWOD_CARTESIAN ||
+  else if (geometry_type == lbs::GeometryType::TWOD_CARTESIAN or
            geometry_type == lbs::GeometryType::TWOD_CYLINDRICAL)
   {
     quadrature_->BuildMomentToDiscreteOperator(scattering_order, 2);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_convergence_test.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_convergence_test.cc
@@ -52,7 +52,7 @@ GSConvergenceTest(KSP ksp, PetscInt n, PetscReal rnorm, KSPConvergedReason* conv
 
   // Print iteration information
   std::string offset;
-  if (context->groupset_.apply_wgdsa_ || context->groupset_.apply_tgdsa_)
+  if (context->groupset_.apply_wgdsa_ or context->groupset_.apply_tgdsa_)
     offset = std::string("    ");
 
   std::stringstream iter_info;

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
@@ -33,7 +33,7 @@ SweepChunk::SweepChunk(std::vector<double>& destination_phi,
     groupset_(groupset),
     xs_(xs),
     num_moments_(num_moments),
-    save_angular_flux_(!destination_psi.empty()),
+    save_angular_flux_(not destination_psi.empty()),
     sweep_dependency_interface_ptr_(std::move(sweep_dependency_interface_ptr)),
     sweep_dependency_interface_(*sweep_dependency_interface_ptr_),
     groupset_angle_group_stride_(groupset_.psi_uk_man_.NumberOfUnknowns() *

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
@@ -59,7 +59,7 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
   //  --------------------------------------------------------------------------
 
   //  coordinate system must be curvilinear
-  if (coord_system_type_ != CoordinateSystemType::CYLINDRICAL &&
+  if (coord_system_type_ != CoordinateSystemType::CYLINDRICAL and
       coord_system_type_ != CoordinateSystemType::SPHERICAL)
   {
     log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
@@ -129,7 +129,7 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
         typedef CylindricalAngularQuadrature CylAngQuad;
         const auto curvilinear_angular_quad_ptr =
           std::dynamic_pointer_cast<CylAngQuad>(angular_quad_ptr);
-        if (!curvilinear_angular_quad_ptr)
+        if (curvilinear_angular_quad_ptr == nullptr)
         {
           log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "
                             << "invalid angular quadrature, static_cast<int>(type) = "
@@ -144,7 +144,7 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
         typedef SphericalAngularQuadrature SphAngQuad;
         const auto curvilinear_angular_quad_ptr =
           std::dynamic_pointer_cast<SphAngQuad>(angular_quad_ptr);
-        if (!curvilinear_angular_quad_ptr)
+        if (curvilinear_angular_quad_ptr == nullptr)
         {
           log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "
                             << "invalid angular quadrature, static_cast<int>(type) = "
@@ -209,7 +209,7 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
   {
     for (const auto& face : cell.faces_)
     {
-      if (!face.has_neighbor_)
+      if (not face.has_neighbor_)
       {
         bool face_orthogonal = false;
         for (size_t d = 0; d < unit_normal_vectors.size(); ++d)
@@ -239,7 +239,7 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
             break;
           }
         }
-        if (!face_orthogonal)
+        if (not face_orthogonal)
         {
           log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "
                             << "mesh contains boundary faces not orthogonal with respect to "

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
@@ -42,7 +42,7 @@ SweepChunkPWLRZ::SweepChunkPWLRZ(
   const auto curvilinear_product_quadrature =
     std::dynamic_pointer_cast<CurvilinearAngularQuadrature>(groupset_.quadrature_);
 
-  if (!curvilinear_product_quadrature)
+  if (curvilinear_product_quadrature == nullptr)
     throw std::invalid_argument("D_DO_RZ_SteadyState::SweepChunkPWL::SweepChunkPWL : "
                                 "invalid angular quadrature");
 

--- a/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/d_do_transient/sweep_chunks/lbts_sweep_chunk_pwl.cc
@@ -33,7 +33,7 @@ lbs::SweepChunkPWLTransientTheta::SweepChunkPWLTransientTheta(
     num_moments_(num_moments),
     num_groups_(groupset.groups_.size()),
     max_num_cell_dofs_(max_num_cell_dofs),
-    save_angular_flux_(!destination_psi.empty()),
+    save_angular_flux_(not destination_psi.empty()),
     psi_prev_(psi_prev_ref),
     theta_(input_theta),
     dt_(time_step),
@@ -78,7 +78,7 @@ lbs::SweepChunkPWLTransientTheta::Upwinder::GetDownwindPsi(int fi,
 void
 lbs::SweepChunkPWLTransientTheta::Sweep(chi_mesh::sweep_management::AngleSet* angle_set)
 {
-  if (!a_and_b_initialized_)
+  if (not a_and_b_initialized_)
   {
     Amat_.resize(max_num_cell_dofs_, std::vector<double>(max_num_cell_dofs_));
     Atemp_.resize(max_num_cell_dofs_, std::vector<double>(max_num_cell_dofs_));

--- a/modules/mg_diffusion/mg_diffusion_solver.cc
+++ b/modules/mg_diffusion/mg_diffusion_solver.cc
@@ -305,7 +305,7 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
       {
         for (const auto& [row_g, gp, sigma_sm] : S.Row(g))
         {
-          if ((std::fabs(sigma_sm) > 1e-10) && (gp > row_g))
+          if ((std::fabs(sigma_sm) > 1e-10) and (gp > row_g))
             lfg = std::min(lfg, static_cast<unsigned int>(row_g));
         }
       }
@@ -316,7 +316,7 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Compute two-grid params
   do_two_grid_ = basic_options_("do_two_grid").BoolValue();
-  if ((lfg == num_groups_) && do_two_grid_)
+  if ((lfg == num_groups_) and do_two_grid_)
   {
     log.Log0Error() << "Two-grid is not possible with no upscattering.";
     do_two_grid_ = false;
@@ -761,7 +761,7 @@ Solver::Execute()
                 << std::setprecision(7) << thermal_error_all << std::endl;
 
     ++thermal_iteration;
-  } while ((thermal_error_all > thermal_tol) && (thermal_iteration < max_thermal_iters));
+  } while ((thermal_error_all > thermal_tol) and (thermal_iteration < max_thermal_iters));
 
   if (iverbose > 0)
   {

--- a/modules/mg_diffusion/mg_diffusion_solver.cc
+++ b/modules/mg_diffusion/mg_diffusion_solver.cc
@@ -249,7 +249,7 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
     }   // for property
 
     // Check valid property
-    if (!found_transport_xs)
+    if (not found_transport_xs)
     {
       log.LogAllError() << "MG-Diff-InitializeMaterials: Found no transport cross-section property "
                            "for "

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
@@ -36,7 +36,7 @@ math_SDM_Test01_Continuous(const InputParameters& input_parameters)
 {
   const ParameterBlock& params = input_parameters.GetParam("arg0");
 
-  const bool export_vtk = params.Has("export_vtk") && params.GetParamValue<bool>("export_vtk");
+  const bool export_vtk = params.Has("export_vtk") and params.GetParamValue<bool>("export_vtk");
 
   // Get grid
   auto grid_ptr = GetCurrentHandler().GetGrid();

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -51,7 +51,7 @@ math_SDM_Test02_DisContinuous(const InputParameters& input_parameters)
   const double penalty_factor =
     params.Has("penalty_factor") ? params.GetParamValue<double>("penalty_factor") : 4.0;
 
-  const bool export_vtk = params.Has("export_vtk") && params.GetParamValue<bool>("export_vtk");
+  const bool export_vtk = params.Has("export_vtk") and params.GetParamValue<bool>("export_vtk");
 
   // Get grid
   auto grid_ptr = GetCurrentHandler().GetGrid();
@@ -485,7 +485,7 @@ HPerpendicular(const CellMapping& cell_mapping, unsigned int f)
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;
-    else if (num_faces == 6 && num_vertices == 8) // Hex
+    else if (num_faces == 6 and num_vertices == 8) // Hex
       hp = volume / surface_area;
     else // Polyhedron
       hp = 6 * volume / surface_area;


### PR DESCRIPTION
This PR replaces `&&`, `||` and `!` in boolean operations so that the code conforms to coding standard.