### PR TITLE
Lower the lua version requirement to 5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPENSN_WITH_LUA "Build with lua support" ON)
 find_package(MPI REQUIRED)
 
 if(OPENSN_WITH_LUA)
-    find_package(Lua 5.4 REQUIRED)
+    find_package(Lua 5.3 REQUIRED)
 endif()
 
 find_package(VTK QUIET)


### PR DESCRIPTION
This allows users to build on older distros like Ubuntu 20.04
