### PR TITLE
Adding support for Scotch partitioner via PETSc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ check_symbol_exists(PETSC_USE_64BIT_INDICES "${PETSC_INCLUDE_DIR}/petscconf.h" P
 if(NOT ${PETSC_USE_64BIT_INDICES} MATCHES 1)
     message(FATAL_ERROR "PETSc has not been configured with the flag --with-64-bit-indices\n")
 endif()
+check_symbol_exists(PETSC_HAVE_PTSCOTCH "${PETSC_INCLUDE_DIR}/petscconf.h" PETSC_HAVE_PTSCOTCH)
+if(NOT ${PETSC_HAVE_PTSCOTCH} MATCHES 1)
+    message(FATAL_ERROR "PETSc has not been configured with PTSCOTCH\n")
+endif()
 
 # compile options
 set(OPENSN_CXX_FLAGS)

--- a/doc/install_linux.md
+++ b/doc/install_linux.md
@@ -106,6 +106,7 @@ and execute the following:
 --download-metis=1  \
 --download-parmetis=1  \
 --download-superlu_dist=1  \
+--download-ptscotch=1  \
 --with-cxx-dialect=C++11  \
 --with-64-bit-indices \
 CC=$CC CXX=$CXX FC=$FC \

--- a/doc/install_macos.md
+++ b/doc/install_macos.md
@@ -83,6 +83,7 @@ cd /path/to/petsc
 --download-metis=1  \
 --download-parmetis=1  \
 --download-superlu_dist=1  \
+--download-ptscotch=1  \
 CC=$CC CXX=$CXX FC=$FC \
 CFLAGS='-fPIC -fopenmp'  \
 CXXFLAGS='-fPIC -fopenmp'  \

--- a/resources/configure_dependencies.py
+++ b/resources/configure_dependencies.py
@@ -381,6 +381,7 @@ def InstallPETSc(pkg: str, ver: str, gold_file: str):
 --download-fblaslapack=1  \\
 --download-metis=1  \\
 --download-parmetis=1  \\
+--download-ptscotch=1  \\
 --download-superlu_dist=1  \\
 CC=$CC CXX=$CXX FC=$FC  \\
 COPTFLAGS='-O3 -march=native -mtune=native'  \\

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -259,6 +259,25 @@
     ]
   },
   {
+    "file": "transport_3d_1_poly_scotch.lua",
+    "comment": "3D LinearBSolver Test Ortho Grid Scotch - PWLD",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "KeyValuePair",
+        "key": "[0]  Max-value1=",
+        "goldvalue": 0.52745,
+        "tol": 0.0001
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "[0]  Max-value2=",
+        "goldvalue": 0.000376339,
+        "tol": 0.0001
+      }
+    ]
+  },
+  {
     "file": "transport_3d_1_poly_qmom_part1.lua",
     "comment": "3D LinearBSolver Test Source moment writing - PWLD",
     "num_procs": 4,

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
@@ -1,0 +1,149 @@
+-- 3D Transport test with Vacuum and Incident-isotropic BC.
+-- SDM: PWLD
+-- Test: Max-value=0.49903 and 7.18243e-4
+num_procs = 4
+
+
+
+
+
+--############################################### Check num_procs
+if (check_num_procs==nil and number_of_processes ~= num_procs) then
+  Log(LOG_0ERROR,"Incorrect amount of processors. " ..
+    "Expected "..tostring(num_procs)..
+    ". Pass check_num_procs=false to override if possible.")
+  os.exit(false)
+end
+
+--############################################### Setup mesh
+Nxy = 32
+nodesxy = {}
+dxy = 2/Nxy
+dz = 1.6/8
+for i=0,(Nxy) do
+  nodesxy[i+1] = -1.0 + i*dxy
+end
+nodesz = {}
+for k=0,8 do
+  nodesz[k+1] = 0.0 + k*dz
+end
+
+meshgen = mesh.MeshGenerator.Create
+({
+  inputs =
+  {
+    mesh.OrthogonalMeshGenerator.Create
+    ({
+      node_sets = {nodesxy, nodesxy, nodesz}
+    }),
+  },
+  partitioner = PETScGraphPartitioner.Create({type="ptscotch"})
+})
+mesh.MeshGenerator.Execute(meshgen)
+
+--############################################### Set Material IDs
+vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+
+vol1 = mesh.RPPLogicalVolume.Create
+({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
+mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+
+
+--############################################### Add materials
+materials = {}
+materials[1] = PhysicsAddMaterial("Test Material");
+materials[2] = PhysicsAddMaterial("Test Material2");
+
+PhysicsMaterialAddProperty(materials[1],TRANSPORT_XSECTIONS)
+PhysicsMaterialAddProperty(materials[2],TRANSPORT_XSECTIONS)
+
+PhysicsMaterialAddProperty(materials[1],ISOTROPIC_MG_SOURCE)
+PhysicsMaterialAddProperty(materials[2],ISOTROPIC_MG_SOURCE)
+
+
+num_groups = 21
+PhysicsMaterialSetProperty(materials[1],TRANSPORT_XSECTIONS,
+  OPENSN_XSFILE,"xs_graphite_pure.xs")
+PhysicsMaterialSetProperty(materials[2],TRANSPORT_XSECTIONS,
+  OPENSN_XSFILE,"xs_graphite_pure.xs")
+
+src={}
+for g=1,num_groups do
+  src[g] = 0.0
+end
+
+PhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+PhysicsMaterialSetProperty(materials[2],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+
+
+
+--############################################### Setup Physics
+pquad0 = CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
+
+lbs_block =
+{
+  num_groups = num_groups,
+  groupsets =
+  {
+    {
+      groups_from_to = {0, 20},
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_type = "single",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  }
+}
+bsrc={}
+for g=1,num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0/4.0/math.pi;
+lbs_options =
+{
+  boundary_conditions = { { name = "zmin", type = "isotropic",
+                            group_strength=bsrc}},
+  scattering_order = 1,
+}
+
+phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys1, lbs_options)
+
+--############################################### Initialize and Execute Solver
+ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+
+SolverInitialize(ss_solver)
+SolverExecute(ss_solver)
+
+--############################################### Get field functions
+fflist,count = LBSGetScalarFieldFunctionList(phys1)
+
+--############################################### Volume integrations
+ffi1 = FFInterpolationCreate(VOLUME)
+curffi = ffi1
+FFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+FFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+FFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+
+FFInterpolationInitialize(curffi)
+FFInterpolationExecute(curffi)
+maxval = FFInterpolationGetValue(curffi)
+
+Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+
+ffi1 = FFInterpolationCreate(VOLUME)
+curffi = ffi1
+FFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+FFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+FFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+
+FFInterpolationInitialize(curffi)
+FFInterpolationExecute(curffi)
+maxval = FFInterpolationGetValue(curffi)
+
+Log(LOG_0,string.format("Max-value2=%.5e", maxval))


### PR DESCRIPTION
This PR updates the PETSc install instructions to install the Scotch graph partitioner. It also adds Scotch to the PETSc install in configure_dependencies.py. I have tested the Scotch partitioner on multiple transport problems with no issues. 

Closes #50.