### PR TITLE
gha: adding caliper into gh-pages workflow dependencies

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,8 @@ jobs:
             doxygen \
             petsc==3.17.5 \
             vtk \
-            lua
+            lua \
+            caliper
           sudo pip install -r doc/requirements.txt
 
       - name: Build doco


### PR DESCRIPTION
`github-pages` workflow started to fail after #196 was merged. We don't test the workflow on PRs, so that slipped through the cracks.