### PR TITLE
Update Linux install instructions and configure_dependencies script

### DIFF
--- a/doc/install_linux.md
+++ b/doc/install_linux.md
@@ -33,7 +33,7 @@ git cmake libopenmpi-dev flex bison \
 libncurses5-dev python3-pip doxygen sphinx
 ```
 
-To ensure that all installations downstream of this install with the required mpi wrappers, the
+To ensure that all downstream installations use the required MPI compiler wrappers, the
 following environment variables must be set:
 
 ```bash
@@ -64,7 +64,7 @@ To configure **PETSc** with the required build options, run:
 
 ```bash
 ./configure  \
---prefix=$PWD/../petsc-3.17.0-install  \
+--prefix=/path/to/dependencies/directory  \
 --download-hypre=1  \
 --with-ssl=0  \
 --with-debugging=0  \
@@ -92,12 +92,7 @@ PETSC_DIR=$PWD
 
 If the configuration fails, consult **PETSc**'s user documentation. 
 
-Follow the **PETSc** build
-prompts to complete the **PETSc** installation.
-
-Add **PETSc** to your `CMAKE_PREFIX_PATH` environment variable, e.g.:
-
-`export CMAKE_PREFIX_PATH=/path/to/dependencies/petsc-3.17.0-install:$CMAKE_PREFIX_PATH`
+Follow the **PETSc** build prompts to complete the **PETSc** installation.
 
 ## Step 3 - Install the Visualization Tool Kit (VTK)
 
@@ -111,7 +106,7 @@ tar -zxf VTK-9.3.0.tar.gz
 cd VTK-9.3.0
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=$PWD/../install  + \
+cmake -DCMAKE_INSTALL_PREFIX=/path/to/dependencies/directory  + \
 -DBUILD_SHARED_LIBS:BOOL=ON  + \
 -DVTK_Group_MPI:BOOL=ON  + \
 -DVTK_GROUP_ENABLE_Qt=NO  + \
@@ -133,30 +128,30 @@ make -j && make install
 
 to install **VTK**.
 
-Add **VTK** to your `CMAKE_PREFIX_PATH` environment variable, e.g.:
-
-`export CMAKE_PREFIX_PATH=/path/to/dependencies/VTK/VTK-9.3.0/install:$CMAKE_PREFIX_PATH`
-
 ## Step 4 - Install Lua
 
-Download and extract **Lua** version 5.3.6+ from https://www.lua.org. Before installing **Lua**,
-you need to edit `src/Makefile` and add `-fPIC` to `MYCFLAGS`, e.g.:
-
-`MYCFLAGS = -fPIC`
-
+Download and extract **Lua** version 5.3.6+ from https://www.lua.org to `dependencies`.
 Install **Lua** as follows:
 
 ```bash
-$ make linux
-$ make local
+$ make linux MYCLFAGS=-fPIC -j
+$ make install INSTALL_TOP=/path/to/dependencies/directory
 ```
 
 If the install complains about missing **readline** includes or libraries, it may be necessary to
 install **readline** and **ncurses**.
 
-Add **Lua** to your `CMAKE_PREFIX_PATH` environment variable, e.g.:
+## Step 6 - Configure Environment
 
-`export CMAKE_PREFIX_PATH=/path/to/dependencies/lua-5.4.6/install:$CMAKE_PREFIX_PATH`
+Before compiling OpenSn, you must add the location of the third-party libraries to your
+`CMAKE_PREFIX_PATH` environment variable. This can be accomplished with the following command:
+
+```bash
+    $ export CMAKE_PREFIX_PATH=/path/to/dependencies/directory:$CMAKE_PREFIX_PATH`
+```
+
+**Important:** It may be a good idea to add the `CMAKE_PREFIX_PATH` variable to your `.bashrc`
+file so that you don't need to specify the path every time you need to re-run `cmake`.
 
 ## Step 5 - Clone OpenSn
 
@@ -176,11 +171,6 @@ To clone your fork of **OpenSn**:
 ```
 
 ## Step 6 - Build OpenSn
-
-**Important:** Now that we have finished buildindg all of the required third-party libraries and
-their locations have been added to the `CMAKE_PREFIX_PATH` environment variable, it may be a good 
-idea to add this variable to your `.bashrc` file so that you don't need to specify the path every
-time you need to re-run `cmake`.
 
 To build OpenSn, create a build directory in the top-level OpenSn directory and run `cmake` to
 generate the build files and `make` to compile OpenSn:

--- a/doc/install_linux.md
+++ b/doc/install_linux.md
@@ -1,20 +1,21 @@
-# Easy Install on Linux Machines
+# Installing on Linux Machines
 
-The following instructions were tested on Ubuntu 22.04.4 LTS. Other Linux distributions might
-require some minor tweaking.
+The following instructions were tested on Ubuntu 22.04.4 LTS. Other Linux
+distributions might require some minor tweaking.
 
-Some portions of these instructions require the use of `sudo`. If you do not have administrative
-privileges, have your system administrator assist you with these steps.
+Some portions of these instructions require the use of `sudo`. If you do not
+have administrative privileges, have your system administrator assist you with
+these steps.
 
-Note that these instructions assume you are using the `bash` shell and may differ slightly for
-other shells.
+Note that these instructions assume you are using the `bash` shell and may
+differ slightly for other shells.
 
 ## Step 1 - Install Development Tools
 
-The following packages are required for OpenSn installation and development:
+The following packages are required for **OpenSn** installation and development:
 
 1. A recent version of clang++/g++ that supports C++17
-2. gfotran (required by the BLAS component of PETSc)
+2. gfortran (required by the BLAS component of PETSc)
 3. flex and bison (required by the PTSCOTCH component of PETSc)
 4. Python 3 v3.9+ and pip (required by PETSc and OpenSn)
 5. ncurses v5 (required by Lua)
@@ -23,9 +24,9 @@ The following packages are required for OpenSn installation and development:
 8. MPI (OpenMPI, MPICH, and MVAPICH have been tested)
 9. Doxygen and Sphinx (required for generating the OpenSn documentation)
 
-Most of these packages can be installed using the package manager available with your Linux
-distribution (e.g., `apt`, `yum`, etc.). For example, on Ubuntu, you can use the following
-command to install all of these packages:
+Most of these packages can be installed using the package manager available with
+your Linux distribution (e.g., `apt`, `yum`, etc.). For example, on Ubuntu, you
+can use the following command to install all of these packages:
 
 ```bash
 $ sudo apt install build-essential gfortran python3 \
