### PR TITLE
Do not serialize non-POD types

### DIFF
--- a/framework/mesh/cell/cell.cc
+++ b/framework/mesh/cell/cell.cc
@@ -232,8 +232,12 @@ CellFace::Serialize() const
   for (uint64_t vid : vertex_ids_)
     raw.Write<uint64_t>(vid);
 
-  raw.Write<Vector3>(normal_);
-  raw.Write<Vector3>(centroid_);
+  raw.Write<double>(normal_.x);
+  raw.Write<double>(normal_.y);
+  raw.Write<double>(normal_.z);
+  raw.Write<double>(centroid_.x);
+  raw.Write<double>(centroid_.y);
+  raw.Write<double>(centroid_.z);
   raw.Write<bool>(has_neighbor_);
   raw.Write<uint64_t>(neighbor_id_);
 
@@ -251,8 +255,12 @@ CellFace::DeSerialize(const ByteArray& raw, size_t& address)
   for (size_t fv = 0; fv < num_face_verts; ++fv)
     face.vertex_ids_.push_back(raw.Read<uint64_t>(address, &address));
 
-  face.normal_ = raw.Read<Vector3>(address, &address);
-  face.centroid_ = raw.Read<Vector3>(address, &address);
+  face.normal_.x = raw.Read<double>(address, &address);
+  face.normal_.y = raw.Read<double>(address, &address);
+  face.normal_.z = raw.Read<double>(address, &address);
+  face.centroid_.x = raw.Read<double>(address, &address);
+  face.centroid_.y = raw.Read<double>(address, &address);
+  face.centroid_.z = raw.Read<double>(address, &address);
   face.has_neighbor_ = raw.Read<bool>(address, &address);
   face.neighbor_id_ = raw.Read<uint64_t>(address, &address);
 
@@ -296,7 +304,9 @@ Cell::Serialize() const
   raw.Write<uint64_t>(global_id_);
   raw.Write<uint64_t>(local_id_);
   raw.Write<uint64_t>(partition_id_);
-  raw.Write<Vector3>(centroid_);
+  raw.Write<double>(centroid_.x);
+  raw.Write<double>(centroid_.y);
+  raw.Write<double>(centroid_.z);
   raw.Write<int>(material_id_);
 
   raw.Write<CellType>(cell_type_);
@@ -316,11 +326,12 @@ Cell::Serialize() const
 Cell
 Cell::DeSerialize(const ByteArray& raw, size_t& address)
 {
-  typedef Vector3 Vec3;
   auto cell_global_id = raw.Read<uint64_t>(address, &address);
   auto cell_local_id = raw.Read<uint64_t>(address, &address);
   auto cell_prttn_id = raw.Read<uint64_t>(address, &address);
-  auto cell_centroid = raw.Read<Vec3>(address, &address);
+  auto cell_centroid_x = raw.Read<double>(address, &address);
+  auto cell_centroid_y = raw.Read<double>(address, &address);
+  auto cell_centroid_z = raw.Read<double>(address, &address);
   auto cell_matrl_id = raw.Read<int>(address, &address);
 
   auto cell_type = raw.Read<CellType>(address, &address);
@@ -330,7 +341,9 @@ Cell::DeSerialize(const ByteArray& raw, size_t& address)
   cell.global_id_ = cell_global_id;
   cell.local_id_ = cell_local_id;
   cell.partition_id_ = cell_prttn_id;
-  cell.centroid_ = cell_centroid;
+  cell.centroid_.x = cell_centroid_x;
+  cell.centroid_.y = cell_centroid_y;
+  cell.centroid_.z = cell_centroid_z;
   cell.material_id_ = cell_matrl_id;
 
   auto num_vertex_ids = raw.Read<size_t>(address, &address);

--- a/test/framework/data_types/data_types_test_00.cc
+++ b/test/framework/data_types/data_types_test_00.cc
@@ -31,19 +31,25 @@ data_types_Test00(const InputParameters&)
   opensn::log.Log() << "Testing ByteArray Write and Read\n";
   ByteArray barr;
 
+  Vector3 v3a(3.0, 2.0, 1.0);
   barr.Write<double>(1.01234567890123456789);
   barr.Write<int>(-15600700);
   barr.Write<double>(2.0987654321);
   barr.Write<bool>(false);
   barr.Write<bool>(true);
-  barr.Write<Vector3>(Vector3(3.0, 2.0, 1.0));
+  barr.Write<double>(v3a.x);
+  barr.Write<double>(v3a.y);
+  barr.Write<double>(v3a.z);
 
   auto dbl_value = barr.Read<double>();
   auto int_value = barr.Read<int>();
   auto dbl_value2 = barr.Read<double>();
   auto bl_value1 = barr.Read<bool>();
   auto bl_value2 = barr.Read<bool>();
-  auto vec3 = barr.Read<Vector3>();
+  auto vec3_x = barr.Read<double>();
+  auto vec3_y = barr.Read<double>();
+  auto vec3_z = barr.Read<double>();
+  Vector3 vec3b(vec3_x, vec3_y, vec3_z);
 
   ByteArray seeker;
   seeker.Write<bool>(false);
@@ -56,8 +62,8 @@ data_types_Test00(const InputParameters&)
   opensn::log.Log() << "Value check " << seeker.Read<double>();
 
   if (dbl_value != 1.01234567890123456789 or int_value != -15600700 or dbl_value2 != 2.0987654321 or
-      bl_value1 or !bl_value2 or vec3[0] != Vector3(3.0, 2.0, 1.0)[0] or
-      vec3[1] != Vector3(3.0, 2.0, 1.0)[1] or vec3[2] != Vector3(3.0, 2.0, 1.0)[2])
+      bl_value1 or !bl_value2 or vec3b[0] != Vector3(3.0, 2.0, 1.0)[0] or
+      vec3b[1] != Vector3(3.0, 2.0, 1.0)[1] or vec3b[2] != Vector3(3.0, 2.0, 1.0)[2])
 
   {
     passed = false;


### PR DESCRIPTION
PR #230 fixed a bug in ByteArray that uncovered another bug in our cell serialization. gcc reports this as:
```
opensn/framework/data_types/byte_array.h:88:16: warning: ‘void* memcpy(void*, const void*, size_t)’ 
writing to an object of type ‘struct opensn::Vector3’ with no trivial copy-assignment; use copy-assignment
or copy-initialization instead [-Wclass-memaccess]
```
But the real problem is that we are attempting to serialize non-POD types.  We should absolutely avoid this. We need to move to a proper serialization library and not write our own routines. In this case, we were serializing `Vector3`, so it's a relatively simple change to deal with each of the individual data members separately.