### PR TITLE
Adding input path to runtime. Changing default split mesh file prefix.

### DIFF
--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -40,9 +40,8 @@ SplitFileMeshGenerator::GetInputParameters()
     "split_mesh",
     "Path of the directory to be created for containing the split meshes.");
 
-  params.AddOptionalParameter("split_file_prefix",
-                              opensn::input_path.stem().string(),
-                              "Prefix to use for all split mesh files");
+  params.AddOptionalParameter(
+    "file_prefix", opensn::input_path.stem().string(), "Prefix to use for all split mesh files");
 
   params.AddOptionalParameter(
     "read_only", false, "Controls whether the split mesh is recreated or just read.");
@@ -60,7 +59,7 @@ SplitFileMeshGenerator::SplitFileMeshGenerator(const InputParameters& params)
   : MeshGenerator(params),
     num_parts_(params.GetParamValue<int>("num_partitions")),
     split_mesh_dir_path_(params.GetParamValue<std::string>("split_mesh_dir_path")),
-    split_file_prefix_(params.GetParamValue<std::string>("split_file_prefix")),
+    file_prefix_(params.GetParamValue<std::string>("file_prefix")),
     read_only_(params.GetParamValue<bool>("read_only")),
     verbosity_level_(params.GetParamValue<int>("verbosity_level"))
 {
@@ -149,7 +148,7 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
   {
     t_write.TimeSectionBegin();
     const std::filesystem::path file_path =
-      dir_path.string() + "/" + split_file_prefix_ + "_" + std::to_string(pid) + ".cmesh";
+      dir_path.string() + "/" + file_prefix_ + "_" + std::to_string(pid) + ".cmesh";
 
     std::ofstream ofile(file_path.string(), std::ios_base::binary | std::ios_base::out);
 
@@ -316,7 +315,7 @@ SplitFileMeshGenerator::ReadSplitMesh()
   const int pid = opensn::mpi_comm.rank();
   const std::filesystem::path dir_path = std::filesystem::absolute(split_mesh_dir_path_);
   const std::filesystem::path file_path =
-    dir_path.string() + "/" + split_file_prefix_ + "_" + std::to_string(pid) + ".cmesh";
+    dir_path.string() + "/" + file_prefix_ + "_" + std::to_string(pid) + ".cmesh";
 
   SplitMeshInfo info_block;
   auto& cells = info_block.cells_;
@@ -329,9 +328,8 @@ SplitFileMeshGenerator::ReadSplitMesh()
   const size_t file_num_parts = ReadBinaryValue<int>(ifile);
 
   ChiLogicalErrorIf(opensn::mpi_comm.size() != file_num_parts,
-                    "Split mesh files with prefix \"" + split_file_prefix_ +
-                      "\" has been created with " + std::to_string(file_num_parts) +
-                      " parts but is now being read with " +
+                    "Split mesh files with prefix \"" + file_prefix_ + "\" has been created with " +
+                      std::to_string(file_num_parts) + " parts but is now being read with " +
                       std::to_string(opensn::mpi_comm.size()) + " processes.");
 
   info_block.mesh_attributes_ = ReadBinaryValue<int>(ifile);

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -40,8 +40,9 @@ SplitFileMeshGenerator::GetInputParameters()
     "split_mesh",
     "Path of the directory to be created for containing the split meshes.");
 
-  params.AddOptionalParameter(
-    "split_file_prefix", "split_mesh", "Prefix to use for all split mesh files");
+  params.AddOptionalParameter("split_file_prefix",
+                              opensn::input_path.stem().string(),
+                              "Prefix to use for all split mesh files");
 
   params.AddOptionalParameter(
     "read_only", false, "Controls whether the split mesh is recreated or just read.");

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -42,7 +42,7 @@ protected:
   // void
   const int num_parts_;
   const std::string split_mesh_dir_path_;
-  const std::string split_file_prefix_;
+  const std::string file_prefix_;
   const bool read_only_;
   const int verbosity_level_;
 };

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -45,6 +45,7 @@ std::vector<std::shared_ptr<PostProcessor>> postprocessor_stack;
 std::vector<std::shared_ptr<Function>> function_stack;
 
 bool suppress_color = false;
