### PR TITLE
Removing `in_` prefix from function argument names

### DIFF
--- a/framework/graphs/directed_graph.h
+++ b/framework/graphs/directed_graph.h
@@ -42,7 +42,7 @@ public:
       VertexAccessor& ref_block;
       size_t ref_element;
 
-      iterator(VertexAccessor& in_block, size_t i) : ref_block(in_block), ref_element(i) {}
+      iterator(VertexAccessor& block, size_t i) : ref_block(block), ref_element(i) {}
 
       iterator operator++()
       {

--- a/framework/graphs/directed_graph_vertex.h
+++ b/framework/graphs/directed_graph_vertex.h
@@ -19,53 +19,53 @@ struct GraphVertex
   std::map<size_t, double> us_weights;
   std::map<size_t, double> ds_weights;
 
-  GraphVertex(size_t in_id, void* in_context) : id(in_id), context(in_context) {}
+  GraphVertex(size_t id, void* context) : id(id), context(context) {}
 
-  explicit GraphVertex(size_t in_id) : id(in_id), context(nullptr) {}
+  explicit GraphVertex(size_t id) : id(id), context(nullptr) {}
 
-  GraphVertex(const GraphVertex& in_v)
+  GraphVertex(const GraphVertex& vertex)
   {
-    this->id = in_v.id;
-    this->context = in_v.context;
+    this->id = vertex.id;
+    this->context = vertex.context;
 
-    us_edge = in_v.us_edge;
-    ds_edge = in_v.ds_edge;
+    us_edge = vertex.us_edge;
+    ds_edge = vertex.ds_edge;
   }
 
-  GraphVertex(GraphVertex&& in_v) noexcept
+  GraphVertex(GraphVertex&& vertex) noexcept
   {
-    this->id = in_v.id;
-    this->context = in_v.context;
+    this->id = vertex.id;
+    this->context = vertex.context;
 
-    us_edge = in_v.us_edge;
-    ds_edge = in_v.ds_edge;
+    us_edge = vertex.us_edge;
+    ds_edge = vertex.ds_edge;
 
-    in_v.context = nullptr;
+    vertex.context = nullptr;
   }
 
-  GraphVertex& operator=(const GraphVertex& in_v)
+  GraphVertex& operator=(const GraphVertex& vertex)
   {
-    if (this == &in_v)
+    if (this == &vertex)
       return *this;
 
-    this->id = in_v.id;
-    this->context = in_v.context;
+    this->id = vertex.id;
+    this->context = vertex.context;
 
-    us_edge = in_v.us_edge;
-    ds_edge = in_v.ds_edge;
+    us_edge = vertex.us_edge;
+    ds_edge = vertex.ds_edge;
 
     return *this;
   }
 
-  GraphVertex& operator=(GraphVertex&& in_v) noexcept
+  GraphVertex& operator=(GraphVertex&& vertex) noexcept
   {
-    this->id = in_v.id;
-    this->context = in_v.context;
+    this->id = vertex.id;
+    this->context = vertex.context;
 
-    us_edge = in_v.us_edge;
-    ds_edge = in_v.ds_edge;
+    us_edge = vertex.us_edge;
+    ds_edge = vertex.ds_edge;
 
-    in_v.context = nullptr;
+    vertex.context = nullptr;
 
     return *this;
   }

--- a/framework/logging/log.h
+++ b/framework/logging/log.h
@@ -295,10 +295,9 @@ struct Logger::EventInfo
   double arb_value = 0.0;
   EventInfo() : arb_info(std::string()) {}
 
-  explicit EventInfo(std::string in_string) : arb_info(std::move(in_string)) {}
-  explicit EventInfo(double in_value) : arb_value(in_value) {}
-  explicit EventInfo(std::string in_string, double in_value)
-    : arb_info(std::move(in_string)), arb_value(in_value)
+  explicit EventInfo(std::string text) : arb_info(std::move(text)) {}
+  explicit EventInfo(double value) : arb_value(value) {}
+  explicit EventInfo(std::string text, double value) : arb_info(std::move(text)), arb_value(value)
   {
   }
 
@@ -314,8 +313,8 @@ struct Logger::Event
   const EventType ev_type = EventType::SINGLE_OCCURRENCE;
   std::shared_ptr<EventInfo> ev_info;
 
-  Event(double in_time, EventType in_ev_type, std::shared_ptr<EventInfo> in_event_info)
-    : ev_time(in_time), ev_type(in_ev_type), ev_info(std::move(in_event_info))
+  Event(double time, EventType ev_type, std::shared_ptr<EventInfo> event_info)
+    : ev_time(time), ev_type(ev_type), ev_info(std::move(event_info))
   {
   }
 };

--- a/framework/math/golub_fischer/golub_fischer.cc
+++ b/framework/math/golub_fischer/golub_fischer.cc
@@ -62,11 +62,11 @@ GolubFischer::GetDiscreteScatAngles(Tvecdbl& mell)
 }
 
 void
-GolubFischer::MCA(Tvecdbl& in_mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
+GolubFischer::MCA(Tvecdbl& mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
 {
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "MCA Start" << '\n';
 
-  int N = in_mell.size() - 1;
+  int N = mell.size() - 1;
   int n = (N + 1) / 2;
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "N " << N << " n " << n << '\n';
@@ -79,11 +79,11 @@ GolubFischer::MCA(Tvecdbl& in_mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
 
   for (int ell = 0; ell < 2 * n; ell++)
   {
-    sigma[0][ell] = in_mell[ell];
+    sigma[0][ell] = mell[ell];
   }
 
   alpha_[0] = a[0] + c[0] * sigma[0][1] / sigma[0][0];
-  beta_[0] = in_mell[0];
+  beta_[0] = mell[0];
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << 0 << " " << alpha_[0] << " " << beta_[0] << "\n";
 
@@ -116,7 +116,7 @@ GolubFischer::MCA(Tvecdbl& in_mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
 }
 
 void
-GolubFischer::RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta)
+GolubFischer::RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta)
 {
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "RootsOrtho Start" << '\n';
 
@@ -139,13 +139,13 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta)
 
   Tvecdbl norm;
   norm.resize(N + 1, 0.0);
-  log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Check 2 " << in_beta[0] << '\n';
-  norm[0] = in_beta[0];
+  log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Check 2 " << beta[0] << '\n';
+  norm[0] = beta[0];
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Check 3a norms" << '\n';
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << norm[0] << '\n';
   for (int i = 1; i < (N + 1); i++)
   {
-    norm[i] = in_beta[i] * norm[i - 1];
+    norm[i] = beta[i] * norm[i - 1];
     log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << norm[i] << '\n';
   }
 
@@ -158,8 +158,8 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta)
     while (i < maxiters)
     {
       double xold = xn[k];
-      double a = Ortho(N, xold, in_alpha, in_beta);
-      double b = dOrtho(N, xold, in_alpha, in_beta);
+      double a = Ortho(N, xold, alpha, beta);
+      double b = dOrtho(N, xold, alpha, beta);
       double c = 0;
 
       for (int j = 0; j < k; j++)
@@ -213,7 +213,7 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta)
 
     for (int k = 0; k < N; k++)
     {
-      wn[i] += Ortho(k, xn[i], in_alpha, in_beta) * Ortho(k, xn[i], in_alpha, in_beta) / norm[k];
+      wn[i] += Ortho(k, xn[i], alpha, beta) * Ortho(k, xn[i], alpha, beta) / norm[k];
     }
 
     wn[i] = 1.0 / wn[i];
@@ -228,7 +228,7 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta)
 }
 
 double
