### PR TITLE
Use OpenSn elapsed time for regression test reporting

### DIFF
--- a/framework/utils/timer.cc
+++ b/framework/utils/timer.cc
@@ -39,7 +39,7 @@ Timer::GetTimeString() const
   double seconds = time_sec - 3600.0 * hours - 60.0 * minutes;
 
   char buff[100];
-  snprintf(buff, 100, "%02d:%02d:%02.1f", hours, minutes, seconds);
+  snprintf(buff, 100, "%02d:%02d:%04.1f", hours, minutes, seconds);
 
   return {buff};
 }

--- a/framework/utils/timer.cc
+++ b/framework/utils/timer.cc
@@ -33,12 +33,13 @@ std::string
 Timer::GetTimeString() const
 {
   double time_sec = this->GetTime() / 1000.0;
-  int hours = std::floor(time_sec / 60 / 60);
-  int minutes = std::floor((time_sec - 60 * 60 * hours) / 60);
-  int seconds = (int)time_sec - 3600 * hours - 60 * minutes;
+  int hours = std::floor(time_sec / 3600);
+  int minutes = std::floor((time_sec - 3600 * hours) / 60);
+  // Keep seconds as a double since we want fractional seconds
+  double seconds = time_sec - 3600.0 * hours - 60.0 * minutes;
 
   char buff[100];
-  snprintf(buff, 100, "%02d:%02d:%02d", hours, minutes, seconds);
+  snprintf(buff, 100, "%02d:%02d:%02.1f", hours, minutes, seconds);
 
   return {buff};
 }

--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -58,8 +58,8 @@ LuaApp::Run(int argc, char** argv)
   console.PostMPIInfo(opensn::mpi_comm.rank(), opensn::mpi_comm.size());
 
   opensn::log.Log() << opensn::name << " version " << GetVersionStr();
-  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
-                    << " in interactive-mode with " << opensn::mpi_comm.size() << " processes.";
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name << " with "
+                    << opensn::mpi_comm.size() << " processes.";
   opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
   opensn::log.LogAll();
   console.FlushConsole();

--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -24,8 +24,6 @@ const std::string command_line_help_string_ =
   "     a=b                         Executes argument as a lua string. "
   "i.e. x=2 or y=[[\"string\"]]\n"
   "     --allow-petsc-error-handler Allows petsc error handler.\n"
-  "     --suppress-beg-end-timelog  Suppresses time logs at the \n"
-  "                                 beginning and end of execution.\n"
   "     --suppress-color            Suppresses the printing of color.\n"
   "                                 useful for unit tests requiring a diff.\n"
   "     --dump-object-registry      Dumps the object registry.\n"
@@ -162,18 +160,11 @@ LuaApp::ParseArguments(int argc, char** argv)
 int
 LuaApp::RunInteractive(int argc, char** argv)
 {
-  if (not supress_beg_end_timelog_)
-  {
-    opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
-                      << " in interactive-mode with " << opensn::mpi_comm.size() << " processes.";
-
-    opensn::log.Log() << opensn::name << " version " << GetVersionStr();
-  }
-
+  opensn::log.Log() << opensn::name << " version " << GetVersionStr();
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
+                    << " in interactive-mode with " << opensn::mpi_comm.size() << " processes.";
   opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
-
   opensn::log.LogAll();
-
   console.FlushConsole();
 
   if (std::filesystem::exists(input_path))
@@ -193,12 +184,9 @@ LuaApp::RunInteractive(int argc, char** argv)
 
   console.RunConsoleLoop();
 
-  if (not supress_beg_end_timelog_)
-  {
-    opensn::log.Log() << "Final program time " << program_timer.GetTimeString();
-    opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
-                      << " finished execution.";
-  }
+  opensn::log.Log() << "Elapsed execution time: " << program_timer.GetTimeString();
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
+                    << " finished execution.";
 
   return 0;
 }
