### PR TITLE
Removing custom relative convergence test

### DIFF
--- a/framework/math/petsc_utils/petsc_utils.cc
+++ b/framework/math/petsc_utils/petsc_utils.cc
@@ -116,37 +116,11 @@ CreateCommonKrylovSolverSetup(Mat ref_matrix,
     setup.ksp, 1.e-50, in_relative_residual_tolerance, 1.0e50, in_maximum_iterations);
   KSPSetInitialGuessNonzero(setup.ksp, PETSC_TRUE);
 
-  KSPSetConvergenceTest(setup.ksp, &RelativeResidualConvergenceTest, nullptr, nullptr);
   KSPSetFromOptions(setup.ksp);
 
   KSPMonitorSet(setup.ksp, &KSPMonitorRelativeToRHS, nullptr, nullptr);
 
   return setup;
-}
-
-PetscErrorCode
-RelativeResidualConvergenceTest(
-  KSP ksp, PetscInt, PetscReal rnorm, KSPConvergedReason* convergedReason, void*)
-{
-  // Compute rhs norm
-  Vec Rhs;
-  KSPGetRhs(ksp, &Rhs);
-  double rhs_norm;
-  VecNorm(Rhs, NORM_2, &rhs_norm);
-  if (rhs_norm < 1.0e-12)
-    rhs_norm = 1.0;
-
-  // Compute test criterion
-  double tol;
-  int64_t maxIts;
-  KSPGetTolerances(ksp, nullptr, &tol, nullptr, &maxIts);
-
-  double relative_residual = rnorm / rhs_norm;
-
-  if (relative_residual < tol)
-    *convergedReason = KSP_CONVERGED_RTOL;
-
-  return KSP_CONVERGED_ITERATING;
 }
 
 PetscErrorCode

--- a/framework/math/petsc_utils/petsc_utils.cc
+++ b/framework/math/petsc_utils/petsc_utils.cc
@@ -153,29 +153,6 @@ KSPMonitorRelativeToRHS(KSP ksp, PetscInt n, PetscReal rnorm, void*)
   return 0;
 }
 