-GolubFischer::Ortho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta)
+GolubFischer::Ortho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta)
 {
   if (ell == 0)
   {
@@ -237,17 +237,17 @@ GolubFischer::Ortho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta)
 
   if (ell == 1)
   {
-    return (x - in_alpha[0]);
+    return (x - alpha[0]);
   }
 
   double Pnm1 = 1.0;
-  double Pn = (x - in_alpha[0]);
+  double Pn = (x - alpha[0]);
   double Pnp1 = 0.0;
 
   for (int n = 2; n < ell + 1; n++)
   {
     int ns = n - 1;
-    Pnp1 = (x - in_alpha[ns]) * Pn - in_beta[ns] * Pnm1;
+    Pnp1 = (x - alpha[ns]) * Pn - beta[ns] * Pnm1;
     Pnm1 = Pn;
     Pn = Pnp1;
   }
@@ -256,12 +256,12 @@ GolubFischer::Ortho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta)
 }
 
 double
-GolubFischer::dOrtho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta)
+GolubFischer::dOrtho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta)
 {
 
   double eps = 0.000001;
-  double y2 = Ortho(ell, x + eps, in_alpha, in_beta);
-  double y1 = Ortho(ell, x - eps, in_alpha, in_beta);
+  double y2 = Ortho(ell, x + eps, alpha, beta);
+  double y1 = Ortho(ell, x - eps, alpha, beta);
 
   double m = (y2 - y1) / 2.0 / eps;
 

--- a/framework/math/golub_fischer/golub_fischer.h
+++ b/framework/math/golub_fischer/golub_fischer.h
@@ -64,13 +64,13 @@ public:
 private:
   /**Applies the Modified Chebyshev Algorithm contained in [1] to find the
    * recursion coefficients for the orthogonal polynomials.*/
-  void MCA(Tvecdbl& in_mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c);
+  void MCA(Tvecdbl& mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c);
   /**Finds the roots of the orthogonal polynomial.*/
-  void RootsOrtho(int& N, Tvecdbl& in_alpha, Tvecdbl& in_beta);
+  void RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta);
   /**Computes the derivative of the orthogonal polynomials.*/
-  double dOrtho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta);
+  double dOrtho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta);
   /**Computes the function evaluation of the orthogonal polynomials.*/
-  double Ortho(int ell, double x, Tvecdbl& in_alpha, Tvecdbl& in_beta);
+  double Ortho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta);
 };
 
 } // namespace opensn

--- a/framework/math/petsc_utils/petsc_utils.cc
+++ b/framework/math/petsc_utils/petsc_utils.cc
@@ -94,26 +94,26 @@ InitMatrixSparsity(Mat& A, int64_t nodal_nnz_in_diag, int64_t nodal_nnz_off_diag
 }
 
 PETScSolverSetup
-CreateCommonKrylovSolverSetup(Mat ref_matrix,
-                              const std::string& in_solver_name,
-                              const std::string& in_solver_type,
-                              const std::string& in_preconditioner_type,
-                              double in_rel_tol,
-                              double in_abs_tol,
-                              int64_t in_maximum_iterations)
+CreateCommonKrylovSolverSetup(Mat matrix,
+                              const std::string& solver_name,
+                              const std::string& solver_type,
+                              const std::string& preconditioner_type,
+                              double rel_tol,
+                              double abs_tol,
+                              int64_t maximum_iterations)
 {
   PETScSolverSetup setup;
 
   KSPCreate(opensn::mpi_comm, &setup.ksp);
-  KSPSetOperators(setup.ksp, ref_matrix, ref_matrix);
-  KSPSetType(setup.ksp, in_solver_type.c_str());
+  KSPSetOperators(setup.ksp, matrix, matrix);
+  KSPSetType(setup.ksp, solver_type.c_str());
 
-  KSPSetOptionsPrefix(setup.ksp, in_solver_name.c_str());
+  KSPSetOptionsPrefix(setup.ksp, solver_name.c_str());
 
   KSPGetPC(setup.ksp, &setup.pc);
-  PCSetType(setup.pc, in_preconditioner_type.c_str());
+  PCSetType(setup.pc, preconditioner_type.c_str());
 
-  KSPSetTolerances(setup.ksp, in_rel_tol, in_abs_tol, 1.0e50, in_maximum_iterations);
+  KSPSetTolerances(setup.ksp, rel_tol, abs_tol, 1.0e50, maximum_iterations);
   KSPSetInitialGuessNonzero(setup.ksp, PETSC_TRUE);
 
   KSPSetFromOptions(setup.ksp);

--- a/framework/math/petsc_utils/petsc_utils.h
+++ b/framework/math/petsc_utils/petsc_utils.h
@@ -13,7 +13,7 @@ struct PETScSolverSetup
   KSP ksp;
   PC pc;
 
-  std::string in_solver_name = "KSPSolver";
+  std::string solver_name = "KSPSolver";
 
   std::string solver_type = KSPGMRES;
   std::string preconditioner_type = PCNONE;
@@ -169,13 +169,13 @@ void InitMatrixSparsity(Mat& A, int64_t nodal_nnz_in_diag, int64_t nodal_nnz_off
  * return setup;
  * \endcode
  */
-PETScSolverSetup CreateCommonKrylovSolverSetup(Mat ref_matrix,
-                                               const std::string& in_solver_name = "KSPSolver",
-                                               const std::string& in_solver_type = KSPGMRES,
-                                               const std::string& in_preconditioner_type = PCNONE,
-                                               double in_rel_tol = PETSC_DEFAULT,
-                                               double in_abs_tol = PETSC_DEFAULT,
-                                               int64_t in_maximum_iterations = 100);
+PETScSolverSetup CreateCommonKrylovSolverSetup(Mat matrix,
+                                               const std::string& solver_name = "KSPSolver",
+                                               const std::string& solver_type = KSPGMRES,
+                                               const std::string& preconditioner_type = PCNONE,
+                                               double rel_tol = PETSC_DEFAULT,
+                                               double abs_tol = PETSC_DEFAULT,
+                                               int64_t maximum_iterations = 100);
 
 /**
  * General monitor that print the residual norm relative to the right-hand side norm.

--- a/framework/math/quadratures/angular_product_quadrature.cc
+++ b/framework/math/quadratures/angular_product_quadrature.cc
@@ -14,12 +14,12 @@ namespace opensn
 void
 ProductQuadrature::AssembleCosines(const std::vector<double>& azimuthal,
                                    const std::vector<double>& polar,
-                                   const std::vector<double>& in_weights,
+                                   const std::vector<double>& weights,
                                    bool verbose)
 {
   size_t Na = azimuthal.size();
   size_t Np = polar.size();
-  size_t Nw = in_weights.size();
+  size_t Nw = weights.size();
 
   if (Nw != Na * Np)
   {
@@ -62,7 +62,7 @@ ProductQuadrature::AssembleCosines(const std::vector<double>& azimuthal,
 
       abscissae_.emplace_back(abscissa);
 
-      const double weight = in_weights[i * Np + j];
+      const double weight = weights[i * Np + j];
       weights_.emplace_back(weight);
       weight_sum += weight;
 
@@ -215,12 +215,12 @@ AngularQuadratureProdGLC::AngularQuadratureProdGLC(int Na, int Np, bool verbose)
 
 AngularQuadratureProdCustom::AngularQuadratureProdCustom(const std::vector<double>& azimuthal,
                                                          const std::vector<double>& polar,
-                                                         const std::vector<double>& in_weights,
+                                                         const std::vector<double>& weights,
                                                          bool verbose)
 {
   size_t Na = azimuthal.size();
   size_t Np = polar.size();
-  size_t Nw = in_weights.size();
+  size_t Nw = weights.size();
 
   if (Nw != Na * Np)
   {

--- a/framework/math/quadratures/angular_product_quadrature.h
+++ b/framework/math/quadratures/angular_product_quadrature.h
@@ -38,7 +38,7 @@ public:
   /**Initializes the quadrature with custom angles and weights.*/
   void AssembleCosines(const std::vector<double>& azimuthal,
                        const std::vector<double>& polar,
-                       const std::vector<double>& in_weights,
+                       const std::vector<double>& weights,
                        bool verbose);
 
   /**Optimizes the angular quadrature for polar symmetry by removing
@@ -90,7 +90,7 @@ public:
   /**Constructor for Custom Angular Product Quadrature.*/
   AngularQuadratureProdCustom(const std::vector<double>& azimuthal,
                               const std::vector<double>& polar,
-                              const std::vector<double>& in_weights,
+                              const std::vector<double>& weights,
                               bool verbose);
 };
 

--- a/framework/math/quadratures/angular_quadrature_base.cc
+++ b/framework/math/quadratures/angular_quadrature_base.cc
@@ -186,12 +186,12 @@ AngularQuadrature::GetMomentToHarmonicsIndexMap() const
 
 AngularQuadratureCustom::AngularQuadratureCustom(std::vector<double>& azimuthal,
                                                  std::vector<double>& polar,
-                                                 std::vector<double>& in_weights,
+                                                 std::vector<double>& weights,
                                                  bool verbose)
 {
   size_t Na = azimuthal.size();
   size_t Np = polar.size();
-  size_t Nw = in_weights.size();
+  size_t Nw = weights.size();
 
   if ((Na - Np != 0) or (Na - Nw != 0))
   {
@@ -210,7 +210,7 @@ AngularQuadratureCustom::AngularQuadratureCustom(std::vector<double>& azimuthal,
 
     abscissae_.push_back(abscissa);
 
-    const double weight = in_weights[i];
+    const double weight = weights[i];
     weights_.push_back(weight);
     weight_sum += weight;
 

--- a/framework/math/quadratures/angular_quadrature_base.h
+++ b/framework/math/quadratures/angular_quadrature_base.h
@@ -40,7 +40,7 @@ public:
     int m = 0;
 
     HarmonicIndices() = default;
-    HarmonicIndices(unsigned int in_ell, int in_m) : ell(in_ell), m(in_m) {}
+    HarmonicIndices(unsigned int ell, int m) : ell(ell), m(m) {}
 
     bool operator==(const HarmonicIndices& other) const
     {
@@ -58,7 +58,7 @@ protected:
 public:
   AngularQuadrature() : type_(AngularQuadratureType::Arbitrary) {}
 
-  explicit AngularQuadrature(AngularQuadratureType in_type) : type_(in_type) {}
+  explicit AngularQuadrature(AngularQuadratureType type) : type_(type) {}
 
   virtual ~AngularQuadrature() = default;
 
@@ -105,7 +105,7 @@ public:
   /**Constructor using custom directions.*/
   AngularQuadratureCustom(std::vector<double>& azimuthal,
                           std::vector<double>& polar,
-                          std::vector<double>& in_weights,
+                          std::vector<double>& weights,
                           bool verbose);
 };
 

--- a/framework/math/quadratures/quadrature.cc
+++ b/framework/math/quadratures/quadrature.cc
@@ -30,10 +30,10 @@ Quadrature::Quadrature(const InputParameters& params)
 }
 
 void
-Quadrature::SetRange(const std::pair<double, double>& in_range)
+Quadrature::SetRange(const std::pair<double, double>& range)
 {
   const auto& old_range = range_;
-  const auto& new_range = in_range;
+  const auto& new_range = range;
 
   const double h_new = new_range.second - new_range.first;
   const double h_old = old_range.second - old_range.first;
@@ -51,7 +51,7 @@ Quadrature::SetRange(const std::pair<double, double>& in_range)
     weights_[i] *= scale_factor;
   }
 
-  range_ = in_range;
+  range_ = range;
 }
 
 } // namespace opensn

--- a/framework/math/quadratures/quadrature.h
+++ b/framework/math/quadratures/quadrature.h
@@ -78,7 +78,7 @@ protected:
 
 protected:
   explicit Quadrature(const InputParameters& params);
-  explicit Quadrature(QuadratureOrder in_order) : order_(in_order), range_({0, 0}) {}
+  explicit Quadrature(QuadratureOrder order) : order_(order), range_({0, 0}) {}
 
 public:
   /**Get the range on which the quadrature is defined
@@ -88,7 +88,7 @@ public:
    * (relevant for one-dimensional quadratures only).
    * Note that calling this method results in translation
    * of the abscissae and scaling of the weights.*/
-  void SetRange(const std::pair<double, double>& in_range);
+  void SetRange(const std::pair<double, double>& range);
 };
 
 } // namespace opensn

