### PR TITLE
Minor fixes to support updated versions of PETSc.

### DIFF
--- a/framework/physics/physics_utils.cc
+++ b/framework/physics/physics_utils.cc
@@ -26,12 +26,20 @@ GetPETScConvergedReasonstring(KSPConvergedReason reason)
     case KSP_CONVERGED_ITS:
       ostr << "KSP_CONVERGED_ITS";
       break;
+#if PETSC_VERSION_LT(3, 19, 0)
     case KSP_CONVERGED_CG_NEG_CURVE:
       ostr << "KSP_CONVERGED_CG_NEG_CURVE";
       break;
+#else
+    case KSP_CONVERGED_NEG_CURVE:
+      ostr << "KSP_CONVERGED_NEG_CURVE";
+      break;
+#endif
+#if PETSC_VERSION_LT(3, 19, 0)
     case KSP_CONVERGED_CG_CONSTRAINED:
       ostr << "KSP_CONVERGED_CG_CONSTRAINED";
       break;
+#endif
     case KSP_CONVERGED_STEP_LENGTH:
       ostr << "KSP_CONVERGED_STEP_LENGTH";
       break;


### PR DESCRIPTION
This fix allows the code to support PETSc versions 3.17.0 - 3.20.5. With versions of PETSc > 3.17.5, the following regression tests fail:

1. `tutorials/fv_test1.lua`
2. `tutorials/fv_test2.lua`
3. `tutorials/pwlc_test1.lua`
4. `tutorials/pwlc_test2.lua`

It looks to me like these tests are checking the residual value at a specific iteration number to determine pass/fail. That's probably not what we want to do.