-PetscErrorCode
-KSPMonitorStraight(KSP ksp, PetscInt n, PetscReal rnorm, void*)
-{
-  // Get solver name
-  const char* ksp_name;
-  KSPGetOptionsPrefix(ksp, &ksp_name);
-
-  // Default to this if ksp_name is NULL
-  const char NONAME_SOLVER[] = "NoName-Solver\0";
-
-  if (ksp_name == nullptr)
-    ksp_name = NONAME_SOLVER;
-
-  // Print message
-  std::stringstream buff;
-  buff << ksp_name << " iteration " << std::setw(4) << n << " - Residual " << std::scientific
-       << std::setprecision(7) << rnorm << std::endl;
-
-  log.Log() << buff.str();
-
-  return 0;
-}
-
 void
 CopyVecToSTLvector(Vec x, std::vector<double>& data, size_t N, bool resize_STL)
 {

--- a/framework/math/petsc_utils/petsc_utils.h
+++ b/framework/math/petsc_utils/petsc_utils.h
@@ -182,12 +182,6 @@ PETScSolverSetup CreateCommonKrylovSolverSetup(Mat ref_matrix,
 PetscErrorCode KSPMonitorRelativeToRHS(KSP ksp, PetscInt n, PetscReal rnorm, void*);
 
 /**
- * General monitor that print the residual norm relative to the
- * right-hand side norm.
- */
-PetscErrorCode KSPMonitorStraight(KSP ksp, PetscInt n, PetscReal rnorm, void*);
-
-/**
  * Copies a PETSc vector to a STL vector. Only the local portion is copied.
  */
 void CopyVecToSTLvector(Vec x, std::vector<double>& data, size_t N, bool resize_STL = true);

--- a/framework/math/petsc_utils/petsc_utils.h
+++ b/framework/math/petsc_utils/petsc_utils.h
@@ -165,7 +165,6 @@ void InitMatrixSparsity(Mat& A, int64_t nodal_nnz_in_diag, int64_t nodal_nnz_off
  * KSPSetInitialGuessNonzero(setup.ksp,PETSC_TRUE);
  *
  * KSPMonitorSet(setup.ksp,&KSPMonitorRelativeToRHS,NULL,NULL);
- * KSPSetConvergenceTest(setup.ksp,&RelativeResidualConvergenceTest,NULL,NULL);
  *
  * return setup;
  * \endcode
@@ -176,18 +175,6 @@ PETScSolverSetup CreateCommonKrylovSolverSetup(Mat ref_matrix,
                                                const std::string& in_preconditioner_type = PCNONE,
                                                double in_relative_residual_tolerance = 1.0e-6,
                                                int64_t in_maximum_iterations = 100);
-
-/**
- * Relative Residual Convergence test. The test uses the L2-norm of the residual
- * (\f$ ||b-Ax||_2 \f$), divided by the L2-norm of the right hand side (\f$ ||b||_2 \f$) compared
- * to a tolerance, \f$ \epsilon \f$.
- * \f[
- *  \frac{||b-Ax||_2}{||b||_2} < \epsilon
- * \f]
- *
- */
-PetscErrorCode RelativeResidualConvergenceTest(
-  KSP ksp, PetscInt n, PetscReal rnorm, KSPConvergedReason* convergedReason, void* monitordestroy);
 
 /**
  * General monitor that print the residual norm relative to the right-hand side norm.

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/acceleration/diffusion.cc
@@ -208,8 +208,6 @@ DiffusionSolver::Solve(std::vector<double>& solution, bool use_initial_guess)
 
   if (options.verbose)
   {
-    KSPSetConvergenceTest(ksp_, &RelativeResidualConvergenceTest, nullptr, nullptr);
-
     KSPMonitorSet(ksp_, &KSPMonitorRelativeToRHS, nullptr, nullptr);
 
     double rhs_norm;
@@ -282,8 +280,6 @@ DiffusionSolver::Solve(Vec petsc_solution, bool use_initial_guess)
 
   if (options.verbose)
   {
-    KSPSetConvergenceTest(ksp_, &RelativeResidualConvergenceTest, nullptr, nullptr);
-
     KSPMonitorSet(ksp_, &KSPMonitorRelativeToRHS, nullptr, nullptr);
 
     double rhs_norm;

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
@@ -152,7 +152,7 @@ math_SDM_Test01_Continuous(const InputParameters& input_parameters)
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
   auto petsc_solver =
-    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCHYPRE, 1.0e-6, 1000);
+    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCHYPRE, 1.0e-9, 1000);
 
   PC pc;
   KSPGetPC(petsc_solver.ksp, &pc);

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -346,7 +346,7 @@ math_SDM_Test02_DisContinuous(const InputParameters& input_parameters)
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
   auto petsc_solver =
-    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCHYPRE, 1.0e-6, 1000);
+    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCHYPRE, 1.0e-9, 1000);
 
   PC pc;
   KSPGetPC(petsc_solver.ksp, &pc);

--- a/test/framework/tutorials/fv_test1.cc
+++ b/test/framework/tutorials/fv_test1.cc
@@ -111,7 +111,7 @@ SimTest01_FV(const InputParameters&)
 
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
-  auto petsc_solver = CreateCommonKrylovSolverSetup(A, "FVDiffSolver", KSPCG, PCGAMG, 1.0e-6, 1000);
+  auto petsc_solver = CreateCommonKrylovSolverSetup(A, "FVDiffSolver", KSPCG, PCGAMG, 1.0e-9, 1000);
 
   // Solve
   KSPSolve(petsc_solver.ksp, b, x);

--- a/test/framework/tutorials/fv_test2.cc
+++ b/test/framework/tutorials/fv_test2.cc
@@ -112,7 +112,7 @@ SimTest02_FV(const InputParameters&)
 
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
-  auto petsc_solver = CreateCommonKrylovSolverSetup(A, "FVDiffSolver", KSPCG, PCGAMG, 1.0e-6, 1000);
+  auto petsc_solver = CreateCommonKrylovSolverSetup(A, "FVDiffSolver", KSPCG, PCGAMG, 1.0e-9, 1000);
 
   // Solve
   KSPSolve(petsc_solver.ksp, b, x);

--- a/test/framework/tutorials/pwlc_test1.cc
+++ b/test/framework/tutorials/pwlc_test1.cc
@@ -137,7 +137,7 @@ SimTest03_PWLC(const InputParameters&)
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
   auto petsc_solver =
-    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCGAMG, 1.0e-6, 1000);
+    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCGAMG, 1.0e-9, 1000);
 
   // Solve
   KSPSolve(petsc_solver.ksp, b, x);

--- a/test/framework/tutorials/pwlc_test2.cc
+++ b/test/framework/tutorials/pwlc_test2.cc
@@ -182,7 +182,7 @@ SimTest04_PWLC(const InputParameters& params)
   // Create Krylov Solver
   opensn::log.Log() << "Solving: ";
   auto petsc_solver =
-    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCGAMG, 1.0e-6, 1000);
+    CreateCommonKrylovSolverSetup(A, "PWLCDiffSolver", KSPCG, PCGAMG, 1.0e-9, 1000);
 
   // Solve
   KSPSolve(petsc_solver.ksp, b, x);

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
@@ -52,6 +52,7 @@ CFEMDiffusionSetBCProperty(phys1,"boundary_type",w_bndry,"dirichlet",0.0)
 CFEMDiffusionSetBCProperty(phys1,"boundary_type",n_bndry,"dirichlet",0.0)
 CFEMDiffusionSetBCProperty(phys1,"boundary_type",s_bndry,"dirichlet",0.0)
 
+SolverSetBasicOption(phys1,"residual_tolerance",1.0e-6)
 SolverInitialize(phys1)
 SolverExecute(phys1)
 

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
@@ -58,6 +58,7 @@ CFEMDiffusionSetBCProperty(phys1,"boundary_type",w_bndry,"dirichlet",0.0)
 CFEMDiffusionSetBCProperty(phys1,"boundary_type",n_bndry,"dirichlet",0.0)
 CFEMDiffusionSetBCProperty(phys1,"boundary_type",s_bndry,"dirichlet",0.0)
 
+SolverSetBasicOption(phys1,"residual_tolerance",1.0e-8)
 SolverInitialize(phys1)
 SolverExecute(phys1)
 

--- a/test/modules/cfem_diffusion/tests.json
+++ b/test/modules/cfem_diffusion/tests.json
@@ -64,7 +64,7 @@
         "type": "FloatCompare",
         "key": "maxval(latest)",
         "wordnum" : 4,
-        "gold": 1.000244,
+        "gold": 1.000257,
         "tol": 1e-10
       }
     ]

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
@@ -52,6 +52,7 @@ DFEMDiffusionSetBCProperty(phys1,"boundary_type",w_bndry,"dirichlet",0.0)
 DFEMDiffusionSetBCProperty(phys1,"boundary_type",n_bndry,"dirichlet",0.0)
 DFEMDiffusionSetBCProperty(phys1,"boundary_type",s_bndry,"dirichlet",0.0)
 
+SolverSetBasicOption(phys1, "residual_tolerance", 1e-8)
 SolverInitialize(phys1)
 SolverExecute(phys1)
 

--- a/test/modules/dfem_diffusion/tests.json
+++ b/test/modules/dfem_diffusion/tests.json
@@ -46,7 +46,7 @@
       {
         "type": "KeyValuePair",
         "key": "[0]  Max-value=",
-        "goldvalue": 0.021923,
+        "goldvalue": 0.021924,
         "tol": 1e-10
       }
     ]

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
@@ -149,7 +149,7 @@ acceleration_Diffusion_CFEM(const InputParameters&)
   // solver.options.ref_solution_lua_function = "MMS_phi";
   // solver.options.source_lua_function = "MMS_q";
   solver.options.verbose = true;
-  solver.options.residual_tolerance = 1.0e-10;
+  solver.options.residual_tolerance = 1.0e-12;
   solver.options.perform_symmetry_check = true;
 
   solver.Initialize();


### PR DESCRIPTION
- Removing RelativeResidualConvergenceTest
- Adjusting the relative tolerance in tests so that the residual drops below the expected "gold" value

Refs #102