@@ -33,28 +34,29 @@ git cmake libopenmpi-dev flex bison \
 libncurses5-dev python3-pip doxygen sphinx
 ```
 
-To ensure that all downstream installations use the required MPI compiler wrappers, the
-following environment variables must be set:
+To ensure that all third-party packages use the required MPI compiler wrappers,
+the following environment variables must be set:
 
 ```bash
-export CC=mpicc
-export CXX=mpicxx
-export FC=mpifort
+    $ export CC=mpicc
+    $ export CXX=mpicxx
+    $ export FC=mpifort
 ```
 
-We recommend creating a separate directory for building the OpenSn dependencies. The following 
-steps assume that you have created a directory named `dependencies` to be used for compiling
-and installing the required third-party libraries.
+**Important:** We recommend creating a separate directory for building the
+**OpenSn** dependencies. 
+
+The following steps assume that you have created a directory named `dependencies`
+to be used for compiling and installing the required third-party libraries.
 
 ## Step 2 - Install PETSc
 
 The current supported version is
 [**PETSc** version 3.17.0+](https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.17.0.tar.gz).
 
-The following command will download and extract **PETSc** into the `dependencies` directory:
+In your `dependencies` directory, install **PETSc** using the following commands:
 
 ```bash
-cd dependencies
 wget https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.17.0.tar.gz
 tar -zxf petsc-3.17.0.tar.gz
 cd petsc-3.17.0
@@ -130,33 +132,35 @@ to install **VTK**.
 
 ## Step 4 - Install Lua
 
-Download and extract **Lua** version 5.3.6+ from https://www.lua.org to `dependencies`.
-Install **Lua** as follows:
+Download and extract **Lua** version 5.3.6+ from https://www.lua.org to
+`dependencies`. Install **Lua** as follows:
 
 ```bash
 $ make linux MYCLFAGS=-fPIC -j
 $ make install INSTALL_TOP=/path/to/dependencies/directory
 ```
 
-If the install complains about missing **readline** includes or libraries, it may be necessary to
-install **readline** and **ncurses**.
+If the install complains about missing **readline** includes or libraries, it
+may be necessary to install **readline** and **ncurses**.
 
-## Step 6 - Configure Environment
+## Step 5 - Configure Environment
 
-Before compiling OpenSn, you must add the location of the third-party libraries to your
-`CMAKE_PREFIX_PATH` environment variable. This can be accomplished with the following command:
+Before compiling **OpenSn**, you must add the location of the third-party
+libraries to your `CMAKE_PREFIX_PATH` environment variable. This can be
+accomplished with the following command:
 
 ```bash
     $ export CMAKE_PREFIX_PATH=/path/to/dependencies/directory:$CMAKE_PREFIX_PATH`
 ```
 
-**Important:** It may be a good idea to add the `CMAKE_PREFIX_PATH` variable to your `.bashrc`
-file so that you don't need to specify the path every time you need to re-run `cmake`.
+**Important:** It may be a good idea to add the `CMAKE_PREFIX_PATH` variable to
+your `.bashrc` file so that you don't need to specify the path every time you
+need to re-run `cmake`.
 
-## Step 5 - Clone OpenSn
+## Step 6 - Clone OpenSn
 
-**Important:**  If you want to contribute to **OpenSn**, it is strongly recommended that you
-first fork the **OpenSn** repository then clone your fork.
+**Important:**  If you want to contribute to **OpenSn**, it is strongly
+recommended that you first fork the **OpenSn** repository then clone your fork.
 
 To clone the **OpenSn** repository:
 
@@ -170,10 +174,11 @@ To clone your fork of **OpenSn**:
     $ git clone https://github.com/<username>/opensn.git
 ```
 
-## Step 6 - Build OpenSn
+## Step 7 - Build OpenSn
 
-To build OpenSn, create a build directory in the top-level OpenSn directory and run `cmake` to
-generate the build files and `make` to compile OpenSn:
+To build **OpenSn**, create a build directory in the top-level **OpenSn**
+directory and run `cmake` to generate the build files and `make` to compile
+**OpenSn**:
 
 ```bash
     $ mkdir build
@@ -182,44 +187,43 @@ generate the build files and `make` to compile OpenSn:
     $ make -j
 ```
 