--- a/framework/math/quadratures/quadrature_gausslegendre.cc
+++ b/framework/math/quadratures/quadrature_gausslegendre.cc
@@ -56,11 +56,11 @@ QuadratureGaussLegendre::QuadratureGaussLegendre(const InputParameters& params) 
   }
 }
 
-QuadratureGaussLegendre::QuadratureGaussLegendre(QuadratureOrder in_order,
+QuadratureGaussLegendre::QuadratureGaussLegendre(QuadratureOrder order,
                                                  bool verbose,
                                                  unsigned int max_iters,
                                                  double tol)
-  : Quadrature(in_order)
+  : Quadrature(order)
 {
   const unsigned int N = std::ceil(((int)order_ + 1) / 2.0);
   Initialize(N, verbose, max_iters, tol);

--- a/framework/math/quadratures/quadrature_gausslegendre.h
+++ b/framework/math/quadratures/quadrature_gausslegendre.h
@@ -17,7 +17,7 @@ public:
    * \f$ \rho(x) x^{p} \f$, with \f$ \rho(x) := 1 \f$,
    * on the interval \f$ [-1;+1] \f$.
    * The number of points generated will be ceil((O+1)/2).*/
-  explicit QuadratureGaussLegendre(QuadratureOrder in_order,
+  explicit QuadratureGaussLegendre(QuadratureOrder order,
                                    bool verbose = false,
                                    unsigned int max_iters = 1000,
                                    double tol = 1.0e-12);

--- a/framework/math/quadratures/quadrature_line.h
+++ b/framework/math/quadratures/quadrature_line.h
@@ -9,7 +9,7 @@ namespace opensn
 class QuadratureLine : public QuadratureGaussLegendre
 {
 public:
-  explicit QuadratureLine(QuadratureOrder in_order) : QuadratureGaussLegendre(in_order)
+  explicit QuadratureLine(QuadratureOrder order) : QuadratureGaussLegendre(order)
   {
     SetRange({0, 1});
   }

--- a/framework/math/quadratures/sldfesq/sldfe_sq.h
+++ b/framework/math/quadratures/sldfesq/sldfe_sq.h
@@ -202,19 +202,19 @@ struct SimplifiedLDFESQ::FUNCTION_WEIGHT_FROM_RHO
   /// Legendre quadrature weights
   std::vector<double>& lqw;
 
-  FUNCTION_WEIGHT_FROM_RHO(SimplifiedLDFESQ::Quadrature& in_sldfesq,
-                           Vertex& in_centroid_xy_tilde,
-                           std::array<Vector3, 4>& in_radii_vectors_xy_tilde,
-                           SphericalQuadrilateral& in_sq,
-                           QuadratureGaussLegendre& in_legendre_quadrature)
-    : sldfesq(in_sldfesq),
-      centroid_xy_tilde(in_centroid_xy_tilde),
-      radii_vectors_xy_tilde(in_radii_vectors_xy_tilde),
-      sq(in_sq),
+  FUNCTION_WEIGHT_FROM_RHO(SimplifiedLDFESQ::Quadrature& sldfesq,
+                           Vertex& centroid_xy_tilde,
+                           std::array<Vector3, 4>& radii_vectors_xy_tilde,
+                           SphericalQuadrilateral& sq,
+                           QuadratureGaussLegendre& legendre_quadrature)
+    : sldfesq(sldfesq),
+      centroid_xy_tilde(centroid_xy_tilde),
+      radii_vectors_xy_tilde(radii_vectors_xy_tilde),
+      sq(sq),
       A(4, 4),
       A_inv(4, 4),
-      lqp(in_legendre_quadrature.qpoints_),
-      lqw(in_legendre_quadrature.weights_)
+      lqp(legendre_quadrature.qpoints_),
+      lqw(legendre_quadrature.weights_)
   {
     // Init RHS
     for (int i = 0; i < 4; ++i)

--- a/framework/math/sparse_matrix/math_sparse_matrix.cc
+++ b/framework/math/sparse_matrix/math_sparse_matrix.cc
@@ -16,16 +16,16 @@ SparseMatrix::SparseMatrix(size_t num_rows, size_t num_cols)
   rowI_indices_.resize(num_rows, std::vector<size_t>());
 }
 
-SparseMatrix::SparseMatrix(const SparseMatrix& in_matrix)
-  : row_size_(in_matrix.NumRows()), col_size_(in_matrix.NumCols())
+SparseMatrix::SparseMatrix(const SparseMatrix& matrix)
+  : row_size_(matrix.NumRows()), col_size_(matrix.NumCols())
 {
   rowI_values_.resize(row_size_, std::vector<double>());
   rowI_indices_.resize(row_size_, std::vector<size_t>());
 
-  for (size_t i = 0; i < in_matrix.rowI_values_.size(); i++)
+  for (size_t i = 0; i < matrix.rowI_values_.size(); i++)
   {
-    rowI_values_[i] = (in_matrix.rowI_values_[i]);
-    rowI_indices_[i] = (in_matrix.rowI_indices_[i]);
+    rowI_values_[i] = (matrix.rowI_values_[i]);
+    rowI_indices_[i] = (matrix.rowI_indices_[i]);
   }
 }
 

--- a/framework/math/sparse_matrix/math_sparse_matrix.h
+++ b/framework/math/sparse_matrix/math_sparse_matrix.h
@@ -28,7 +28,7 @@ public:
   /**Constructor with number of rows and columns constructor.*/
   SparseMatrix(size_t num_rows, size_t num_cols);
   /**Copy constructor.*/
-  SparseMatrix(const SparseMatrix& in_matrix);
+  SparseMatrix(const SparseMatrix& matrix);
 
   size_t NumRows() const { return row_size_; }
   size_t NumCols() const { return col_size_; }
@@ -64,8 +64,8 @@ public:
     const size_t& column_index;
     double& value;
 
-    EntryReference(const size_t& row_id, const size_t& column_id, double& in_value)
-      : row_index(row_id), column_index(column_id), value(in_value)
+    EntryReference(const size_t& row_id, const size_t& column_id, double& value)
+      : row_index(row_id), column_index(column_id), value(value)
     {
     }
   };
@@ -77,8 +77,8 @@ public:
     const size_t& column_index;
     const double& value;
 
-    ConstEntryReference(const size_t& row_id, const size_t& column_id, const double& in_value)
-      : row_index(row_id), column_index(column_id), value(in_value)
+    ConstEntryReference(const size_t& row_id, const size_t& column_id, const double& value)
+      : row_index(row_id), column_index(column_id), value(value)
     {
     }
   };

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.cc
@@ -199,10 +199,10 @@ PieceWiseLinearContinuous::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_
 
     DOFHandler(int64_t block_start,
                int64_t block_end,
-               const std::vector<uint64_t>& in_locJ_block_address)
+               const std::vector<uint64_t>& locJ_block_address)
       : local_block_start(block_start),
         local_block_end(block_end),
-        locI_block_addr(in_locJ_block_address)
+        locI_block_addr(locJ_block_address)
     {
     }
 

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.cc
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.cc
@@ -19,14 +19,14 @@ FiniteVolume::FiniteVolume(const MeshContinuum& grid, CoordinateSystemType cs_ty
 }
 
 std::shared_ptr<FiniteVolume>
-FiniteVolume::New(const MeshContinuum& in_grid, CoordinateSystemType in_cs_type)
+FiniteVolume::New(const MeshContinuum& grid, CoordinateSystemType cs_type)
 {
   // First try to find an existing spatial discretization that matches the
   // one requested.
   for (auto& sdm : sdm_stack)
     if (sdm->Type() == SpatialDiscretizationType::FINITE_VOLUME and
-        std::addressof(sdm->Grid()) == std::addressof(in_grid) and
-        sdm->GetCoordinateSystemType() == in_cs_type)
+        std::addressof(sdm->Grid()) == std::addressof(grid) and
+        sdm->GetCoordinateSystemType() == cs_type)
     {
       auto sdm_ptr = std::dynamic_pointer_cast<FiniteVolume>(sdm);
 
@@ -37,7 +37,7 @@ FiniteVolume::New(const MeshContinuum& in_grid, CoordinateSystemType in_cs_type)
 
   // If no existing discretization was found then go ahead and make a
   // new one
-  auto new_sdm = std::shared_ptr<FiniteVolume>(new FiniteVolume(in_grid, in_cs_type));
+  auto new_sdm = std::shared_ptr<FiniteVolume>(new FiniteVolume(grid, cs_type));
 
   sdm_stack.push_back(new_sdm);
 

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.h
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.h
@@ -27,8 +27,7 @@ public:
    * Publicly accessible construction handler.
    */
   static std::shared_ptr<FiniteVolume>
-  New(const MeshContinuum& in_grid,
-      CoordinateSystemType in_cs_type = CoordinateSystemType::CARTESIAN);
+  New(const MeshContinuum& grid, CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN);
 
   void CreateCellMappings();
 

--- a/framework/math/statistics/cdfsampler.cc
+++ b/framework/math/statistics/cdfsampler.cc
@@ -13,11 +13,11 @@ namespace opensn
 CDFSampler::SubIntvl::SubIntvl(std::string offset,
                                int ibin,
                                int fbin,
-                               std::vector<double>& in_cdf,
+                               std::vector<double>& cdf,
                                int subdiv_factor,
                                int final_res,
                                bool inhibit)
-  : ref_cdf(in_cdf)
+  : ref_cdf(cdf)
 {
   inhibited = inhibit;
   cbin_i = ibin;
@@ -56,20 +56,19 @@ CDFSampler::SubIntvl::SubIntvl(std::string offset,
   }
 }
 
-CDFSampler::CDFSampler(std::vector<double>& in_cdf, int subdiv_factor, int final_res)
-  : ref_cdf_(in_cdf)
+CDFSampler::CDFSampler(std::vector<double>& cdf, int subdiv_factor, int final_res) : ref_cdf_(cdf)
 {
   // Setting sub-division factor
   if (subdiv_factor >= 1)
     this->subdiv_factor_ = subdiv_factor;
   else
   {
-    if (in_cdf.size() <= 10)
+    if (cdf.size() <= 10)
       this->subdiv_factor_ = 1;
-    else if (in_cdf.size() <= 10000)
+    else if (cdf.size() <= 10000)
       this->subdiv_factor_ = 10;
     else
-      this->subdiv_factor_ = 10; // sqrt(in_cdf.size());
+      this->subdiv_factor_ = 10; // sqrt(cdf.size());
   }
 
   // Setting final resolution
@@ -85,7 +84,7 @@ CDFSampler::CDFSampler(std::vector<double>& in_cdf, int subdiv_factor, int final
   //    << " " << this->final_res;
 
   // Sub-dividing the interval
-  size_t cdf_size = in_cdf.size();
+  size_t cdf_size = cdf.size();
   size_t intvl_size = ceil(cdf_size / (double)this->subdiv_factor_);
 
   if (intvl_size < this->final_res_)

--- a/framework/math/statistics/cdfsampler.h
+++ b/framework/math/statistics/cdfsampler.h
@@ -18,7 +18,7 @@ namespace opensn
  * it because it has some over-head to it that gets executed in the constructor.
  *
  \code
- CDFSampler sampler(in_cdf);
+ CDFSampler sampler(cdf);
  \endcode
  *
  * */
@@ -37,7 +37,7 @@ private:
 
 public:
   /** constructor.*/
-  CDFSampler(std::vector<double>& in_cdf,
+  CDFSampler(std::vector<double>& cdf,
              int subdiv_factor = AUTO_SUBDIV,
              int final_res = AUTO_FINERES);
 
@@ -62,7 +62,7 @@ struct CDFSampler::SubIntvl
   SubIntvl(std::string offset,
            int ibin,
            int fbin,
-           std::vector<double>& in_cdf,
+           std::vector<double>& cdf,
            int subdiv_factor = 10,
            int final_res = 10,
            bool inhibit = false);

--- a/framework/math/unknown_manager/unknown_manager.cc
+++ b/framework/math/unknown_manager/unknown_manager.cc
@@ -131,7 +131,7 @@ UnknownManager::SetUnknownComponentNumOffBlockConnections(unsigned int unknown_i
 }
 
 void
-UnknownManager::SetUnknownTextName(unsigned int unknown_id, const std::string& in_text_name)
+UnknownManager::SetUnknownTextName(unsigned int unknown_id, const std::string& text_name)
 {
   auto& log = Logger::GetInstance();
 
@@ -143,13 +143,13 @@ UnknownManager::SetUnknownTextName(unsigned int unknown_id, const std::string& i
     Exit(EXIT_FAILURE);
   }
 
-  unknowns_[unknown_id].text_name_ = in_text_name;
+  unknowns_[unknown_id].text_name_ = text_name;
 }
 
 void
 UnknownManager::SetUnknownComponentTextName(unsigned int unknown_id,
                                             unsigned int component,
-                                            const std::string& in_text_name)
+                                            const std::string& text_name)
 {
   auto& log = Logger::GetInstance();
 
@@ -169,7 +169,7 @@ UnknownManager::SetUnknownComponentTextName(unsigned int unknown_id,
     Exit(EXIT_FAILURE);
   }
 
-  unknowns_[unknown_id].component_text_names_[component] = in_text_name;
+  unknowns_[unknown_id].component_text_names_[component] = text_name;
 }
 
 } // namespace opensn

--- a/framework/math/unknown_manager/unknown_manager.h
+++ b/framework/math/unknown_manager/unknown_manager.h
@@ -36,15 +36,13 @@ public:
   std::vector<int> num_off_block_connections_;
 
 public:
-  explicit Unknown(UnknownType in_type,
-                   unsigned int in_num_components = 1,
-                   unsigned int in_map_begin = 0)
-    : type_(in_type),
+  explicit Unknown(UnknownType type, unsigned int num_components = 1, unsigned int map_begin = 0)
+    : type_(type),
       num_components_((type_ == UnknownType::SCALAR)     ? 1
                       : (type_ == UnknownType::VECTOR_2) ? 2
                       : (type_ == UnknownType::VECTOR_3) ? 3
-                                                         : in_num_components),
-      map_begin_(in_map_begin)
+                                                         : num_components),
+      map_begin_(map_begin)
   {
     component_text_names_.resize(num_components_, std::string());
     for (unsigned int c = 0; c < num_components_; ++c)
@@ -122,30 +120,30 @@ public:
 
   typedef std::pair<UnknownType, unsigned int> UnknownInfo;
   // Constructors
-  explicit UnknownManager(UnknownStorageType in_storage_type = UnknownStorageType::NODAL) noexcept
-    : dof_storage_type_(in_storage_type)
+  explicit UnknownManager(UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
+    : dof_storage_type_(storage_type)
   {
   }
 
   UnknownManager(std::initializer_list<UnknownInfo> unknown_info_list,
-                 UnknownStorageType in_storage_type = UnknownStorageType::NODAL) noexcept
-    : dof_storage_type_(in_storage_type)
+                 UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
+    : dof_storage_type_(storage_type)
   {
     for (const auto& uk_info : unknown_info_list)
       AddUnknown(uk_info.first, uk_info.second);
   }
 
   explicit UnknownManager(const std::vector<Unknown>& unknown_info_list,
-                          UnknownStorageType in_storage_type = UnknownStorageType::NODAL) noexcept
-    : dof_storage_type_(in_storage_type)
+                          UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
+    : dof_storage_type_(storage_type)
   {
     for (const auto& uk : unknown_info_list)
       AddUnknown(uk.type_, uk.num_components_);
   }
 
   UnknownManager(std::initializer_list<Unknown> unknowns,
-                 UnknownStorageType in_storage_type = UnknownStorageType::NODAL) noexcept
-    : dof_storage_type_(in_storage_type)
+                 UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
+    : dof_storage_type_(storage_type)
   {
     size_t ukid = 0;
     for (const auto& uk : unknowns)
@@ -175,9 +173,9 @@ public:
   size_t NumberOfUnknowns() const { return unknowns_.size(); }
   const Unknown& GetUnknown(size_t id) const { return unknowns_[id]; }
 
-  void SetDOFStorageType(const UnknownStorageType in_storage_type)
+  void SetDOFStorageType(const UnknownStorageType storage_type)
   {
-    dof_storage_type_ = in_storage_type;
+    dof_storage_type_ = storage_type;
   }
 
   UnknownStorageType GetDOFStorageType() const { return dof_storage_type_; }
@@ -205,13 +203,13 @@ public:
                                                  int num_conn);
 
   /**Sets a text name for the indicated unknown.*/
-  void SetUnknownTextName(unsigned int unknown_id, const std::string& in_text_name);
+  void SetUnknownTextName(unsigned int unknown_id, const std::string& text_name);
 
   /**Sets the text name to be associated with each component of the
    * unknown.*/
   void SetUnknownComponentTextName(unsigned int unknown_id,
                                    unsigned int component,
-                                   const std::string& in_text_name);
+                                   const std::string& text_name);
 
   ~UnknownManager() = default;
 };

--- a/framework/memory_usage.h
+++ b/framework/memory_usage.h
@@ -15,15 +15,15 @@ struct CSTMemory
 
   CSTMemory() = default;
 
-  explicit CSTMemory(double in_mem)
+  explicit CSTMemory(double mem)
   {
-    memory_bytes = in_mem;
-    memory_kbytes = in_mem / 1024.0;
-    memory_mbytes = in_mem / 1024.0 / 1024.0;
-    memory_gbytes = in_mem / 1024.0 / 1024.0 / 1024.0;
+    memory_bytes = mem;
+    memory_kbytes = mem / 1024.0;
+    memory_mbytes = mem / 1024.0 / 1024.0;
+    memory_gbytes = mem / 1024.0 / 1024.0 / 1024.0;
   }
 
-  CSTMemory& operator=(const CSTMemory& in_struct) = default;
+  CSTMemory& operator=(const CSTMemory& cst_mem) = default;
 };
 
 /**

--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -89,8 +89,8 @@ public:
   Cell(const Cell& other);
   /**Move constructor*/
   Cell(Cell&& other) noexcept;
-  explicit Cell(CellType in_cell_type, CellType in_cell_sub_type)
-    : cell_type_(in_cell_type), cell_sub_type_(in_cell_sub_type)
+  explicit Cell(CellType cell_type, CellType cell_sub_type)
+    : cell_type_(cell_type), cell_sub_type_(cell_sub_type)
   {
   }
 

--- a/framework/mesh/mesh_continuum/mesh_continuum_global_cell_handler.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum_global_cell_handler.h
@@ -20,14 +20,14 @@ private:
   std::map<uint64_t, uint64_t>& global_cell_id_to_foreign_id_map;
 
 private:
-  explicit GlobalCellHandler(std::vector<std::unique_ptr<Cell>>& in_native_cells,
-                             std::vector<std::unique_ptr<Cell>>& in_foreign_cells,
-                             std::map<uint64_t, uint64_t>& in_global_cell_id_to_native_id_map,
-                             std::map<uint64_t, uint64_t>& in_global_cell_id_to_foreign_id_map)
-    : local_cells_ref_(in_native_cells),
-      ghost_cells_ref_(in_foreign_cells),
-      global_cell_id_to_native_id_map(in_global_cell_id_to_native_id_map),
-      global_cell_id_to_foreign_id_map(in_global_cell_id_to_foreign_id_map)
+  explicit GlobalCellHandler(std::vector<std::unique_ptr<Cell>>& native_cells,
+                             std::vector<std::unique_ptr<Cell>>& foreign_cells,
+                             std::map<uint64_t, uint64_t>& global_cell_id_to_native_id_map,
+                             std::map<uint64_t, uint64_t>& global_cell_id_to_foreign_id_map)
+    : local_cells_ref_(native_cells),
+      ghost_cells_ref_(foreign_cells),
+      global_cell_id_to_native_id_map(global_cell_id_to_native_id_map),
+      global_cell_id_to_foreign_id_map(global_cell_id_to_foreign_id_map)
   {
   }
 

--- a/framework/mesh/mesh_continuum/mesh_continuum_local_cell_handler.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum_local_cell_handler.h
@@ -15,8 +15,8 @@ public:
 
 private:
   /**Constructor.*/
-  explicit LocalCellHandler(std::vector<std::unique_ptr<Cell>>& in_native_cells)
-    : native_cells(in_native_cells)
+  explicit LocalCellHandler(std::vector<std::unique_ptr<Cell>>& native_cells)
+    : native_cells(native_cells)
   {
   }
 
@@ -33,7 +33,7 @@ public:
     LocalCellHandler& ref_block;
     size_t ref_element;
 
-    iterator(LocalCellHandler& in_block, size_t i) : ref_block(in_block), ref_element(i) {}
+    iterator(LocalCellHandler& block, size_t i) : ref_block(block), ref_element(i) {}
 
     iterator operator++()
     {
@@ -59,9 +59,7 @@ public:
     const LocalCellHandler& ref_block;
     size_t ref_element;
 
-    const_iterator(const LocalCellHandler& in_block, size_t i) : ref_block(in_block), ref_element(i)
-    {
-    }
+    const_iterator(const LocalCellHandler& block, size_t i) : ref_block(block), ref_element(i) {}
 
     const_iterator operator++()
     {

--- a/framework/mesh/raytrace/raytracer.h
+++ b/framework/mesh/raytrace/raytracer.h
@@ -33,11 +33,11 @@ private:
 
 public:
   explicit RayTracer(const MeshContinuum& grid,
-                     std::vector<double> in_cell_sizes,
-                     bool in_perform_concavity_checks = true)
+                     std::vector<double> cell_sizes,
+                     bool perform_concavity_checks = true)
     : reference_grid_(grid),
-      cell_sizes_(std::move(in_cell_sizes)),
-      perform_concavity_checks_(in_perform_concavity_checks)
+      cell_sizes_(std::move(cell_sizes)),
+      perform_concavity_checks_(perform_concavity_checks)
   {
   }
 

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -28,8 +28,7 @@ public:
     uint64_t neighbor = 0;
 
     LightWeightFace() = default;
-    explicit LightWeightFace(std::vector<uint64_t> in_vertex_ids)
-      : vertex_ids(std::move(in_vertex_ids))
+    explicit LightWeightFace(std::vector<uint64_t> vertex_ids) : vertex_ids(std::move(vertex_ids))
     {
     }
   };
@@ -42,10 +41,7 @@ public:
     std::vector<uint64_t> vertex_ids;
     std::vector<LightWeightFace> faces;
 
-    explicit LightWeightCell(CellType in_type, CellType in_sub_type)
-      : type(in_type), sub_type(in_sub_type)
-    {
-    }
+    explicit LightWeightCell(CellType type, CellType sub_type) : type(type), sub_type(sub_type) {}
   };
 
   struct Options

