### PR TITLE
XS Scaling Factors API

### DIFF
--- a/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
+++ b/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
@@ -18,6 +18,8 @@ RegisterLuaFunctionNamespace(XSCreate, xs, Create);
 RegisterLuaFunctionNamespace(XSSet, xs, Set);
 RegisterLuaFunctionNamespace(XSMakeCombined, xs, MakeCombined);
 RegisterLuaFunctionNamespace(XSSetCombined, xs, SetCombined);
+RegisterLuaFunctionNamespace(XSMakeScaled, xs, MakeScaled);
+RegisterLuaFunctionNamespace(XSSetScalingFactor, xs, SetScalingFactor);
 RegisterLuaFunctionNamespace(XSGet, xs, Get);
 RegisterLuaFunctionNamespace(XSExportToOpenSnFormat, xs, ExportToOpenSnFormat);
 
@@ -330,6 +332,55 @@ XSSetCombined(lua_State* L)
 
   xs->Initialize(combinations);
 
+  return LuaReturn(L);
+}
+
+int
+XSMakeScaled(lua_State* L)
+{
+  const std::string fname = "xs.MakeScaled";
+  LuaCheckArgs<int, double>(L, fname);
+
+  const auto handle = LuaArg<int>(L, 1);
+  auto factor = LuaArg<double>(L, 2);
+
+  std::shared_ptr<MultiGroupXS> xs;
+  try
+  {
+    xs = opensn::GetStackItemPtr(opensn::multigroup_xs_stack, handle);
+  }
+  catch (const std::out_of_range& o)
+  {
+    OpenSnInvalidArgument("Invalid handle for cross sections in call to " + fname + ".");
+  }
+
+  auto new_xs = std::shared_ptr<MultiGroupXS>(xs);
+  new_xs->SetScalingFactor(factor);
+  opensn::multigroup_xs_stack.push_back(new_xs);
+  auto num_xs = opensn::multigroup_xs_stack.size();
+  return LuaReturn(L, num_xs - 1);
+}
+
+int
+XSSetScalingFactor(lua_State* L)
+{
+  const std::string fname = "xs.SetScalingFactor";
+  LuaCheckArgs<int, double>(L, fname);
+
+  const auto handle = LuaArg<int>(L, 1);
+  auto factor = LuaArg<double>(L, 2);
+
+  std::shared_ptr<MultiGroupXS> xs;
+  try
+  {
+    xs = opensn::GetStackItemPtr(opensn::multigroup_xs_stack, handle);
+  }
+  catch (const std::out_of_range& o)
+  {
+    OpenSnInvalidArgument("Invalid handle for cross sections in call to " + fname + ".");
+  }
+
+  xs->SetScalingFactor(factor);
   return LuaReturn(L);
 }
 