-To configure OpenSn for building the documentation, in addition to the OpenSn application, add the
-`-DOPENSN_WITH_DOCS` option to `cmake`:
+To configure **OpenSn** for building the documentation, in addition to the
+**OpenSn** application, add the `-DOPENSN_WITH_DOCS` option to `cmake`:
 
 ```bash
     $ mkdir build
-    $ cd bukld
+    $ cd build
     $ cmake -DOPENSN_WITH_DOCS=ON ..
     $ make -j
 ```
 
-For more information on building the documentation, see **Step 8** below.
+For more information on building the documentation, see **Step 9** below.
 
-## Step 7 - Run Regression Tests
+## Step 8 - Run Regression Tests
 
-To run the regression tests, simply run `make test` from the build directory. This will run all of
-the regression tests in the `opensn/test` directory.
+To run the regression tests, simply run `make test` from the build directory.
+This will run all of the regression tests in the `opensn/test` directory.
 
-## Step 8 - Build the OpenSn Documentation
+## Step 9 - Build the OpenSn Documentation
 
-If you configured the OpenSn build environment with support for building the documentation
-(see **Step 6**), these instructions will help you install the necessary tools and build the
-documentation.
+If you configured the **OpenSn** build environment with support for building the
+documentation (see **Step 7**), these instructions will help you install the
+necessary tools and build the documentation.
 
-To generate the documentation from your local working copy of OpenSn, you need to use `pip` to
-install the required Python packages:
+To generate the documentation from your local working copy of **OpenSn**, you
+need to use `pip` to install the required **Python** packages:
 
 ```bash
 pip install breathe myst-parser sphinx_rtd_theme
 ```
 
-Then, from your `build` directory, you can run the command `make doc` to generate the
-documentation:
-
+Then, from your `build` directory, you can run the command `make doc` to generate
+the documentation:
 
 ```bash
 cd build
 make doc
 ```
 
-Once the build process has completed, you can view the generated documentation by opening
-`opensn/build/doc/index.html` in your favorite web browser.
+Once the build process has completed, you can view the generated documentation by
+opening `opensn/build/doc/index.html` in your favorite web browser.

--- a/doc/install_linux_easy.md
+++ b/doc/install_linux_easy.md
@@ -3,8 +3,11 @@
 The following instructions were tested on Ubuntu 22.04.4 LTS. Other Linux distributions might
 require some minor tweaking.
 
-Some portions of this document indicate the use of `sudo`. If you do not have administrative
+Some portions of these instructions require the use of `sudo`. If you do not have administrative
 privileges, have your system administrator assist you with these steps.
+
+Note that these instructions assume you are using the `bash` shell and may differ slightly for
+other shells.
 
 ## Step 1 - Install Development Tools
 
@@ -13,14 +16,13 @@ The following packages are required for OpenSn installation and development:
 1. A recent version of clang++/g++ that supports C++17
 2. gfotran (required by the BLAS component of PETSc)
 3. flex and bison (required by the PTSCOTCH component of PETSc)
-4. Python 3 v3.9+ (required by PETSc and OpenSn)
+4. Python 3 v3.9+ and pip (required by PETSc and OpenSn)
 5. ncurses v5 (required by Lua)
 6. Git version control system
 7. CMake v3.12+
 8. MPI (OpenMPI, MPICH, and MVAPICH have been tested)
-9. Python 3 pip  (required for generating the OpenSn documentation)
-10. Doxygen and Sphinx (required for generating the OpenSn documentation)
-11. curl (required to download and install the OpenSn third-party dependencies)
+9. Doxygen and Sphinx (required for generating the OpenSn documentation)
+10. curl (required to download and install the OpenSn third-party dependencies)
 
 Most of these packages can be installed using the package manager available with your Linux
 distribution (e.g., `apt`, `yum`, etc.). For example, on Ubuntu, you can use the following
@@ -72,8 +74,8 @@ the speed of your machine.
 ## Step 3 - Configure Environment
 
 Before compiling OpenSn, you must add the location of the third-party libraries to your
-`CMAKE_PREFIX` environment variable. We have provided a script to do this for you. You can update
-your environment variables by running the command:
+`CMAKE_PREFIX_PATH` environment variable. We have provided a script to do this for you. You can
+update your environment variables by running the command:
 
 ```bash
     $ source ../dependencies/configure_deproots.sh

--- a/doc/install_linux_easy.md
+++ b/doc/install_linux_easy.md
@@ -1,20 +1,21 @@
 # Easy Install on Linux Machines
 
-The following instructions were tested on Ubuntu 22.04.4 LTS. Other Linux distributions might
-require some minor tweaking.
+The following instructions were tested on Ubuntu 22.04.4 LTS. Other Linux
+distributions might require some minor tweaking.
 
-Some portions of these instructions require the use of `sudo`. If you do not have administrative
-privileges, have your system administrator assist you with these steps.
+Some portions of these instructions require the use of `sudo`. If you do not have
+administrative privileges, have your system administrator assist you with these
+steps.
 
-Note that these instructions assume you are using the `bash` shell and may differ slightly for
-other shells.
+Note that these instructions assume you are using the `bash` shell and may differ
+slightly for other shells.
 
 ## Step 1 - Install Development Tools
 
 The following packages are required for OpenSn installation and development:
 
 1. A recent version of clang++/g++ that supports C++17
-2. gfotran (required by the BLAS component of PETSc)
+2. gfortran (required by the BLAS component of PETSc)
 3. flex and bison (required by the PTSCOTCH component of PETSc)
 4. Python 3 v3.9+ and pip (required by PETSc and OpenSn)
 5. ncurses v5 (required by Lua)
@@ -24,9 +25,9 @@ The following packages are required for OpenSn installation and development:
 9. Doxygen and Sphinx (required for generating the OpenSn documentation)
 10. curl (required to download and install the OpenSn third-party dependencies)
 
-Most of these packages can be installed using the package manager available with your Linux
-distribution (e.g., `apt`, `yum`, etc.). For example, on Ubuntu, you can use the following
-command to install all of these packages:
+Most of these packages can be installed using the package manager available with
+your Linux distribution (e.g., `apt`, `yum`, etc.). For example, on Ubuntu, you
+can use the following command to install all of these packages:
 
 ```bash
 $ sudo apt install build-essential gfortran python3 \
