### PR TITLE
Updating mpicpp-lite

### DIFF
--- a/external/mpicpp-lite/impl/Group.h
+++ b/external/mpicpp-lite/impl/Group.h
@@ -122,7 +122,6 @@ inline void
 Group::free()
 {
     MPI_CHECK(MPI_Group_free(&this->group));
-    this->group = UNDEFINED;
 }
 
 inline int


### PR DESCRIPTION
This fixes the problem that OpenSn does not compile when using openmpi.

Closes #200
