### PR TITLE
LUA modules, pt. 2

### DIFF
--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -18,8 +18,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(physics, FieldFunctionGridBased);
-
 InputParameters
 FieldFunctionGridBased::GetInputParameters()
 {

--- a/framework/field_functions/operations/field_copy.cc
+++ b/framework/field_functions/operations/field_copy.cc
@@ -6,8 +6,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(physics::field_operations, FieldCopyOperation);
-
 InputParameters
 FieldCopyOperation::GetInputParameters()
 {

--- a/framework/field_functions/operations/multi_field.cc
+++ b/framework/field_functions/operations/multi_field.cc
@@ -6,8 +6,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(physics::field_operations, MultiFieldOperation);
-
 InputParameters
 MultiFieldOperation::GetInputParameters()
 {

--- a/framework/field_functions/operations/partitioner_predicate.cc
+++ b/framework/field_functions/operations/partitioner_predicate.cc
@@ -9,8 +9,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(physics::field_operations, PartitionerPredicate);
-
 InputParameters
 PartitionerPredicate::GetInputParameters()
 {

--- a/framework/graphs/kba_graph_partitioner.cc
+++ b/framework/graphs/kba_graph_partitioner.cc
@@ -13,7 +13,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(KBAGraphPartitioner);
+OpenSnRegisterObjectInNamespace(mesh, KBAGraphPartitioner);
 
 InputParameters
 KBAGraphPartitioner::GetInputParameters()

--- a/framework/graphs/linear_graph_partitioner.cc
+++ b/framework/graphs/linear_graph_partitioner.cc
@@ -10,7 +10,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(LinearGraphPartitioner);
+OpenSnRegisterObjectInNamespace(mesh, LinearGraphPartitioner);
 
 InputParameters
 LinearGraphPartitioner::GetInputParameters()

--- a/framework/graphs/petsc_graph_partitioner.cc
+++ b/framework/graphs/petsc_graph_partitioner.cc
@@ -10,7 +10,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(PETScGraphPartitioner);
+OpenSnRegisterObjectInNamespace(mesh, PETScGraphPartitioner);
 
 InputParameters
 PETScGraphPartitioner::GetInputParameters()

--- a/framework/materials/mat_prop_scalarfuncXYZTV.cc
+++ b/framework/materials/mat_prop_scalarfuncXYZTV.cc
@@ -6,8 +6,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(objects, MaterialPropertyScalarFuncXYZTV);
-
 InputParameters
 MaterialPropertyScalarFuncXYZTV::GetInputParameters()
 {

--- a/framework/materials/material.cc
+++ b/framework/materials/material.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(objects, Material);
-
 InputParameters
 Material::GetInputParameters()
 {

--- a/framework/materials/material_property.cc
+++ b/framework/materials/material_property.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(objects, MaterialProperty);
-
 InputParameters
 MaterialProperty::GetInputParameters()
 {

--- a/framework/math/functions/piecewise_linear_1d.cc
+++ b/framework/math/functions/piecewise_linear_1d.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(math::functions, PiecewiseLinear1D);
-
 InputParameters
 PiecewiseLinear1D::GetInputParameters()
 {

--- a/framework/math/nonlinear_solver/nonlinear_solver_options.cc
+++ b/framework/math/nonlinear_solver/nonlinear_solver_options.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectParametersOnlyInNamespace(math, NonLinearSolverOptions);
-
 InputParameters
 NonLinearSolverOptions::GetInputParameters()
 {

--- a/framework/math/time_integrations/crank_nicolson_time_intgr.cc
+++ b/framework/math/time_integrations/crank_nicolson_time_intgr.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(math, CrankNicolsonTimeIntegration);
-
 InputParameters
 CrankNicolsonTimeIntegration::GetInputParameters()
 {

--- a/framework/math/time_integrations/implicit_euler_time_intgr.cc
+++ b/framework/math/time_integrations/implicit_euler_time_intgr.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(math, ImplicitEulerTimeIntegration);
-
 InputParameters
 ImplicitEulerTimeIntegration::GetInputParameters()
 {

--- a/framework/math/time_integrations/theta_scheme_time_intgr.cc
+++ b/framework/math/time_integrations/theta_scheme_time_intgr.cc
@@ -5,8 +5,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(math, ThetaSchemeTimeIntegration);
-
 InputParameters
 ThetaSchemeTimeIntegration::GetInputParameters()
 {

--- a/framework/mesh/logical_volume/boolean_logical_volume.cc
+++ b/framework/mesh/logical_volume/boolean_logical_volume.cc
@@ -7,8 +7,8 @@ namespace opensn
 
 InputParameters BooleanLogicalVolumeArgumentPair();
 
-OpenSnRegisterObjectInNamespace(mesh, BooleanLogicalVolume);
-OpenSnRegisterSyntaxBlockInNamespace(mesh,
+OpenSnRegisterObjectInNamespace(logvol, BooleanLogicalVolume);
+OpenSnRegisterSyntaxBlockInNamespace(logvol,
                                      BooleanLogicalVolumeArgumentPair,
                                      BooleanLogicalVolumeArgumentPair);
 

--- a/framework/mesh/logical_volume/rcc_logical_volume.cc
+++ b/framework/mesh/logical_volume/rcc_logical_volume.cc
@@ -5,7 +5,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(mesh, RCCLogicalVolume);
+OpenSnRegisterObjectInNamespace(logvol, RCCLogicalVolume);
 
 InputParameters
 RCCLogicalVolume::GetInputParameters()

--- a/framework/mesh/logical_volume/rpp_logical_volume.cc
+++ b/framework/mesh/logical_volume/rpp_logical_volume.cc
@@ -5,7 +5,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(mesh, RPPLogicalVolume);
+OpenSnRegisterObjectInNamespace(logvol, RPPLogicalVolume);
 
 InputParameters
 RPPLogicalVolume::GetInputParameters()

--- a/framework/mesh/logical_volume/sphere_logical_volume.cc
+++ b/framework/mesh/logical_volume/sphere_logical_volume.cc
@@ -5,7 +5,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(mesh, SphereLogicalVolume);
+OpenSnRegisterObjectInNamespace(logvol, SphereLogicalVolume);
 
 InputParameters
 SphereLogicalVolume::GetInputParameters()

--- a/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
+++ b/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
@@ -11,7 +11,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(mesh, SurfaceMeshLogicalVolume);
+OpenSnRegisterObjectInNamespace(logvol, SurfaceMeshLogicalVolume);
 
 InputParameters
 SurfaceMeshLogicalVolume::GetInputParameters()

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -62,7 +62,7 @@ MeshGenerator::MeshGenerator(const InputParameters& params)
     auto& factory = ObjectFactory::GetInstance();
     auto valid_params = PETScGraphPartitioner::GetInputParameters();
     partitioner_handle =
-      factory.MakeRegisteredObjectOfType("PETScGraphPartitioner", ParameterBlock());
+      factory.MakeRegisteredObjectOfType("mesh::PETScGraphPartitioner", ParameterBlock());
   }
   partitioner_ = &GetStackItem<GraphPartitioner>(object_stack, partitioner_handle, __FUNCTION__);
 }

--- a/framework/post_processors/aggregate_nodal_value_post_processor.cc
+++ b/framework/post_processors/aggregate_nodal_value_post_processor.cc
@@ -9,7 +9,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(AggregateNodalValuePostProcessor);
+OpenSnRegisterObjectInNamespace(post, AggregateNodalValuePostProcessor);
 
 InputParameters
 AggregateNodalValuePostProcessor::GetInputParameters()

--- a/framework/post_processors/cell_volume_integral_post_processor.cc
+++ b/framework/post_processors/cell_volume_integral_post_processor.cc
@@ -10,7 +10,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(CellVolumeIntegralPostProcessor);
+OpenSnRegisterObjectInNamespace(post, CellVolumeIntegralPostProcessor);
 
 InputParameters
 CellVolumeIntegralPostProcessor::GetInputParameters()

--- a/framework/post_processors/post_processor.cc
+++ b/framework/post_processors/post_processor.cc
@@ -9,8 +9,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectParametersOnly(PostProcessor);
-
 InputParameters
 PostProcessor::GetInputParameters()
 {

--- a/framework/post_processors/solver_info_post_processor.cc
+++ b/framework/post_processors/solver_info_post_processor.cc
@@ -11,7 +11,7 @@
 namespace opensn
 {
 
-OpenSnRegisterObject(SolverInfoPostProcessor);
+OpenSnRegisterObjectInNamespace(post, SolverInfoPostProcessor);
 
 InputParameters
 SolverInfoPostProcessor::GetInputParameters()

--- a/lua/framework/mesh/logical_volume/lua_logic_volume.cc
+++ b/lua/framework/mesh/logical_volume/lua_logic_volume.cc
@@ -198,7 +198,7 @@ LogVolCreate(lua_State* L)
     params.AddParameter("surface_mesh_handle", surf_mesh_hndle);
 
     const size_t handle =
-      object_maker.MakeRegisteredObjectOfType("mesh::SurfaceMeshLogicalVolume", params);
+      object_maker.MakeRegisteredObjectOfType("logvol::SurfaceMeshLogicalVolume", params);
 
     lua_pushinteger(L, static_cast<lua_Integer>(handle));
     return 1;

--- a/lua/framework/post_processors/lua_execute_post_processors.cc
+++ b/lua/framework/post_processors/lua_execute_post_processors.cc
@@ -10,9 +10,10 @@ namespace opensn
 InputParameters GetSyntax_ExecutePostProcessors();
 ParameterBlock ExecutePostProcessors(const InputParameters& params);
 
-RegisterWrapperFunction(ExecutePostProcessors,
-                        GetSyntax_ExecutePostProcessors,
-                        ExecutePostProcessors);
+RegisterWrapperFunctionNamespace(post,
+                                 Execute,
+                                 GetSyntax_ExecutePostProcessors,
+                                 ExecutePostProcessors);
 
 InputParameters
 GetSyntax_ExecutePostProcessors()

--- a/lua/framework/post_processors/lua_post_processor_get_value.cc
+++ b/lua/framework/post_processors/lua_post_processor_get_value.cc
@@ -11,9 +11,10 @@ namespace opensn
 InputParameters GetSyntax_PostProcessorGetValue();
 ParameterBlock PostProcessorGetValue(const InputParameters& params);
 
-RegisterWrapperFunction(PostProcessorGetValue,
-                        GetSyntax_PostProcessorGetValue,
-                        PostProcessorGetValue);
+RegisterWrapperFunctionNamespace(post,
+                                 GetValue,
+                                 GetSyntax_PostProcessorGetValue,
+                                 PostProcessorGetValue);
 
 InputParameters
 GetSyntax_PostProcessorGetValue()

--- a/lua/framework/post_processors/lua_pp_printer_set_options.cc
+++ b/lua/framework/post_processors/lua_pp_printer_set_options.cc
@@ -18,9 +18,10 @@ ParameterBlock PostProcessorPrinterSetOptions(const InputParameters& params);
 
 OpenSnRegisterSyntaxBlock(PostProcessorPrinterOptions, PostProcessorPrinterOptions);
 
-RegisterWrapperFunction(PostProcessorPrinterSetOptions,
-                        GetSyntax_PPPrinterSetOptions,
-                        PostProcessorPrinterSetOptions);
+RegisterWrapperFunctionNamespace(post,
+                                 SetPrinterOptions,
+                                 GetSyntax_PPPrinterSetOptions,
+                                 PostProcessorPrinterSetOptions);
 
 InputParameters
 PostProcessorPrinterOptions()

--- a/lua/framework/post_processors/lua_print_post_processors.cc
+++ b/lua/framework/post_processors/lua_print_post_processors.cc
@@ -12,7 +12,7 @@ namespace opensn
 InputParameters GetSyntax_PrintPostProcessors();
 ParameterBlock PrintPostProcessors(const InputParameters& params);
 
-RegisterWrapperFunction(PrintPostProcessors, GetSyntax_PrintPostProcessors, PrintPostProcessors);
+RegisterWrapperFunctionNamespace(post, Print, GetSyntax_PrintPostProcessors, PrintPostProcessors);
 
 InputParameters
 GetSyntax_PrintPostProcessors()

--- a/test/framework/mesh/logical_volume/lv_boolean_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_boolean_test1.lua
@@ -22,19 +22,19 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 -- assign matID 10 to all cells
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 -- create logical volume lv1 as an analytical sphere
-lv1 = mesh.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
+lv1 = logvol.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
 
 -- create logical volume lv2 as an analytical rcc
-lv2 = mesh.RCCLogicalVolume.Create({r = 1.3,
+lv2 = logvol.RCCLogicalVolume.Create({r = 1.3,
                                         x0=-0.8, y0=-0.8, z0=-1.5,
                                         vx=1.0, vy=1.0, vz=3.0})
 
 -- create logical volume lv3 as boolean: true if cell is in lv2 and false if in lv1
-lv3 = mesh.BooleanLogicalVolume.Create
+lv3 = logvol.BooleanLogicalVolume.Create
 ({
   parts = { { op=true, lv=lv2 },
             { op=false, lv=lv1 } }

--- a/test/framework/mesh/logical_volume/lv_lua_func.lua
+++ b/test/framework/mesh/logical_volume/lv_lua_func.lua
@@ -17,7 +17,7 @@ meshgen = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen)
 
 -- assign mat ID 10 to whole domain
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 --Sets lua function describing a sphere (material 11)
@@ -32,4 +32,3 @@ mesh.SetMaterialIDFromFunction("MatIDFunction1")
 
 -- export to vtk
 mesh.ExportToVTK("lv_lua_func_out")
-

--- a/test/framework/mesh/logical_volume/lv_rcc_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_rcc_test1.lua
@@ -13,10 +13,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
-lv1 = mesh.RCCLogicalVolume.Create({r = 1.3, x0=L/2, y0=L/2, z0 = -1.0, vz = 2.0})
+lv1 = logvol.RCCLogicalVolume.Create({r = 1.3, x0=L/2, y0=L/2, z0 = -1.0, vz = 2.0})
 mesh.SetMaterialIDFromLogicalVolume(lv1, 1)
 
-lv2 = mesh.RCCLogicalVolume.Create({r = 1.3,
+lv2 = logvol.RCCLogicalVolume.Create({r = 1.3,
                                         x0=-0.8, y0=-0.8, z0=-1.5,
                                         vx=1.0, vy=1.0, vz=3.0})
 mesh.SetMaterialIDFromLogicalVolume(lv2, 2)

--- a/test/framework/mesh/logical_volume/lv_rpp_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_rpp_test1.lua
@@ -1,10 +1,10 @@
-lv1 = mesh.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0})
+lv1 = logvol.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0})
 
 print("lv1 test 1:", logvol.PointSense(lv1, -13.0, 0.1, 0.1))
 print("lv1 test 2:", logvol.PointSense(lv1, -11.0, 0.1, 0.1))
 print("lv1 test 3:", logvol.PointSense(lv1, -11.0, -1.0, -1.0))
 
-lv2 = mesh.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0,
+lv2 = logvol.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0,
                                         infy = true, infz = true})
 print()
 print("lv2 test 1:", logvol.PointSense(lv2, -13.0, 0.1, 0.1))

--- a/test/framework/mesh/logical_volume/lv_skinmesh.lua
+++ b/test/framework/mesh/logical_volume/lv_skinmesh.lua
@@ -17,11 +17,11 @@ meshgen = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen)
 
 -- assign mat ID 10 to whole domain
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 -- create a logical volume as an analytical RPP
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=0.8,ymax=1.5, zmin=-1.5,zmax=0.5,  })
 -- assign mat ID 11 to lv of RPP
 mesh.SetMaterialIDFromLogicalVolume(vol1, 11)
@@ -30,7 +30,7 @@ mesh.SetMaterialIDFromLogicalVolume(vol1, 11)
 surfmesh = mesh.SurfaceMeshCreate()
 skin_mesh_file = "./cube_with_normals.obj"
 mesh.SurfaceMeshImportFromOBJFile(surfmesh, skin_mesh_file)
-lv_skinmesh = mesh.SurfaceMeshLogicalVolume.Create({surface_mesh_handle=surfmesh})
+lv_skinmesh = logvol.SurfaceMeshLogicalVolume.Create({surface_mesh_handle=surfmesh})
 -- assign mat ID 15 to lv of skin mesh
 mesh.SetMaterialIDFromLogicalVolume(lv_skinmesh, 15)
 

--- a/test/framework/mesh/logical_volume/lv_sphere_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_sphere_test1.lua
@@ -1,4 +1,4 @@
-lv1 = mesh.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
+lv1 = logvol.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
 
 print("lv1 test 1:", logvol.PointSense(lv1, 1.0,-1.0,2.0))
 print("lv1 test 2:", logvol.PointSense(lv1, 1.0+1.3,-1.0,2.0))

--- a/test/framework/mesh/mesh_generators/meshgen_extruder_kba.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_extruder_kba.lua
@@ -8,7 +8,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=1.1, n=2}, {z=2.1, n=3}},
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=2,
     xcuts = {0.0}, ycuts = {0.0}, zcuts = {1.1}

--- a/test/framework/post_processors/solver_info_01.lua
+++ b/test/framework/post_processors/solver_info_01.lua
@@ -4,7 +4,7 @@
 -- Example Point-Reactor Kinetics solver
 phys0 = prk.TransientSolver.Create({ initial_source = 0.0 })
 
-pp0 = SolverInfoPostProcessor.Create
+pp0 = post.SolverInfoPostProcessor.Create
 ({
   name = "neutron_population",
   solver = phys0,
@@ -12,7 +12,7 @@ pp0 = SolverInfoPostProcessor.Create
   print_on = { "ProgramExecuted" }
 })
 
-PostProcessorPrinterSetOptions
+post.SetPrinterOptions
 ({
   csv_filename = "solver_info_01.csv"
 })
@@ -31,4 +31,4 @@ for t=1,20 do
 end
 
 print("Manually printing Post-Processor:")
-PrintPostProcessors({pp0, pp1})
+post.Print({pp0, pp1})

--- a/test/framework/post_processors/solver_info_02.lua
+++ b/test/framework/post_processors/solver_info_02.lua
@@ -6,21 +6,21 @@
 phys0 = prk.TransientSolver.Create({ initial_source = 0.0 })
 
 for k = 1, 20 do
-  SolverInfoPostProcessor.Create({
+  post.SolverInfoPostProcessor.Create({
     name = "neutron_population" .. tostring(k),
     solver = phys0,
     info = { name = "neutron_population" },
     print_on = { "" }
   })
 end
-pp21 = SolverInfoPostProcessor.Create({
+pp21 = post.SolverInfoPostProcessor.Create({
   name = "neutron_population" .. tostring(21),
   solver = phys0,
   info = { name = "neutron_population" },
   print_on = { "" }
 })
 
-PostProcessorPrinterSetOptions({
+post.SetPrinterOptions({
   time_history_limit = 5,
 })
 
@@ -38,6 +38,6 @@ for t = 1, 20 do
 end
 
 print("Manual neutron_population1=",
-  string.format("%.5f", PostProcessorGetValue("neutron_population1")))
+  string.format("%.5f", post.GetValue("neutron_population1")))
 print("Manual neutron_population1=",
-  string.format("%.5f", PostProcessorGetValue(pp21)))
+  string.format("%.5f", post.GetValue(pp21)))

--- a/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
@@ -85,10 +85,10 @@ end
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-AggregateNodalValuePostProcessor.Create
+post.AggregateNodalValuePostProcessor.Create
 ({
     name = "maxval",
     field_function = math.floor(fflist[1]),
     operation = "max"
 })
-ExecutePostProcessors({"maxval"})
+post.Execute({"maxval"})

--- a/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
@@ -30,10 +30,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
@@ -14,10 +14,10 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
@@ -36,10 +36,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
@@ -76,10 +76,10 @@ end
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-CellVolumeIntegralPostProcessor.Create
+post.CellVolumeIntegralPostProcessor.Create
 ({
     name = "avgval",
     field_function = math.floor(fflist[1]),
     compute_volume_average = true
 })
-ExecutePostProcessors({"avgval"})
+post.Execute({"avgval"})

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
@@ -75,10 +75,10 @@ end
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-CellVolumeIntegralPostProcessor.Create
+post.CellVolumeIntegralPostProcessor.Create
 ({
     name = "avgval",
     field_function = math.floor(fflist[1]),
     compute_volume_average = true
 })
-ExecutePostProcessors({"avgval"})
+post.Execute({"avgval"})

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
@@ -13,10 +13,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
@@ -35,10 +35,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
@@ -67,10 +67,10 @@ end
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-AggregateNodalValuePostProcessor.Create
+post.AggregateNodalValuePostProcessor.Create
 ({
     name = "maxval",
     field_function = math.floor(fflist[1]),
     operation = "max"
 })
-ExecutePostProcessors({"maxval"})
+post.Execute({"maxval"})

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
@@ -28,10 +28,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
@@ -34,10 +34,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
@@ -73,10 +73,10 @@ end
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-AggregateNodalValuePostProcessor.Create
+post.AggregateNodalValuePostProcessor.Create
 ({
     name = "maxval",
     field_function = math.floor(fflist[1]),
     operation = "max"
 })
-ExecutePostProcessors({"maxval"})
+post.Execute({"maxval"})

--- a/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
@@ -30,10 +30,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -83,7 +83,7 @@ if (master_export == nil) then
 end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
@@ -13,10 +13,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
@@ -35,10 +35,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -74,7 +74,7 @@ if (master_export == nil) then
 end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_AVG)

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
@@ -13,10 +13,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
@@ -35,10 +35,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -74,7 +74,7 @@ if (master_export == nil) then
 end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_AVG)

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
@@ -28,10 +28,10 @@ end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -65,7 +65,7 @@ if (master_export == nil) then
 end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
@@ -33,10 +33,10 @@ end
 
 -- Set boundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -71,7 +71,7 @@ if (master_export == nil) then
 end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3c_l2_error_mms.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3c_l2_error_mms.lua
@@ -36,10 +36,10 @@ end
 
 -- Set boundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = mesh.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = mesh.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = mesh.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = mesh.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
+w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
+n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
+s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
 
 e_bndry = 0
 w_bndry = 1
@@ -60,7 +60,7 @@ if (master_export == nil) then
 end
 
 ----############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 --
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
 fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
@@ -14,6 +14,6 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-1000.0,xmax=10.0,ymin=-1000.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
@@ -38,7 +38,7 @@ end
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
@@ -36,10 +36,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
@@ -28,7 +28,7 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = mesh.RPPLogicalVolume.Create(
+vol1a = logvol.RPPLogicalVolume.Create(
         {
             infx = true,
             ymin = 0.0, ymax = 0.8 * L,
@@ -38,7 +38,7 @@ vol1a = mesh.RPPLogicalVolume.Create(
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = mesh.RPPLogicalVolume.Create(
+vol0 = logvol.RPPLogicalVolume.Create(
         {
             xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
             infy = true,
@@ -47,7 +47,7 @@ vol0 = mesh.RPPLogicalVolume.Create(
 )
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol2 = mesh.RPPLogicalVolume.Create(
+vol2 = logvol.RPPLogicalVolume.Create(
         {
             xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
             ymin = 0.0, ymax = 2 * 0.166666,
@@ -56,7 +56,7 @@ vol2 = mesh.RPPLogicalVolume.Create(
 )
 mesh.SetMaterialIDFromLogicalVolume(vol2, 2)
 
-vol1b = mesh.RPPLogicalVolume.Create(
+vol1b = logvol.RPPLogicalVolume.Create(
         {
             xmin = -1 + 2.5, xmax = 1 + 2.5,
             ymin = 0.9 * L, ymax = L,
@@ -126,7 +126,7 @@ ff_m1 = fieldfunc.GetHandleByName("phi_g000_m01")
 ff_m2 = fieldfunc.GetHandleByName("phi_g000_m02")
 
 -- Define QoI region
-qoi_vol = mesh.RPPLogicalVolume.Create(
+qoi_vol = logvol.RPPLogicalVolume.Create(
         {
             xmin = 0.5, xmax = 0.8333,
             ymin = 4.16666, ymax = 4.33333,

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
@@ -27,7 +27,7 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = mesh.RPPLogicalVolume.Create(
+vol1a = logvol.RPPLogicalVolume.Create(
         {
             infx = true,
             ymin = 0.0, ymax = 0.8 * L,
@@ -37,7 +37,7 @@ vol1a = mesh.RPPLogicalVolume.Create(
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = mesh.RPPLogicalVolume.Create(
+vol0 = logvol.RPPLogicalVolume.Create(
         {
             xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
             infy = true,
@@ -46,7 +46,7 @@ vol0 = mesh.RPPLogicalVolume.Create(
 )
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1b = mesh.RPPLogicalVolume.Create(
+vol1b = logvol.RPPLogicalVolume.Create(
         {
             xmin = -1 + 2.5, xmax = 1 + 2.5,
             ymin = 0.9 * L, ymax = L,
@@ -117,7 +117,7 @@ ff_m1 = fieldfunc.GetHandleByName("phi_g000_m01")
 ff_m2 = fieldfunc.GetHandleByName("phi_g000_m02")
 
 -- Define QoI region
-qoi_vol = mesh.RPPLogicalVolume.Create(
+qoi_vol = logvol.RPPLogicalVolume.Create(
         {
             xmin = 0.5, xmax = 0.8333,
             ymin = 4.16666, ymax = 4.33333,

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
@@ -38,7 +38,7 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = mesh.RPPLogicalVolume.Create(
+vol1a = logvol.RPPLogicalVolume.Create(
         {
             infx = true,
             ymin = 0.0, ymax = 0.8 * L,
@@ -48,7 +48,7 @@ vol1a = mesh.RPPLogicalVolume.Create(
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = mesh.RPPLogicalVolume.Create(
+vol0 = logvol.RPPLogicalVolume.Create(
         {
             xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
             infy = true,
@@ -57,7 +57,7 @@ vol0 = mesh.RPPLogicalVolume.Create(
 )
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1b = mesh.RPPLogicalVolume.Create(
+vol1b = logvol.RPPLogicalVolume.Create(
         {
             xmin = -1 + 2.5, xmax = 1 + 2.5,
             ymin = 0.9 * L, ymax = L,
@@ -122,7 +122,7 @@ solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 -- Define QoI region
-qoi_vol = mesh.RPPLogicalVolume.Create(
+qoi_vol = logvol.RPPLogicalVolume.Create(
         {
             xmin = 0.5, xmax = 0.8333,
             ymin = 4.16666, ymax = 4.33333,

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
@@ -13,6 +13,6 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-1000.0,xmax=10.0,ymin=-1000.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
@@ -135,7 +135,7 @@ fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
 fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
@@ -36,7 +36,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-10.0, zmax=10.0})
+vol1 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-10.0, zmax=10.0})
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -25,7 +25,7 @@ meshgen1 = mesh.MeshGenerator.Create
       filename="../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
     }),
   },
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0},

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -34,7 +34,7 @@ meshgen1 = mesh.MeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
@@ -30,9 +30,9 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
-vol1 = mesh.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
+vol1 = logvol.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
@@ -30,9 +30,9 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(SetMaterialIDFromLogicalVolumevol0,0)
-vol1 = mesh.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
+vol1 = logvol.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -34,7 +34,7 @@ meshgen1 = mesh.MeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -25,7 +25,7 @@ meshgen1 = mesh.MeshGenerator.Create
       filename="../../../../resources/TestMeshes/TriangleMesh2x2Cuts.obj"
     }),
   },
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0},

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -25,7 +25,7 @@ meshgen1 = mesh.MeshGenerator.Create
       filename="../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
     }),
   },
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0},

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -135,7 +135,7 @@ fieldfunc.Initialize(slice2)
 fieldfunc.Execute(slice2)
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
@@ -36,7 +36,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
@@ -36,7 +36,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
@@ -151,7 +151,7 @@ fieldfunc.Initialize(slice2)
 fieldfunc.Execute(slice2)
 
 ----############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
 fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
@@ -32,10 +32,10 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodesxy,nodesxy,no
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -26,7 +26,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -35,10 +35,10 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5/8,xmax=0.5/8,ymin=-0.5/8,ymax=0.5/8, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -26,7 +26,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -35,10 +35,10 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5/8,xmax=0.5/8,ymin=-0.5/8,ymax=0.5/8, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
@@ -37,7 +37,7 @@ meshgen = mesh.MeshGenerator.Create
       node_sets = {nodesxy, nodesxy, nodesz}
     }),
   },
-  partitioner = PETScGraphPartitioner.Create({type="ptscotch"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="ptscotch"})
 })
 mesh.MeshGenerator.Execute(meshgen)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
@@ -42,10 +42,10 @@ meshgen = mesh.MeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
@@ -35,10 +35,10 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
@@ -26,7 +26,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
@@ -39,7 +39,7 @@ end
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
@@ -36,10 +36,10 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
@@ -26,7 +26,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
@@ -37,7 +37,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
@@ -35,10 +35,10 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
-vol1 = mesh.RPPLogicalVolume.Create
+vol1 = logvol.RPPLogicalVolume.Create
 ({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol1,1)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
@@ -26,7 +26,7 @@ meshgen1 = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
@@ -113,7 +113,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --end
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
 fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
@@ -27,7 +27,7 @@ meshgen1 = mesh.MeshGenerator.Create
       filename = "../../../../resources/TestMeshes/Sphere.case"
     }),
   },
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=1,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
@@ -129,21 +129,21 @@ solver.Execute(ss_solver)
 --############################################### Get field functions
 fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 
-pp1 = CellVolumeIntegralPostProcessor.Create
+pp1 = post.CellVolumeIntegralPostProcessor.Create
 ({
   name="max-grp0",
   field_function = fflist[1],
   compute_volume_average = true,
   print_numeric_format = "scientific"
 })
-pp2 = CellVolumeIntegralPostProcessor.Create
+pp2 = post.CellVolumeIntegralPostProcessor.Create
 ({
   name="max-grp19",
   field_function = fflist[20],
   compute_volume_average = true,
   print_numeric_format = "scientific"
 })
-ExecutePostProcessors({ pp1, pp2 })
+post.Execute({ pp1, pp2 })
 
 if (master_export == nil) then
   fieldfunc.ExportToVTKMulti(fflist,"ZPhi")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
@@ -132,21 +132,21 @@ solver.Execute(ss_solver)
 --############################################### Get field functions
 fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 
-pp1 = CellVolumeIntegralPostProcessor.Create
+pp1 = post.CellVolumeIntegralPostProcessor.Create
 ({
   name="max-grp0",
   field_function = fflist[1],
   compute_volume_average = true,
   print_numeric_format = "scientific"
 })
-pp2 = CellVolumeIntegralPostProcessor.Create
+pp2 = post.CellVolumeIntegralPostProcessor.Create
 ({
   name="max-grp19",
   field_function = fflist[20],
   compute_volume_average = true,
   print_numeric_format = "scientific"
 })
-ExecutePostProcessors({ pp1, pp2 })
+post.Execute({ pp1, pp2 })
 
 if (master_export == nil) then
   fieldfunc.ExportToVTKMulti(fflist,"ZPhi")

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
@@ -137,7 +137,7 @@ fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 --############################################### Volume integrations
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
 fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -34,7 +34,7 @@ meshgen1 = mesh.MeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -25,7 +25,7 @@ meshgen1 = mesh.MeshGenerator.Create
       filename = "../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
     }),
   },
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.0}, ycuts = {0.0}

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
@@ -33,7 +33,7 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes[1],nodes[2]}
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create
+vol0 = logvol.RPPLogicalVolume.Create
 ({ xmin=0.0,xmax=length[1],ymin=0.0,ymax=length[2], infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
@@ -33,7 +33,7 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes[1],nodes[2]}
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create
+vol0 = logvol.RPPLogicalVolume.Create
 ({ xmin=0.0,xmax=length[1],ymin=0.0,ymax=length[2], infz=true })
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
@@ -32,7 +32,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-L/4, zmax=L/4})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-L/4, zmax=L/4})
 mesh.SetMaterialIDFromLogicalVolume(vol0,1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
@@ -32,7 +32,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol0 = mesh.RPPLogicalVolume.Create({xmin=-L/16, xmax=L/16,
+vol0 = logvol.RPPLogicalVolume.Create({xmin=-L/16, xmax=L/16,
                                          ymin=-L/16, ymax=L/16,
                                          zmin=-L/16, zmax=L/16})
 mesh.SetMaterialIDFromLogicalVolume(vol0,1)

--- a/tutorials/lbs/first/first_example.lua
+++ b/tutorials/lbs/first/first_example.lua
@@ -70,7 +70,7 @@ The resulting mesh and partition is shown below:
 meshgen = mesh.OrthogonalMeshGenerator.Create
 ({
   node_sets = {nodes,nodes},
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.0}, ycuts = {0.0},

--- a/tutorials/lbs/first/first_example.lua
+++ b/tutorials/lbs/first/first_example.lua
@@ -86,7 +86,7 @@ to all cells found inside the logical volume. Logical volumes are quite powerful
 post-processing.
 --]]
 -- Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 --[[ @doc

--- a/tutorials/meshing/extrusion.lua
+++ b/tutorials/meshing/extrusion.lua
@@ -27,10 +27,8 @@ meshgen = mesh.ExtruderMeshGenerator.Create
     }),
   },
   layers = {{z=1.1, n=2}, {z=2.1, n=3}},
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 })
 mesh.MeshGenerator.Execute(meshgen)
 
 mesh.ExportToVTK("Extruded_mesh_only")
-
-

--- a/tutorials/meshing/ortho_2D.lua
+++ b/tutorials/meshing/ortho_2D.lua
@@ -38,7 +38,7 @@ to avoid issues).
 meshgen = mesh.OrthogonalMeshGenerator.Create
 ({
   node_sets = {nodes,nodes},
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2,
     xcuts = {0.}, ycuts = {0.}
@@ -71,7 +71,7 @@ Now, we use the Parmetis partitioner.
 meshgen = mesh.OrthogonalMeshGenerator.Create
 ({
   node_sets = {nodes,nodes},
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 
 })
 mesh.MeshGenerator.Execute(meshgen)

--- a/tutorials/meshing/ortho_2D.lua
+++ b/tutorials/meshing/ortho_2D.lua
@@ -53,7 +53,7 @@ to all cells found inside the logical volume. Logical volumes are quite powerful
 post-processing.
 --]]
 -- Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 --[[ @doc
@@ -83,4 +83,3 @@ On such a simple regular mesh, both partitioners are giving the same result. The
 --]]
 -- Exporting the mesh
 mesh.ExportToVTK("ortho_2D_Parmetis")
-

--- a/tutorials/meshing/ortho_3D.lua
+++ b/tutorials/meshing/ortho_3D.lua
@@ -32,7 +32,7 @@ meshgen = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen)
 
 -- Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 --[[ @doc
@@ -56,7 +56,7 @@ meshgen = mesh.OrthogonalMeshGenerator.Create
 mesh.MeshGenerator.Execute(meshgen)
 
 -- Set Material IDs
-vol0 = mesh.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
 mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 
 --[[ @doc
@@ -66,4 +66,3 @@ Note that now, both partitioners are not giving the same result. The Parmetis pa
 --]]
 -- Exporting the mesh
 mesh.ExportToVTK("ortho_3D_Parmetis")
-

--- a/tutorials/meshing/ortho_3D.lua
+++ b/tutorials/meshing/ortho_3D.lua
@@ -23,7 +23,7 @@ end
 meshgen = mesh.OrthogonalMeshGenerator.Create
 ({
   node_sets = {nodes,nodes,nodes},
-  partitioner = KBAGraphPartitioner.Create
+  partitioner = mesh.KBAGraphPartitioner.Create
   ({
     nx = 2, ny=2, nz=2,
     xcuts = {0.}, ycuts = {0.}, zcuts = {0.}
@@ -50,7 +50,7 @@ A simple orthogonal 3D mesh with Parmetis partitioner.
 meshgen = mesh.OrthogonalMeshGenerator.Create
 ({
   node_sets = {nodes,nodes,nodes},
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 
 })
 mesh.MeshGenerator.Execute(meshgen)

--- a/tutorials/meshing/read_2D_msh.lua
+++ b/tutorials/meshing/read_2D_msh.lua
@@ -30,7 +30,7 @@ meshgen = mesh.MeshGenerator.Create
       filename="../../test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/mesh/2D_c5g7_coarse.msh"
     }),
   },
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 })
 mesh.MeshGenerator.Execute(meshgen)
 

--- a/tutorials/meshing/read_2D_obj.lua
+++ b/tutorials/meshing/read_2D_obj.lua
@@ -40,9 +40,8 @@ meshgen = mesh.MeshGenerator.Create
         filename="./tri_2mat_bc_1542.obj"
     }),
   },
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 })
 mesh.MeshGenerator.Execute(meshgen)
 
 mesh.ExportToVTK("Triangle_1542_mesh_only")
-

--- a/tutorials/meshing/read_3D_vtu.lua
+++ b/tutorials/meshing/read_3D_vtu.lua
@@ -17,7 +17,7 @@ meshgen = mesh.MeshGenerator.Create
       filename="../../resources/TestMeshes/GMSH_AllTets.vtu"
     }),
   },
-  partitioner = PETScGraphPartitioner.Create({type="parmetis"})
+  partitioner = mesh.PETScGraphPartitioner.Create({type="parmetis"})
 })
 mesh.MeshGenerator.Execute(meshgen)
 


### PR DESCRIPTION
- Moving objects in logical_volume into `logvol` module
- Removing object registration for object that are not user-facing
- Moving partitioner objects into `mesh` module
- Introducing a post processor module in LUA layer

Refs #122