--- a/framework/parameters/parameter_block.h
+++ b/framework/parameters/parameter_block.h
@@ -279,7 +279,7 @@ public:
     ParameterBlock& ref_block;
     size_t ref_id;
 
-    iterator(ParameterBlock& in_block, size_t i) : ref_block(in_block), ref_id(i) {}
+    iterator(ParameterBlock& block, size_t i) : ref_block(block), ref_id(i) {}
 
     iterator operator++()
     {
@@ -304,7 +304,7 @@ public:
     const ParameterBlock& ref_block;
     size_t ref_id;
 
-    const_iterator(const ParameterBlock& in_block, size_t i) : ref_block(in_block), ref_id(i) {}
+    const_iterator(const ParameterBlock& block, size_t i) : ref_block(block), ref_id(i) {}
 
     const_iterator operator++()
     {

--- a/framework/physics/basic_options/basic_options.h
+++ b/framework/physics/basic_options/basic_options.h
@@ -37,10 +37,10 @@ public:
   int64_t IntegerValue() const { return value_.IntegerValue(); }
   double FloatValue() const { return value_.FloatValue(); }
 
-  void SetStringValue(const std::string& in_string_value) { value_ = in_string_value; }
-  void SetBoolValue(const bool& in_bool_value) { value_ = in_bool_value; }
-  void SetIntegerValue(const int64_t& in_integer_value) { value_ = in_integer_value; }
-  void SetFloatValue(const double& in_float_value) { value_ = in_float_value; }
+  void SetStringValue(const std::string& value) { value_ = value; }
+  void SetBoolValue(const bool& value) { value_ = value; }
+  void SetIntegerValue(const int64_t& value) { value_ = value; }
+  void SetFloatValue(const double& value) { value_ = value; }
 };
 
 /**Class for basic options*/
@@ -53,7 +53,7 @@ public:
   BasicOptions() = default;
 
   /**Constructor with initializer list.*/
-  BasicOptions(std::initializer_list<BasicOption> in_options) : options_(in_options) {}
+  BasicOptions(std::initializer_list<BasicOption> options) : options_(options) {}
 
   // Operators
   /**Returns a constant reference to an option that matches the

--- a/framework/physics/physics_material/material_property_base.h
+++ b/framework/physics/physics_material/material_property_base.h
@@ -22,7 +22,7 @@ private:
 public:
   std::string property_name;
 
-  explicit PhysicsMaterialProperty(PropertyType in_type) : type_(in_type) {}
+  explicit PhysicsMaterialProperty(PropertyType type) : type_(type) {}
 
   virtual ~PhysicsMaterialProperty() = default;
 

--- a/framework/physics/solver_base/solver.cc
+++ b/framework/physics/solver_base/solver.cc
@@ -37,15 +37,15 @@ Solver::GetInputParameters()
   return params;
 }
 
-Solver::Solver(std::string in_text_name)
-  : timestepper_(InitTimeStepper(GetInputParameters())), text_name_(std::move(in_text_name))
+Solver::Solver(std::string name)
+  : timestepper_(InitTimeStepper(GetInputParameters())), text_name_(std::move(name))
 {
 }
 
-Solver::Solver(std::string in_text_name, std::initializer_list<BasicOption> in_options)
-  : basic_options_(in_options),
+Solver::Solver(std::string name, std::initializer_list<BasicOption> options)
+  : basic_options_(options),
     timestepper_(InitTimeStepper(GetInputParameters())),
-    text_name_(std::move(in_text_name))
+    text_name_(std::move(name))
 {
 }
 

--- a/framework/physics/solver_base/solver.h
+++ b/framework/physics/solver_base/solver.h
@@ -21,8 +21,8 @@ class Solver : public Object
 public:
   /**Returns the input parameters.*/
   static InputParameters GetInputParameters();
-  explicit Solver(std::string in_text_name);
-  Solver(std::string in_text_name, std::initializer_list<BasicOption> in_options);
+  explicit Solver(std::string name);
+  Solver(std::string name, std::initializer_list<BasicOption> options);
   explicit Solver(const InputParameters& params);
   virtual ~Solver() = default;
 

--- a/modules/cfem_diffusion/cfem_diffusion_solver.cc
+++ b/modules/cfem_diffusion/cfem_diffusion_solver.cc
@@ -13,8 +13,8 @@ namespace opensn
 namespace cfem_diffusion
 {
 
-Solver::Solver(const std::string& in_solver_name)
-  : opensn::Solver(in_solver_name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
+Solver::Solver(const std::string& name)
+  : opensn::Solver(name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
 {
 }
 

--- a/modules/cfem_diffusion/cfem_diffusion_solver.h
+++ b/modules/cfem_diffusion/cfem_diffusion_solver.h
@@ -44,7 +44,7 @@ public:
   BoundaryPreferences boundary_preferences_;
   std::map<uint64_t, Boundary> boundaries_;
 
-  explicit Solver(const std::string& in_solver_name);
+  explicit Solver(const std::string& name);
   ~Solver() override;
 
   void SetDCoefFunction(std::shared_ptr<ScalarSpatialMaterialFunction> function);

--- a/modules/dfem_diffusion/dfem_diffusion_solver.cc
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.cc
@@ -13,8 +13,8 @@ namespace opensn
 namespace dfem_diffusion
 {
 
-Solver::Solver(const std::string& in_solver_name)
-  : opensn::Solver(in_solver_name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
+Solver::Solver(const std::string& name)
+  : opensn::Solver(name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
 {
 }
 

--- a/modules/dfem_diffusion/dfem_diffusion_solver.h
+++ b/modules/dfem_diffusion/dfem_diffusion_solver.h
@@ -44,7 +44,7 @@ public:
   BoundaryPreferences boundary_preferences_;
   std::map<uint64_t, Boundary> boundaries_;
 
-  explicit Solver(const std::string& in_solver_name);
+  explicit Solver(const std::string& name);
   ~Solver() override;
 
   void SetDCoefFunction(std::shared_ptr<ScalarSpatialMaterialFunction> function);

--- a/modules/fv_diffusion/fv_diffusion_solver.cc
+++ b/modules/fv_diffusion/fv_diffusion_solver.cc
@@ -14,8 +14,8 @@ namespace opensn
 namespace fv_diffusion
 {
 
-Solver::Solver(const std::string& in_solver_name)
-  : opensn::Solver(in_solver_name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
+Solver::Solver(const std::string& name)
+  : opensn::Solver(name, {{"max_iters", int64_t(500)}, {"residual_tolerance", 1.0e-2}})
 {
 }
 

--- a/modules/fv_diffusion/fv_diffusion_solver.h
+++ b/modules/fv_diffusion/fv_diffusion_solver.h
@@ -44,7 +44,7 @@ public:
   BoundaryPreferences boundary_preferences_;
   std::map<uint64_t, Boundary> boundaries_;
 
-  explicit Solver(const std::string& in_solver_name);
+  explicit Solver(const std::string& name);
   ~Solver() override;
 
   void SetDCoefFunction(std::shared_ptr<ScalarSpatialMaterialFunction> function);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/aah_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/aah_angle_set.h
@@ -23,7 +23,7 @@ public:
                std::vector<size_t>& angle_indices,
                std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                int sweep_eager_limit,
-               const MPICommunicatorSet& in_comm_set);
+               const MPICommunicatorSet& comm_set);
 
   void InitializeDelayedUpstreamData() override;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/aah_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/aah_async_comm.cc
@@ -16,8 +16,8 @@ AAH_ASynchronousCommunicator::AAH_ASynchronousCommunicator(FLUDS& fluds,
                                                            size_t num_groups,
                                                            size_t num_angles,
                                                            int sweep_eager_limit,
-                                                           const MPICommunicatorSet& in_comm_set)
-  : AsynchronousCommunicator(fluds, in_comm_set), num_groups_(num_groups), num_angles_(num_angles)
+                                                           const MPICommunicatorSet& comm_set)
+  : AsynchronousCommunicator(fluds, comm_set), num_groups_(num_groups), num_angles_(num_angles)
 {
   done_sending = false;
   data_initialized = false;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/aah_async_comm.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/aah_async_comm.h
@@ -57,7 +57,7 @@ public:
                                size_t num_groups,
                                size_t num_angles,
                                int sweep_eager_limit,
-                               const MPICommunicatorSet& in_comm_set);
+                               const MPICommunicatorSet& comm_set);
   /**
    * Returns the private flag done_sending.
    */

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
@@ -11,12 +11,12 @@ namespace opensn
 namespace lbs
 {
 
-SweepScheduler::SweepScheduler(SchedulingAlgorithm in_scheduler_type,
-                               AngleAggregation& in_angle_agg,
-                               SweepChunk& in_sweep_chunk)
-  : scheduler_type_(in_scheduler_type),
-    angle_agg_(in_angle_agg),
-    sweep_chunk_(in_sweep_chunk),
+SweepScheduler::SweepScheduler(SchedulingAlgorithm scheduler_type,
+                               AngleAggregation& angle_agg,
+                               SweepChunk& sweep_chunk)
+  : scheduler_type_(scheduler_type),
+    angle_agg_(angle_agg),
+    sweep_chunk_(sweep_chunk),
     sweep_event_tag_(log.GetRepeatingEventTag("Sweep Timing")),
     sweep_timing_events_tag_(
       {log.GetRepeatingEventTag("Sweep Chunk Only Timing"), sweep_event_tag_})
@@ -28,13 +28,13 @@ SweepScheduler::SweepScheduler(SchedulingAlgorithm in_scheduler_type,
     InitializeAlgoDOG();
 
   // Initialize delayed upstream data
-  for (auto& angsetgrp : in_angle_agg.angle_set_groups)
+  for (auto& angsetgrp : angle_agg.angle_set_groups)
     for (auto& angset : angsetgrp.AngleSets())
       angset->InitializeDelayedUpstreamData();
 
   // Get local max num messages accross anglesets
   int local_max_num_messages = 0;
-  for (auto& angsetgrp : in_angle_agg.angle_set_groups)
+  for (auto& angsetgrp : angle_agg.angle_set_groups)
     for (auto& angset : angsetgrp.AngleSets())
       local_max_num_messages = std::max(angset->GetMaxBufferMessages(), local_max_num_messages);
 
@@ -43,7 +43,7 @@ SweepScheduler::SweepScheduler(SchedulingAlgorithm in_scheduler_type,
   mpi_comm.all_reduce(local_max_num_messages, global_max_num_messages, mpi::op::max<int>());
 
   // Propogate items back to sweep buffers
-  for (auto& angsetgrp : in_angle_agg.angle_set_groups)
+  for (auto& angsetgrp : angle_agg.angle_set_groups)
     for (auto& angset : angsetgrp.AngleSets())
       angset->SetMaxBufferMessages(global_max_num_messages);
 }
@@ -348,9 +348,9 @@ SweepScheduler::GetAngleSetTimings()
 }
 
 void
-SweepScheduler::SetDestinationPhi(std::vector<double>& in_destination_phi)
+SweepScheduler::SetDestinationPhi(std::vector<double>& destination_phi)
 {
-  sweep_chunk_.SetDestinationPhi(in_destination_phi);
+  sweep_chunk_.SetDestinationPhi(destination_phi);
 }
 
 void
@@ -366,9 +366,9 @@ SweepScheduler::GetDestinationPhi()
 }
 
 void
-SweepScheduler::SetDestinationPsi(std::vector<double>& in_destination_psi)
+SweepScheduler::SetDestinationPsi(std::vector<double>& destination_psi)
 {
-  sweep_chunk_.SetDestinationPsi(in_destination_psi);
+  sweep_chunk_.SetDestinationPsi(destination_psi);
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.h
@@ -53,9 +53,9 @@ private:
   const std::vector<size_t> sweep_timing_events_tag_;
 
 public:
-  SweepScheduler(SchedulingAlgorithm in_scheduler_type,
-                 AngleAggregation& in_angle_agg,
-                 SweepChunk& in_sweep_chunk);
+  SweepScheduler(SchedulingAlgorithm scheduler_type,
+                 AngleAggregation& angle_agg,
+                 SweepChunk& sweep_chunk);
 
   AngleAggregation& AngleAgg() { return angle_agg_; }
 
@@ -104,7 +104,7 @@ public:
   /**
    * Sets the location where flux moments are to be written.
    */
-  void SetDestinationPhi(std::vector<double>& in_destination_phi);
+  void SetDestinationPhi(std::vector<double>& destination_phi);
 
   /**
    * Sets all elements of the output vector to zero.
@@ -119,7 +119,7 @@ public:
   /**
    * Sets the location where angular fluxes are to be written.
    */
-  void SetDestinationPsi(std::vector<double>& in_destination_psi);
+  void SetDestinationPsi(std::vector<double>& destination_psi);
 
   /**
    * Sets all elements of the output angular flux vector to zero.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
@@ -12,8 +12,8 @@ namespace lbs
 class SPDS
 {
 public:
-  SPDS(const Vector3& in_omega, const MeshContinuum& in_grid, bool verbose)
-    : omega_(in_omega), grid_(in_grid), verbose_(verbose)
+  SPDS(const Vector3& omega, const MeshContinuum& grid, bool verbose)
+    : omega_(omega), grid_(grid), verbose_(verbose)
   {
   }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -27,8 +27,8 @@ public:
    */
   std::vector<MomentCallbackF> moment_callbacks;
 
-  SweepChunk(std::vector<double>& in_destination_phi,
-             std::vector<double>& in_destination_psi,
+  SweepChunk(std::vector<double>& destination_phi,
+             std::vector<double>& destination_psi,
              const MeshContinuum& grid,
              const SpatialDiscretization& discretization,
              const std::vector<lbs::UnitCellMatrices>& unit_cell_matrices,
@@ -49,12 +49,12 @@ public:
       xs_(xs),
       num_moments_(num_moments),
       max_num_cell_dofs_(max_num_cell_dofs),
-      save_angular_flux_(not in_destination_psi.empty()),
+      save_angular_flux_(not destination_psi.empty()),
       groupset_angle_group_stride_(groupset_.psi_uk_man_.NumberOfUnknowns() *
                                    groupset_.groups_.size()),
       groupset_group_stride_(groupset_.groups_.size()),
-      destination_phi(&in_destination_phi),
-      destination_psi(&in_destination_psi)
+      destination_phi(&destination_phi),
+      destination_psi(&destination_psi)
   {
   }
 
@@ -72,10 +72,7 @@ public:
 protected:
   friend class SweepScheduler;
   /**Sets the location where flux moments are to be written.*/
-  void SetDestinationPhi(std::vector<double>& in_destination_phi)
-  {
-    destination_phi = (&in_destination_phi);
-  }
+  void SetDestinationPhi(std::vector<double>& phi) { destination_phi = (&phi); }
 
   /**Sets all elements of the output vector to zero.*/
   void ZeroDestinationPhi() { (*destination_phi).assign((*destination_phi).size(), 0.0); }
@@ -84,10 +81,7 @@ protected:
   std::vector<double>& GetDestinationPhi() { return *destination_phi; }
 
   /**Sets the location where angular fluxes are to be written.*/
-  void SetDestinationPsi(std::vector<double>& in_destination_psi)
-  {
-    destination_psi = (&in_destination_psi);
-  }
+  void SetDestinationPsi(std::vector<double>& psi) { destination_psi = (&psi); }
 
   /**Sets all elements of the output angular flux vector to zero.*/
   void ZeroDestinationPsi() { (*destination_psi).assign((*destination_psi).size(), 0.0); }

--- a/modules/mg_diffusion/mg_diffusion_solver.cc
+++ b/modules/mg_diffusion/mg_diffusion_solver.cc
@@ -19,8 +19,8 @@ namespace opensn
 namespace mg_diffusion
 {
 
-Solver::Solver(const std::string& in_solver_name)
-  : opensn::Solver(in_solver_name,
+Solver::Solver(const std::string& name)
+  : opensn::Solver(name,
                    {{"max_inner_iters", int64_t(500)},
                     {"residual_tolerance", 1.0e-2},
                     {"verbose_level", int64_t(0)},

--- a/modules/mg_diffusion/mg_diffusion_solver.h
+++ b/modules/mg_diffusion/mg_diffusion_solver.h
@@ -78,7 +78,7 @@ public:
   BoundaryPreferences boundary_preferences_;
   std::vector<Boundary> boundaries_;
 
-  explicit Solver(const std::string& in_solver_name);
+  explicit Solver(const std::string& name);
   ~Solver() override;
 
   void Initialize() override;


### PR DESCRIPTION
- Renaming function argument names in directed_graph.h
- Renaming function argument names in directed_graph_vertex.h
- Renaming function argument names in log.h
- Renaming function argument names in petsc_utils.{cc|h}
- Renaming function argument names in math_sparse_matrix.{cc|h}
- Renaming function argument names in piecewise_linear_continuous.cc
- Renaming function argument names in finite_volume.{cc|h}
- Renaming function argument names in cdfsampler.{cc|h}
- Renaming function argument names in unknown_manager.{cc|h}
- Renaming function argument names in cell.h
- Renaming function argument names in mesh_continuum_global_cell_handler.h
- Renaming function argument names in raytracer.h
- Renaming function argument names in unpartitioned_mesh.h
- Renaming function argument names in parameter_block.h
- Renaming function argument names in basic_options.h
- Renaming function argument names in material_property_base.h
- Renaming function argument names in solver.{cc|h}
- Renaming function argument names in mesh_continuum_local_cell_handler.h
- Renaming function argument names in memory_usage.h
- Renaming function argument names in cfem_diffusion_solver.{cc|h}
- Renaming function argument names in dfem_diffusion_solver.{cc|h}
- Renaming function argument names in fv_diffusion_solver.{cc|h}
- Renaming function argument names in aah_angle_set.h
- Renaming function argument names in aah_async_comm.{cc|h}
- Renaming function argument names in sweep_scheduler.{cc|h}
- Renaming function argument names in spds.h
- Renaming function argument names in sweep_chunk.h
- Renaming function argument names in mg_diffusion_solver.{cc|h}
- Renaming function argument names in golub_fischer.{cc|h}
- Renaming function argument names in sldfe_sq.h
- Renaming function argument names in angular_product_quadrature.{cc|h}
- Renaming function argument names in angular_quadrature_base.{cc|h}
- Renaming function argument names in quadrature.{cc|h}
- Renaming function argument names in quadrature_gausslegendre.{cc|h}
- Renaming function argument names in quadrature_line.h

Closes #173