+std::filesystem::path input_path;
 
 int
 Initialize()

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <stdexcept>
 #include <memory>
+#include <filesystem>
 #include "mpicpp-lite/mpicpp-lite.h"
 
 namespace mpi = mpicpp_lite;
@@ -57,6 +58,7 @@ extern std::vector<std::shared_ptr<Function>> function_stack;
 const size_t SIZE_T_INVALID = ((size_t)-1);
 
 extern bool suppress_color;
+extern std::filesystem::path input_path;
 
 /**Customized exceptions.*/
 class RecoverableException : public std::runtime_error

--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -142,7 +142,7 @@ LuaApp::ParseArguments(int argc, char** argv)
     } //-v
     else if ((argument.find('=') == std::string::npos) and (not input_file_found))
     {
-      input_file_name_ = argument;
+      opensn::input_path = argument;
       input_file_found = true;
       sim_option_interactive_ = false;
     } // no =
@@ -176,13 +176,11 @@ LuaApp::RunInteractive(int argc, char** argv)
 
   console.FlushConsole();
 
-  const auto& input_fname = input_file_name_;
-
-  if (not input_fname.empty())
+  if (std::filesystem::exists(input_path))
   {
     try
     {
-      console.ExecuteFile(input_fname, argc, argv);
+      console.ExecuteFile(opensn::input_path.string(), argc, argv);
     }
     catch (const std::exception& excp)
     {
@@ -190,6 +188,8 @@ LuaApp::RunInteractive(int argc, char** argv)
       // No quitting if file execution fails
     }
   }
+  else
+    opensn::log.Log0Error() << "Could not open file " << opensn::input_path.string() << ".";
 
   console.RunConsoleLoop();
 
@@ -232,14 +232,13 @@ LuaApp::RunBatch(int argc, char** argv)
   mpi_comm.barrier();
 #endif
 
-  const auto& input_fname = input_file_name_;
   int error_code = 0;
 
-  if ((not input_fname.empty()) and (not termination_posted_))
+  if (std::filesystem::exists(input_path) and (not termination_posted_))
   {
     try
     {
-      error_code = console.ExecuteFile(input_fname, argc, argv);
+      error_code = console.ExecuteFile(opensn::input_path.string(), argc, argv);
     }
     catch (const std::exception& excp)
     {
@@ -247,12 +246,17 @@ LuaApp::RunBatch(int argc, char** argv)
       Exit(EXIT_FAILURE);
     }
   }
+  else
+  {
+    opensn::log.Log0Error() << "Could not open file " << opensn::input_path.string() << ".";
+    Exit(EXIT_FAILURE);
+  }
 
   if (not supress_beg_end_timelog_)
   {
     opensn::log.Log() << "\nFinal program time " << program_timer.GetTimeString();
     opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
-                      << " finished execution of " << input_file_name_;
+                      << " finished execution of " << opensn::input_path.string();
   }
 
   return error_code;

--- a/lua/framework/lua_app.h
+++ b/lua/framework/lua_app.h
@@ -33,7 +33,6 @@ protected:
 private:
   // run_time quantities
   bool termination_posted_ = false;
-  std::string input_file_name_;
   bool sim_option_interactive_ = true;
   bool allow_petsc_error_handler_ = false;
   bool supress_beg_end_timelog_ = false;

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -409,8 +409,7 @@
         "gold": 7.340585e-04,
         "tol": 1.0e-9
       }
-    ],
-    "skip": "Failing because of shared 'split_mesh' directory.  - WDH"
+    ]
   },
   {
     "file": "transport_3d_6b_split_mesh.lua",


### PR DESCRIPTION
This PR adds the input path to the openSn runtime as a `std::filesystem::path` object. This allows us to use the input path and filename stem throughout the code. In this case, I'm using the input filename stem as the default prefix for split mesh files. This prevents a whole host of issues when using the same filename prefix across multiple runs. IMHO, we should be using the input file stem for all files generated by the code instead of generic names that lack provenance.

This should fix the race condition encountered with the split file regression tests, and I have re-enabled the offending test.

There may already be a Lua method for grabbing the input file path from the command-line.  I'm not very familiar with Lua or the Lua interface yet. If such a method exists, I'm happy to use it in place of the changes I've made here.