### PR TITLE
Do not manipulate directory name with extracted sources in configure_dependencies.py

### DIFF
--- a/resources/configure_dependencies.py
+++ b/resources/configure_dependencies.py
@@ -48,7 +48,7 @@ error_end = TextColors.ENDC
 
 # Process commandline arguments
 arguments_help = textwrap.dedent('''\
-Run the dependency builder. 
+Run the dependency builder.
 ''')
 
 parser = argparse.ArgumentParser(
@@ -196,15 +196,6 @@ def ExtractPackage(pkg, ver):
 
     if not success:
         raise RuntimeError(err)
-
-    # Check if folder defaulted to upper
-    if os.path.exists(f"{pkg.upper()}-{ver}") and not os.path.exists(f"{pkg}-{ver}"):
-        success, err, outstr = ExecSub(f"mv {pkg.upper()}-{ver}/ {pkg}-{ver}/", log_file)
-
-        if not success:
-            raise RuntimeError(err)
-
-    os.chdir(f"{pkg}-{ver}")
 
 
 # Install command for ncurses and readline


### PR DESCRIPTION
If the directory name with extracted sources was all upper case, it was changed to lower case. This caused the build process to fail on case-sensitive file systems, since the build process honors the choice the package developers picked for the names of directories.
    
Closes #147