@@ -34,10 +35,19 @@ git cmake libopenmpi-dev flex bison \
 libncurses5-dev python3-pip doxygen sphinx curl
 ```
 
+To ensure that all third-party packages use the required MPI compiler wrappers,
+the following environment variables must be set:
+
+```bash
+    $ export CC=mpicc
+    $ export CXX=mpicxx
+    $ export FC=mpifort
+```
+
 ## Step 2 - Clone OpenSn
 
-**Important:**  If you want to contribute to **OpenSn**, it is strongly recommended that you
-first fork the **OpenSn** repository then clone your fork.
+**Important:**  If you want to contribute to **OpenSn**, it is strongly
+recommended that you first fork the **OpenSn** repository then clone your fork.
 
 To clone the **OpenSn** repository:
 
@@ -51,41 +61,39 @@ To clone your fork of **OpenSn**:
     $ git clone https://github.com/<username>/opensn.git
 ```
 
-Before building OpenSn's third-party dependencies, you need to export the following variables for
-the PETSc install:
+## Step 3 - Install Third-Party Libraries
 
-```bash
-    $ export CC=mpicc
-    $ export CXX=mpicxx
-    $ export FC=mpifort
-```
+**Important:** We recommend creating a separate directory for building the
+**OpenSn** dependencies.
 
-**Important:** We recommend creating a separate directory for building the OpenSn dependencies.
-Assuming you created a directory named `dependencies` in the same location as your clone of
-OpenSn, you can run the following command to download, configure, and build all of the third-party
-dependencies for OpenSn. Note that this command may take several minutes to complete depending on
-the speed of your machine.
+Assuming you created a directory named `dependencies` to be used for building the
+required third-party packages, the following command automates the install and
+build process:
 
 ```bash
     $ cd opensn
-    $ python3 resources/configure_dependencies.py -d ../dependencies
+    $ python3 resources/configure_dependencies.py -d ../path/to/dependencies/directory
 ```
 
-## Step 3 - Configure Environment
+## Step 4 - Configure Environment
 
-Before compiling OpenSn, you must add the location of the third-party libraries to your
-`CMAKE_PREFIX_PATH` environment variable. We have provided a script to do this for you. You can
-update your environment variables by running the command:
+Before compiling **OpenSn**, you must add the location of the third-party
+libraries to your `CMAKE_PREFIX_PATH` environment variable. We have provided a
+script to do this for you. You can update your environment variables by running
+the command:
 
 ```bash
     $ source ../dependencies/configure_deproots.sh
 ```
-**Note:** You can replace ```$ source ``` in the above command with ```$ . ```
+**Important:** It may be a good idea to source this script int your `.bashrc`
+file so that you don't need to specify the path every time you need to re-run
+`cmake`.
 
-## Step 4 - Build OpenSn
+## Step 5 - Build OpenSn
 
-To build OpenSn, create a build directory in the top-level OpenSn directory and run `cmake` to
-generate the build files and `make` to compile OpenSn:
+To build **OpenSn**, create a build directory in the top-level **OpenSn**
+directory and run `cmake` to generate the build files and `make` to compile
+**OpenSn**:
 
 ```bash
     $ mkdir build
@@ -94,44 +102,43 @@ generate the build files and `make` to compile OpenSn:
     $ make -j
 ```
 
-To configure OpenSn for building the documentation, in addition to the OpenSn application, add the
-`-DOPENSN_WITH_DOCS` option to `cmake`:
+To configure **OpenSn** for building the documentation, in addition to the 
+**OpenSn** application, add the `-DOPENSN_WITH_DOCS` option to `cmake`:
 
 ```bash
     $ mkdir build
-    $ cd bukld
+    $ cd build
     $ cmake -DOPENSN_WITH_DOCS=ON ..
     $ make -j
 ```
 
-For more information on building the documentation, see **Step 6** below.
+For more information on building the documentation, see **Step 7** below.
 
-## Step 5 - Run Regression Tests
+## Step 6 - Run Regression Tests
 
-To run the regression tests, simply run `make test` from the build directory. This will run all of
-the regression tests in the `opensn/test` directory.
+To run the regression tests, simply run `make test` from the build directory.
+This will run all of the regression tests in the `opensn/test` directory.
 
