### PR TITLE
Private dependency linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,10 @@ target_include_directories(libopensn
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/external
     PUBLIC
-    ${LUA_INCLUDE_DIR}
-    ${PETSC_INCLUDE_DIR}
-    ${caliper_INCLUDE_DIR}
-    ${HDF5_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${LUA_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${HDF5_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${caliper_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${PETSC_INCLUDE_DIR}>
 )
 
 target_link_libraries(libopensn

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -14,10 +14,10 @@ target_include_directories(libopensnlua
 
 target_link_libraries(libopensnlua
     PRIVATE
+    libopensn
     ${LUA_LIBRARIES}
     ${PETSC_LIBRARY}
     MPI::MPI_CXX
-    libopensn
     caliper
 )
 


### PR DESCRIPTION
This PR changes CMakeLists.txt to link everything privately. An issue arose building an external application using OpenSn with dependencies built with conda. Privately linking everything fixed the problem. As far as I am aware, this change will necessitate external applications that use dependencies of OpenSn to also link to those libraries instead of those dependencies being available with OpenSn. This is not my area of expertise, so any feedback is welcomed.