@@ -206,14 +194,9 @@ LuaApp::RunInteractive(int argc, char** argv)
 int
 LuaApp::RunBatch(int argc, char** argv)
 {
-  if (not supress_beg_end_timelog_)
-  {
-    opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
-                      << " in batch-mode with " << opensn::mpi_comm.size() << " processes.";
-
-    opensn::log.Log() << opensn::name << " version " << GetVersionStr();
-  }
-
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
+                    << " in batch-mode with " << opensn::mpi_comm.size() << " processes.";
+  opensn::log.Log() << opensn::name << " version " << GetVersionStr();
   opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
 
   if (argc <= 1)
@@ -228,12 +211,10 @@ LuaApp::RunBatch(int argc, char** argv)
       usleep(1000000);
       opensn::log.Log() << k;
     }
-
   mpi_comm.barrier();
 #endif
 
   int error_code = 0;
-
   if (std::filesystem::exists(input_path) and (not termination_posted_))
   {
     try
@@ -252,12 +233,9 @@ LuaApp::RunBatch(int argc, char** argv)
     Exit(EXIT_FAILURE);
   }
 
-  if (not supress_beg_end_timelog_)
-  {
-    opensn::log.Log() << "\nFinal program time " << program_timer.GetTimeString();
-    opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
-                      << " finished execution of " << opensn::input_path.string();
-  }
+  opensn::log.Log() << "\nElapsed execution time: " << program_timer.GetTimeString();
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
+                    << " finished execution of " << opensn::input_path.string();
 
   return error_code;
 }

--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -57,6 +57,13 @@ LuaApp::Run(int argc, char** argv)
   opensn::Initialize();
   console.PostMPIInfo(opensn::mpi_comm.rank(), opensn::mpi_comm.size());
 
+  opensn::log.Log() << opensn::name << " version " << GetVersionStr();
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
+                    << " in interactive-mode with " << opensn::mpi_comm.size() << " processes.";
+  opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
+  opensn::log.LogAll();
+  console.FlushConsole();
+
   int error_code = 0;
   ParseArguments(argc, argv);
   if (not termination_posted_)
@@ -69,6 +76,10 @@ LuaApp::Run(int argc, char** argv)
 
   opensn::Finalize();
   PetscFinalize();
+
+  opensn::log.Log() << "Elapsed execution time: " << program_timer.GetTimeString();
+  opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
+                    << " finished execution.";
 
   return error_code;
 }
@@ -87,10 +98,6 @@ LuaApp::ParseArguments(int argc, char** argv)
     {
       opensn::log.Log() << command_line_help_string_;
       termination_posted_ = true;
-    }
-    else if (argument.find("--suppress-beg-end-timelog") != std::string::npos)
-    {
-      supress_beg_end_timelog_ = true;
     }
     else if (argument.find("--allow-petsc-error-handler") != std::string::npos)
     {
@@ -160,13 +167,6 @@ LuaApp::ParseArguments(int argc, char** argv)
 int
 LuaApp::RunInteractive(int argc, char** argv)
 {
-  opensn::log.Log() << opensn::name << " version " << GetVersionStr();
-  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
-                    << " in interactive-mode with " << opensn::mpi_comm.size() << " processes.";
-  opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
-  opensn::log.LogAll();
-  console.FlushConsole();
-
   if (std::filesystem::exists(input_path))
   {
     try
@@ -184,21 +184,12 @@ LuaApp::RunInteractive(int argc, char** argv)
 
   console.RunConsoleLoop();
 
-  opensn::log.Log() << "Elapsed execution time: " << program_timer.GetTimeString();
-  opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
-                    << " finished execution.";
-
   return 0;
 }
 
 int
 LuaApp::RunBatch(int argc, char** argv)
 {
-  opensn::log.Log() << Timer::GetLocalDateTimeString() << " Running " << opensn::name
-                    << " in batch-mode with " << opensn::mpi_comm.size() << " processes.";
-  opensn::log.Log() << opensn::name << " version " << GetVersionStr();
-  opensn::log.Log() << opensn::name << " number of arguments supplied: " << argc - 1;
-
   if (argc <= 1)
     opensn::log.Log() << command_line_help_string_;
   console.FlushConsole();
@@ -232,10 +223,6 @@ LuaApp::RunBatch(int argc, char** argv)
     opensn::log.Log0Error() << "Could not open file " << opensn::input_path.string() << ".";
     Exit(EXIT_FAILURE);
   }
-
-  opensn::log.Log() << "\nElapsed execution time: " << program_timer.GetTimeString();
-  opensn::log.Log() << Timer::GetLocalDateTimeString() << " " << opensn::name
-                    << " finished execution of " << opensn::input_path.string();
 
   return error_code;
 }

--- a/lua/framework/lua_app.h
+++ b/lua/framework/lua_app.h
@@ -35,7 +35,6 @@ private:
   bool termination_posted_ = false;
   bool sim_option_interactive_ = true;
   bool allow_petsc_error_handler_ = false;
-  bool supress_beg_end_timelog_ = false;
   bool dump_registry_ = false;
 };
 