-## Step 6 - Build the OpenSn Documentation
+## Step 7 - Build the OpenSn Documentation
 
-If you configured the OpenSn build environment with support for building the documentation
-(see **Step 4**), these instructions will help you install the necessary tools and build the
-documentation.
+If you configured the **OpenSn** build environment with support for building the
+documentation (see **Step 5**), these instructions will help you install the
+necessary tools and build the documentation.
 
-To generate the documentation from your local working copy of OpenSn, you need to use `pip` to
-install the required Python packages:
+To generate the documentation from your local working copy of **OpenSn**, you
+need to use `pip` to install the required **Python** packages:
 
 ```bash
 pip install breathe myst-parser sphinx_rtd_theme
 ```
 
-Then, from your `build` directory, you can run the command `make doc` to generate the
-documentation:
-
+Then, from your `build` directory, you can run the command `make doc` to generate
+the documentation:
 
 ```bash
 cd build
 make doc
 ```
 
-Once the build process has completed, you can view the generated documentation by opening
-`opensn/build/doc/index.html` in your favorite web browser.
+Once the build process has completed, you can view the generated documentation by
+opening `opensn/build/doc/index.html` in your favorite web browser.

--- a/doc/install_macos_easy.md
+++ b/doc/install_macos_easy.md
@@ -8,7 +8,7 @@ The following packages should be installed via Homebrew
 - make
 - cmake
 - gcc
-- wget
+- curl
 
 To install any missing packages use
 ```shell

--- a/doc/install_macos_easy.md
+++ b/doc/install_macos_easy.md
@@ -2,20 +2,31 @@
 
 The following instructions were tested on MacOS Sonoma (= version 14).
 
-## Prerequisites
+## Step 1 - Install Development Tools
 
-The following packages should be installed via Homebrew
+The following packages should be installed via [Homebrew](https://brew.sh):
+
 - make
 - cmake
 - gcc
 - curl
+- bison
+- m4
+- doxygen
+- sphinx
 
 To install any missing packages use
 ```shell
 brew install <package name>
 ```
+Pay close attention to the output of `brew`. It may be necessary to add
+locations to your `PATH` environment variable to use the newly installed
+utilities.
 
-## Step 1 - MPICH
+**Important:** The `sphinx` package may not be available via `Homebrew`. It
+is only needed to build the OpenSn documentation.
+
+## Step 2 - Install MPICH
 
 Download a suitable version of [MPICH 4+](https://www.mpich.org/static/downloads).
 Versions above 4.0 are recommended.
@@ -61,7 +72,7 @@ export FC="${MPI_DIR}/mpifort"
 export F77="${MPI_DIR}/mpif77"
 ```
 
-## Step 2 - Clone OpenSn
+## Step 3 - Clone OpenSn
 
 Note:  If you want to contribute to OpenSn, it is strongly recommended
 to first fork the OpenSn repository into your own Git account and then to
@@ -76,7 +87,13 @@ or
 git clone https://github.com/<username>/opensn.git /path/to/opensn
 ```
 
-## Step 3 - Set Up the Environment
+## Step 4 - Set Up the Environment
+
+**Important:** XCode 15's linker breaks a number of things in the name of
+progress. It may be necssary to modify `configure_dependencies.py`
+to use PETSc 3.20.x. It may also require that you add the line
+`link_libraries("-ld_classic")` to the OpenSn `CMakeLists.txt`
+file.
 
 Next, run the script to compile the necessary dependencies with
 ```shell
@@ -91,7 +108,7 @@ generated script:
 source /path/to/dependencies/configure_deproots.sh
 ```
 
-## Step 4 - Configure and Build OpenSn
+## Step 5 - Configure and Build OpenSn
 
 OpenSn is configured within a build directory with
 ```shell
@@ -100,9 +117,16 @@ mkdir build
 cd build
 cmake ..
 ```
-This will configure the project for building it.
+To configure with support for building the documentation use
+```shell
+cd /path/to/opensn
+mkdir build
+cd build
+cmake -DOPENSN_WITH_DOCS=ON ..
+```
 In general, the build directory will be within the source tree.
-OpenSn can then be built within the build directory via
+Once configuration is complete, OpenSn can then be built within
+the build directory via
 ```shell
 make -j<N>
 ```
@@ -111,7 +135,7 @@ Note: OpenSn may need to be reconfigured with dependency changes, the addition
 of new files, etc. When this occurs, clear the `build` directory and repeat
 the configuration process above.
 
-## Step 5 - Run Regression Tests
+## Step 6 - Run Regression Tests
 
 To check if the code compiled correctly execute the test scripts:
 ```shell
@@ -119,23 +143,25 @@ cd /path/to/opensn
 test/run_tests -j<N>
 ```
 
-## Step 6 - OpenSn Documentation
+## Step 7 - OpenSn Documentation
 
-The documentation can be found [online](https://xxx.io), or
-generated locally. To generate the documentation locally, first make sure
-doxygen and LaTeX are installed:
-```shell
-sudo apt-get install doxygen texlive
+If you configured the OpenSn build environment with support for building the
+documentation (see **Step 5**), these instructions will help you install the
+necessary tools and build the documentation.
+
+To generate the documentation from your local working copy of OpenSn, you need
+to use `pip3` to install the required Python packages:
+```bash
+pip3 install breathe myst-parser sphinx_rtd_theme
 ```
 