--- a/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.h
+++ b/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.h
@@ -144,6 +144,47 @@ int XSMakeCombined(lua_State* L);
 int XSSetCombined(lua_State* L);
 
 /**
+ * Creates cross sections by scaling other cross sections.
+ *
+ *  \param XS_handle int Handle to the cross section to be modified.
+ *  \param ScalingFactor double The scaling factor to apply.
+ *
+ *  ## _
+ *
+ * ###Example
+ * Example Lua code:
+ * \code
+ * micro_xs = xs.Create()
+ * xs.Set(micro_xs, OPENSN_XSFILE, "test/xs_graphite_pure.xs")
+ * macro_xs = xs.SetScalingFactor(micro_xs, 1.134e23)  -- Number density for 2.26 g/cc
+ * \endcode
+ *
+ * \ingroup LuaTransportXSs
+ */
+int XSMakeScaled(lua_State* L);
+
+/**
+ * Sets the scaling factor for cross sections. This routine can be called multiple times on the
+ * same handle to modify scaling factors.
+ *
+ *  \param XS_handle int Handle to the cross section to be modified.
+ *  \param ScalingFactor double The scaling factor to apply.
+ *
+ *  ## _
+ *
+ * ###Example
+ * Example Lua code:
+ * \code
+ * xs_1 = xs.Create()
+ * xs.Set(xs_1, OPENSN_XSFILE, "test/xs_graphite_pure.xs")
+ * xs.SetScalingFactor(xs_1, 1.134e23)  -- Number density for 2.26 g/cc
+ * \endcode
+ *
+ * \ingroup LuaTransportXSs
+ */
+int XSSetScalingFactor(lua_State* L);
+
+/**
  * Obtains a lua table of all the cross-section values.
  *
  * \param XS_handle int Handle to the cross section to be modified.

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
@@ -8,25 +8,25 @@ num_procs = 2
 
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                       "Expected "..tostring(num_procs)..
-                       ". Pass check_num_procs=false to override if possible.")
+if (check_num_procs == nil and number_of_processes ~= num_procs) then
+    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
     os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=100.0
+nodes = {}
+N = 20
+L = 100.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -44,20 +44,20 @@ mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
 mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
 
 -- Define microscopic cross sections
-xss = xs.Create()
+micro_xs = xs.Create()
 xs_file = "tests/transport_transient/subcritical_1g.xs"
-xs.Set(xss, OPENSN_XSFILE, xs_file)
+xs.Set(micro_xs, OPENSN_XSFILE, xs_file)
 
 -- Define macroscopic cross sections
---xss = xs.MakeCombined({{xss, 0.00264086}}) -- just sub-critical
-xss = xs.MakeCombined({{xss, 0.0424459}}) -- just sub-critical
+--macro_xs = xs.MakeScaled(micro_xs, 0.00264086) -- just sub-critical
+macro_xs = xs.MakeCombined(micro_xs, 0.0424459) -- just sub-critical
 
 num_groups = 1
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xss)
-mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, xss)
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, macro_xs)
+mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, macro_xs)
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
     src[g] = 0.0
 end
 --src[1] = 1.0
@@ -69,7 +69,7 @@ phys1 = LBSCreateTransientSolver()
 
 --========== Groups
 grp = {}
-for g=1,num_groups do
+for g = 1, num_groups do
     grp[g] = LBSCreateGroup(phys1)
 end
 
@@ -79,14 +79,14 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 16)
 --========== Groupset def
 gs0 = LBSCreateGroupset(phys1)
 cur_gs = gs0
-LBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
-LBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
-LBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
-LBSGroupsetSetGroupSubsets(phys1,cur_gs,8)
-LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_GMRES)
-LBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
-LBSGroupsetSetMaxIterations(phys1,cur_gs,1000)
-LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+LBSGroupsetAddGroups(phys1, cur_gs, 0, num_groups - 1)
+LBSGroupsetSetQuadrature(phys1, cur_gs, pquad)
+LBSGroupsetSetAngleAggDiv(phys1, cur_gs, 1)
+LBSGroupsetSetGroupSubsets(phys1, cur_gs, 8)
+LBSGroupsetSetIterativeMethod(phys1, cur_gs, KRYLOV_GMRES)
+LBSGroupsetSetResidualTolerance(phys1, cur_gs, 1.0e-6)
+LBSGroupsetSetMaxIterations(phys1, cur_gs, 1000)
+LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --LBSGroupsetSetWGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 --LBSGroupsetSetTGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 
@@ -99,8 +99,8 @@ LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
 --bsrc[1] = 1.0/2
 ----LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.INCIDENT_ISOTROPIC,bsrc);
 --
-LBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD)
-LBSSetProperty(phys1,SCATTERING_ORDER,1)
+LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
+LBSSetProperty(phys1, SCATTERING_ORDER, 1)
 
 LBKESSetProperty(phys1, "MAX_ITERATIONS", 100)
 LBKESSetProperty(phys1, "TOLERANCE", 1.0e-8)
@@ -134,15 +134,15 @@ phys1name = solver.GetName(phys1);
 
 time = 0.0
 time_stop = 20.0
-k=0
+k = 0
 while (time < time_stop) do
     k = k + 1
     solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1,"NEW")
-    FRi = lbs.ComputeFissionRate(phys1,"OLD")
+    FRf = lbs.ComputeFissionRate(phys1, "NEW")
+    FRi = lbs.ComputeFissionRate(phys1, "OLD")
     dt = LBTSGetProperty(phys1, "TIMESTEP")
     time = LBTSGetProperty(phys1, "TIME")
-    period = dt/math.log(FRf/FRi)
+    period = dt / math.log(FRf / FRi)
     log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-            phys1name,k,time,dt,period,FRf))
+                                 phys1name, k, time, dt, period, FRf))
 end

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
@@ -8,25 +8,25 @@ num_procs = 2
 
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-            "Expected "..tostring(num_procs)..
-            ". Pass check_num_procs=false to override if possible.")
+if (check_num_procs == nil and number_of_processes ~= num_procs) then
+    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
     os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=4
-L=100.0
+nodes = {}
+N = 4
+L = 100.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -48,8 +48,7 @@ xs.Set(xs_21cent, OPENSN_XSFILE, "tests/transport_transient/xs_inf_21cent_1g.xs"
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_critical)
 
-src={0.0}
-mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
     mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
@@ -61,7 +60,7 @@ phys1 = LBSCreateTransientSolver()
 
 --========== Groups
 grp = {}
-for g=1,num_groups do
+for g = 1, num_groups do
     grp[g] = LBSCreateGroup(phys1)
 end
 
@@ -71,14 +70,14 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 16)
 --========== Groupset def
 gs0 = LBSCreateGroupset(phys1)
 cur_gs = gs0
-LBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
-LBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
-LBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
-LBSGroupsetSetGroupSubsets(phys1,cur_gs,8)
-LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_GMRES)
-LBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
-LBSGroupsetSetMaxIterations(phys1,cur_gs,1000)
-LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+LBSGroupsetAddGroups(phys1, cur_gs, 0, num_groups - 1)
+LBSGroupsetSetQuadrature(phys1, cur_gs, pquad)
+LBSGroupsetSetAngleAggDiv(phys1, cur_gs, 1)
+LBSGroupsetSetGroupSubsets(phys1, cur_gs, 8)
+LBSGroupsetSetIterativeMethod(phys1, cur_gs, KRYLOV_GMRES)
+LBSGroupsetSetResidualTolerance(phys1, cur_gs, 1.0e-6)
+LBSGroupsetSetMaxIterations(phys1, cur_gs, 1000)
+LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --LBSGroupsetSetWGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 --LBSGroupsetSetTGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 
@@ -89,11 +88,11 @@ LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
 --    bsrc[g] = 0.0
 --end
 --bsrc[1] = 1.0/2
-LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMAX,LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMIN, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMAX, LBSBoundaryTypes.REFLECTING);
 --
-LBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD)
-LBSSetProperty(phys1,SCATTERING_ORDER,1)
+LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
+LBSSetProperty(phys1, SCATTERING_ORDER, 1)
 
 LBKESSetProperty(phys1, "MAX_ITERATIONS", 100)
 LBKESSetProperty(phys1, "TOLERANCE", 1.0e-8)
@@ -113,7 +112,7 @@ LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
 phys1name = solver.GetName(phys1);
-initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
+initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
 --for k=1,2 do
@@ -130,18 +129,18 @@ initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
 
 time = 0.0
 time_stop = 1.0
-k=0
+k = 0
 swapped = false
 while (time < time_stop) do
     k = k + 1
     solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1,"NEW")
-    FRi = lbs.ComputeFissionRate(phys1,"OLD")
+    FRf = lbs.ComputeFissionRate(phys1, "NEW")
+    FRi = lbs.ComputeFissionRate(phys1, "OLD")
     dt = LBTSGetProperty(phys1, "TIMESTEP")
     time = LBTSGetProperty(phys1, "TIME")
-    period = dt/math.log(FRf/FRi)
+    period = dt / math.log(FRf / FRi)
     log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-            phys1name,k,time,dt,period,FRf/initial_FR))
+                                 phys1name, k, time, dt, period, FRf / initial_FR))
     if (time >= 0.2 and not swapped) then
         SwapXS(phys1, xs_21cent)
         swapped = true

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
@@ -8,32 +8,32 @@ num_procs = 2
 
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-            "Expected "..tostring(num_procs)..
-            ". Pass check_num_procs=false to override if possible.")
+if (check_num_procs == nil and number_of_processes ~= num_procs) then
+    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
     os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=2000
-L=100.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 2000
+L = 100.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-L/4, zmax=L/4})
-mesh.SetMaterialIDFromLogicalVolume(vol0,1)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, zmin = -L / 4, zmax = L / 4 })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 1)
 
 --############################################### Add materials
 materials = {}
@@ -54,17 +54,16 @@ xs_weak_fuelB_micro = xs.Create()
 xs.Set(xs_weak_fuelB_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_weak_1g.xs")
 
 atom_density = 0.056559
-xs_strong_fuel = xs.MakeCombined({{xs_strong_fuel_micro, atom_density}}) --critical
-xs_weak_fuelA  = xs.MakeCombined({{ xs_weak_fuelA_micro, atom_density}}) --critical
-xs_weak_fuelB  = xs.MakeCombined({{xs_weak_fuelB_micro, atom_density}})   --critical
+xs_strong_fuel = xs.MakeScaled(xs_strong_fuel_micro, atom_density) --critical
+xs_weak_fuelA = xs.MakeScaled(xs_weak_fuelA_micro, atom_density) --critical
+xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density)   --critical
 
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_strong_fuel)
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, xs_weak_fuelA)
 
-src={0.0}
-mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
-mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
+mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
     mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
@@ -76,7 +75,7 @@ phys1 = LBSCreateTransientSolver()
 
 --========== Groups
 grp = {}
-for g=1,num_groups do
+for g = 1, num_groups do
     grp[g] = LBSCreateGroup(phys1)
 end
 
@@ -86,15 +85,15 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 16)
 --========== Groupset def
 gs0 = LBSCreateGroupset(phys1)
 cur_gs = gs0
-LBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
-LBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
-LBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
-LBSGroupsetSetGroupSubsets(phys1,cur_gs,8)
-LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_GMRES)
+LBSGroupsetAddGroups(phys1, cur_gs, 0, num_groups - 1)
+LBSGroupsetSetQuadrature(phys1, cur_gs, pquad)
+LBSGroupsetSetAngleAggDiv(phys1, cur_gs, 1)
+LBSGroupsetSetGroupSubsets(phys1, cur_gs, 8)
+LBSGroupsetSetIterativeMethod(phys1, cur_gs, KRYLOV_GMRES)
 --LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_RICHARDSON)
-LBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
-LBSGroupsetSetMaxIterations(phys1,cur_gs,1000)
-LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+LBSGroupsetSetResidualTolerance(phys1, cur_gs, 1.0e-6)
+LBSGroupsetSetMaxIterations(phys1, cur_gs, 1000)
+LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --LBSGroupsetSetWGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 --LBSGroupsetSetTGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 
@@ -108,8 +107,8 @@ LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
 --LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.REFLECTING);
 --LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMAX,LBSBoundaryTypes.REFLECTING);
 --
-LBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD)
-LBSSetProperty(phys1,SCATTERING_ORDER,1)
+LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
+LBSSetProperty(phys1, SCATTERING_ORDER, 1)
 
 LBKESSetProperty(phys1, "MAX_ITERATIONS", 1000)
 LBKESSetProperty(phys1, "TOLERANCE", 1.0e-8)
@@ -124,14 +123,14 @@ LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
-LBTSSetProperty(phys1, "TIMESTEP", 1e-3*100)
-LBTSSetProperty(phys1, "TIMESTOP", 1.0*100)
+LBTSSetProperty(phys1, "TIMESTEP", 1e-3 * 100)
+LBTSSetProperty(phys1, "TIMESTOP", 1.0 * 100)
 LBTSSetProperty(phys1, "MAX_TIMESTEPS", -1)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
 phys1name = solver.GetName(phys1);
-initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
+initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 
 --time = 0.0
@@ -184,20 +183,20 @@ initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
 --        timestep_rejected = false
 --    end
 --end
-swapped=false
+swapped = false
 function MyCallBack()
-    FRf = lbs.ComputeFissionRate(phys1,"NEW")
-    FRi = lbs.ComputeFissionRate(phys1,"OLD")
+    FRf = lbs.ComputeFissionRate(phys1, "NEW")
+    FRi = lbs.ComputeFissionRate(phys1, "OLD")
     dt = LBTSGetProperty(phys1, "TIMESTEP")
     time = LBTSGetProperty(phys1, "TIME")
-    period = dt/math.log(FRf/FRi)
+    period = dt / math.log(FRf / FRi)
 
     if (time >= 0.2 and not swapped) then
         SwapXS(phys1, xs_weak_fuelB)
         swapped = true
     end
-    log.Log(LOG_0,string.format("%s time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                phys1name,time,dt,period,FRf/initial_FR))
+    log.Log(LOG_0, string.format("%s time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+                                 phys1name, time, dt, period, FRf / initial_FR))
 end
 LBTSSetProperty(phys1, "CALLBACK", "MyCallBack")
 solver.Execute(phys1)

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
@@ -8,25 +8,25 @@ num_procs = 2
 
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-            "Expected "..tostring(num_procs)..
-            ". Pass check_num_procs=false to override if possible.")
+if (check_num_procs == nil and number_of_processes ~= num_procs) then
+    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
     os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=4
-L=100.0
+nodes = {}
+N = 4
+L = 100.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -48,8 +48,7 @@ xs.Set(xs_21cent, OPENSN_XSFILE, "tests/transport_transient/xs_inf_21cent_1g.xs"
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_critical)
 
-src={0.0}
-mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
     mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
@@ -61,26 +60,26 @@ phys1 = LBSCreateTransientSolver()
 
 --========== Groups
 grp = {}
-for g=1,num_groups do
+for g = 1, num_groups do
     grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
-fac=1
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4*fac, 3*fac)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+fac = 1
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4 * fac, 3 * fac)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 --========== Groupset def
 gs0 = LBSCreateGroupset(phys1)
 cur_gs = gs0
-LBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
-LBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
-LBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
-LBSGroupsetSetGroupSubsets(phys1,cur_gs,8)
-LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_GMRES_CYCLES)
-LBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
-LBSGroupsetSetMaxIterations(phys1,cur_gs,1000)
-LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+LBSGroupsetAddGroups(phys1, cur_gs, 0, num_groups - 1)
+LBSGroupsetSetQuadrature(phys1, cur_gs, pquad)
+LBSGroupsetSetAngleAggDiv(phys1, cur_gs, 1)
+LBSGroupsetSetGroupSubsets(phys1, cur_gs, 8)
+LBSGroupsetSetIterativeMethod(phys1, cur_gs, KRYLOV_GMRES_CYCLES)
+LBSGroupsetSetResidualTolerance(phys1, cur_gs, 1.0e-6)
+LBSGroupsetSetMaxIterations(phys1, cur_gs, 1000)
+LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --LBSGroupsetSetWGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 --LBSGroupsetSetTGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 
@@ -91,13 +90,13 @@ LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
 --    bsrc[g] = 0.0
 --end
 --bsrc[1] = 1.0/2
-LBSSetProperty(phys1,BOUNDARY_CONDITION,XMIN,LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1,BOUNDARY_CONDITION,XMAX,LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1,BOUNDARY_CONDITION,YMIN,LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1,BOUNDARY_CONDITION,YMAX,LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, XMIN, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, XMAX, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, YMIN, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, YMAX, LBSBoundaryTypes.REFLECTING);
 --
-LBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD)
-LBSSetProperty(phys1,SCATTERING_ORDER,1)
+LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
+LBSSetProperty(phys1, SCATTERING_ORDER, 1)
 
 LBKESSetProperty(phys1, "MAX_ITERATIONS", 100)
 LBKESSetProperty(phys1, "TOLERANCE", 1.0e-8)
@@ -117,7 +116,7 @@ LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
 phys1name = solver.GetName(phys1);
-initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
+initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
 --for k=1,2 do
@@ -134,18 +133,18 @@ initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
 
 time = 0.0
 time_stop = 1.0
-k=0
+k = 0
 swapped = false
 while (time < time_stop) do
     k = k + 1
     solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1,"NEW")
-    FRi = lbs.ComputeFissionRate(phys1,"OLD")
+    FRf = lbs.ComputeFissionRate(phys1, "NEW")
+    FRi = lbs.ComputeFissionRate(phys1, "OLD")
     dt = LBTSGetProperty(phys1, "TIMESTEP")
     time = LBTSGetProperty(phys1, "TIME")
-    period = dt/math.log(FRf/FRi)
+    period = dt / math.log(FRf / FRi)
     log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-            phys1name,k,time,dt,period,FRf/initial_FR))
+                                 phys1name, k, time, dt, period, FRf / initial_FR))
     if (time >= 0.2 and not swapped) then
         SwapXS(phys1, xs_21cent)
         swapped = true

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
@@ -8,34 +8,34 @@ num_procs = 2
 
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-            "Expected "..tostring(num_procs)..
-            ". Pass check_num_procs=false to override if possible.")
+if (check_num_procs == nil and number_of_processes ~= num_procs) then
+    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
+        "Expected " .. tostring(num_procs) ..
+        ". Pass check_num_procs=false to override if possible.")
     os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=160
-L=80.96897163
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 160
+L = 80.96897163
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+    k = i - 1
+    nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol0 = logvol.RPPLogicalVolume.Create({xmin=-L/16, xmax=L/16,
-                                         ymin=-L/16, ymax=L/16,
-                                         zmin=-L/16, zmax=L/16})
-mesh.SetMaterialIDFromLogicalVolume(vol0,1)
+vol0 = logvol.RPPLogicalVolume.Create({ xmin = -L / 16, xmax = L / 16,
+                                        ymin = -L / 16, ymax = L / 16,
+                                        zmin = -L / 16, zmax = L / 16 })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 1)
 
 mesh.ExportToVTK("TheMesh")
 
@@ -58,17 +58,16 @@ xs_weak_fuelB_micro = xs.Create()
 xs.Set(xs_weak_fuelB_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_weak2_1g.xs")
 
 atom_density = 0.056559
-xs_strong_fuel = xs.MakeCombined({{xs_strong_fuel_micro, atom_density}}) --critical
-xs_weak_fuelA  = xs.MakeCombined({{ xs_weak_fuelA_micro, atom_density}}) --critical
-xs_weak_fuelB  = xs.MakeCombined({{xs_weak_fuelB_micro, atom_density}})   --critical
+xs_strong_fuel = xs.MakeScaled(xs_strong_fuel_micro, atom_density) --critical
+xs_weak_fuelA = xs.MakeScaled(xs_weak_fuelA_micro, atom_density) --critical
+xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density)   --critical
 
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_strong_fuel)
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, xs_weak_fuelA)
 
-src={0.0}
-mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
-mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
+mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
     mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
@@ -80,26 +79,26 @@ phys1 = LBSCreateTransientSolver()
 
 --========== Groups
 grp = {}
-for g=1,num_groups do
+for g = 1, num_groups do
     grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
-fac=3
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2*fac, 2*fac)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+fac = 3
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2 * fac, 2 * fac)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 --========== Groupset def
 gs0 = LBSCreateGroupset(phys1)
 cur_gs = gs0
-LBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
-LBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
-LBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
-LBSGroupsetSetGroupSubsets(phys1,cur_gs,1)
-LBSGroupsetSetIterativeMethod(phys1,cur_gs,KRYLOV_GMRES_CYCLES)
-LBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
-LBSGroupsetSetMaxIterations(phys1,cur_gs,1000)
-LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+LBSGroupsetAddGroups(phys1, cur_gs, 0, num_groups - 1)
+LBSGroupsetSetQuadrature(phys1, cur_gs, pquad)
+LBSGroupsetSetAngleAggDiv(phys1, cur_gs, 1)
+LBSGroupsetSetGroupSubsets(phys1, cur_gs, 1)
+LBSGroupsetSetIterativeMethod(phys1, cur_gs, KRYLOV_GMRES_CYCLES)
+LBSGroupsetSetResidualTolerance(phys1, cur_gs, 1.0e-6)
+LBSGroupsetSetMaxIterations(phys1, cur_gs, 1000)
+LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --LBSGroupsetSetWGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 --LBSGroupsetSetTGDSA(phys1,cur_gs,30,1.0e-4,false," ")
 
@@ -113,8 +112,8 @@ LBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
 --LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.REFLECTING);
 --LBSSetProperty(phys1,BOUNDARY_CONDITION,ZMAX,LBSBoundaryTypes.REFLECTING);
 --
-LBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD)
-LBSSetProperty(phys1,SCATTERING_ORDER,0)
+LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
+LBSSetProperty(phys1, SCATTERING_ORDER, 0)
 
 LBKESSetProperty(phys1, "MAX_ITERATIONS", 1000)
 LBKESSetProperty(phys1, "TOLERANCE", 1.0e-8)
@@ -134,7 +133,7 @@ LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
 phys1name = solver.GetName(phys1);
-initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
+initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
 --for k=1,2 do
@@ -151,18 +150,18 @@ initial_FR = lbs.ComputeFissionRate(phys1,"OLD")
 
 time = 0.0
 time_stop = 1.0
-k=0
+k = 0
 swapped = false
 while (time < time_stop) do
     k = k + 1
     solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1,"NEW")
-    FRi = lbs.ComputeFissionRate(phys1,"OLD")
+    FRf = lbs.ComputeFissionRate(phys1, "NEW")
+    FRi = lbs.ComputeFissionRate(phys1, "OLD")
     dt = LBTSGetProperty(phys1, "TIMESTEP")
     time = LBTSGetProperty(phys1, "TIME")
-    period = dt/math.log(FRf/FRi)
+    period = dt / math.log(FRf / FRi)
     log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-            phys1name,k,time,dt,period,FRf/initial_FR))
+                                 phys1name, k, time, dt, period, FRf / initial_FR))
     if (time >= 0.2 and not swapped) then
         SwapXS(phys1, xs_weak_fuelB)
         swapped = true


### PR DESCRIPTION
This PR introduces a Lua API for setting cross section scaling factors. In order to do this before, one had to call `new_xs_handle = xs.MakeCombined({{ xs_handle, factor }})`. By construction, this routine sets the scaling factor for `xs_handle` to `factor` and then sets `new_xs_handle` to the scaled `xs_handle` with a scaling factor of 1. This is convoluted and unintuitive.

The new API routines make this process intuitive. A user can now either create a new XS object by scaling another with `macro_xs = xs.MakeScaled(micro_xs, factor)` or set the scaling factor in an existing XS object with `xs.SetScalingFactor(macro_xs, factor)` in Lua.