--- a/test/framework/post_processors/gold/solver_info_01.lua.gold
+++ b/test/framework/post_processors/gold/solver_info_01.lua.gold
@@ -1,9 +1,10 @@
-mpiexec -np 1 /Users/vermjc/Repos/ChiTech/chi-tech/test/bin/ChiTech_test solver_info_01.lua --suppress_color --supress_beg_end_timelog master_export=false 
-[0]  Parsing argument 1 solver_info_01.lua
-[0m[0]  Parsing argument 2 --suppress_color
-[0m[0]  Parsing argument 3 --supress_beg_end_timelog
-[0]  Parsing argument 4 master_export=false
-[0]  ChiTech number of arguments supplied: 4
+srun -n 1 /usr/WS1/dhawkins/openSn/dhawkins/openSn/build/test/opensn-test solver_info_01.lua --suppress-color master_export=false 
+[0]  OpenSn version 0.0.1
+[0m[0]  2024-03-13 21:40:26 Running OpenSn in interactive-mode with 1 processes.
+[0m[0]  OpenSn number of arguments supplied: 3
+[0m[0]  Parsing argument 1 solver_info_01.lua
+[0m[0]  Parsing argument 2 --suppress-color
+[0m[0]  Parsing argument 3 master_export=false
 [0]  Created solver prk_TransientSolver
 [0]  lambdas = 0.0124 0.0304 0.111 0.301 1.14 3.01 
 [0]  betas = 0.00021 0.00142 0.00127 0.00257 0.00075 0.00027 
@@ -84,5 +85,5 @@ Manually printing Post-Processor:
 [0]  | neutron_population(latest) |        5.611508 |
 [0]  *----------------------------*-----------------*
 [0]  
-
-
+[0]  Elapsed execution time: 00:00:00.3
+[0]  2024-03-13 21:40:26 OpenSn finished execution.

--- a/test/framework/post_processors/gold/solver_info_02.lua.gold
+++ b/test/framework/post_processors/gold/solver_info_02.lua.gold
@@ -1,9 +1,10 @@
-mpiexec -np 1 /Users/vermjc/Repos/ChiTech/chi-tech/test/bin/ChiTech_test solver_info_02.lua --suppress_color --supress_beg_end_timelog master_export=false 
-[0]  Parsing argument 1 solver_info_02.lua
-[0m[0]  Parsing argument 2 --suppress_color
-[0m[0]  Parsing argument 3 --supress_beg_end_timelog
-[0]  Parsing argument 4 master_export=false
-[0]  ChiTech number of arguments supplied: 4
+srun -n 1 /usr/WS1/dhawkins/openSn/dhawkins/openSn/build/test/opensn-test solver_info_02.lua --suppress-color master_export=false 
+[0]  OpenSn version 0.0.1
+[0m[0]  2024-03-13 21:40:27 Running OpenSn in interactive-mode with 1 processes.
+[0m[0]  OpenSn number of arguments supplied: 3
+[0m[0]  Parsing argument 1 solver_info_02.lua
+[0m[0]  Parsing argument 2 --suppress-color
+[0m[0]  Parsing argument 3 master_export=false
 [0]  Created solver prk_TransientSolver
 [0]  lambdas = 0.0124 0.0304 0.111 0.301 1.14 3.01 
 [0]  betas = 0.00021 0.00142 0.00127 0.00257 0.00075 0.00027 
@@ -50,5 +51,5 @@ mpiexec -np 1 /Users/vermjc/Repos/ChiTech/chi-tech/test/bin/ChiTech_test solver_
 20	0.200 5.61151
 Manual neutron_population1=	5.61151
 Manual neutron_population1=	5.61151
-
-
+[0]  Elapsed execution time: 00:00:00.3
+[0]  2024-03-13 21:40:27 OpenSn finished execution.

--- a/test/framework/post_processors/tests.json
+++ b/test/framework/post_processors/tests.json
@@ -4,7 +4,7 @@
     "num_procs": 1,
     "checks": [
       {
-        "type" : "GoldFile", "skiplines_top" : 6
+        "type" : "GoldFile", "skiplines_top" : 7, "check_numlines" : 80
       },
       {
         "type" : "GoldFile", "candidate_filename" : "solver_info_01.csv"
@@ -16,7 +16,7 @@
     "num_procs": 1,
     "checks": [
       {
-        "type" : "GoldFile", "skiplines_top" : 6
+        "type" : "GoldFile", "skiplines_top" : 6, "check_numlines" : 46
       }
     ]
   }

--- a/test/src/checks.py
+++ b/test/src/checks.py
@@ -485,6 +485,7 @@ class GoldFileCheck(Check):
         self.scope_keyword: str = ""
         self.candidate_filename: str = ""
         self.skiplines_top: int = 0
+        self.check_numlines: int = 0
 
         if "scope_keyword" in params:
             self.scope_keyword = params["scope_keyword"]
@@ -492,6 +493,8 @@ class GoldFileCheck(Check):
             self.candidate_filename = params["candidate_filename"]
         if "skiplines_top" in params:
             self.skiplines_top = params["skiplines_top"]
+        if "check_numlines" in params:
+            self.check_numlines = params["check_numlines"]
 
     def __str__(self):
         if self.scope_keyword != "":
@@ -533,12 +536,21 @@ class GoldFileCheck(Check):
                           f"Maybe {self.scope_keyword}_BEGIN/_END was not found?")
                 return False
 
-            diff = list(difflib.unified_diff(lines_a[self.skiplines_top:],
-                                             lines_b[self.skiplines_top:],
-                                             fromfile=filename,
-                                             tofile=golddir + goldfilename,
-                                             n=0  # Removes context
-                                             ))
+            if self.check_numlines == 0:
+                diff = list(difflib.unified_diff(lines_a[self.skiplines_top:],
+                                                 lines_b[self.skiplines_top:],
+                                                 fromfile=filename,
+                                                 tofile=golddir + goldfilename,
+                                                 n=0  # Removes context
+                                                ))
+            else:
+                diff = list(difflib.unified_diff(lines_a[self.skiplines_top:self.skiplines_top+self.check_numlines],
+                                                 lines_b[self.skiplines_top:self.skiplines_top+self.check_numlines],
+                                                 fromfile=filename,
+                                                 tofile=golddir + goldfilename,
+                                                 n=0  # Removes context
+                                                ))
+
             if len(diff) == 0:
                 return True
             elif verbose:

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import time
+import re
 
 
 class TestSlot:
@@ -134,19 +135,18 @@ class TestSlot:
         width = 120 - len(prefix + test_file_name) + pad
         message = message.rjust(width, ".")
 
-        elapsed_sec = 0
+        opensn_elapsed_time_sec = 0
         if os.path.exists(output_filename):
-          infile = open(output_filename, 'r')
-          lines = infile.readlines()
-          import re
-          for line in lines:
-            if re.search("Elapsed execution time:", line):
+          for line in open(output_filename, 'r'):
+            found = re.search("Elapsed execution time:", line)
+            if found:
               values_slice = re.split(r'[,:]',line.strip())
-              elapsed_sec = int(values_slice[1])*3600 + int(values_slice[2])*60 + int(values_slice[3])
+              opensn_elapsed_time_sec = int(values_slice[1])*3600 + int(values_slice[2])*60 + int(values_slice[3])
+              break;
 
-        time_taken_message = " {:.0f}s".format(elapsed_sec)
+        time_taken_message = " {:.0f}s".format(opensn_elapsed_time_sec)
 
-        print(test_path + time_taken_message)
+        print(test_path + message + time_taken_message)
 
         if test.skip != "":
             print("Skip reason: " + test.skip)

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -133,9 +133,9 @@ class TestSlot:
           for line in open(output_filename, 'r'):
             found = re.search("Elapsed execution time:", line)
             if found:
-              values_slice = re.split(r'[,:]',line.strip())
+              values_slice = re.split(r'[,:]', line.strip())
               opensn_elapsed_time_sec = float(values_slice[1])*3600 + float(values_slice[2])*60 + float(values_slice[3])
-              break;
+              break
 
         time_taken_message = " {:.1f}s".format(opensn_elapsed_time_sec)
 

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -134,8 +134,19 @@ class TestSlot:
         width = 120 - len(prefix + test_file_name) + pad
         message = message.rjust(width, ".")
 
-        time_taken_message = " {:.2f}s".format(self.time_end - self.time_start)
+        elapsed_sec = 0
+        if os.path.exists(output_filename):
+          infile = open(output_filename, 'r')
+          lines = infile.readlines()
+          import re
+          for line in lines:
+            if re.search("Elapsed execution time:", line):
+              values_slice = re.split(r'[,:]',line.strip())
+              elapsed_sec = int(values_slice[1])*3600 + int(values_slice[2])*60 + int(values_slice[3])
 
-        print(prefix + " " + test_file_name + message + time_taken_message)
+        time_taken_message = " {:.0f}s".format(elapsed_sec)
+
+        print(test_path + time_taken_message)
+
         if test.skip != "":
             print("Skip reason: " + test.skip)

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import time
 import re
 
 
@@ -13,9 +12,6 @@ class TestSlot:
         self.test = test
         self.passed = False
         self.argv = argv
-
-        self.time_start = time.perf_counter()
-        self.time_end = self.time_start
         self.command: str = ""
 
         self._Run()
@@ -32,7 +28,6 @@ class TestSlot:
         cmd += self.argv.exe + " "
         cmd += test.filename + " "
         cmd += "--suppress-color "
-        cmd += "--suppress-beg-end-timelog "
         cmd += "master_export=false "
         for arg in test.args:
             if arg.find("\"") >= 0:
@@ -70,8 +65,6 @@ class TestSlot:
         if self.process.poll() is not None:
 
             out, err = self.process.communicate()
-
-            self.time_end = time.perf_counter()
 
             file = open(test.file_dir + f"out/{test.GetOutFilenamePrefix()}.out", "w")
             file.write(self.command + "\n")
@@ -135,16 +128,16 @@ class TestSlot:
         width = 120 - len(prefix + test_file_name) + pad
         message = message.rjust(width, ".")
 
-        opensn_elapsed_time_sec = 0
+        opensn_elapsed_time_sec = 0.0
         if os.path.exists(output_filename):
           for line in open(output_filename, 'r'):
             found = re.search("Elapsed execution time:", line)
             if found:
               values_slice = re.split(r'[,:]',line.strip())
-              opensn_elapsed_time_sec = int(values_slice[1])*3600 + int(values_slice[2])*60 + int(values_slice[3])
+              opensn_elapsed_time_sec = float(values_slice[1])*3600 + float(values_slice[2])*60 + float(values_slice[3])
               break;
 
-        time_taken_message = " {:.0f}s".format(opensn_elapsed_time_sec)
+        time_taken_message = " {:.1f}s".format(opensn_elapsed_time_sec)
 
         print(test_path + message + time_taken_message)
 


### PR DESCRIPTION
This MR modifies the Lua app to always report the OpenSn version header, program start time, and program elapsed time. In addition, it modifies the regression test script to pull the elapsed time from the OpenSn output file for reporting purposes. This eliminates timing overhead introduced by Python, batch job systems, etc. I've also added a new parameter to the test script: `check_numlines`. This parameter defines the number of lines after `skiplines_top` to diff for regression purposes. This should make our regression testing a bit more robust... especially for console output.