-The documentation is contained in the `doc` directory of the OpenSn source
-tree and can be generated with
-```shell
-./YReGenerateDocumentation.sh
+Then, from your `build` directory, you can run the command `make doc` to generate
+the documentation:
+```bash
+cd build
+make doc
 ```
-from within the `doc` directory. Once finished, the generated documentation
-can be viewed with
-```shell
-doc/HTMLdocs/html/index.html
-```
-in a web browser.
+
+Once the build process has completed, you can view the generated documentation by
+opening
+`opensn/build/doc/index.html` in your favorite web browser.

--- a/resources/configure_dependencies.py
+++ b/resources/configure_dependencies.py
@@ -7,10 +7,6 @@ NOTES:
   supplied ones are known to work (so you would just remove the option --download-fblaslapack=1)
 - If you have set CC, CXX and FC in your environment, make sure they are CC=mpicc, CXX=mpicxx and FC=mpifort.
 
-NOTES for clang compiler:
-- clang compiler does not support `-march=native`, so you will want to remove that from COPTFLAGS, CXXOPTFLAGS and
-  FOPTFLAGS.
-
 NOTES for building on MacOS:
 - you may need to `export MACOSX_DEPLOYMENT_TARGET=10.15` in your environment
 """
@@ -304,9 +300,9 @@ def InstallPETSc(pkg: str, ver: str, gold_file: str):
 --download-ptscotch=1  \\
 --download-superlu_dist=1  \\
 CC=$CC CXX=$CXX FC=$FC  \\
-COPTFLAGS='-O3 -march=native -mtune=native'  \\
-CXXOPTFLAGS='-O3 -march=native -mtune=native'  \\
-FOPTFLAGS='-O3 -march=native -mtune=native'  \\
+COPTFLAGS='-O3'  \\
+CXXOPTFLAGS='-O3'  \\
+FOPTFLAGS='-O3'  \\
 PETSC_DIR={install_dir}/src/{pkg}-{ver}"""
 
         success, err, outstr = ExecSub(

--- a/resources/configure_dependencies.py
+++ b/resources/configure_dependencies.py
@@ -3,7 +3,7 @@ This is a utility script for the download and installation of OpenSn
 dependencies.
 
 NOTES:
-- If you see errors in building fblaslapack, try to use different BLAS/LAPACK. For example, on MacOSX, the Apple
+- If you see errors in building fblaslapack, try using a  different BLAS/LAPACK. For example, on MacOSX, the Apple
   supplied ones are known to work (so you would just remove the option --download-fblaslapack=1)
 - If you have set CC, CXX and FC in your environment, make sure they are CC=mpicc, CXX=mpicxx and FC=mpifort.
 
@@ -85,14 +85,6 @@ parser.add_argument(
 VERSION = 0
 URL = 1
 package_info = {
-    "readline": [
-        "8.0",
-        "ftp://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
-    ],
-    "ncurses": [
-        "6.1",
-        "https://invisible-mirror.net/archives/ncurses/ncurses-6.1.tar.gz"
-    ],
     "lua": [
         "5.4.6",
         "https://www.lua.org/ftp/lua-5.4.6.tar.gz"
@@ -147,13 +139,13 @@ def CheckExecutableExists(thingname: str, thing: str):
         log_file.write(f"{thingname} found\n\n")
 
 
-# Downloads a package using either wget or curl
-def DownloadPackage(downloader, url, pkg, ver):
+# Downloads a package using curl
+def DownloadPackage(url, pkg, ver):
     pkgdir = f"{install_dir}/downloads"
     log_file.write(f"Downloading {pkg.upper()} {ver} to \"{pkgdir}\" " +
-                   f"with command: {downloader} {url}")
-    download_cmd = f"{downloader}" if downloader == "wget" else f"{downloader}"
-    output_cmd = "" if downloader == "wget" else f"-L --output {pkg}-{ver}.tar.gz"
+                   f"with command: curl {url}")
+    download_cmd = f"curl"
+    output_cmd = f"-L --output {pkg}-{ver}.tar.gz"
 
     pkgdir_relative = os.path.relpath(pkgdir)
 
@@ -198,77 +190,10 @@ def ExtractPackage(pkg, ver):
         raise RuntimeError(err)
 
 
-# Install command for ncurses and readline
-def InstallPackage(pkg: str, ver: str, gold_file: str):
-    package_log_filename = f"{install_dir}/logs/{pkg}_log.txt"
-    pkg_install_dir = f"{install_dir}"
-
-    shutil.copy(f"{install_dir}/downloads/{pkg}-{ver}.tar.gz",
-                f"{install_dir}/src/{pkg}-{ver}.tar.gz")
-
-    os.chdir(f"{install_dir}/src")
-
-    # Check if it is installed already
-    if not os.path.exists(f"{pkg_install_dir}/{gold_file}"):
-        ExtractPackage(pkg, ver)
-
-        package_log_file = open(package_log_filename, "w")
-
-        print(f"Configuring {pkg.upper()} {ver} to \"{os.getcwd()}\"", flush=True)
-        log_file.write(f"Configuring {pkg.upper()} {ver} to \"{os.getcwd()}\"")
-        log_file.write(f" See {package_log_filename}\n")
-        log_file.flush()
-
-        env_vars = os.environ.copy()
-        if len(os.getenv("CC")) == 0:
-            env_vars["CC"] = shutil.which("mpicc")
-        if len(os.getenv("CXX")) == 0:
-            env_vars["CXX"] = shutil.which("mpicxx")
-        if len(os.getenv("FC")) == 0:
-            env_vars["FC"] = shutil.which("mpifort")
-
-        command = f"./configure --prefix={pkg_install_dir}"
-        success, err, outstr = ExecSub(command, out_log=package_log_file, env_vars=env_vars)
-        if not success:
-            print(command, err)
-            log_file.write(f"{command}\n{err}\n")
-            package_log_file.write(f"{command}\n{err}\n")
-            raise RuntimeError(f"Failed to configure {pkg}");
-
-        command = f"make -j{argv.jobs}"
-        success, err, outstr = ExecSub(command, out_log=package_log_file, env_vars=env_vars)
-        if not success:
-            print(command, err)
-            log_file.write(f"{command}\n{err}\n")
-            package_log_file.write(f"{command}\n{err}\n")
-            raise RuntimeError(f"Failed to build {pkg}");
-
-        command = "make install"
-        success, err, outstr = ExecSub(command, out_log=package_log_file, env_vars=env_vars)
-        if not success:
-            print(command, err)
-            log_file.write(f"{command}\n{err}\n")
-            package_log_file.write(f"{command}\n{err}\n")
-            raise RuntimeError(f"Failed to install {pkg}");
-
-        package_log_file.close()
-    else:
-        print(f"{pkg} already installed")
-
-    os.chdir(install_dir)
-
-    if os.path.exists(f"{pkg_install_dir}/{gold_file}"):
-        return True
-    else:
-        return False
-
-
-# Install command for lua
+# Install Lua
 def InstallLuaPackage(pkg: str,
                       ver: str,
-                      gold_file: str,
-                      readline_install: str,
-                      ncurses_install: str):
+                      gold_file: str):
     package_log_filename = f"{install_dir}/logs/{pkg}_log.txt"
     pkg_install_dir = f"{install_dir}"
 
@@ -283,7 +208,7 @@ def InstallLuaPackage(pkg: str,
 
         package_log_file = open(package_log_filename, "w")
 
-        print(f"Configuring {pkg.upper()} {ver} to \"{os.getcwd()}\"", flush=True)
+        print(f"Configuring {pkg.upper()} {ver} in \"{os.getcwd()}\"", flush=True)
         log_file.write(f"Configuring {pkg.upper()} {ver} to \"{os.getcwd()}\"")
         log_file.write(f" See {package_log_filename}\n")
         log_file.flush()
@@ -295,19 +220,12 @@ def InstallLuaPackage(pkg: str,
             env_vars["CXX"] = shutil.which("mpicxx")
         if len(os.getenv("FC")) == 0:
             env_vars["FC"] = shutil.which("mpifort")
-
-        lib_path = env_vars.get("LIBRARY_PATH", "")
-        lib_path = f"{lib_path}:{readline_install}/lib:" \
-                   f"{ncurses_install}/lib"
-        env_vars["LIBRARY_PATH"] = lib_path
-
-        c_path = env_vars.get('CPATH', "")
-        c_path = f"{c_path}:{readline_install}/include"
-        env_vars["CPATH"] = c_path
 
         os_tag = "linux"
         if "Darwin" in os.uname():
             os_tag = "macosx"
+
+        os.chdir(f"{pkg}-{ver}")
 
         command = f"make {os_tag} MYCFLAGS=-fPIC MYLIBS=-lncurses -j{argv.jobs}"
         success, err, outstr = ExecSub(
@@ -341,7 +259,7 @@ def InstallLuaPackage(pkg: str,
         return False
 
 
-# Install command for PETSc
+# Install PETSc
 def InstallPETSc(pkg: str, ver: str, gold_file: str):
     package_log_filename = f"{install_dir}/logs/{pkg}_log.txt"
     pkg_install_dir = f"{install_dir}"
@@ -369,6 +287,8 @@ def InstallPETSc(pkg: str, ver: str, gold_file: str):
             env_vars["CXX"] = shutil.which("mpicxx")
         if len(os.getenv("FC")) == 0:
             env_vars["FC"] = shutil.which("mpifort")
+
+        os.chdir(f"{pkg}-{ver}")
 
         command = f"""./configure --prefix={pkg_install_dir} \\
 --with-shared-libraries=1  \\
@@ -551,22 +471,13 @@ try:
     # Check system environment
 
     # Check for download utils
-    log_file.write("Checking for wget/curl: ")
-    downloader = ""
-    if shutil.which("wget") is None:
-        log_file.write("wget not found. ")
-        if shutil.which("curl") is None:
-            log_file.write("curl not found. ")
-            raise Exception("Neither wget nor curl found on this system. " +
-                            "The script then has no means to download the " +
-                            "dependencies.")
-        else:
-            log_file.write("curl found\n")
-            downloader = "curl"
+    log_file.write("Checking for curl: ")
+    if shutil.which("curl") is None:
+        log_file.write("curl not found. ")
+        raise Exception("Missing Curl utility. " +
+                        "Unable to download dependencies.")
     else:
-        log_file.write("wget found\n")
-        downloader = "wget"
-    # downloader = "curl"
+        log_file.write("curl found\n")
 
     # Check mpicc, mpicxx, mpifort
     mpicc = os.getenv("CC") if len(os.getenv("CC")) > 0 else "mpicc"
@@ -586,7 +497,7 @@ try:
     os.chdir(f"{install_dir}/downloads")
     dl_errors = []
     for pkg in package_info:
-        if not DownloadPackage(downloader, package_info[pkg][URL], pkg,
+        if not DownloadPackage(package_info[pkg][URL], pkg,
                                package_info[pkg][VERSION]):
             dl_errors.append(pkg)
     os.chdir(f"{install_dir}")
@@ -624,16 +535,8 @@ try:
         log_file.flush()
         ver = package_info[pkg][VERSION]
         success = False
-        if pkg == 'readline':
-            success = InstallPackage(pkg, ver, gold_file="lib/libreadline.a")
-        elif pkg == 'ncurses':
-            success = InstallPackage(pkg, ver, gold_file="lib/libncurses.a")
-        elif pkg == 'lua':
-            readline_install = f"{install_dir}"
-            ncurses_install = f"{install_dir}"
-            success = InstallLuaPackage(pkg, ver, gold_file="lib/liblua.a",
-                                        readline_install=readline_install,
-                                        ncurses_install=ncurses_install)
+        if pkg == 'lua':
+            success = InstallLuaPackage(pkg, ver, gold_file="lib/liblua.a")
         elif pkg == 'petsc':
             success = InstallPETSc(pkg, ver, gold_file="include/petsc")
         elif pkg == 'vtk':
@@ -662,53 +565,24 @@ try:
     # Create envvars file
     module_file = open(module_file_name, "w")
 
-    lua_version = package_info["lua"][VERSION]
-    petsc_version = package_info["petsc"][VERSION]
-    vtk_version = package_info["vtk"][VERSION]
-
-    petsc_dir = f"{install_dir}"
-    vtk_dir = f"{install_dir}"
+    #lua_version = package_info["lua"][VERSION]
+    #petsc_version = package_info["petsc"][VERSION]
+    #vtk_version = package_info["vtk"][VERSION]
+    #caliper_version = package_info["caliper"][VERSION]
 
     module_file.write(f'export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:"{install_dir}"\n')
-    module_file.write(f'export PETSC_DIR={petsc_dir}\n')
-
-    if os.path.exists(f"{vtk_dir}/lib64"):
-        module_file.write(f'export LD_LIBRARY_PATH="{vtk_dir}/lib64":$LD_LIBRARY_PATH\n')
-    else:
-        module_file.write(f'export LD_LIBRARY_PATH="{vtk_dir}/lib":$LD_LIBRARY_PATH\n')
-    module_file.write('echo "Environment set for compiling. ' +
-                      'If recompiling changed sources execute"\n')
-    module_file.write('echo "     ./configure clean"\n')
-    module_file.write('echo " "\n')
-    module_file.write('echo "Otherwise just execute:"\n')
-    module_file.write('echo "     ./configure"\n')
-
     module_file.close()
 
     ExecSub(f"chmod u+x {module_file_name}", log_file)
     log_file.close()
 
     print("\n########## OpenSn Dependency install complete ##########")
-    print("\nWhen opening OpenSn in an IDE, the following environment variables" +
-          " need to be set:\n")
-
+    print("\nWhen compiling OpenSn the following environment variable" +
+          " may need to be set:\n")
     print(f'CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:"{install_dir}"')
-    print(f'PETSC_DIR={petsc_dir}')
     print()
-    print(TextColors.WARNING +
-          "When compiling OpenSn, in a terminal, the following environment "
-          "variables need to be set:\n" + TextColors.ENDC)
-
-    print(f'export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:"{install_dir}"')
-    print(f'export PETSC_DIR="{petsc_dir}"')
-    if os.path.exists(f"{vtk_dir}/lib64"):
-        print(f'export LD_LIBRARY_PATH="{vtk_dir}/lib":$LD_LIBRARY_PATH')
-    else:
-        print(f'export LD_LIBRARY_PATH="{vtk_dir}/lib64":$LD_LIBRARY_PATH')
-
-    print()
-    print(f"To set these terminal environment variables automatically, execute:")
-    print(f"    $ {module_file_name}\n")
+    print(f"To set this environment variable automatically in a `bash` shell, execute:")
+    print(f"    $ source {module_file_name}\n")
 
 except RuntimeError as e:
     print(f"{TextColors.RED}{e}{TextColors.ENDC}")

--- a/resources/configure_dependencies.py
+++ b/resources/configure_dependencies.py
@@ -561,11 +561,6 @@ try:
     # Create envvars file
     module_file = open(module_file_name, "w")
 
-    #lua_version = package_info["lua"][VERSION]
-    #petsc_version = package_info["petsc"][VERSION]
-    #vtk_version = package_info["vtk"][VERSION]
-    #caliper_version = package_info["caliper"][VERSION]
-
     module_file.write(f'export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:"{install_dir}"\n')
     module_file.close()
 


### PR DESCRIPTION
This PR updates the Linux install instructions and configure_dependencies.py script. I've made some simplifications to configure_dependencies.py to make the automated install less error prone (forcing the use of curl for downloads, removing march=native compiler flags, etc.). Both sets of instructions were successfully tested on a clean install of Ubuntu 22.04.4. 

This should partially address #87, but the MacOS installation instructions may still need updating.

I've testing the MacOS instructions and made slight modifications.