### PR TITLE
Cell-wise densities

### DIFF
--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/nl_keigen_ags_residual_func.cc
@@ -21,6 +21,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   const auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto& q_moments_local = lbs_solver.QMomentsLocal();
+  const auto& densities_local = lbs_solver.DensitiesLocal();
 
   auto active_set_source_function = lbs_solver.GetActiveSetSourceFunction();
 
@@ -38,6 +39,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
     active_set_source_function(groupset,
                                q_moments_local,
                                phi_old_local,
+                               densities_local,
                                lbs::APPLY_AGS_FISSION_SOURCES | lbs::APPLY_WGS_FISSION_SOURCES);
 
   const double k_eff = lbs_solver.ComputeFissionProduction(phi_old_local);
@@ -51,7 +53,8 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
     SourceFlags source_flags = lbs::APPLY_AGS_SCATTER_SOURCES | lbs::APPLY_WGS_SCATTER_SOURCES;
     if (supress_wgs)
       source_flags |= lbs::SUPPRESS_WG_SCATTER;
-    active_set_source_function(groupset, q_moments_local, phi_old_local, source_flags);
+    active_set_source_function(
+      groupset, q_moments_local, phi_old_local, densities_local, source_flags);
   }
 
   // Sweep all the groupsets

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/power_iteration_keigen.cc
@@ -34,6 +34,7 @@ PowerIterationKEigen(LBSSolver& lbs_solver, double tolerance, int max_iterations
   auto& q_moments_local = lbs_solver.QMomentsLocal();
   auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto& phi_new_local = lbs_solver.PhiNewLocal();
+  const auto& densities_local = lbs_solver.DensitiesLocal();
   auto primary_ags_solver = lbs_solver.GetPrimaryAGSSolver();
   auto& groupsets = lbs_solver.Groupsets();
   auto active_set_source_function = lbs_solver.GetActiveSetSourceFunction();
@@ -59,6 +60,7 @@ PowerIterationKEigen(LBSSolver& lbs_solver, double tolerance, int max_iterations
       active_set_source_function(groupset,
                                  q_moments_local,
                                  phi_old_local,
+                                 densities_local,
                                  APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
 
     Scale(q_moments_local, 1.0 / k_eff);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/power_iteration_keigen2.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/power_iteration_keigen2.cc
@@ -43,6 +43,7 @@ PowerIterationKEigen2(LBSSolver& lbs_solver, double tolerance, int max_iteration
   auto& q_moments_local = lbs_solver.QMomentsLocal();
   auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto& phi_new_local = lbs_solver.PhiNewLocal();
+  const auto& densities_local = lbs_solver.DensitiesLocal();
   auto primary_ags_solver = lbs_solver.GetPrimaryAGSSolver();
   auto& groupsets = lbs_solver.Groupsets();
   auto active_set_source_function = lbs_solver.GetActiveSetSourceFunction();
@@ -87,11 +88,14 @@ PowerIterationKEigen2(LBSSolver& lbs_solver, double tolerance, int max_iteration
 
   /**Lambda for the creation of fission sources.*/
   auto SetLBSFissionSource =
-    [&active_set_source_function, &front_gs](const VecDbl& input, VecDbl& output)
+    [&active_set_source_function, &front_gs, &densities_local](const VecDbl& input, VecDbl& output)
   {
     Set(output, 0.0);
-    active_set_source_function(
-      front_gs, output, input, APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+    active_set_source_function(front_gs,
+                               output,
+                               input,
+                               densities_local,
+                               APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   };
 
   // Start power iterations
@@ -121,6 +125,7 @@ PowerIterationKEigen2(LBSSolver& lbs_solver, double tolerance, int max_iteration
     active_set_source_function(front_gs,
                                q_moments_local,
                                phi_new_local,
+                               densities_local,
                                APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES);
 
     frons_wgs_context->ApplyInverseTransportOperator(SourceFlags());

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_context.cc
@@ -39,7 +39,11 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
   // Setting the source using updated phi_old
   auto& q_moments_local = lbs_solver_.QMomentsLocal();
   q_moments_local.assign(q_moments_local.size(), 0.0);
-  set_source_function_(groupset, q_moments_local, lbs_solver.PhiOldLocal(), lhs_src_scope_);
+  set_source_function_(groupset,
+                       q_moments_local,
+                       lbs_solver.PhiOldLocal(),
+                       lbs_solver.DensitiesLocal(),
+                       lhs_src_scope_);
 
   // Apply transport operator
   gs_context_ptr->ApplyInverseTransportOperator(lhs_src_scope_);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/iterative_methods/wgs_linear_solver.cc
@@ -158,8 +158,11 @@ WGSLinearSolver::SetRHS()
   if (not single_richardson)
   {
     const auto scope = gs_context_ptr->rhs_src_scope_ | ZERO_INCOMING_DELAYED_PSI;
-    gs_context_ptr->set_source_function_(
-      groupset, lbs_solver.QMomentsLocal(), lbs_solver.PhiOldLocal(), scope);
+    gs_context_ptr->set_source_function_(groupset,
+                                         lbs_solver.QMomentsLocal(),
+                                         lbs_solver.PhiOldLocal(),
+                                         lbs_solver.DensitiesLocal(),
+                                         scope);
 
     // Apply transport operator
     gs_context_ptr->ApplyInverseTransportOperator(scope);
@@ -186,8 +189,11 @@ WGSLinearSolver::SetRHS()
   else
   {
     const auto scope = gs_context_ptr->rhs_src_scope_ | gs_context_ptr->lhs_src_scope_;
-    gs_context_ptr->set_source_function_(
-      groupset, lbs_solver.QMomentsLocal(), lbs_solver.PhiOldLocal(), scope);
+    gs_context_ptr->set_source_function_(groupset,
+                                         lbs_solver.QMomentsLocal(),
+                                         lbs_solver.PhiOldLocal(),
+                                         lbs_solver.DensitiesLocal(),
+                                         scope);
 
     // Apply transport operator
     gs_context_ptr->ApplyInverseTransportOperator(scope);

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.cc
@@ -355,6 +355,18 @@ LBSSolver::PsiNewLocal() const
   return psi_new_local_;
 }
 
+std::vector<double>&
+LBSSolver::DensitiesLocal()
+{
+  return densities_local_;
+}
+
+const std::vector<double>&
+LBSSolver::DensitiesLocal() const
+{
+  return densities_local_;
+}
+
 const std::map<uint64_t, std::shared_ptr<SweepBndry>>&
 LBSSolver::SweepBoundaries() const
 {
@@ -872,6 +884,9 @@ LBSSolver::PerformInputChecks()
     options_.geometry_type = GeometryType::THREED_CARTESIAN;
   else
     OpenSnLogicalError("Cannot deduce geometry type from mesh.");
+
+  // Assign placeholder unit densities
+  densities_local_.assign(grid_ptr_->local_cells.size(), 1.0);
 }
 
 void
@@ -2423,7 +2438,8 @@ LBSSolver::MakeSourceMomentsFromPhi()
   {
     active_set_source_function_(groupset,
                                 source_moments,
-                                PhiOldLocal(),
+                                phi_old_local_,
+                                densities_local_,
                                 APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES |
                                   APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   }

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_solver.h
@@ -253,6 +253,16 @@ public:
   const std::vector<VecDbl>& PsiNewLocal() const;
 
   /**
+   * Read/write access to the cell-wise densities.
+   */
+  std::vector<double>& DensitiesLocal();
+
+  /**
+   * Read access to the cell-wise densities.
+   */
+  const std::vector<double>& DensitiesLocal() const;
+
+  /**
    * Returns the sweep boundaries as a read only reference
    */
   const std::map<uint64_t, std::shared_ptr<SweepBndry>>& SweepBoundaries() const;
@@ -558,6 +568,7 @@ protected:
   std::vector<double> phi_new_local_, phi_old_local_;
   std::vector<std::vector<double>> psi_new_local_;
   std::vector<double> precursor_new_local_;
+  std::vector<double> densities_local_;
 
   SetSourceFunction active_set_source_function_;
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/lbs_structs.h
@@ -196,10 +196,11 @@ enum class PhiSTLOption
 };
 
 class LBSGroupset;
-typedef std::function<void(LBSGroupset& groupset,
-                           std::vector<double>& destination_q,
+typedef std::function<void(const LBSGroupset& groupset,
+                           std::vector<double>& q,
                            const std::vector<double>& phi,
-                           SourceFlags source_flags)>
+                           const std::vector<double>& densities,
+                           const SourceFlags source_flags)>
   SetSourceFunction;
 
 class AGSSchemeEntry;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/source_function.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/source_function.h
@@ -48,7 +48,8 @@ public:
    *
    * \param groupset The groupset the under consideration.
    * \param q A vector to contribute the source to.
-   * \param phi_local The primary STL vector to operate off.
+   * \param phi The primary STL vector to operate off.
+   * \param densities The densities of the local cells.
    * \param source_flags Flags for adding specific terms into the
    *        destination vector. Available flags are for applying
    *        the material source, across/within-group scattering,
@@ -58,6 +59,7 @@ public:
   virtual void operator()(const LBSGroupset& groupset,
                           std::vector<double>& q,
                           const std::vector<double>& phi,
+                          const std::vector<double>& densities,
                           const SourceFlags source_flags);
 
   virtual double AddSourceMoments() const;
@@ -65,6 +67,7 @@ public:
   typedef std::vector<MultiGroupXS::Precursor> PrecursorList;
   /**Adds delayed particle precursor sources.*/
   virtual double AddDelayedFission(const PrecursorList& precursors,
+                                   const double& rho,
                                    const std::vector<double>& nu_delayed_sigma_f,
                                    const double* phi) const;
 

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/transient_source_function.cc
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/transient_source_function.cc
@@ -14,6 +14,7 @@ TransientSourceFunction::TransientSourceFunction(const LBSSolver& lbs_solver,
 
 double
 TransientSourceFunction::AddDelayedFission(const PrecursorList& precursors,
+                                           const double& rho,
                                            const std::vector<double>& nu_delayed_sigma_f,
                                            const double* phi) const
 {
@@ -39,8 +40,8 @@ TransientSourceFunction::AddDelayedFission(const PrecursorList& precursors,
           const double coeff = precursor.emission_spectrum[g_] * precursor.decay_constant /
                                (1.0 + eff_dt * precursor.decay_constant);
 
-          value += coeff * eff_dt * precursor.fractional_yield * nu_delayed_sigma_f[gp] * phi[gp] /
-                   cell_volume_;
+          value += coeff * eff_dt * precursor.fractional_yield * rho * nu_delayed_sigma_f[gp] *
+                   phi[gp] / cell_volume_;
         }
 
   if (apply_wgs_fission_src_)
@@ -50,8 +51,8 @@ TransientSourceFunction::AddDelayedFission(const PrecursorList& precursors,
         const double coeff = precursor.emission_spectrum[g_] * precursor.decay_constant /
                              (1.0 + eff_dt * precursor.decay_constant);
 
-        value += coeff * eff_dt * precursor.fractional_yield * nu_delayed_sigma_f[gp] * phi[gp] /
-                 cell_volume_;
+        value += coeff * eff_dt * precursor.fractional_yield * rho * nu_delayed_sigma_f[gp] *
+                 phi[gp] / cell_volume_;
       }
 
   return value;

--- a/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/transient_source_function.h
+++ b/modules/linear_boltzmann_solvers/a_lbs_solver/source_functions/transient_source_function.h
@@ -24,6 +24,7 @@ public:
   TransientSourceFunction(const LBSSolver& lbs_solver, double& ref_dt, SteppingMethod& method);
 
   double AddDelayedFission(const PrecursorList& precursors,
+                           const double& rho,
                            const std::vector<double>& nu_delayed_sigma_f,
                            const double* phi) const override;
 };

--- a/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/lbs_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/b_diffusion_dfem_solver/lbs_mip_solver.cc
@@ -46,7 +46,7 @@ DiffusionDFEMSolver::Initialize()
   // Initialize source func
   using namespace std::placeholders;
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
 
   // Initialize groupsets preconditioning
   for (auto& groupset : groupsets_)

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -139,7 +139,11 @@ SweepWGSContext::PostSolveCallback()
 
     const auto scope = lhs_src_scope_ | rhs_src_scope_;
 
-    set_source_function_(groupset_, lbs_solver_.QMomentsLocal(), lbs_solver_.PhiOldLocal(), scope);
+    set_source_function_(groupset_,
+                         lbs_solver_.QMomentsLocal(),
+                         lbs_solver_.PhiOldLocal(),
+                         lbs_solver_.DensitiesLocal(),
+                         scope);
     sweep_scheduler_.SetDestinationPhi(lbs_solver_.PhiNewLocal());
 
     ApplyInverseTransportOperator(scope);

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -108,7 +108,7 @@ DiscreteOrdinatesSolver::Initialize()
   using namespace std::placeholders;
   auto src_function = std::make_shared<SourceFunction>(*this);
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
 
   // Initialize groupsets for sweeping
   InitializeSweepDataStructures();
@@ -606,7 +606,8 @@ DiscreteOrdinatesSolver::ComputeBalance()
     q_moments_local_.assign(q_moments_local_.size(), 0.0);
     active_set_source_function_(groupset,
                                 q_moments_local_,
-                                PhiOldLocal(),
+                                phi_old_local_,
+                                densities_local_,
                                 APPLY_FIXED_SOURCES | APPLY_AGS_FISSION_SOURCES |
                                   APPLY_WGS_FISSION_SOURCES);
     LBSSolver::GSScopedCopyPrimarySTLvectors(groupset, q_moments_local_, mat_src);
@@ -1278,6 +1279,7 @@ DiscreteOrdinatesSolver::SetSweepChunk(LBSGroupset& groupset)
                                                        *discretization_,
                                                        unit_cell_matrices_,
                                                        cell_transport_views_,
+                                                       densities_local_,
                                                        phi_new_local_,
                                                        psi_new_local_[groupset.id_],
                                                        q_moments_local_,
@@ -1296,6 +1298,7 @@ DiscreteOrdinatesSolver::SetSweepChunk(LBSGroupset& groupset)
                                                        *discretization_,
                                                        unit_cell_matrices_,
                                                        cell_transport_views_,
+                                                       densities_local_,
                                                        q_moments_local_,
                                                        groupset,
                                                        matid_to_xs_map_,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
@@ -11,6 +11,7 @@ AahSweepChunk::AahSweepChunk(const MeshContinuum& grid,
                              const SpatialDiscretization& discretization,
                              const std::vector<UnitCellMatrices>& unit_cell_matrices,
                              std::vector<lbs::CellLBSView>& cell_transport_views,
+                             const std::vector<double>& densities,
                              std::vector<double>& destination_phi,
                              std::vector<double>& destination_psi,
                              const std::vector<double>& source_moments,
@@ -24,6 +25,7 @@ AahSweepChunk::AahSweepChunk(const MeshContinuum& grid,
                discretization,
                unit_cell_matrices,
                cell_transport_views,
+               densities,
                source_moments,
                groupset,
                xs,
@@ -72,6 +74,7 @@ AahSweepChunk::Sweep(AngleSet& angle_set)
     const auto& face_orientations = spds.CellFaceOrientations()[cell_local_id];
     std::vector<double> face_mu_values(cell_num_faces);
 
+    const auto& rho = densities_[cell.local_id_];
     const auto& sigma_t = xs_.at(cell.material_id_)->SigmaTotal();
 
     // Get cell matrices
@@ -160,7 +163,7 @@ AahSweepChunk::Sweep(AngleSet& angle_set)
       // Looping over groups, assembling mass terms
       for (int gsg = 0; gsg < gs_ss_size; ++gsg)
       {
-        double sigma_tg = sigma_t[gs_gi + gsg];
+        double sigma_tg = rho * sigma_t[gs_gi + gsg];
 
         // Contribute source moments q = M_n^T * q_moms
         for (int i = 0; i < cell_num_nodes; ++i)

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.h
@@ -16,6 +16,7 @@ public:
                 const SpatialDiscretization& discretization,
                 const std::vector<UnitCellMatrices>& unit_cell_matrices,
                 std::vector<lbs::CellLBSView>& cell_transport_views,
+                const std::vector<double>& densities,
                 std::vector<double>& destination_phi,
                 std::vector<double>& destination_psi,
                 const std::vector<double>& source_moments,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.h
@@ -19,6 +19,7 @@ public:
                 const SpatialDiscretization& discretization,
                 const std::vector<UnitCellMatrices>& unit_cell_matrices,
                 std::vector<lbs::CellLBSView>& cell_transport_views,
+                const std::vector<double>& densities,
                 const std::vector<double>& source_moments,
                 const LBSGroupset& groupset,
                 const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,

--- a/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/b_discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -33,6 +33,7 @@ public:
              const SpatialDiscretization& discretization,
              const std::vector<lbs::UnitCellMatrices>& unit_cell_matrices,
              std::vector<lbs::CellLBSView>& cell_transport_views,
+             const std::vector<double>& densities,
              const std::vector<double>& source_moments,
              const lbs::LBSGroupset& groupset,
              const std::map<int, std::shared_ptr<MultiGroupXS>>& xs,
@@ -42,6 +43,7 @@ public:
       discretization_(discretization),
       unit_cell_matrices_(unit_cell_matrices),
       cell_transport_views_(cell_transport_views),
+      densities_(densities),
       source_moments_(source_moments),
       groupset_(groupset),
       xs_(xs),
@@ -103,6 +105,7 @@ protected:
   const SpatialDiscretization& discretization_;
   const std::vector<lbs::UnitCellMatrices>& unit_cell_matrices_;
   std::vector<lbs::CellLBSView>& cell_transport_views_;
+  const std::vector<double>& densities_;
   const std::vector<double>& source_moments_;
   const lbs::LBSGroupset& groupset_;
   const std::map<int, std::shared_ptr<MultiGroupXS>>& xs_;

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
@@ -67,7 +67,7 @@ DiscreteOrdinatesAdjointSolver::Initialize()
   using namespace std::placeholders;
   auto src_function = std::make_shared<SourceFunction>(*this);
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
 
   // Initialize groupsets for sweeping
   InitializeSweepDataStructures();

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
@@ -389,6 +389,7 @@ DiscreteOrdinatesCurvilinearSolver::SetSweepChunk(lbs::LBSGroupset& groupset)
                                                        unit_cell_matrices_,
                                                        secondary_unit_cell_matrices_,
                                                        cell_transport_views_,
+                                                       densities_local_,
                                                        phi_new_local_,
                                                        psi_new_local_[groupset.id_],
                                                        q_moments_local_,

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
@@ -16,6 +16,7 @@ SweepChunkPwlrz::SweepChunkPwlrz(
   const std::vector<lbs::UnitCellMatrices>& unit_cell_matrices,
   const std::vector<lbs::UnitCellMatrices>& secondary_unit_cell_matrices,
   std::vector<lbs::CellLBSView>& cell_transport_views,
+  const std::vector<double>& densities,
   std::vector<double>& destination_phi,
   std::vector<double>& destination_psi,
   const std::vector<double>& source_moments,
@@ -29,6 +30,7 @@ SweepChunkPwlrz::SweepChunkPwlrz(
                discretization_primary,
                unit_cell_matrices,
                cell_transport_views,
+               densities,
                source_moments,
                groupset,
                xs,
@@ -109,6 +111,7 @@ SweepChunkPwlrz::Sweep(AngleSet& angle_set)
     const auto& face_orientations = spds.CellFaceOrientations()[cell_local_id];
     std::vector<double> face_mu_values(cell_num_faces);
 
+    const auto& rho = densities_[cell.local_id_];
     const auto& sigma_t = xs_.at(cell.material_id_)->SigmaTotal();
 
     // Get cell matrices
@@ -243,7 +246,7 @@ SweepChunkPwlrz::Sweep(AngleSet& angle_set)
       // Looping over groups, assembling mass terms
       for (int gsg = 0; gsg < gs_ss_size; ++gsg)
       {
-        double sigma_tg = sigma_t[gs_gi + gsg];
+        double sigma_tg = rho * sigma_t[gs_gi + gsg];
 
         // Contribute source moments q = M_n^T * q_moms
         for (int i = 0; i < cell_num_nodes; ++i)

--- a/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.h
+++ b/modules/linear_boltzmann_solvers/c_discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.h
@@ -18,6 +18,7 @@ public:
                   const std::vector<lbs::UnitCellMatrices>& unit_cell_matrices,
                   const std::vector<lbs::UnitCellMatrices>& secondary_unit_cell_matrices,
                   std::vector<lbs::CellLBSView>& cell_transport_views,
+                  const std::vector<double>& densities,
                   std::vector<double>& destination_phi,
                   std::vector<double>& destination_psi,
                   const std::vector<double>& source_moments,

--- a/modules/linear_boltzmann_solvers/d_do_transient/lbts_transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/d_do_transient/lbts_transient_solver.cc
@@ -59,7 +59,7 @@ DiscOrdTransientSolver::Initialize()
 
   using namespace std::placeholders;
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
 }
 
 void

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen.cc
@@ -163,8 +163,11 @@ XXPowerIterationKEigen::SetLBSFissionSource(const VecDbl& input, const bool addi
 {
   if (not additive)
     Set(q_moments_local_, 0.0);
-  active_set_source_function_(
-    front_gs_, q_moments_local_, input, APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+  active_set_source_function_(front_gs_,
+                              q_moments_local_,
+                              input,
+                              lbs_solver_.DensitiesLocal(),
+                              APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
 }
 
 void
@@ -177,7 +180,8 @@ XXPowerIterationKEigen::SetLBSScatterSource(const VecDbl& input,
   SourceFlags source_flags = APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES;
   if (suppress_wg_scat)
     source_flags |= SUPPRESS_WG_SCATTER;
-  active_set_source_function_(front_gs_, q_moments_local_, input, source_flags);
+  active_set_source_function_(
+    front_gs_, q_moments_local_, input, lbs_solver_.DensitiesLocal(), source_flags);
 }
 
 } // namespace lbs


### PR DESCRIPTION
Implementation of cell-wise densities into the LBS framework. This change has the effect of the code "assuming" microscopic cross sections instead of macroscopic. This allows for more control over cross sections based on material states and flexibility in how the problem is defined. Of course, using a default density of one in all cells has the same effect as assuming a macroscopic cross sections.

### What this PR does

- Added a density attribute that gets initialized to one in `LBSSolver` and associated getters.
- Hooked up densities to source functions for scaling scattering and fission sources.
- Hooked up densities to sweepers for scaling `sigma_t`.

### What this PR doesn't do

- Read in and set cell-wise densities from files
- Include routines to set densities outside of the non-const getter.

