### PR TITLE
Formatting input files for consistency

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,10 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2 
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false

--- a/test/framework/math/quadrature/quadrature_test1.lua
+++ b/test/framework/math/quadrature/quadrature_test1.lua
@@ -1,19 +1,21 @@
 function PrintTable(t, indent)
-  if not indent then indent = 0 end
-  strform = "%"..tostring(indent).."s"
+  if not indent then
+    indent = 0
+  end
+  strform = "%" .. tostring(indent) .. "s"
 
-  for k,v in pairs(t) do
-    if (type(v) == "table") then
-      print(string.rep(" ", indent)..k.." ".."table")
-      PrintTable(v, indent+2)
+  for k, v in pairs(t) do
+    if type(v) == "table" then
+      print(string.rep(" ", indent) .. k .. " " .. "table")
+      PrintTable(v, indent + 2)
     else
-      print(string.rep(" ", indent)..k.." "..tostring(v))
+      print(string.rep(" ", indent) .. k .. " " .. tostring(v))
     end
   end
 end
 
 print("GOLD_BEGIN")
-q = squad.GaussLegendreQuadrature.Create({N = 4, verbose = true})
+q = squad.GaussLegendreQuadrature.Create({ N = 4, verbose = true })
 
 qdata = math.Get1DQuadratureData(q)
 
@@ -24,7 +26,7 @@ PrintTable(qdata.weights, 2)
 print()
 
 --################################################
-q = squad.GaussChebyshevQuadrature.Create({N = 4, verbose = true})
+q = squad.GaussChebyshevQuadrature.Create({ N = 4, verbose = true })
 
 qdata = math.Get1DQuadratureData(q)
 
@@ -38,7 +40,13 @@ print("Legendre(1, 0.25)", aquad.Legendre(1, 0.25))
 print("LegendreDerivative(0, 0.25)", aquad.LegendreDerivative(0, 0.25))
 print("LegendreDerivative(1, 0.25)", aquad.LegendreDerivative(1, 0.25))
 
-print("Ylm(0, 0, 45*math.pi/180.0, 45*math.pi/180.0)", aquad.Ylm(0, 0, 45*math.pi/180.0, 45*math.pi/180.0))
-print("Ylm(1, 0, 45*math.pi/180.0, 45*math.pi/180.0)", aquad.Ylm(1, 0, 45*math.pi/180.0, 45*math.pi/180.0))
+print(
+  "Ylm(0, 0, 45*math.pi/180.0, 45*math.pi/180.0)",
+  aquad.Ylm(0, 0, 45 * math.pi / 180.0, 45 * math.pi / 180.0)
+)
+print(
+  "Ylm(1, 0, 45*math.pi/180.0, 45*math.pi/180.0)",
+  aquad.Ylm(1, 0, 45 * math.pi / 180.0, 45 * math.pi / 180.0)
+)
 
 print("GOLD_END")

--- a/test/framework/math/spatial_discretization/cg/mesh_1d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_1d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_2d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_2d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes, nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_2d_tri.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_2d_tri.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/TriangleMesh2x2.obj"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/TriangleMesh2x2.obj",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_3d_hex.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_3d_hex.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/GMSH_AllHexes.vtu"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/GMSH_AllHexes.vtu",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_3d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_3d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=30
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 30
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes, nodes, nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_3d_prism.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_3d_prism.lua
@@ -1,13 +1,10 @@
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="../../../../../resources/TestMeshes/TriangleMesh2x2.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../../resources/TestMeshes/TriangleMesh2x2.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/mesh_3d_tets.lua
+++ b/test/framework/math/spatial_discretization/cg/mesh_3d_tets.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/GMSH_AllTets.vtu"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/GMSH_AllTets.vtu",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01a_pwlc_1d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01a_pwlc_1d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_1d_ortho.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
-  sdm_type = "PWLC"
-});
+unit_tests.math_SDM_Test01_Continuous({
+  sdm_type = "PWLC",
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01b_pwlc_2d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01b_pwlc_2d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_2d_ortho.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
-  sdm_type = "PWLC"
-});
+unit_tests.math_SDM_Test01_Continuous({
+  sdm_type = "PWLC",
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01c_pwlc_3d_ortho.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01c_pwlc_3d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_3d_ortho.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
-  sdm_type = "PWLC"
-});
+unit_tests.math_SDM_Test01_Continuous({
+  sdm_type = "PWLC",
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01d_pwlc_2d_tri.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01d_pwlc_2d_tri.lua
@@ -1,6 +1,5 @@
 dofile("mesh_2d_tri.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
-  sdm_type = "PWLC"
-});
+unit_tests.math_SDM_Test01_Continuous({
+  sdm_type = "PWLC",
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01e_pwlc_3d_prism.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01e_pwlc_3d_prism.lua
@@ -1,6 +1,5 @@
 dofile("mesh_3d_prism.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
-  sdm_type = "PWLC"
-});
+unit_tests.math_SDM_Test01_Continuous({
+  sdm_type = "PWLC",
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01f_pwlc_3d_hex.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01f_pwlc_3d_hex.lua
@@ -1,7 +1,6 @@
 dofile("mesh_3d_hex.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
+unit_tests.math_SDM_Test01_Continuous({
   sdm_type = "PWLC",
   --export_vtk = true
-});
+})

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01g_pwlc_3d_tets.lua
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01g_pwlc_3d_tets.lua
@@ -1,7 +1,6 @@
 dofile("mesh_3d_tets.lua")
 
-unit_tests.math_SDM_Test01_Continuous
-({
+unit_tests.math_SDM_Test01_Continuous({
   sdm_type = "PWLC",
   --export_vtk = true
-});
+})

--- a/test/framework/math/spatial_discretization/dg/mesh_1d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_1d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_2d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_2d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes, nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_2d_tri.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_2d_tri.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/TriangleMesh2x2.obj"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/TriangleMesh2x2.obj",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_3d_hex.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_3d_hex.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/GMSH_AllHexes.vtu"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/GMSH_AllHexes.vtu",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_3d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_3d_ortho.lua
@@ -1,13 +1,13 @@
 --############################################### Setup mesh
-nodes={}
-N=30
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 30
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes, nodes, nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_3d_prism.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_3d_prism.lua
@@ -1,13 +1,10 @@
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="../../../../../resources/TestMeshes/TriangleMesh2x2.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../../resources/TestMeshes/TriangleMesh2x2.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/mesh_3d_tets.lua
+++ b/test/framework/math/spatial_discretization/dg/mesh_3d_tets.lua
@@ -1,6 +1,5 @@
 --############################################### Setup mesh
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="../../../../../resources/TestMeshes/GMSH_AllTets.vtu"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "../../../../../resources/TestMeshes/GMSH_AllTets.vtu",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02a_pwld_1d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02a_pwld_1d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_1d_ortho.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
-  sdm_type = "PWLD"
-});
+unit_tests.math_SDM_Test02_DisContinuous({
+  sdm_type = "PWLD",
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02b_pwld_2d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02b_pwld_2d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_2d_ortho.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
-  sdm_type = "PWLD"
-});
+unit_tests.math_SDM_Test02_DisContinuous({
+  sdm_type = "PWLD",
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02c_pwld_3d_ortho.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02c_pwld_3d_ortho.lua
@@ -1,6 +1,5 @@
 dofile("mesh_3d_ortho.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
-  sdm_type = "PWLD"
-});
+unit_tests.math_SDM_Test02_DisContinuous({
+  sdm_type = "PWLD",
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02d_pwld_2d_tri.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02d_pwld_2d_tri.lua
@@ -1,6 +1,5 @@
 dofile("mesh_2d_tri.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
-  sdm_type = "PWLD"
-});
+unit_tests.math_SDM_Test02_DisContinuous({
+  sdm_type = "PWLD",
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02e_pwld_3d_prism.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02e_pwld_3d_prism.lua
@@ -1,7 +1,6 @@
 dofile("mesh_3d_prism.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
+unit_tests.math_SDM_Test02_DisContinuous({
   sdm_type = "PWLD",
   --export_vtk = true,
-});
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02f_pwld_3d_hex.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02f_pwld_3d_hex.lua
@@ -1,7 +1,6 @@
 dofile("mesh_3d_hex.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
+unit_tests.math_SDM_Test02_DisContinuous({
   sdm_type = "PWLD",
   --export_vtk = true,
-});
+})

--- a/test/framework/math/spatial_discretization/dg/sdm_test_02g_pwld_3d_tets.lua
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_02g_pwld_3d_tets.lua
@@ -1,7 +1,6 @@
 dofile("mesh_3d_tets.lua")
 
-unit_tests.math_SDM_Test02_DisContinuous
-({
+unit_tests.math_SDM_Test02_DisContinuous({
   sdm_type = "PWLD",
   --export_vtk = true,
-});
+})

--- a/test/framework/mesh/bnd_ids_from_function.lua
+++ b/test/framework/mesh/bnd_ids_from_function.lua
@@ -1,15 +1,15 @@
 -- Setup mesh
-nodes={}
-N=10
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 -- Setting left, right, top and bottom boundaries
@@ -17,30 +17,28 @@ mesh.MeshGenerator.Execute(meshgen1)
 -- right = 1
 -- bottom = 2
 -- top = 3
-function dot_product(v1,v2)
-    result = v1[1]*v2[1] +
-             v1[2]*v2[2] +
-             v1[3]*v2[3]
-    return result
+function dot_product(v1, v2)
+  result = v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3]
+  return result
 end
 
-function bnd_id(pt,normal,cur_bid)
-    epsilon = 1.0e-6
-    n = {normal.x,normal.y,normal.z}
-    if (dot_product(n,{-1.0,0.0,0.0}) > (1.0-epsilon)) then
-        return 0
-    end
-    if (dot_product(n,{1.0,0.0,0.0}) > (1.0-epsilon)) then
-        return 1
-    end
-    if (dot_product(n,{0.0,-1.0,0.0}) > (1.0-epsilon)) then
-        return 2
-    end
-    if (dot_product(n,{0.0,1.0,0.0}) > (1.0-epsilon)) then
-        return 3
-    end
+function bnd_id(pt, normal, cur_bid)
+  epsilon = 1.0e-6
+  n = { normal.x, normal.y, normal.z }
+  if dot_product(n, { -1.0, 0.0, 0.0 }) > (1.0 - epsilon) then
+    return 0
+  end
+  if dot_product(n, { 1.0, 0.0, 0.0 }) > (1.0 - epsilon) then
+    return 1
+  end
+  if dot_product(n, { 0.0, -1.0, 0.0 }) > (1.0 - epsilon) then
+    return 2
+  end
+  if dot_product(n, { 0.0, 1.0, 0.0 }) > (1.0 - epsilon) then
+    return 3
+  end
 
-    return cur_bid
+  return cur_bid
 end
 
 mesh.SetBoundaryIDFromFunction("bnd_id")

--- a/test/framework/mesh/logical_volume/lv_boolean_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_boolean_test1.lua
@@ -6,38 +6,41 @@ test for boolean operations on logical volumes:
 --]]
 
 -- set up orthogonal 3D geometry
-nodes={}
-N=40
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-meshgen1 = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes,nodes},
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 -- assign matID 10 to all cells
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 -- create logical volume lv1 as an analytical sphere
-lv1 = logvol.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
+lv1 = logvol.SphereLogicalVolume.Create({ r = 1.3, x = 1.0, y = -1.0, z = 2.0 })
 
 -- create logical volume lv2 as an analytical rcc
-lv2 = logvol.RCCLogicalVolume.Create({r = 1.3,
-                                        x0=-0.8, y0=-0.8, z0=-1.5,
-                                        vx=1.0, vy=1.0, vz=3.0})
+lv2 = logvol.RCCLogicalVolume.Create({
+  r = 1.3,
+  x0 = -0.8,
+  y0 = -0.8,
+  z0 = -1.5,
+  vx = 1.0,
+  vy = 1.0,
+  vz = 3.0,
+})
 
 -- create logical volume lv3 as boolean: true if cell is in lv2 and false if in lv1
-lv3 = logvol.BooleanLogicalVolume.Create
-({
-  parts = { { op=true, lv=lv2 },
-            { op=false, lv=lv1 } }
+lv3 = logvol.BooleanLogicalVolume.Create({
+  parts = { { op = true, lv = lv2 }, { op = false, lv = lv1 } },
 })
 
 -- assign matID 1 to all cells in lv3 which is the part of lv2 that is not in lv1

--- a/test/framework/mesh/logical_volume/lv_lua_func.lua
+++ b/test/framework/mesh/logical_volume/lv_lua_func.lua
@@ -1,31 +1,30 @@
 -- test for lua function used as a logical volume
 -- set up orthogonal 3D geometry
-nodes={}
-N=50
-L=5.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 50
+L = 5.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes,nodes},
+meshgen = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen)
 
 -- assign mat ID 10 to whole domain
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 --Sets lua function describing a sphere (material 11)
-function MatIDFunction1(pt,cur_id)
-    if (pt.x*pt.x + pt.y*pt.y + pt.z*pt.z < 1.0) then
-        return 11
-    end
-    return cur_id
+function MatIDFunction1(pt, cur_id)
+  if pt.x * pt.x + pt.y * pt.y + pt.z * pt.z < 1.0 then
+    return 11
+  end
+  return cur_id
 end
 -- assign mat ID 11 to lv using lua function
 mesh.SetMaterialIDFromFunction("MatIDFunction1")

--- a/test/framework/mesh/logical_volume/lv_rcc_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_rcc_test1.lua
@@ -1,24 +1,29 @@
-nodes={}
-N=40
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-meshgen1 = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes,nodes},
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
-lv1 = logvol.RCCLogicalVolume.Create({r = 1.3, x0=L/2, y0=L/2, z0 = -1.0, vz = 2.0})
+lv1 = logvol.RCCLogicalVolume.Create({ r = 1.3, x0 = L / 2, y0 = L / 2, z0 = -1.0, vz = 2.0 })
 mesh.SetMaterialIDFromLogicalVolume(lv1, 1)
 
-lv2 = logvol.RCCLogicalVolume.Create({r = 1.3,
-                                        x0=-0.8, y0=-0.8, z0=-1.5,
-                                        vx=1.0, vy=1.0, vz=3.0})
+lv2 = logvol.RCCLogicalVolume.Create({
+  r = 1.3,
+  x0 = -0.8,
+  y0 = -0.8,
+  z0 = -1.5,
+  vx = 1.0,
+  vy = 1.0,
+  vz = 3.0,
+})
 mesh.SetMaterialIDFromLogicalVolume(lv2, 2)
 
 mesh.ExportToPVTU("lv_rcc_test1")

--- a/test/framework/mesh/logical_volume/lv_rpp_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_rpp_test1.lua
@@ -1,12 +1,11 @@
-lv1 = logvol.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0})
+lv1 = logvol.RPPLogicalVolume.Create({ xmin = -12.0, xmax = 12.0 })
 
-print("lv1 test 1:", logvol.PointSense(lv1, {x = -13.0, y = 0.1, z = 0.1}))
-print("lv1 test 2:", logvol.PointSense(lv1, {x = -11.0, y = 0.1, z = 0.1}))
-print("lv1 test 3:", logvol.PointSense(lv1, {x = -11.0, y = -1.0, z = -1.0}))
+print("lv1 test 1:", logvol.PointSense(lv1, { x = -13.0, y = 0.1, z = 0.1 }))
+print("lv1 test 2:", logvol.PointSense(lv1, { x = -11.0, y = 0.1, z = 0.1 }))
+print("lv1 test 3:", logvol.PointSense(lv1, { x = -11.0, y = -1.0, z = -1.0 }))
 
-lv2 = logvol.RPPLogicalVolume.Create({xmin = -12.0, xmax = 12.0,
-                                        infy = true, infz = true})
+lv2 = logvol.RPPLogicalVolume.Create({ xmin = -12.0, xmax = 12.0, infy = true, infz = true })
 print()
-print("lv2 test 1:", logvol.PointSense(lv2, {x = -13.0, y = 0.1, z = 0.1}))
-print("lv2 test 2:", logvol.PointSense(lv2, {x = -11.0, y = 0.1, z = 0.1}))
-print("lv2 test 3:", logvol.PointSense(lv2, {x = -11.0, y = -1.0, z = -1.0}))
+print("lv2 test 1:", logvol.PointSense(lv2, { x = -13.0, y = 0.1, z = 0.1 }))
+print("lv2 test 2:", logvol.PointSense(lv2, { x = -11.0, y = 0.1, z = 0.1 }))
+print("lv2 test 3:", logvol.PointSense(lv2, { x = -11.0, y = -1.0, z = -1.0 }))

--- a/test/framework/mesh/logical_volume/lv_skinmesh.lua
+++ b/test/framework/mesh/logical_volume/lv_skinmesh.lua
@@ -20,8 +20,14 @@ vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 -- create a logical volume as an analytical RPP
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = 0.8, ymax = 1.5, zmin = -1.5, zmax = 0.5 })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -0.5,
+  xmax = 0.5,
+  ymin = 0.8,
+  ymax = 1.5,
+  zmin = -1.5,
+  zmax = 0.5,
+})
 -- assign mat ID 11 to lv of RPP
 mesh.SetMaterialIDFromLogicalVolume(vol1, 11)
 

--- a/test/framework/mesh/logical_volume/lv_skinmesh.lua
+++ b/test/framework/mesh/logical_volume/lv_skinmesh.lua
@@ -1,28 +1,27 @@
 -- test for skin (surface) mesh used as a delimiter for a logical volume
 -- set up orthogonal 3D geometry
-nodes={}
-N=50
-L=5.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 50
+L = 5.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes,nodes},
+meshgen = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen)
 
 -- assign mat ID 10 to whole domain
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 10)
 
 -- create a logical volume as an analytical RPP
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=0.8,ymax=1.5, zmin=-1.5,zmax=0.5,  })
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = 0.8, ymax = 1.5, zmin = -1.5, zmax = 0.5 })
 -- assign mat ID 11 to lv of RPP
 mesh.SetMaterialIDFromLogicalVolume(vol1, 11)
 
@@ -30,7 +29,7 @@ mesh.SetMaterialIDFromLogicalVolume(vol1, 11)
 surfmesh = mesh.SurfaceMeshCreate()
 skin_mesh_file = "./cube_with_normals.obj"
 mesh.SurfaceMeshImportFromOBJFile(surfmesh, skin_mesh_file)
-lv_skinmesh = logvol.SurfaceMeshLogicalVolume.Create({surface_mesh_handle=surfmesh})
+lv_skinmesh = logvol.SurfaceMeshLogicalVolume.Create({ surface_mesh_handle = surfmesh })
 -- assign mat ID 15 to lv of skin mesh
 mesh.SetMaterialIDFromLogicalVolume(lv_skinmesh, 15)
 

--- a/test/framework/mesh/logical_volume/lv_sphere_test1.lua
+++ b/test/framework/mesh/logical_volume/lv_sphere_test1.lua
@@ -1,5 +1,5 @@
-lv1 = logvol.SphereLogicalVolume.Create({r = 1.3, x=1.0, y=-1.0, z=2.0})
+lv1 = logvol.SphereLogicalVolume.Create({ r = 1.3, x = 1.0, y = -1.0, z = 2.0 })
 
-print("lv1 test 1:", logvol.PointSense(lv1, {x = 1.0,y = -1.0, z = 2.0}))
-print("lv1 test 2:", logvol.PointSense(lv1, {x = 1.0+1.3, y = -1.0, z = 2.0}))
-print("lv1 test 3:", logvol.PointSense(lv1, {x = 1.0+1.301, y = -1.0, z = 2.0}))
+print("lv1 test 1:", logvol.PointSense(lv1, { x = 1.0, y = -1.0, z = 2.0 }))
+print("lv1 test 2:", logvol.PointSense(lv1, { x = 1.0 + 1.3, y = -1.0, z = 2.0 }))
+print("lv1 test 3:", logvol.PointSense(lv1, { x = 1.0 + 1.301, y = -1.0, z = 2.0 }))

--- a/test/framework/mesh/mat_ids_from_function.lua
+++ b/test/framework/mesh/mat_ids_from_function.lua
@@ -1,23 +1,23 @@
 -- Setup mesh
-nodes={}
-N=10
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --Sets a middle square to material 1
-function mat_id(pt,cur_id)
-    if (math.abs(pt.x)<L/10 and math.abs(pt.y)<L/10) then
-        return 1
-    end
-    return cur_id
+function mat_id(pt, cur_id)
+  if math.abs(pt.x) < L / 10 and math.abs(pt.y) < L / 10 then
+    return 1
+  end
+  return cur_id
 end
 
 mesh.SetMaterialIDFromFunction("mat_id")

--- a/test/framework/mesh/mesh_generators/meshgen_example_a.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_example_a.lua
@@ -1,6 +1,5 @@
-nodes = {-1.0,-0.75,-0.5,-0.25,0.0,0.25,0.5,0.75,1.0}
-meshgen1 = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes},
+nodes = { -1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0 }
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/mesh/mesh_generators/meshgen_example_b.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_example_b.lua
@@ -1,5 +1,4 @@
-meshgen1 = mesh.FromFileMeshGenerator.Create
-({
-  filename="triangle_mesh_2x2.obj"
+meshgen1 = mesh.FromFileMeshGenerator.Create({
+  filename = "triangle_mesh_2x2.obj",
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/mesh/mesh_generators/meshgen_example_c.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_example_c.lua
@@ -1,12 +1,9 @@
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="triangle_mesh_2x2.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "triangle_mesh_2x2.obj",
     }),
   },
-  layers = {{z=1.1, n=2}, {z=2.1, n=3}}
+  layers = { { z = 1.1, n = 2 }, { z = 2.1, n = 3 } },
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/mesh/mesh_generators/meshgen_example_d.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_example_d.lua
@@ -1,15 +1,11 @@
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="triangle_mesh_2x2.obj"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "triangle_mesh_2x2.obj",
     }),
-    mesh.ExtruderMeshGenerator.Create
-    ({
-      layers = {{z=1.1, n=2}, {z=2.1, n=3}}
-    })
-  }
+    mesh.ExtruderMeshGenerator.Create({
+      layers = { { z = 1.1, n = 2 }, { z = 2.1, n = 3 } },
+    }),
+  },
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/mesh/mesh_generators/meshgen_extruder_kba.lua
+++ b/test/framework/mesh/mesh_generators/meshgen_extruder_kba.lua
@@ -1,17 +1,17 @@
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="triangle_mesh_2x2.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "triangle_mesh_2x2.obj",
     }),
   },
-  layers = {{z=1.1, n=2}, {z=2.1, n=3}},
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=2,
-    xcuts = {0.0}, ycuts = {0.0}, zcuts = {1.1}
-  })
+  layers = { { z = 1.1, n = 2 }, { z = 2.1, n = 3 } },
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 2,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+    zcuts = { 1.1 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/framework/mesh/read_wavefront_obj1.lua
+++ b/test/framework/mesh/read_wavefront_obj1.lua
@@ -4,30 +4,28 @@
 num_procs = 4
 --Unstructured mesh
 
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-                        "Expected "..tostring(num_procs)..
-                        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "reactor_pin_mesh.obj"
-    })
-  }
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "reactor_pin_mesh.obj",
+    }),
+  },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Exports
 if master_export == nil then
-    mesh.ExportToPVTU("ZObjMesh")
+  mesh.ExportToPVTU("ZObjMesh")
 end

--- a/test/framework/parameters/params_test_00.lua
+++ b/test/framework/parameters/params_test_00.lua
@@ -1,23 +1,18 @@
-
-
-block =
-{
+block = {
   enabled = true,
   it_method = "gmres",
   nl_abs_tol = 1.0e-12,
   nl_max_its = 33,
-  sub1 =
-  {
+  sub1 = {
     ax_method = 2,
-    l_abs_tol = 1.0e-2
+    l_abs_tol = 1.0e-2,
   },
-  sub2 =
-  {
+  sub2 = {
     ax_method = 3,
     l_abs_tol = 1.0e-3,
-    blocks = {99, 98, 97},
-    cblocks = {{1,2,3},{4,5,6},{7,8,9}}
-  }
+    blocks = { 99, 98, 97 },
+    cblocks = { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 } },
+  },
 }
 
-unit_tests.ParameterBlock_Test00(--[[verbose=]]true, block)
+unit_tests.ParameterBlock_Test00(--[[verbose=]] true, block)

--- a/test/framework/parameters/params_test_01a.lua
+++ b/test/framework/parameters/params_test_01a.lua
@@ -3,19 +3,17 @@ sub_obj = {
 }
 
 --Optional parameter "limiter_type". Should create a deprecation warning
-unit_testsB.TestObject.Create(
-  {
-    solver_type = "B",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    limiter_type = 2
-  })
+unit_testsB.TestObject.Create({
+  solver_type = "B",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  limiter_type = 2,
+})
 
 --Optional parameter "scheme". Should create a deprecation error.
-unit_testsB.TestObject.Create(
-  {
-    solver_type = "B",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    scheme = "Snotty"
-  })
+unit_testsB.TestObject.Create({
+  solver_type = "B",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  scheme = "Snotty",
+})

--- a/test/framework/parameters/params_test_01b.lua
+++ b/test/framework/parameters/params_test_01b.lua
@@ -2,19 +2,17 @@ sub_obj = {
   num_groups = 2,
 }
 
-unit_testsB.ChildTestObject.Create(
-  {
-    solver_type = "C",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    num_sub_groups = 3
-  })
+unit_testsB.ChildTestObject.Create({
+  solver_type = "C",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  num_sub_groups = 3,
+})
 
 --Required parameter "format". Should create a deprecation error.
-unit_testsB.TestObject.Create(
-  {
-    solver_type = "B",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    format = true
-  })
+unit_testsB.TestObject.Create({
+  solver_type = "B",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  format = true,
+})

--- a/test/framework/parameters/params_test_01c.lua
+++ b/test/framework/parameters/params_test_01c.lua
@@ -4,10 +4,9 @@ sub_obj = {
 
 --Optional parameter "use_my_stuff". Should create an error with
 --                                   renaming message
-unit_testsB.TestObject.Create(
-  {
-    solver_type = "B",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    use_my_stuff = true
-  })
+unit_testsB.TestObject.Create({
+  solver_type = "B",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  use_my_stuff = true,
+})

--- a/test/framework/parameters/params_test_01d.lua
+++ b/test/framework/parameters/params_test_01d.lua
@@ -4,10 +4,9 @@ sub_obj = {
 
 --Required parameter "use_ragusas_stuff". Should create an error with
 --                                        renaming message
-unit_testsB.TestObject.Create(
-  {
-    solver_type = "B",
-    coupled_field = "T",
-    sub_obj1 = sub_obj,
-    use_ragusas_stuff = true
-  })
+unit_testsB.TestObject.Create({
+  solver_type = "B",
+  coupled_field = "T",
+  sub_obj1 = sub_obj,
+  use_ragusas_stuff = true,
+})

--- a/test/framework/post_processors/solver_info_01.lua
+++ b/test/framework/post_processors/solver_info_01.lua
@@ -4,31 +4,29 @@
 -- Example Point-Reactor Kinetics solver
 phys0 = prk.TransientSolver.Create({ initial_source = 0.0 })
 
-pp0 = post.SolverInfoPostProcessor.Create
-({
+pp0 = post.SolverInfoPostProcessor.Create({
   name = "neutron_population",
   solver = phys0,
-  info = {name = "neutron_population"},
-  print_on = { "ProgramExecuted" }
+  info = { name = "neutron_population" },
+  print_on = { "ProgramExecuted" },
 })
 
-post.SetPrinterOptions
-({
-  csv_filename = "solver_info_01.csv"
+post.SetPrinterOptions({
+  csv_filename = "solver_info_01.csv",
 })
 
 solver.Initialize(phys0)
 
-for t=1,20 do
+for t = 1, 20 do
   solver.Step(phys0)
   time = solver.GetInfo(phys0, "time_next")
-  print(t, string.format("%.3f %.5f",time, solver.GetInfo(phys0, "population_next")))
+  print(t, string.format("%.3f %.5f", time, solver.GetInfo(phys0, "population_next")))
 
   solver.Advance(phys0)
-  if (time > 0.1) then
+  if time > 0.1 then
     prk.SetParam(phys0, "rho", 0.8)
   end
 end
 
 print("Manually printing Post-Processor:")
-post.Print({pp0, pp1})
+post.Print({ pp0, pp1 })

--- a/test/framework/post_processors/solver_info_02.lua
+++ b/test/framework/post_processors/solver_info_02.lua
@@ -10,14 +10,14 @@ for k = 1, 20 do
     name = "neutron_population" .. tostring(k),
     solver = phys0,
     info = { name = "neutron_population" },
-    print_on = { "" }
+    print_on = { "" },
   })
 end
 pp21 = post.SolverInfoPostProcessor.Create({
   name = "neutron_population" .. tostring(21),
   solver = phys0,
   info = { name = "neutron_population" },
-  print_on = { "" }
+  print_on = { "" },
 })
 
 post.SetPrinterOptions({
@@ -29,15 +29,13 @@ solver.Initialize(phys0)
 for t = 1, 20 do
   solver.Step(phys0)
   time = solver.GetInfo(phys0, "time_next")
-  print(t, string.format("%.3f %.5f",time, solver.GetInfo(phys0, "population_next")))
+  print(t, string.format("%.3f %.5f", time, solver.GetInfo(phys0, "population_next")))
 
   solver.Advance(phys0)
-  if (time > 0.1) then
+  if time > 0.1 then
     prk.SetParam(phys0, "rho", 0.8)
   end
 end
 
-print("Manual neutron_population1=",
-  string.format("%.5f", post.GetValue("neutron_population1")))
-print("Manual neutron_population1=",
-  string.format("%.5f", post.GetValue(pp21)))
+print("Manual neutron_population1=", string.format("%.5f", post.GetValue("neutron_population1")))
+print("Manual neutron_population1=", string.format("%.5f", post.GetValue(pp21)))

--- a/test/framework/tutorials/fv_test1.lua
+++ b/test/framework/tutorials/fv_test1.lua
@@ -1,25 +1,24 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes}
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-unit_sim_tests.SimTest01_FV();
+unit_sim_tests.SimTest01_FV()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm CodeTut1_FV*")
+if location_id == 0 then
+  os.execute("rm CodeTut1_FV*")
 end

--- a/test/framework/tutorials/fv_test2.lua
+++ b/test/framework/tutorials/fv_test2.lua
@@ -1,25 +1,24 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create
-({
-  node_sets = {nodes,nodes}
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes, nodes },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-unit_sim_tests.SimTest02_FV();
+unit_sim_tests.SimTest02_FV()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm CodeTut2_FV*")
+if location_id == 0 then
+  os.execute("rm CodeTut2_FV*")
 end

--- a/test/framework/tutorials/pwlc_test1.lua
+++ b/test/framework/tutorials/pwlc_test1.lua
@@ -1,22 +1,22 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-unit_sim_tests.SimTest03_PWLC();
+unit_sim_tests.SimTest03_PWLC()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm CodeTut3_PWLC*")
+if location_id == 0 then
+  os.execute("rm CodeTut3_PWLC*")
 end

--- a/test/framework/tutorials/pwlc_test2.lua
+++ b/test/framework/tutorials/pwlc_test2.lua
@@ -1,31 +1,33 @@
 --############################################### Setup mesh
-if (nmesh==nil) then nmesh = 10 end
-
-nodes={}
-N=nmesh
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+if nmesh == nil then
+  nmesh = 10
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+nodes = {}
+N = nmesh
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
+end
+
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
 function MMS_phi(pt)
-    return math.cos(math.pi*pt.x) + math.cos(math.pi*pt.y)
+  return math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y)
 end
 function MMS_q(pt)
-    return math.pi*math.pi * (math.cos(math.pi*pt.x)+math.cos(math.pi*pt.y))
+  return math.pi * math.pi * (math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y))
 end
 
 unit_tests.SimTest04_PWLC()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm CodeTut4_PWLC*")
+if location_id == 0 then
+  os.execute("rm CodeTut4_PWLC*")
 end

--- a/test/framework/tutorials/tutorial_06_wdd.lua
+++ b/test/framework/tutorials/tutorial_06_wdd.lua
@@ -1,24 +1,26 @@
 --############################################### Setup mesh
-if (nmesh==nil) then nmesh = 10 end
-
-nodes={}
-N=nmesh
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+if nmesh == nil then
+  nmesh = 10
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+nodes = {}
+N = nmesh
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
+end
+
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-unit_testsB.SimTest06_WDD();
+unit_testsB.SimTest06_WDD()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm SimTest_06*")
+if location_id == 0 then
+  os.execute("rm SimTest_06*")
 end

--- a/test/framework/tutorials/tutorial_91a_pwld.lua
+++ b/test/framework/tutorials/tutorial_91a_pwld.lua
@@ -1,25 +1,24 @@
 --############################################### Setup mesh
-nodes={}
-N=25
-L=2.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 25
+L = 2.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-
-unit_tests.SimTest91_PWLD();
+unit_tests.SimTest91_PWLD()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm SimTest_91*")
+if location_id == 0 then
+  os.execute("rm SimTest_91*")
 end
 
 --[0]  Iteration     0   1.000e+00

--- a/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
@@ -1,77 +1,79 @@
 --############################################### Setup mesh
-nodes={}
-N=10
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-D = {1.0}
-Q = {0.0}
-XSa = {0.0}
-function D_coef(i,pt)
-    return D[i+1]
+D = { 1.0 }
+Q = { 0.0 }
+XSa = { 0.0 }
+function D_coef(i, pt)
+  return D[i + 1]
 end
-function Q_ext(i,pt)
-    return Q[i+1]
+function Q_ext(i, pt)
+  return Q[i + 1]
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
     {
       boundary = e_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.0 }
+      coeffs = { 0.25, 0.5, 0.0 },
     },
     {
       boundary = n_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = s_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = w_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 1.0 }
-    }
-  }
+      coeffs = { 0.25, 0.5, 1.0 },
+    },
+  },
 }
 
 -- CFEM solver
 phys1 = diffusion.CFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 
@@ -79,34 +81,33 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_linear")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_linear")
 end
 
 --############################################### Line plot
 cline = fieldfunc.FFInterpolationCreate(LINE)
-fieldfunc.SetProperty(cline,LINE_FIRSTPOINT, {x = -L/2})
-fieldfunc.SetProperty(cline,LINE_SECONDPOINT, {x = L/2})
-fieldfunc.SetProperty(cline,LINE_NUMBEROFPOINTS, 50)
-fieldfunc.SetProperty(cline,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(cline, LINE_FIRSTPOINT, { x = -L / 2 })
+fieldfunc.SetProperty(cline, LINE_SECONDPOINT, { x = L / 2 })
+fieldfunc.SetProperty(cline, LINE_NUMBEROFPOINTS, 50)
+fieldfunc.SetProperty(cline, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
-if (master_export == nil) then
-    fieldfunc.ExportToCSV(cline)
+if master_export == nil then
+  fieldfunc.ExportToCSV(cline)
 end
 
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-post.AggregateNodalValuePostProcessor.Create
-({
-    name = "maxval",
-    field_function = math.floor(fflist[1]),
-    operation = "max"
+post.AggregateNodalValuePostProcessor.Create({
+  name = "maxval",
+  field_function = math.floor(fflist[1]),
+  operation = "max",
 })
-post.Execute({"maxval"})
+post.Execute({ "maxval" })

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2a_dir_bcs.lua
@@ -1,85 +1,86 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
-
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
-D = {1.0,0.01}
-Q = {1.0,10.0}
-XSa = {1.0,10.0}
-function D_coef(i,pt)
-    return D[i+1]
+D = { 1.0, 0.01 }
+Q = { 1.0, 10.0 }
+XSa = { 1.0, 10.0 }
+function D_coef(i, pt)
+  return D[i + 1]
 end
-function Q_ext(i,pt)
-    return Q[i+1]
+function Q_ext(i, pt)
+  return Q[i + 1]
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- CFEM solver
 phys1 = diffusion.CFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 
@@ -87,20 +88,19 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_Dirichlet")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_Dirichlet")
 end
 
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-post.CellVolumeIntegralPostProcessor.Create
-({
-    name = "avgval",
-    field_function = math.floor(fflist[1]),
-    compute_volume_average = true
+post.CellVolumeIntegralPostProcessor.Create({
+  name = "avgval",
+  field_function = math.floor(fflist[1]),
+  compute_volume_average = true,
 })
-post.Execute({"avgval"})
+post.Execute({ "avgval" })

--- a/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_2b_robin_bcs.lua
@@ -1,82 +1,84 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
-D = {1.0,5.0}
-Q = {0.0,1.0}
-XSa = {1.0,1.0}
-function D_coef(i,pt)
-    return D[i+1] -- + x
+D = { 1.0, 5.0 }
+Q = { 0.0, 1.0 }
+XSa = { 1.0, 1.0 }
+function D_coef(i, pt)
+  return D[i + 1] -- + x
 end
-function Q_ext(i,pt)
-    return Q[i+1] -- x*x
+function Q_ext(i, pt)
+  return Q[i + 1] -- x*x
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
     {
       boundary = e_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.0 }
+      coeffs = { 0.25, 0.5, 0.0 },
     },
     {
       boundary = n_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = s_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = w_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.1 }
-    }
-  }
+      coeffs = { 0.25, 0.5, 0.1 },
+    },
+  },
 }
 
 -- CFEM solver
 phys1 = diffusion.CFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 
@@ -84,20 +86,19 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_RobinRefl","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_RobinRefl", "flux")
 end
 
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-post.CellVolumeIntegralPostProcessor.Create
-({
-    name = "avgval",
-    field_function = math.floor(fflist[1]),
-    compute_volume_average = true
+post.CellVolumeIntegralPostProcessor.Create({
+  name = "avgval",
+  field_function = math.floor(fflist[1]),
+  compute_volume_average = true,
 })
-post.Execute({"avgval"})
+post.Execute({ "avgval" })

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3a_analytical_coef.lua
@@ -1,77 +1,78 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-
-function D_coef(i,pt)
-    return 3.0 + pt.x + pt.y
+function D_coef(i, pt)
+  return 3.0 + pt.x + pt.y
 end
-function Q_ext(i,pt)
-    return pt.x*pt.x
+function Q_ext(i, pt)
+  return pt.x * pt.x
 end
-function Sigma_a(i,pt)
-    return pt.x*pt.y*pt.y
+function Sigma_a(i, pt)
+  return pt.x * pt.y * pt.y
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- CFEM solver
 phys1 = diffusion.CFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-6
+  residual_tolerance = 1e-6,
 })
 diffusion.SetOptions(phys1, diff_options)
 
@@ -79,20 +80,19 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_analytic_coef","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_analytic_coef", "flux")
 end
 
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-post.AggregateNodalValuePostProcessor.Create
-({
-    name = "maxval",
-    field_function = math.floor(fflist[1]),
-    operation = "max"
+post.AggregateNodalValuePostProcessor.Create({
+  name = "maxval",
+  field_function = math.floor(fflist[1]),
+  operation = "max",
 })
-post.Execute({"maxval"})
+post.Execute({ "maxval" })

--- a/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_3b_analytical_coef2.lua
@@ -1,15 +1,15 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=1
+nodes = {}
+N = 40
+L = 1
 xmin = 0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -22,62 +22,64 @@ mesh.SetUniformMaterialID(0)
 --    volumetric source term: q(,x) = 2*pi*pi * sin(pi.x) * sin(pi.y)
 -- the factor 2 is the dim of the problem
 
-function D_coef(i,pt)
-    return 1.0
+function D_coef(i, pt)
+  return 1.0
 end
-function Q_ext(i,pt)
-    return 2.*math.pi*math.pi * math.sin(math.pi*pt.x) * math.sin(math.pi*pt.y)
+function Q_ext(i, pt)
+  return 2. * math.pi * math.pi * math.sin(math.pi * pt.x) * math.sin(math.pi * pt.y)
 end
-function Sigma_a(i,pt)
-    return 0.0
+function Sigma_a(i, pt)
+  return 0.0
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- CFEM solver
 phys1 = diffusion.CFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 
@@ -85,20 +87,19 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_analytic_coef2","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_analytic_coef2", "flux")
 end
 
 --############################################### Volume integrations
 
 --############################################### PostProcessors
-post.AggregateNodalValuePostProcessor.Create
-({
-    name = "maxval",
-    field_function = math.floor(fflist[1]),
-    operation = "max"
+post.AggregateNodalValuePostProcessor.Create({
+  name = "maxval",
+  field_function = math.floor(fflist[1]),
+  operation = "max",
 })
-post.Execute({"maxval"})
+post.Execute({ "maxval" })

--- a/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
@@ -52,28 +52,28 @@ diff_options = {
     {
       boundary = e_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.0 }
+      coeffs = { 0.25, 0.5, 0.0 },
     },
     {
       boundary = n_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = s_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = w_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 1.0 }
-    }
-  }
+      coeffs = { 0.25, 0.5, 1.0 },
+    },
+  },
 }
 
 -- DFEM solver
 phys1 = diffusion.DFEMSolver.Create({
   name = "CFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 

--- a/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
@@ -1,49 +1,51 @@
 --############################################### Setup mesh
-nodes={}
-N=10
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-D = {1.0}
-Q = {0.0}
-XSa = {0.0}
-function D_coef(i,pt)
-    return D[i+1]
+D = { 1.0 }
+Q = { 0.0 }
+XSa = { 0.0 }
+function D_coef(i, pt)
+  return D[i + 1]
 end
-function Q_ext(i,pt)
-    return Q[i+1]
+function Q_ext(i, pt)
+  return Q[i + 1]
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
@@ -78,39 +80,38 @@ diffusion.SetOptions(phys1, diff_options)
 solver.Initialize(phys1)
 solver.Execute(phys1)
 
-
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"DFEMDiff2D_linear")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "DFEMDiff2D_linear")
 end
 
 --############################################### Line plot
 cline = fieldfunc.FFInterpolationCreate(LINE)
-fieldfunc.SetProperty(cline,LINE_FIRSTPOINT, {x = -L/2})
-fieldfunc.SetProperty(cline,LINE_SECONDPOINT, {x = L/2})
-fieldfunc.SetProperty(cline,LINE_NUMBEROFPOINTS, 50)
-fieldfunc.SetProperty(cline,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(cline, LINE_FIRSTPOINT, { x = -L / 2 })
+fieldfunc.SetProperty(cline, LINE_SECONDPOINT, { x = L / 2 })
+fieldfunc.SetProperty(cline, LINE_NUMBEROFPOINTS, 50)
+fieldfunc.SetProperty(cline, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
-if (master_export == nil) then
-    fieldfunc.ExportToCSV(cline)
+if master_export == nil then
+  fieldfunc.ExportToCSV(cline)
 end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(ffvol, OPERATION, OP_MAX)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Max-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Max-value=%.6f", maxval))

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
@@ -1,54 +1,56 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
-D = {1.0,0.01}
-Q = {1.0,10.0}
-XSa = {1.0,10.0}
-function D_coef(i,pt)
-    return D[i+1]
+D = { 1.0, 0.01 }
+Q = { 1.0, 10.0 }
+XSa = { 1.0, 10.0 }
+function D_coef(i, pt)
+  return D[i + 1]
 end
-function Q_ext(i,pt)
-    return Q[i+1]
+function Q_ext(i, pt)
+  return Q[i + 1]
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
@@ -85,25 +87,24 @@ diffusion.SetOptions(phys1, diff_options)
 solver.Initialize(phys1)
 solver.Execute(phys1)
 
-
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"DFEMDiff2D_Dirichlet","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "DFEMDiff2D_Dirichlet", "flux")
 end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_AVG)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(ffvol, OPERATION, OP_AVG)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Avg-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Avg-value=%.6f", maxval))

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2a_dir_bcs.lua
@@ -57,30 +57,30 @@ diff_options = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- DFEM solver
 phys1 = diffusion.DFEMSolver.Create({
   name = "DFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
@@ -1,54 +1,56 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
-D = {1.0,5.0}
-Q = {0.0,1.0}
-XSa = {1.0,1.0}
-function D_coef(i,pt)
-    return D[i+1] -- + x
+D = { 1.0, 5.0 }
+Q = { 0.0, 1.0 }
+XSa = { 1.0, 1.0 }
+function D_coef(i, pt)
+  return D[i + 1] -- + x
 end
-function Q_ext(i,pt)
-    return Q[i+1] -- x*x
+function Q_ext(i, pt)
+  return Q[i + 1] -- x*x
 end
-function Sigma_a(i,pt)
-    return XSa[i+1]
+function Sigma_a(i, pt)
+  return XSa[i + 1]
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
@@ -84,23 +86,23 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"DFEMDiff2D_RobinRefl","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "DFEMDiff2D_RobinRefl", "flux")
 end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_AVG)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(ffvol, OPERATION, OP_AVG)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Avg-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Avg-value=%.6f", maxval))

--- a/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_2b_robin_bcs.lua
@@ -57,28 +57,28 @@ diff_options = {
     {
       boundary = e_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.0 }
+      coeffs = { 0.25, 0.5, 0.0 },
     },
     {
       boundary = n_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = s_bndry,
-      type = "reflecting"
+      type = "reflecting",
     },
     {
       boundary = w_bndry,
       type = "robin",
-      coeffs = { 0.25, 0.5, 0.1 }
-    }
-  }
+      coeffs = { 0.25, 0.5, 0.1 },
+    },
+  },
 }
 
 -- DFEM solver
 phys1 = diffusion.DFEMSolver.Create({
   name = "DFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
@@ -49,30 +49,30 @@ diff_options = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- DFEM solver
 phys1 = diffusion.DFEMSolver.Create({
   name = "DFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3a_analytical_coef.lua
@@ -1,47 +1,48 @@
 --############################################### Setup mesh
-nodes={}
-N=100
-L=2
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 100
+L = 2
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-
-function D_coef(i,pt)
-    return 3.0 + pt.x + pt.y
+function D_coef(i, pt)
+  return 3.0 + pt.x + pt.y
 end
-function Q_ext(i,pt)
-    return pt.x*pt.x
+function Q_ext(i, pt)
+  return pt.x * pt.x
 end
-function Sigma_a(i,pt)
-    return pt.x*pt.y*pt.y
+function Sigma_a(i, pt)
+  return pt.x * pt.y * pt.y
 end
 
 -- Setboundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
@@ -79,23 +80,23 @@ solver.Initialize(phys1)
 solver.Execute(phys1)
 
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"CFEMDiff2D_analytic_coef","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "CFEMDiff2D_analytic_coef", "flux")
 end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(ffvol, OPERATION, OP_MAX)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Max-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Max-value=%.6f", maxval))

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
@@ -55,30 +55,30 @@ diff_options = {
     {
       boundary = e_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = n_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = s_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
+      coeffs = { 0.0 },
     },
     {
       boundary = w_bndry,
       type = "dirichlet",
-      coeffs = { 0.0 }
-    }
-  }
+      coeffs = { 0.0 },
+    },
+  },
 }
 
 -- DFEM solver
 phys1 = diffusion.DFEMSolver.Create({
   name = "DFEMSolver",
-  residual_tolerance = 1e-8
+  residual_tolerance = 1e-8,
 })
 diffusion.SetOptions(phys1, diff_options)
 

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3b_analytical_coef2.lua
@@ -1,15 +1,15 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=1
+nodes = {}
+N = 40
+L = 1
 xmin = 0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -21,32 +21,34 @@ mesh.SetUniformMaterialID(0)
 --    boundary = zero-Dirichlet on all 4 sides
 --    volumetric source term: q(,x) = 2*pi*pi * sin(pi.x) * sin(pi.y)
 -- the factor 2 is the dim of the problem
-function D_coef(i,pt)
-    return 1.0
+function D_coef(i, pt)
+  return 1.0
 end
-function Q_ext(i,pt)
-    return 2.*math.pi*math.pi * math.sin(math.pi*pt.x) * math.sin(math.pi*pt.y)
+function Q_ext(i, pt)
+  return 2. * math.pi * math.pi * math.sin(math.pi * pt.x) * math.sin(math.pi * pt.y)
 end
-function Sigma_a(i,pt)
-    return 0.0
+function Sigma_a(i, pt)
+  return 0.0
 end
 
 -- Set boundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = "0"
 w_bndry = "1"
 n_bndry = "2"
 s_bndry = "3"
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 diff_options = {
   boundary_conditions = {
@@ -83,25 +85,24 @@ diffusion.SetOptions(phys1, diff_options)
 solver.Initialize(phys1)
 solver.Execute(phys1)
 
-
 --############################################### Get field functions
-fflist,count = solver.GetFieldFunctionList(phys1)
+fflist, count = solver.GetFieldFunctionList(phys1)
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(fflist[1],"DFEMDiff2D_analytic_coef2","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(fflist[1], "DFEMDiff2D_analytic_coef2", "flux")
 end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(ffvol, OPERATION, OP_MAX)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Max-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Max-value=%.6f", maxval))

--- a/test/modules/dfem_diffusion/d_diffusion_2d_3c_l2_error_mms.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_3c_l2_error_mms.lua
@@ -1,15 +1,15 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=1
+nodes = {}
+N = 40
+L = 1
 xmin = 0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -21,54 +21,56 @@ mesh.SetUniformMaterialID(0)
 --    boundary = zero-Dirichlet on all 4 sides
 --    volumetric source term: q(,x) = 2*pi*pi * sin(pi.x) * sin(pi.y)
 -- the factor 2 is the dim of the problem
-function D_coef(i,pt)
-    return 1.0
+function D_coef(i, pt)
+  return 1.0
 end
-function Q_ext(i,pt)
-    return 2.*math.pi*math.pi * math.sin(math.pi*pt.x) * math.sin(math.pi*pt.y)
+function Q_ext(i, pt)
+  return 2. * math.pi * math.pi * math.sin(math.pi * pt.x) * math.sin(math.pi * pt.y)
 end
-function Sigma_a(i,pt)
-    return 0.0
+function Sigma_a(i, pt)
+  return 0.0
 end
-function MMS_phi(i,pt)
-    return math.sin(math.pi*pt.x) * math.sin(math.pi*pt.y)
+function MMS_phi(i, pt)
+  return math.sin(math.pi * pt.x) * math.sin(math.pi * pt.y)
 end
 
 -- Set boundary IDs
 -- xmin,xmax,ymin,ymax,zmin,zmax
-e_vol = logvol.RPPLogicalVolume.Create({xmin=0.99999,xmax=1000.0  , infy=true, infz=true})
-w_vol = logvol.RPPLogicalVolume.Create({xmin=-1000.0,xmax=-0.99999, infy=true, infz=true})
-n_vol = logvol.RPPLogicalVolume.Create({ymin=0.99999,ymax=1000.0  , infx=true, infz=true})
-s_vol = logvol.RPPLogicalVolume.Create({ymin=-1000.0,ymax=-0.99999, infx=true, infz=true})
+e_vol = logvol.RPPLogicalVolume.Create({ xmin = 0.99999, xmax = 1000.0, infy = true, infz = true })
+w_vol =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = -0.99999, infy = true, infz = true })
+n_vol = logvol.RPPLogicalVolume.Create({ ymin = 0.99999, ymax = 1000.0, infx = true, infz = true })
+s_vol =
+  logvol.RPPLogicalVolume.Create({ ymin = -1000.0, ymax = -0.99999, infx = true, infz = true })
 
 e_bndry = 0
 w_bndry = 1
 n_bndry = 2
 s_bndry = 3
 
-mesh.SetBoundaryIDFromLogicalVolume(e_vol,e_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(w_vol,w_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(n_vol,n_bndry)
-mesh.SetBoundaryIDFromLogicalVolume(s_vol,s_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(e_vol, e_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(w_vol, w_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(n_vol, n_bndry)
+mesh.SetBoundaryIDFromLogicalVolume(s_vol, s_bndry)
 
 --############################################### Call Lua Sim Test
 SimTest_IP_MMS_L2error() --simtest_IP_MMS_L2_handle becomes available here
 
 --############################################### Export VTU
-if (master_export == nil) then
-    fieldfunc.ExportToVTK(simtest_IP_MMS_L2_handle,"DFEMDiff2D_MMS","flux")
+if master_export == nil then
+  fieldfunc.ExportToVTK(simtest_IP_MMS_L2_handle, "DFEMDiff2D_MMS", "flux")
 end
 
 ----############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 --
 ffvol = fieldfunc.FFInterpolationCreate(VOLUME)
-fieldfunc.SetProperty(ffvol,OPERATION,OP_MAX)
-fieldfunc.SetProperty(ffvol,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(ffvol,ADD_FIELDFUNCTION,simtest_IP_MMS_L2_handle)
+fieldfunc.SetProperty(ffvol, OPERATION, OP_MAX)
+fieldfunc.SetProperty(ffvol, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(ffvol, ADD_FIELDFUNCTION, simtest_IP_MMS_L2_handle)
 --
 fieldfunc.Initialize(ffvol)
 fieldfunc.Execute(ffvol)
 maxval = fieldfunc.GetValue(ffvol)
 
-log.Log(LOG_0,string.format("Max-value=%.6f", maxval))
+log.Log(LOG_0, string.format("Max-value=%.6f", maxval))

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.lua
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.lua
@@ -1,18 +1,20 @@
 --############################################### Setup mesh
-if (nmesh==nil) then nmesh = 10 end
-
-nodes={}
-N=nmesh
-L=2.0
-xmin = -L/2
---xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+if nmesh == nil then
+  nmesh = 10
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+nodes = {}
+N = nmesh
+L = 2.0
+xmin = -L / 2
+--xmin = 0.0
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
+end
+
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -21,16 +23,16 @@ mesh.SetUniformMaterialID(0)
 mesh.SetupOrthogonalBoundaries()
 
 function MMS_phi(pt)
-    return math.cos(math.pi*pt.x) + math.cos(math.pi*pt.y)
+  return math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y)
 end
 function MMS_q(pt)
-    return math.pi*math.pi * (math.cos(math.pi*pt.x)+math.cos(math.pi*pt.y))
+  return math.pi * math.pi * (math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y))
 end
 
-unit_tests.acceleration_Diffusion_CFEM();
+unit_tests.acceleration_Diffusion_CFEM()
 MPIBarrier()
-if (location_id == 0) then
-    --os.execute("rm SimTest_92*")
+if location_id == 0 then
+  --os.execute("rm SimTest_92*")
 end
 
 --[0]  Iteration     0   1.000e+00

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.lua
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.lua
@@ -1,18 +1,20 @@
 --############################################### Setup mesh
-if (nmesh==nil) then nmesh = 10 end
-
-nodes={}
-N=nmesh
-L=2.0
-xmin = -L/2
---xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+if nmesh == nil then
+  nmesh = 10
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+nodes = {}
+N = nmesh
+L = 2.0
+xmin = -L / 2
+--xmin = 0.0
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
+end
+
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -21,16 +23,16 @@ mesh.SetUniformMaterialID(0)
 mesh.SetupOrthogonalBoundaries()
 
 function MMS_phi(pt)
-    return math.cos(math.pi*pt.x) + math.cos(math.pi*pt.y)
+  return math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y)
 end
 function MMS_q(pt)
-    return math.pi*math.pi * (math.cos(math.pi*pt.x)+math.cos(math.pi*pt.y))
+  return math.pi * math.pi * (math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y))
 end
 
-unit_tests.acceleration_Diffusion_DFEM();
+unit_tests.acceleration_Diffusion_DFEM()
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm SimTest_92*")
+if location_id == 0 then
+  os.execute("rm SimTest_92*")
 end
 
 --[0]  Iteration     0   1.000e+00

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_1d_1g.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_1d_1g.lua
@@ -6,11 +6,15 @@ num_procs = 4
 --       variable=[[argument]]
 
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-                        "Expected "..tostring(num_procs)..
-                        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 MPIBarrier()
@@ -20,24 +24,41 @@ MPIBarrier()
 -- ##################################################
 
 -- Mesh variables
-if (L == nil) then L = 100.0 end
-if (n_cells == nil) then n_cells = 50 end
+if L == nil then
+  L = 100.0
+end
+if n_cells == nil then
+  n_cells = 50
+end
 
 -- Transport angle information
-if (n_angles == nil) then n_angles = 16 end
-if (scat_order == nil) then scat_order = 0 end
+if n_angles == nil then
+  n_angles = 16
+end
+if scat_order == nil then
+  scat_order = 0
+end
 
 -- k-eigenvalue iteration parameters
-if (kes_max_iterations == nil) then kes_max_iterations = 5000 end
-if (kes_tolerance == nil) then kes_tolerance = 1e-8 end
+if kes_max_iterations == nil then
+  kes_max_iterations = 5000
+end
+if kes_tolerance == nil then
+  kes_tolerance = 1e-8
+end
 
 -- Source iteration parameters
-if (si_max_iterations == nil) then si_max_iterations = 500 end
-if (si_tolerance == nil) then si_tolerance = 1e-8 end
+if si_max_iterations == nil then
+  si_max_iterations = 500
+end
+if si_tolerance == nil then
+  si_tolerance = 1e-8
+end
 
 -- Delayed neutrons
-if (use_precursors == nil) then use_precursors = true end
-
+if use_precursors == nil then
+  use_precursors = true
+end
 
 -- ##################################################
 -- ##### Run problem #####
@@ -45,12 +66,12 @@ if (use_precursors == nil) then use_precursors = true end
 
 --############################################### Setup mesh
 nodes = {}
-dx = L/n_cells
-for i=0,n_cells do
-  nodes[i+1] = i*dx
+dx = L / n_cells
+for i = 0, n_cells do
+  nodes[i + 1] = i * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -65,26 +86,23 @@ mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 
 --############################################### Setup Physics
 num_groups = 1
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
-      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE,n_angles),
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, n_angles),
       inner_linear_method = "gmres",
       l_max_its = si_max_iterations,
       l_abs_tol = si_tolerance,
-    }
-  }
+    },
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = scat_order,
 
-  use_precursors = use_precursors ,
+  use_precursors = use_precursors,
 
   verbose_inner_iterations = false,
   verbose_outer_iterations = true,
@@ -93,11 +111,10 @@ lbs_options =
 phys = lbs.DiffusionDFEMSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
-k_solver0 = lbs.NonLinearKEigen.Create
-({
+k_solver0 = lbs.NonLinearKEigen.Create({
   lbs_solver_handle = phys,
   nl_max_its = kes_max_iterations,
-  nl_abs_tol = kes_tolerance
+  nl_abs_tol = kes_tolerance,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_2d_1a_qblock.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_2d_1a_qblock.lua
@@ -5,30 +5,29 @@ dofile("utils/qblock_mesh.lua")
 dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad,
       inner_linear_method = "gmres",
       l_max_its = 50,
       gmres_restart_interval = 50,
       l_abs_tol = 1.0e-10,
       groupset_num_subsets = 2,
-    }
-  }
+    },
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "reflecting"},
-                          { name = "ymin", type = "reflecting"} },
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
+  },
   scattering_order = 2,
 
   use_precursors = false,
@@ -40,13 +39,11 @@ lbs_options =
 phys1 = lbs.DiffusionDFEMSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
-
-k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_2d_1b_qblock.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_2d_1b_qblock.lua
@@ -5,47 +5,45 @@ dofile("utils/qblock_mesh.lua")
 dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
-    num_groups = num_groups,
-    groupsets =
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_max_its = 50,
-            gmres_restart_interval = 50,
-            l_abs_tol = 1.0e-10,
-            groupset_num_subsets = 2,
-        }
-    }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_max_its = 50,
+      gmres_restart_interval = 50,
+      l_abs_tol = 1.0e-10,
+      groupset_num_subsets = 2,
+    },
+  },
 }
 
-lbs_options =
-{
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
-    scattering_order = 2,
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
+  },
+  scattering_order = 2,
 
-    use_precursors = false,
+  use_precursors = false,
 
-    verbose_inner_iterations = false,
-    verbose_outer_iterations = true,
+  verbose_inner_iterations = false,
+  verbose_outer_iterations = true,
 }
 
 phys1 = lbs.DiffusionDFEMSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
-
-k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_materials.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_materials.lua
@@ -1,8 +1,8 @@
 --############################################### Create cross sections
 xss = {}
 
-for m=0,1 do
-    xss[tostring(m)] = xs.Create()
+for m = 0, 1 do
+  xss[tostring(m)] = xs.Create()
 end
 
 xs.Set(xss["0"], OPENSN_XSFILE, "../transport_keigen/xs_water_g2.xs")
@@ -13,8 +13,8 @@ num_groups = water_xs["num_groups"]
 
 --############################################### Create materials
 materials = {}
-for m=0,1 do
-    key = tostring(m)
-    materials[key] = mat.AddMaterial("Material_"..key)
-    mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
+for m = 0, 1 do
+  key = tostring(m)
+  materials[key] = mat.AddMaterial("Material_" .. key)
+  mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
@@ -14,6 +14,11 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 10.0, ymin = -1000.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -1000.0,
+  xmax = 10.0,
+  ymin = -1000.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_mesh.lua
@@ -1,19 +1,19 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=14.0
+nodes = {}
+N = 40
+L = 14.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-1000.0,xmax=10.0,ymin=-1000.0,ymax=10.0, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 10.0, ymin = -1000.0, ymax = 10.0, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
@@ -2,69 +2,75 @@
 -- SDM: PWLD
 -- Test: Max-value=5.28310e-01 and 8.04576e-04
 num_procs = 4
-if (reflecting == nil) then reflecting = true end
-
-
-
+if reflecting == nil then
+  reflecting = true
+end
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=10
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-znodes={}
-for i=1,(N/2+1) do
-  k=i-1
-  znodes[i] = xmin + k*dx
+znodes = {}
+for i = 1, (N / 2 + 1) do
+  k = i - 1
+  znodes[i] = xmin + k * dx
 end
-if (reflecting) then
-  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,znodes} })
+if reflecting then
+  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, znodes } })
 else
-  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,nodes} })
+  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 end
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 num_groups = 21
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "../transport_steady/xs_graphite_pure.xs")
+mat.SetProperty(
+  materials[1],
+  TRANSPORT_XSECTIONS,
+  OPENSN_XSFILE,
+  "../transport_steady/xs_graphite_pure.xs"
+)
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
-pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
+pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -74,28 +80,27 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
-if (reflecting) then
-  lbs_options.boundary_conditions = {{name = "zmax", type = "reflecting"}}
+if reflecting then
+  lbs_options.boundary_conditions = { { name = "zmax", type = "reflecting" } }
 end
 
 phys1 = lbs.DiffusionDFEMSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -114,40 +119,39 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  if (reflecting) then
-    fieldfunc.ExportToVTKMulti(fflist,"ZPhi3DReflected")
+if master_export == nil then
+  if reflecting then
+    fieldfunc.ExportToVTKMulti(fflist, "ZPhi3DReflected")
   else
-    fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
+    fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
   end
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
@@ -38,8 +38,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -10.0,
+  xmax = 10.0,
+  ymin = -10.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
@@ -5,11 +5,15 @@
 num_procs = 4
 
 -- Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-            "Expected " .. tostring(num_procs) ..
-            ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 -- Create mesh
@@ -19,7 +23,7 @@ ds = L / N
 
 nodes = {}
 for i = 0, N do
-    nodes[i + 1] = i * ds
+  nodes[i + 1] = i * ds
 end
 
 meshgen = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
@@ -28,48 +32,46 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = logvol.RPPLogicalVolume.Create(
-        {
-            infx = true,
-            ymin = 0.0, ymax = 0.8 * L,
-            infz = true
-        }
-)
+vol1a = logvol.RPPLogicalVolume.Create({
+  infx = true,
+  ymin = 0.0,
+  ymax = 0.8 * L,
+  infz = true,
+})
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
-            infy = true,
-            infz = true
-        }
-)
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = 2.5 - 0.166666,
+  xmax = 2.5 + 0.166666,
+  infy = true,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol2 = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
-            ymin = 0.0, ymax = 2 * 0.166666,
-            infz = true
-        }
-)
+vol2 = logvol.RPPLogicalVolume.Create({
+  xmin = 2.5 - 0.166666,
+  xmax = 2.5 + 0.166666,
+  ymin = 0.0,
+  ymax = 2 * 0.166666,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol2, 2)
 
-vol1b = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = -1 + 2.5, xmax = 1 + 2.5,
-            ymin = 0.9 * L, ymax = L,
-            infz = true
-        }
-)
+vol1b = logvol.RPPLogicalVolume.Create({
+  xmin = -1 + 2.5,
+  xmax = 1 + 2.5,
+  ymin = 0.9 * L,
+  ymax = L,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1b, 1)
 
 -- Create materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material1");
-materials[2] = mat.AddMaterial("Test Material2");
-materials[3] = mat.AddMaterial("Test Material3");
+materials[1] = mat.AddMaterial("Test Material1")
+materials[2] = mat.AddMaterial("Test Material2")
+materials[3] = mat.AddMaterial("Test Material3")
 
 -- Add cross sections to materials
 num_groups = 1
@@ -80,11 +82,11 @@ mat.SetProperty(materials[3], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.3 * 20, 0
 -- Create sources
 src = {}
 for g = 1, num_groups do
-    if g == 1 then
-        src[g] = 3.0
-    else
-        src[g] = 0.0
-    end
+  if g == 1 then
+    src[g] = 3.0
+  else
+    src[g] = 0.0
+  end
 end
 mat.SetProperty(materials[3], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
@@ -93,18 +95,18 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 48, 6)
 aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 lbs_block = {
-    num_groups = num_groups,
-    groupsets = {
-        {
-            groups_from_to = { 0, num_groups - 1 },
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 500,
-            gmres_restart_interval = 100,
-        },
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 500,
+      gmres_restart_interval = 100,
     },
-    options = { scattering_order = 0 }
+  },
+  options = { scattering_order = 0 },
 }
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
@@ -120,13 +122,13 @@ ff_m1 = fieldfunc.GetHandleByName("phi_g000_m01")
 ff_m2 = fieldfunc.GetHandleByName("phi_g000_m02")
 
 -- Define QoI region
-qoi_vol = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 0.5, xmax = 0.8333,
-            ymin = 4.16666, ymax = 4.33333,
-            infz = true
-        }
-)
+qoi_vol = logvol.RPPLogicalVolume.Create({
+  xmin = 0.5,
+  xmax = 0.8333,
+  ymin = 4.16666,
+  ymax = 4.33333,
+  infz = true,
+})
 
 -- Compute QoI
 ffi = fieldfunc.FFInterpolationCreate(VOLUME)
@@ -139,14 +141,12 @@ fieldfunc.Execute(ffi)
 fwd_qoi = fieldfunc.GetValue(ffi)
 
 -- Create adjoint source
-adjoint_source = lbs.DistributedSource.Create(
-        { logical_volume_handle = qoi_vol }
-)
+adjoint_source = lbs.DistributedSource.Create({ logical_volume_handle = qoi_vol })
 
 -- Switch to adjoint mode
 adjoint_options = {
-    adjoint = true,
-    distributed_sources = { adjoint_source }
+  adjoint = true,
+  distributed_sources = { adjoint_source },
 }
 lbs.SetOptions(phys, adjoint_options)
 
@@ -158,11 +158,11 @@ lbs.WriteFluxMoments(phys, "adjoint_2d_1")
 buffers = { { name = "buff", file_prefixes = { flux_moments = "adjoint_2d_1" } } }
 mat_sources = { { material_id = 2, strength = src } }
 response_options = {
-    lbs_solver_handle = phys,
-    options = {
-        buffers = buffers,
-        sources = { material = mat_sources }
-    }
+  lbs_solver_handle = phys,
+  options = {
+    buffers = buffers,
+    sources = { material = mat_sources },
+  },
 }
 evaluator = lbs.ResponseEvaluator.Create(response_options)
 
@@ -175,6 +175,6 @@ log.Log(LOG_0, string.format("Inner Product=%.5e", adj_qoi))
 
 -- Cleanup
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm adjoint_2d_1*")
+if location_id == 0 then
+  os.execute("rm adjoint_2d_1*")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
@@ -5,11 +5,15 @@
 num_procs = 4
 
 -- Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-            "Expected " .. tostring(num_procs) ..
-            ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 -- Setup mesh
@@ -19,7 +23,7 @@ ds = L / N
 
 nodes = {}
 for i = 0, N do
-    nodes[i + 1] = i * ds
+  nodes[i + 1] = i * ds
 end
 meshgen = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen)
@@ -27,40 +31,38 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = logvol.RPPLogicalVolume.Create(
-        {
-            infx = true,
-            ymin = 0.0, ymax = 0.8 * L,
-            infz = true
-        }
-)
+vol1a = logvol.RPPLogicalVolume.Create({
+  infx = true,
+  ymin = 0.0,
+  ymax = 0.8 * L,
+  infz = true,
+})
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
-            infy = true,
-            infz = true
-        }
-)
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = 2.5 - 0.166666,
+  xmax = 2.5 + 0.166666,
+  infy = true,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1b = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = -1 + 2.5, xmax = 1 + 2.5,
-            ymin = 0.9 * L, ymax = L,
-            infz = true
-        }
-)
+vol1b = logvol.RPPLogicalVolume.Create({
+  xmin = -1 + 2.5,
+  xmax = 1 + 2.5,
+  ymin = 0.9 * L,
+  ymax = L,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1b, 1)
 
 -- Add materials
 num_groups = 1
 
 materials = {}
-materials[1] = mat.AddMaterial("Test Material1");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material1")
+materials[2] = mat.AddMaterial("Test Material2")
 
 -- Add cross sections
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.01, 0.01)
@@ -69,11 +71,11 @@ mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.1 * 20, 0
 -- Add sources
 src = {}
 for g = 1, num_groups do
-    if g == 1 then
-        src[g] = 1.0
-    else
-        src[g] = 0.0
-    end
+  if g == 1 then
+    src[g] = 1.0
+  else
+    src[g] = 0.0
+  end
 end
 
 loc = { 1.25 - 0.5 * ds, 1.5 * ds, 0.0 }
@@ -84,21 +86,21 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 48, 6)
 aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 lbs_block = {
-    num_groups = num_groups,
-    groupsets = {
-        {
-            groups_from_to = { 0, num_groups - 1 },
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 500,
-            gmres_restart_interval = 100,
-        }
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 500,
+      gmres_restart_interval = 100,
     },
-    options = {
-        scattering_order = 0,
-        point_sources = { pt_src }
-    }
+  },
+  options = {
+    scattering_order = 0,
+    point_sources = { pt_src },
+  },
 }
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
@@ -114,13 +116,13 @@ ff_m1 = fieldfunc.GetHandleByName("phi_g000_m01")
 ff_m2 = fieldfunc.GetHandleByName("phi_g000_m02")
 
 -- Define QoI region
-qoi_vol = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 0.5, xmax = 0.8333,
-            ymin = 4.16666, ymax = 4.33333,
-            infz = true
-        }
-)
+qoi_vol = logvol.RPPLogicalVolume.Create({
+  xmin = 0.5,
+  xmax = 0.8333,
+  ymin = 4.16666,
+  ymax = 4.33333,
+  infz = true,
+})
 
 -- Compute QoI
 ffi = fieldfunc.FFInterpolationCreate(VOLUME)
@@ -133,14 +135,12 @@ fieldfunc.Execute(ffi)
 fwd_qoi = fieldfunc.GetValue(ffi)
 
 -- Create adjoint source
-adjoint_source = lbs.DistributedSource.Create(
-        { logical_volume_handle = qoi_vol }
-)
+adjoint_source = lbs.DistributedSource.Create({ logical_volume_handle = qoi_vol })
 
 -- Switch to adjoint mode
 adjoint_options = {
-    adjoint = true,
-    distributed_sources = { adjoint_source }
+  adjoint = true,
+  distributed_sources = { adjoint_source },
 }
 lbs.SetOptions(phys, adjoint_options)
 
@@ -152,11 +152,11 @@ lbs.WriteFluxMoments(phys, "adjoint_2d_2")
 buffers = { { name = "buff", file_prefixes = { flux_moments = "adjoint_2d_2" } } }
 pt_sources = { pt_src }
 response_options = {
-    lbs_solver_handle = phys,
-    options = {
-        buffers = buffers,
-        sources = { point = pt_sources }
-    }
+  lbs_solver_handle = phys,
+  options = {
+    buffers = buffers,
+    sources = { point = pt_sources },
+  },
 }
 evaluator = lbs.ResponseEvaluator.Create(response_options)
 
@@ -169,6 +169,6 @@ log.Log(LOG_0, string.format("Inner Product=%.5e", adj_qoi))
 
 -- Cleanup
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm adjoint_2d_2*")
+if location_id == 0 then
+  os.execute("rm adjoint_2d_2*")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
@@ -16,11 +16,15 @@
 num_procs = 4
 
 -- Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-            "Expected " .. tostring(num_procs) ..
-            ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 -- Create mesh
@@ -30,7 +34,7 @@ ds = L / N
 
 nodes = {}
 for i = 0, N do
-    nodes[i + 1] = i * ds
+  nodes[i + 1] = i * ds
 end
 meshgen = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen)
@@ -38,38 +42,36 @@ mesh.MeshGenerator.Execute(meshgen)
 -- Set material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1a = logvol.RPPLogicalVolume.Create(
-        {
-            infx = true,
-            ymin = 0.0, ymax = 0.8 * L,
-            infz = true
-        }
-)
+vol1a = logvol.RPPLogicalVolume.Create({
+  infx = true,
+  ymin = 0.0,
+  ymax = 0.8 * L,
+  infz = true,
+})
 
 mesh.SetMaterialIDFromLogicalVolume(vol1a, 1)
 
-vol0 = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 2.5 - 0.166666, xmax = 2.5 + 0.166666,
-            infy = true,
-            infz = true
-        }
-)
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = 2.5 - 0.166666,
+  xmax = 2.5 + 0.166666,
+  infy = true,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1b = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = -1 + 2.5, xmax = 1 + 2.5,
-            ymin = 0.9 * L, ymax = L,
-            infz = true
-        }
-)
+vol1b = logvol.RPPLogicalVolume.Create({
+  xmin = -1 + 2.5,
+  xmax = 1 + 2.5,
+  ymin = 0.9 * L,
+  ymax = L,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1b, 1)
 
 -- Create materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material1");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material1")
+materials[2] = mat.AddMaterial("Test Material2")
 
 -- Add cross sections to materials
 num_groups = 10
@@ -79,11 +81,11 @@ mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "response_2d_3
 -- Create sources
 src = {}
 for g = 1, num_groups do
-    if g == 1 then
-        src[g] = 1.0
-    else
-        src[g] = 0.0
-    end
+  if g == 1 then
+    src[g] = 1.0
+  else
+    src[g] = 0.0
+  end
 end
 
 loc = { 1.25 - 0.5 * ds, 1.5 * ds, 0.0 }
@@ -94,21 +96,21 @@ pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 12, 2)
 aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 lbs_block = {
-    num_groups = num_groups,
-    groupsets = {
-        {
-            groups_from_to = { 0, num_groups - 1 },
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 500,
-            gmres_restart_interval = 100,
-        }
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 500,
+      gmres_restart_interval = 100,
     },
-    options = {
-        scattering_order = 0,
-        point_sources = { pt_src }
-    }
+  },
+  options = {
+    scattering_order = 0,
+    point_sources = { pt_src },
+  },
 }
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
@@ -119,57 +121,56 @@ solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 -- Define QoI region
-qoi_vol = logvol.RPPLogicalVolume.Create(
-        {
-            xmin = 0.5, xmax = 0.8333,
-            ymin = 4.16666, ymax = 4.33333,
-            infz = true
-        }
-)
+qoi_vol = logvol.RPPLogicalVolume.Create({
+  xmin = 0.5,
+  xmax = 0.8333,
+  ymin = 4.16666,
+  ymax = 4.33333,
+  infz = true,
+})
 
 -- Compute QoI
 fwd_qois = {}
 fwd_qoi_sum = 0.0
 for g = 0, num_groups - 1 do
-    ff = fieldfunc.GetHandleByName(
-            "phi_g" .. string.format("%03d", g) .. "_m" .. string.format("%02d", 0))
-    ffi = fieldfunc.FFInterpolationCreate(VOLUME)
-    fieldfunc.SetProperty(ffi, OPERATION, OP_SUM)
-    fieldfunc.SetProperty(ffi, LOGICAL_VOLUME, qoi_vol)
-    fieldfunc.SetProperty(ffi, ADD_FIELDFUNCTION, ff)
+  ff = fieldfunc.GetHandleByName(
+    "phi_g" .. string.format("%03d", g) .. "_m" .. string.format("%02d", 0)
+  )
+  ffi = fieldfunc.FFInterpolationCreate(VOLUME)
+  fieldfunc.SetProperty(ffi, OPERATION, OP_SUM)
+  fieldfunc.SetProperty(ffi, LOGICAL_VOLUME, qoi_vol)
+  fieldfunc.SetProperty(ffi, ADD_FIELDFUNCTION, ff)
 
-    fieldfunc.Initialize(ffi)
-    fieldfunc.Execute(ffi)
-    fwd_qois[g + 1] = fieldfunc.GetValue(ffi)
+  fieldfunc.Initialize(ffi)
+  fieldfunc.Execute(ffi)
+  fwd_qois[g + 1] = fieldfunc.GetValue(ffi)
 
-    fwd_qoi_sum = fwd_qoi_sum + fwd_qois[g + 1]
+  fwd_qoi_sum = fwd_qoi_sum + fwd_qois[g + 1]
 end
 
 -- Create adjoint source
 function ResponseFunction(xyz, mat_id)
-    response = {}
-    for g = 1, num_groups do
-        if g == 6 then
-            response[g] = 1.0
-        else
-            response[g] = 0.0
-        end
+  response = {}
+  for g = 1, num_groups do
+    if g == 6 then
+      response[g] = 1.0
+    else
+      response[g] = 0.0
     end
-    return response
+  end
+  return response
 end
 response_func = opensn.LuaSpatialMaterialFunction.Create({ lua_function_name = "ResponseFunction" })
 
-adjoint_source = lbs.DistributedSource.Create(
-        {
-            logical_volume_handle = qoi_vol,
-            function_handle = response_func
-        }
-)
+adjoint_source = lbs.DistributedSource.Create({
+  logical_volume_handle = qoi_vol,
+  function_handle = response_func,
+})
 
 -- Switch to adjoint mode
 adjoint_options = {
-    adjoint = true,
-    distributed_sources = { adjoint_source }
+  adjoint = true,
+  distributed_sources = { adjoint_source },
 }
 lbs.SetOptions(phys, adjoint_options)
 
@@ -181,11 +182,11 @@ lbs.WriteFluxMoments(phys, "adjoint_2d_3")
 buffers = { { name = "buff", file_prefixes = { flux_moments = "adjoint_2d_3" } } }
 pt_sources = { pt_src }
 response_options = {
-    lbs_solver_handle = phys,
-    options = {
-        buffers = buffers,
-        sources = { point = pt_sources }
-    }
+  lbs_solver_handle = phys,
+  options = {
+    buffers = buffers,
+    sources = { point = pt_sources },
+  },
 }
 evaluator = lbs.ResponseEvaluator.Create(response_options)
 
@@ -194,14 +195,14 @@ response = lbs.EvaluateResponse(evaluator, "buff")
 
 -- Print results
 for g = 1, num_groups do
-    pref = "QoI Value[" .. tostring(g - 1) .. "]"
-    log.Log(LOG_0, string.format(pref .. "= %.5e", fwd_qois[g]))
+  pref = "QoI Value[" .. tostring(g - 1) .. "]"
+  log.Log(LOG_0, string.format(pref .. "= %.5e", fwd_qois[g]))
 end
 log.Log(LOG_0, string.format("sum(QoI Values)= %.5e", fwd_qoi_sum))
 log.Log(LOG_0, string.format("Inner Product=%.5e", response))
 
 -- Cleanup
 MPIBarrier()
-if (location_id == 0) then
-    os.execute("rm adjoint_2d_3*")
+if location_id == 0 then
+  os.execute("rm adjoint_2d_3*")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.lua
@@ -6,118 +6,113 @@ dofile("materials/materials.lua")
 -- Setup Physics
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-if (string.find(k_method, "scdsa") or string.find(k_method, "smm")) then
-    inner_linear_method = "richardson"
-    l_max_its = 1
+if string.find(k_method, "scdsa") or string.find(k_method, "smm") then
+  inner_linear_method = "richardson"
+  l_max_its = 1
 else
-    inner_linear_method = "gmres"
-    l_max_its = 5
+  inner_linear_method = "gmres"
+  l_max_its = 5
 end
 
-
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = inner_linear_method,
-            l_max_its = l_max_its,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = inner_linear_method,
+      l_max_its = l_max_its,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "AAH"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+  },
+  sweep_type = "AAH",
 })
 
 -- Execute Solver
-if (k_method == "pi") then
-    k_solver = lbs.PowerIterationKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        k_tol = 1.0e-8
-    })
-elseif (k_method == "pi_scdsa") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwld",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_scdsa_pwlc") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwlc",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_smm") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwlc",
-    })
-elseif (k_method == "pi_smm_pwld") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwld"
-    })
-elseif (k_method == "jfnk") then
-    k_solver = lbs.NonLinearKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        nl_max_its = 50,
-        nl_abs_tol = 1.0e-10,
-        nl_rel_tol = 1.0e-10,
-        l_max_its = 20,
-        num_initial_power_iterations = 2,
-    })
+if k_method == "pi" then
+  k_solver = lbs.PowerIterationKEigen.Create({
+    lbs_solver_handle = phys1,
+    k_tol = 1.0e-8,
+  })
+elseif k_method == "pi_scdsa" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwld",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_scdsa_pwlc" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwlc",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_smm" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwlc",
+  })
+elseif k_method == "pi_smm_pwld" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwld",
+  })
+elseif k_method == "jfnk" then
+  k_solver = lbs.NonLinearKEigen.Create({
+    lbs_solver_handle = phys1,
+    nl_max_its = 50,
+    nl_abs_tol = 1.0e-10,
+    nl_rel_tol = 1.0e-10,
+    l_max_its = 20,
+    num_initial_power_iterations = 2,
+  })
 else
-    log.Log(LOG_0ERROR, "k_method must be specified. \"pi\", "..
-      "\"pi_scdsa\", \"pi_scdsa_pwlc\", \"pi_smm\", \"pi_smm_pwld\", " ..
-      "or \"jfnk\"")
-    return
+  log.Log(
+    LOG_0ERROR,
+    'k_method must be specified. "pi", '
+      .. '"pi_scdsa", "pi_scdsa_pwlc", "pi_smm", "pi_smm_pwld", '
+      .. 'or "jfnk"'
+  )
+  return
 end
 
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_jfnk.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_jfnk.lua
@@ -6,118 +6,113 @@ dofile("materials/materials.lua")
 -- Setup Physics
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-if (string.find(k_method, "scdsa") or string.find(k_method, "smm")) then
-    inner_linear_method = "richardson"
-    l_max_its = 1
+if string.find(k_method, "scdsa") or string.find(k_method, "smm") then
+  inner_linear_method = "richardson"
+  l_max_its = 1
 else
-    inner_linear_method = "gmres"
-    l_max_its = 5
+  inner_linear_method = "gmres"
+  l_max_its = 5
 end
 
-
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = inner_linear_method,
-            l_max_its = l_max_its,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = inner_linear_method,
+      l_max_its = l_max_its,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "AAH"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+  },
+  sweep_type = "AAH",
 })
 
 -- Execute Solver
-if (k_method == "pi") then
-    k_solver = lbs.PowerIterationKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        k_tol = 1.0e-8
-    })
-elseif (k_method == "pi_scdsa") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwld",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_scdsa_pwlc") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwlc",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_smm") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwlc",
-    })
-elseif (k_method == "pi_smm_pwld") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwld"
-    })
-elseif (k_method == "jfnk") then
-    k_solver = lbs.NonLinearKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        nl_max_its = 50,
-        nl_abs_tol = 1.0e-10,
-        nl_rel_tol = 1.0e-10,
-        l_max_its = 20,
-        num_initial_power_iterations = 2,
-    })
+if k_method == "pi" then
+  k_solver = lbs.PowerIterationKEigen.Create({
+    lbs_solver_handle = phys1,
+    k_tol = 1.0e-8,
+  })
+elseif k_method == "pi_scdsa" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwld",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_scdsa_pwlc" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwlc",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_smm" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwlc",
+  })
+elseif k_method == "pi_smm_pwld" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwld",
+  })
+elseif k_method == "jfnk" then
+  k_solver = lbs.NonLinearKEigen.Create({
+    lbs_solver_handle = phys1,
+    nl_max_its = 50,
+    nl_abs_tol = 1.0e-10,
+    nl_rel_tol = 1.0e-10,
+    l_max_its = 20,
+    num_initial_power_iterations = 2,
+  })
 else
-    log.Log(LOG_0ERROR, "k_method must be specified. \"pi\", "..
-      "\"pi_scdsa\", \"pi_scdsa_pwlc\", \"pi_smm\", \"pi_smm_pwld\", " ..
-      "or \"jfnk\"")
-    return
+  log.Log(
+    LOG_0ERROR,
+    'k_method must be specified. "pi", '
+      .. '"pi_scdsa", "pi_scdsa_pwlc", "pi_smm", "pi_smm_pwld", '
+      .. 'or "jfnk"'
+  )
+  return
 end
 
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi.lua
@@ -6,118 +6,113 @@ dofile("materials/materials.lua")
 -- Setup Physics
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-if (string.find(k_method, "scdsa") or string.find(k_method, "smm")) then
-    inner_linear_method = "richardson"
-    l_max_its = 1
+if string.find(k_method, "scdsa") or string.find(k_method, "smm") then
+  inner_linear_method = "richardson"
+  l_max_its = 1
 else
-    inner_linear_method = "gmres"
-    l_max_its = 5
+  inner_linear_method = "gmres"
+  l_max_its = 5
 end
 
-
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = inner_linear_method,
-            l_max_its = l_max_its,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = inner_linear_method,
+      l_max_its = l_max_its,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "AAH"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+  },
+  sweep_type = "AAH",
 })
 
 -- Execute Solver
-if (k_method == "pi") then
-    k_solver = lbs.PowerIterationKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        k_tol = 1.0e-8
-    })
-elseif (k_method == "pi_scdsa") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwld",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_scdsa_pwlc") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwlc",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_smm") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwlc",
-    })
-elseif (k_method == "pi_smm_pwld") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwld"
-    })
-elseif (k_method == "jfnk") then
-    k_solver = lbs.NonLinearKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        nl_max_its = 50,
-        nl_abs_tol = 1.0e-10,
-        nl_rel_tol = 1.0e-10,
-        l_max_its = 20,
-        num_initial_power_iterations = 2,
-    })
+if k_method == "pi" then
+  k_solver = lbs.PowerIterationKEigen.Create({
+    lbs_solver_handle = phys1,
+    k_tol = 1.0e-8,
+  })
+elseif k_method == "pi_scdsa" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwld",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_scdsa_pwlc" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwlc",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_smm" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwlc",
+  })
+elseif k_method == "pi_smm_pwld" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwld",
+  })
+elseif k_method == "jfnk" then
+  k_solver = lbs.NonLinearKEigen.Create({
+    lbs_solver_handle = phys1,
+    nl_max_its = 50,
+    nl_abs_tol = 1.0e-10,
+    nl_rel_tol = 1.0e-10,
+    l_max_its = 20,
+    num_initial_power_iterations = 2,
+  })
 else
-    log.Log(LOG_0ERROR, "k_method must be specified. \"pi\", "..
-      "\"pi_scdsa\", \"pi_scdsa_pwlc\", \"pi_smm\", \"pi_smm_pwld\", " ..
-      "or \"jfnk\"")
-    return
+  log.Log(
+    LOG_0ERROR,
+    'k_method must be specified. "pi", '
+      .. '"pi_scdsa", "pi_scdsa_pwlc", "pi_smm", "pi_smm_pwld", '
+      .. 'or "jfnk"'
+  )
+  return
 end
 
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi_scdsa.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi_scdsa.lua
@@ -6,118 +6,113 @@ dofile("materials/materials.lua")
 -- Setup Physics
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-if (string.find(k_method, "scdsa") or string.find(k_method, "smm")) then
-    inner_linear_method = "richardson"
-    l_max_its = 1
+if string.find(k_method, "scdsa") or string.find(k_method, "smm") then
+  inner_linear_method = "richardson"
+  l_max_its = 1
 else
-    inner_linear_method = "gmres"
-    l_max_its = 5
+  inner_linear_method = "gmres"
+  l_max_its = 5
 end
 
-
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = inner_linear_method,
-            l_max_its = l_max_its,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = inner_linear_method,
+      l_max_its = l_max_its,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "AAH"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+  },
+  sweep_type = "AAH",
 })
 
 -- Execute Solver
-if (k_method == "pi") then
-    k_solver = lbs.PowerIterationKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        k_tol = 1.0e-8
-    })
-elseif (k_method == "pi_scdsa") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwld",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_scdsa_pwlc") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwlc",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_smm") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwlc",
-    })
-elseif (k_method == "pi_smm_pwld") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwld"
-    })
-elseif (k_method == "jfnk") then
-    k_solver = lbs.NonLinearKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        nl_max_its = 50,
-        nl_abs_tol = 1.0e-10,
-        nl_rel_tol = 1.0e-10,
-        l_max_its = 20,
-        num_initial_power_iterations = 2,
-    })
+if k_method == "pi" then
+  k_solver = lbs.PowerIterationKEigen.Create({
+    lbs_solver_handle = phys1,
+    k_tol = 1.0e-8,
+  })
+elseif k_method == "pi_scdsa" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwld",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_scdsa_pwlc" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwlc",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_smm" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwlc",
+  })
+elseif k_method == "pi_smm_pwld" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwld",
+  })
+elseif k_method == "jfnk" then
+  k_solver = lbs.NonLinearKEigen.Create({
+    lbs_solver_handle = phys1,
+    nl_max_its = 50,
+    nl_abs_tol = 1.0e-10,
+    nl_rel_tol = 1.0e-10,
+    l_max_its = 20,
+    num_initial_power_iterations = 2,
+  })
 else
-    log.Log(LOG_0ERROR, "k_method must be specified. \"pi\", "..
-      "\"pi_scdsa\", \"pi_scdsa_pwlc\", \"pi_smm\", \"pi_smm_pwld\", " ..
-      "or \"jfnk\"")
-    return
+  log.Log(
+    LOG_0ERROR,
+    'k_method must be specified. "pi", '
+      .. '"pi_scdsa", "pi_scdsa_pwlc", "pi_smm", "pi_smm_pwld", '
+      .. 'or "jfnk"'
+  )
+  return
 end
 
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi_smm.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7_pi_smm.lua
@@ -6,118 +6,113 @@ dofile("materials/materials.lua")
 -- Setup Physics
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-if (string.find(k_method, "scdsa") or string.find(k_method, "smm")) then
-    inner_linear_method = "richardson"
-    l_max_its = 1
+if string.find(k_method, "scdsa") or string.find(k_method, "smm") then
+  inner_linear_method = "richardson"
+  l_max_its = 1
 else
-    inner_linear_method = "gmres"
-    l_max_its = 5
+  inner_linear_method = "gmres"
+  l_max_its = 5
 end
 
-
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = inner_linear_method,
-            l_max_its = l_max_its,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = inner_linear_method,
+      l_max_its = l_max_its,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "AAH"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+  },
+  sweep_type = "AAH",
 })
 
 -- Execute Solver
-if (k_method == "pi") then
-    k_solver = lbs.PowerIterationKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        k_tol = 1.0e-8
-    })
-elseif (k_method == "pi_scdsa") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwld",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_scdsa_pwlc") then
-    k_solver = lbs.PowerIterationKEigenSCDSA.Create
-    ({
-        lbs_solver_handle = phys1,
-        diff_accel_sdm = "pwlc",
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 50,
-    })
-elseif (k_method == "pi_smm") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwlc",
-    })
-elseif (k_method == "pi_smm_pwld") then
-    k_solver = lbs.PowerIterationKEigenSMM.Create
-    ({
-        lbs_solver_handle = phys1,
-        accel_pi_verbose = true,
-        k_tol = 1.0e-8,
-        accel_pi_k_tol = 1.0e-8,
-        accel_pi_max_its = 30,
-        diff_sdm = "pwld"
-    })
-elseif (k_method == "jfnk") then
-    k_solver = lbs.NonLinearKEigen.Create
-    ({
-        lbs_solver_handle = phys1,
-        nl_max_its = 50,
-        nl_abs_tol = 1.0e-10,
-        nl_rel_tol = 1.0e-10,
-        l_max_its = 20,
-        num_initial_power_iterations = 2,
-    })
+if k_method == "pi" then
+  k_solver = lbs.PowerIterationKEigen.Create({
+    lbs_solver_handle = phys1,
+    k_tol = 1.0e-8,
+  })
+elseif k_method == "pi_scdsa" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwld",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_scdsa_pwlc" then
+  k_solver = lbs.PowerIterationKEigenSCDSA.Create({
+    lbs_solver_handle = phys1,
+    diff_accel_sdm = "pwlc",
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 50,
+  })
+elseif k_method == "pi_smm" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwlc",
+  })
+elseif k_method == "pi_smm_pwld" then
+  k_solver = lbs.PowerIterationKEigenSMM.Create({
+    lbs_solver_handle = phys1,
+    accel_pi_verbose = true,
+    k_tol = 1.0e-8,
+    accel_pi_k_tol = 1.0e-8,
+    accel_pi_max_its = 30,
+    diff_sdm = "pwld",
+  })
+elseif k_method == "jfnk" then
+  k_solver = lbs.NonLinearKEigen.Create({
+    lbs_solver_handle = phys1,
+    nl_max_its = 50,
+    nl_abs_tol = 1.0e-10,
+    nl_rel_tol = 1.0e-10,
+    l_max_its = 20,
+    num_initial_power_iterations = 2,
+  })
 else
-    log.Log(LOG_0ERROR, "k_method must be specified. \"pi\", "..
-      "\"pi_scdsa\", \"pi_scdsa_pwlc\", \"pi_smm\", \"pi_smm_pwld\", " ..
-      "or \"jfnk\"")
-    return
+  log.Log(
+    LOG_0ERROR,
+    'k_method must be specified. "pi", '
+      .. '"pi_scdsa", "pi_scdsa_pwlc", "pi_smm", "pi_smm_pwld", '
+      .. 'or "jfnk"'
+  )
+  return
 end
 
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/materials/materials.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/materials/materials.lua
@@ -1,8 +1,8 @@
 --############################################### Create cross sections
 xss = {}
 
-for m=0,6 do
-    xss[tostring(m)] = xs.Create()
+for m = 0, 6 do
+  xss[tostring(m)] = xs.Create()
 end
 
 -- GMesh mesh
@@ -17,12 +17,12 @@ xs.Set(xss["6"], OPENSN_XSFILE, "materials/XS_fission_chamber.xs")
 water_xs = xs.Get(xss["0"])
 
 num_groups = water_xs["num_groups"]
-log.Log(LOG_0,"Num groups: "..tostring(num_groups))
+log.Log(LOG_0, "Num groups: " .. tostring(num_groups))
 
 --############################################### Create materials
 materials = {}
-for m=0,6 do
-    key = tostring(m)
-    materials[key] = mat.AddMaterial("Material_"..key)
-    mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
+for m = 0, 6 do
+  key = tostring(m)
+  materials[key] = mat.AddMaterial("Material_" .. key)
+  mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/mesh/gmesh_coarse.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/mesh/gmesh_coarse.lua
@@ -1,13 +1,10 @@
 --############################################### Setup mesh
 
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "mesh/2D_c5g7_coarse.msh"
-    })
-  }
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "mesh/2D_c5g7_coarse.msh",
+    }),
+  },
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/mesh/gmesh_refined.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/mesh/gmesh_refined.lua
@@ -1,13 +1,10 @@
 --############################################### Setup mesh
 
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "mesh/2D_c5g7_refined.msh"
-    })
-  }
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "mesh/2D_c5g7_refined.msh",
+    }),
+  },
 })
 mesh.MeshGenerator.Execute(meshgen1)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.lua
@@ -2,23 +2,20 @@
 
 -- Setup mesh
 
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "c5g7/mesh/2D_c5g7_coarse.msh"
-    })
-  }
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "c5g7/mesh/2D_c5g7_coarse.msh",
+    }),
+  },
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 -- Create cross sections
 xss = {}
 
-for m=0,6 do
-    xss[tostring(m)] = xs.Create()
+for m = 0, 6 do
+  xss[tostring(m)] = xs.Create()
 end
 
 xs.Set(xss["0"], OPENSN_XSFILE, "c5g7/materials/XS_water.xs")
@@ -32,65 +29,63 @@ xs.Set(xss["6"], OPENSN_XSFILE, "c5g7/materials/XS_fission_chamber.xs")
 water_xs = xs.Get(xss["0"])
 
 num_groups = water_xs["num_groups"]
-log.Log(LOG_0,"Num groups: "..tostring(num_groups))
+log.Log(LOG_0, "Num groups: " .. tostring(num_groups))
 
 -- Create materials
 materials = {}
-for m=0,6 do
-    key = tostring(m)
-    materials[key] = mat.AddMaterial("Material_"..key)
-    mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
+for m = 0, 6 do
+  key = tostring(m)
+  materials[key] = mat.AddMaterial("Material_" .. key)
+  mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end
 
 -- Angular quadrature
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
 -- Solver
-phys1 = lbs.DiscreteOrdinatesSolver.Create
-({
-    num_groups = num_groups,
-    groupsets =
+phys1 = lbs.DiscreteOrdinatesSolver.Create({
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_max_its = 5,
-            l_abs_tol = 1.0e-10,
-            angle_aggregation_type = "polar",
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_max_its = 5,
+      l_abs_tol = 1.0e-10,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 1,
-        verbose_outer_iterations = true,
-        verbose_inner_iterations = true,
-        power_field_function_on = true,
-        power_default_kappa = 1.0,
-        power_normalization = 1.0,
-        save_angular_flux = true,
-        --write_restart_time_interval = 60,
-        --write_restart_path = "c5g7_restart/c5g7",
-	read_restart_path = "c5g7_restart/c5g7"
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "CBC"
+    scattering_order = 1,
+    verbose_outer_iterations = true,
+    verbose_inner_iterations = true,
+    power_field_function_on = true,
+    power_default_kappa = 1.0,
+    power_normalization = 1.0,
+    save_angular_flux = true,
+    --write_restart_time_interval = 60,
+    --write_restart_path = "c5g7_restart/c5g7",
+    read_restart_path = "c5g7_restart/c5g7",
+  },
+  sweep_type = "CBC",
 })
 
 -- Execute Solver
-k_solver = lbs.PowerIterationKEigen.Create
-({
-    lbs_solver_handle = phys1,
-    k_tol = 1.0e-8
+k_solver = lbs.PowerIterationKEigen.Create({
+  lbs_solver_handle = phys1,
+  k_tol = 1.0e-8,
 })
 solver.Initialize(k_solver)
 solver.Execute(k_solver)
 
-if (master_export == nil) then
-    fflist,count = lbs.GetScalarFieldFunctionList(phys1)
-    fieldfunc.ExportToVTKMulti(fflist,"solutions/ZPhi")
+if master_export == nil then
+  fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+  fieldfunc.ExportToVTKMulti(fflist, "solutions/ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.lua
@@ -6,11 +6,15 @@ num_procs = 4
 --       variable=[[argument]]
 
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                       "Expected "..tostring(num_procs)..
-                       ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 MPIBarrier()
@@ -20,24 +24,41 @@ MPIBarrier()
 -- ##################################################
 
 -- Mesh variables
-if (L == nil) then L = 100.0 end
-if (n_cells == nil) then n_cells = 50 end
+if L == nil then
+  L = 100.0
+end
+if n_cells == nil then
+  n_cells = 50
+end
 
 -- Transport angle information
-if (n_angles == nil) then n_angles = 16 end
-if (scat_order == nil) then scat_order = 0 end
+if n_angles == nil then
+  n_angles = 16
+end
+if scat_order == nil then
+  scat_order = 0
+end
 
 -- k-eigenvalue iteration parameters
-if (kes_max_iterations == nil) then kes_max_iterations = 5000 end
-if (kes_tolerance == nil) then kes_tolerance = 1e-8 end
+if kes_max_iterations == nil then
+  kes_max_iterations = 5000
+end
+if kes_tolerance == nil then
+  kes_tolerance = 1e-8
+end
 
 -- Source iteration parameters
-if (si_max_iterations == nil) then si_max_iterations = 500 end
-if (si_tolerance == nil) then si_tolerance = 1e-8 end
+if si_max_iterations == nil then
+  si_max_iterations = 500
+end
+if si_tolerance == nil then
+  si_tolerance = 1e-8
+end
 
 -- Delayed neutrons
-if (use_precursors == nil) then use_precursors = true end
-
+if use_precursors == nil then
+  use_precursors = true
+end
 
 -- ##################################################
 -- ##### Run problem #####
@@ -45,12 +66,12 @@ if (use_precursors == nil) then use_precursors = true end
 
 --############################################### Setup mesh
 nodes = {}
-dx = L/n_cells
-for i=0,n_cells do
-  nodes[i+1] = i*dx
+dx = L / n_cells
+for i = 0, n_cells do
+  nodes[i + 1] = i * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -65,26 +86,23 @@ mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 
 --############################################### Setup Physics
 num_groups = 1
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
-      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE,n_angles),
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, n_angles),
       inner_linear_method = "gmres",
       l_max_its = si_max_iterations,
       l_abs_tol = si_tolerance,
-    }
-  }
+    },
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = scat_order,
 
-  use_precursors = use_precursors ,
+  use_precursors = use_precursors,
 
   verbose_inner_iterations = false,
   verbose_outer_iterations = true,
@@ -93,11 +111,10 @@ lbs_options =
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
-k_solver0 = lbs.NonLinearKEigen.Create
-({
+k_solver0 = lbs.NonLinearKEigen.Create({
   lbs_solver_handle = phys,
   nl_max_its = kes_max_iterations,
-  nl_abs_tol = kes_tolerance
+  nl_abs_tol = kes_tolerance,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.lua
@@ -6,11 +6,15 @@ num_procs = 4
 --       variable=[[argument]]
 
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                       "Expected "..tostring(num_procs)..
-                       ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 MPIBarrier()
@@ -20,24 +24,41 @@ MPIBarrier()
 -- ##################################################
 
 -- Mesh variables
-if (L == nil) then L = 100.0 end
-if (n_cells == nil) then n_cells = 50 end
+if L == nil then
+  L = 100.0
+end
+if n_cells == nil then
+  n_cells = 50
+end
 
 -- Transport angle information
-if (n_angles == nil) then n_angles = 16 end
-if (scat_order == nil) then scat_order = 0 end
+if n_angles == nil then
+  n_angles = 16
+end
+if scat_order == nil then
+  scat_order = 0
+end
 
 -- k-eigenvalue iteration parameters
-if (kes_max_iterations == nil) then kes_max_iterations = 5000 end
-if (kes_tolerance == nil) then kes_tolerance = 1e-8 end
+if kes_max_iterations == nil then
+  kes_max_iterations = 5000
+end
+if kes_tolerance == nil then
+  kes_tolerance = 1e-8
+end
 
 -- Source iteration parameters
-if (si_max_iterations == nil) then si_max_iterations = 500 end
-if (si_tolerance == nil) then si_tolerance = 1e-8 end
+if si_max_iterations == nil then
+  si_max_iterations = 500
+end
+if si_tolerance == nil then
+  si_tolerance = 1e-8
+end
 
 -- Delayed neutrons
-if (use_precursors == nil) then use_precursors = true end
-
+if use_precursors == nil then
+  use_precursors = true
+end
 
 -- ##################################################
 -- ##### Run problem #####
@@ -45,12 +66,12 @@ if (use_precursors == nil) then use_precursors = true end
 
 --############################################### Setup mesh
 nodes = {}
-dx = L/n_cells
-for i=0,n_cells do
-  nodes[i+1] = i*dx
+dx = L / n_cells
+for i = 0, n_cells do
+  nodes[i + 1] = i * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -65,41 +86,35 @@ mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 
 --############################################### Setup Physics
 num_groups = 1
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
-      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE,n_angles),
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, n_angles),
       inner_linear_method = "gmres",
       l_max_its = si_max_iterations,
       l_abs_tol = si_tolerance,
-    }
+    },
   },
-  options =
-  {
+  options = {
     scattering_order = scat_order,
 
-    use_precursors = use_precursors ,
+    use_precursors = use_precursors,
 
     verbose_inner_iterations = false,
     verbose_outer_iterations = true,
-    save_angular_flux = true
+    save_angular_flux = true,
   },
-  sweep_type = "CBC"
+  sweep_type = "CBC",
 }
-
-
 
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
-k_solver0 = lbs.NonLinearKEigen.Create
-({
+k_solver0 = lbs.NonLinearKEigen.Create({
   lbs_solver_handle = phys,
   nl_max_its = kes_max_iterations,
-  nl_abs_tol = kes_tolerance
+  nl_abs_tol = kes_tolerance,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock.lua
@@ -6,34 +6,33 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad,
       inner_linear_method = "gmres",
       l_max_its = 50,
       gmres_restart_interval = 50,
       l_abs_tol = 1.0e-10,
       groupset_num_subsets = 2,
-    }
+    },
   },
-  options =
-  {
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
+    },
     scattering_order = 2,
 
     use_precursors = false,
 
     verbose_inner_iterations = false,
     verbose_outer_iterations = true,
-  }
+  },
 }
 
 --lbs_options =
@@ -51,13 +50,11 @@ lbs_block =
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 --lbs.SetOptions(phys1, lbs_options)
 
-
-k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.lua
@@ -6,36 +6,35 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad,
       inner_linear_method = "gmres",
       l_max_its = 50,
       gmres_restart_interval = 50,
       l_abs_tol = 1.0e-10,
       groupset_num_subsets = 2,
-    }
+    },
   },
-  options =
-  {
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
+    },
     scattering_order = 2,
 
     use_precursors = false,
 
     verbose_inner_iterations = false,
     verbose_outer_iterations = true,
-    save_angular_flux = true
+    save_angular_flux = true,
   },
-  sweep_type = "CBC"
+  sweep_type = "CBC",
 }
 
 --lbs_options =
@@ -53,13 +52,11 @@ lbs_block =
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 --lbs.SetOptions(phys1, lbs_options)
 
-
-k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.lua
@@ -6,46 +6,44 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
-    num_groups = num_groups,
-    groupsets =
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_max_its = 50,
-            gmres_restart_interval = 50,
-            l_abs_tol = 1.0e-10,
-            groupset_num_subsets = 2,
-        }
-    }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_max_its = 50,
+      gmres_restart_interval = 50,
+      l_abs_tol = 1.0e-10,
+      groupset_num_subsets = 2,
+    },
+  },
 }
 
-lbs_options =
-{
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
-    scattering_order = 2,
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
+  },
+  scattering_order = 2,
 
-    use_precursors = false,
+  use_precursors = false,
 
-    verbose_inner_iterations = false,
-    verbose_outer_iterations = true,
+  verbose_inner_iterations = false,
+  verbose_outer_iterations = true,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
-
-k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.lua
@@ -6,47 +6,44 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
-    num_groups = num_groups,
-    groupsets =
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, num_groups-1},
-            angular_quadrature_handle = pquad,
-            inner_linear_method = "gmres",
-            l_max_its = 50,
-            gmres_restart_interval = 50,
-            l_abs_tol = 1.0e-10,
-            groupset_num_subsets = 2,
-        }
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      inner_linear_method = "gmres",
+      l_max_its = 50,
+      gmres_restart_interval = 50,
+      l_abs_tol = 1.0e-10,
+      groupset_num_subsets = 2,
     },
-    options =
-    {
-        boundary_conditions = { { name = "xmin", type = "reflecting"},
-                                { name = "ymin", type = "reflecting"} },
-        scattering_order = 2,
-
-        use_precursors = false,
-
-        verbose_inner_iterations = false,
-        verbose_outer_iterations = true,
-        save_angular_flux = true
+  },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
     },
-    sweep_type = "CBC"
+    scattering_order = 2,
+
+    use_precursors = false,
+
+    verbose_inner_iterations = false,
+    verbose_outer_iterations = true,
+    save_angular_flux = true,
+  },
+  sweep_type = "CBC",
 }
-
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
-
-k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1, })
+k_solver0 = lbs.NonLinearKEigen.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock.lua
@@ -6,35 +6,34 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad,
       inner_linear_method = "richardson",
       l_max_its = 1,
       gmres_restart_interval = 50,
       l_abs_tol = 1.0e-10,
       groupset_num_subsets = 1,
-    }
+    },
   },
-  options =
-  {
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
+    },
     scattering_order = 2,
 
     use_precursors = false,
 
     verbose_inner_iterations = true,
     verbose_outer_iterations = true,
-    save_angular_flux = true
-  }
+    save_angular_flux = true,
+  },
 }
 
 --lbs_options =
@@ -52,20 +51,17 @@ lbs_block =
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 --lbs.SetOptions(phys1, lbs_options)
 
-
 --k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1, })
-k_solver0 = lbs.PowerIterationKEigenSCDSA.Create
-({
+k_solver0 = lbs.PowerIterationKEigenSCDSA.Create({
   lbs_solver_handle = phys1,
   diff_accel_sdm = "pwld",
   accel_pi_verbose = false,
-  k_tol = 1.0e-8
+  k_tol = 1.0e-8,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.lua
@@ -6,36 +6,35 @@ dofile("utils/qblock_materials.lua") --num_groups assigned here
 
 --############################################### Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 4)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad,
       inner_linear_method = "richardson",
       l_max_its = 1,
       gmres_restart_interval = 50,
       l_abs_tol = 1.0e-10,
       groupset_num_subsets = 1,
-    }
+    },
   },
-  options =
-  {
-    boundary_conditions = { { name = "xmin", type = "reflecting"},
-                            { name = "ymin", type = "reflecting"} },
+  options = {
+    boundary_conditions = {
+      { name = "xmin", type = "reflecting" },
+      { name = "ymin", type = "reflecting" },
+    },
     scattering_order = 2,
 
     use_precursors = false,
 
     verbose_inner_iterations = true,
     verbose_outer_iterations = true,
-    save_angular_flux = true
+    save_angular_flux = true,
   },
-  sweep_type = "CBC"
+  sweep_type = "CBC",
 }
 
 --lbs_options =
@@ -53,20 +52,17 @@ lbs_block =
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 --lbs.SetOptions(phys1, lbs_options)
 
-
 --k_solver0 = lbs.PowerIterationKEigen.Create({ lbs_solver_handle = phys1, })
-k_solver0 = lbs.PowerIterationKEigenSCDSA.Create
-({
+k_solver0 = lbs.PowerIterationKEigenSCDSA.Create({
   lbs_solver_handle = phys1,
   diff_accel_sdm = "pwld",
   accel_pi_verbose = false,
-  k_tol = 1.0e-8
+  k_tol = 1.0e-8,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)
 
-
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --fieldfunc.ExportToVTKMulti(fflist,"tests/BigTests/QBlock/solutions/Flux")
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.lua
@@ -1,13 +1,13 @@
 -- 3D 172G KEigenvalue::Solver test using power iteration and OpenMC MGXS library
 -- Test: Final k-eigenvalue: 2.2800213
-num_procs = 4 
+num_procs = 4
 
 --########## Mesh ##########
 
 -- Cells
 Nx = 5
-Ny = 5 
-Nz = 5 
+Ny = 5
+Nz = 5
 
 -- Dimensions
 Lx = 2.0
@@ -16,29 +16,29 @@ Lz = 2.0
 
 xmesh = {}
 xmin = 0.0
-dx = Lx/Nx
-for i = 1, (Nx+1) do
-  k = i-1
-  xmesh[i] = xmin + k*dx
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
 end
 
 ymesh = {}
 ymin = 0.0
-dy = Ly/Ny
-for i = 1, (Ny+1) do
-  k = i-1
-  ymesh[i] = ymin + k*dy
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
 end
 
 zmesh = {}
 zmin = 0.0
-dz = Lz/Nz
-for i = 1, (Nz+1) do
-  k = i-1
-  zmesh[i] = zmin + k*dz
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh, ymesh, zmesh} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh, zmesh } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --########## Materials ##########
@@ -51,29 +51,28 @@ mesh.SetUniformMaterialID(0)
 --########## Solver ##########
 
 num_groups = 172
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 8, 2),
       inner_linear_method = "gmres",
       l_max_its = 500,
-      l_abs_tol = 1.0e-12
-    }
-  }
+      l_abs_tol = 1.0e-12,
+    },
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "reflecting"},
-                          { name = "xmax", type = "reflecting"},
-                          { name = "ymin", type = "reflecting"},
-                          { name = "ymax", type = "reflecting"},
-                          { name = "zmin", type = "reflecting"},
-                          { name = "zmax", type = "reflecting"} },
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "xmax", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
+    { name = "ymax", type = "reflecting" },
+    { name = "zmin", type = "reflecting" },
+    { name = "zmax", type = "reflecting" },
+  },
   scattering_order = 1,
   use_precursors = false,
   verbose_inner_iterations = false,
@@ -83,11 +82,10 @@ lbs_options =
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
-k_solver0 = lbs.NonLinearKEigen.Create
-({
+k_solver0 = lbs.NonLinearKEigen.Create({
   lbs_solver_handle = phys,
   nl_max_its = 500,
-  nl_abs_tol = 1.0e-8
+  nl_abs_tol = 1.0e-8,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.lua
@@ -1,13 +1,13 @@
 -- 3D 172G KEigenvalue::Solver test using power iteration and OpenMC MGXS library
 -- Test: Final k-eigenvalue: 1.5029618
-num_procs = 4 
+num_procs = 4
 
 --########## Mesh ##########
 
 -- Cells
 Nx = 5
-Ny = 5 
-Nz = 5 
+Ny = 5
+Nz = 5
 
 -- Dimensions
 Lx = 2.0
@@ -16,29 +16,29 @@ Lz = 2.0
 
 xmesh = {}
 xmin = 0.0
-dx = Lx/Nx
-for i = 1, (Nx+1) do
-  k = i-1
-  xmesh[i] = xmin + k*dx
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
 end
 
 ymesh = {}
 ymin = 0.0
-dy = Ly/Ny
-for i = 1, (Ny+1) do
-  k = i-1
-  ymesh[i] = ymin + k*dy
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
 end
 
 zmesh = {}
 zmin = 0.0
-dz = Lz/Nz
-for i = 1, (Nz+1) do
-  k = i-1
-  zmesh[i] = zmin + k*dz
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh, ymesh, zmesh} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh, zmesh } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --########## Materials ##########
@@ -51,29 +51,28 @@ mesh.SetUniformMaterialID(0)
 --########## Solver ##########
 
 num_groups = 172
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 8, 2),
       inner_linear_method = "gmres",
       l_max_its = 500,
-      l_abs_tol = 1.0e-12
-    }
-  }
+      l_abs_tol = 1.0e-12,
+    },
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "reflecting"},
-                          { name = "xmax", type = "reflecting"},
-                          { name = "ymin", type = "reflecting"},
-                          { name = "ymax", type = "reflecting"},
-                          { name = "zmin", type = "reflecting"},
-                          { name = "zmax", type = "reflecting"} },
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "xmax", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
+    { name = "ymax", type = "reflecting" },
+    { name = "zmin", type = "reflecting" },
+    { name = "zmax", type = "reflecting" },
+  },
   scattering_order = 1,
   use_precursors = false,
   verbose_inner_iterations = false,
@@ -83,11 +82,10 @@ lbs_options =
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys, lbs_options)
 
-k_solver0 = lbs.NonLinearKEigen.Create
-({
+k_solver0 = lbs.NonLinearKEigen.Create({
   lbs_solver_handle = phys,
   nl_max_its = 500,
-  nl_abs_tol = 1.0e-8
+  nl_abs_tol = 1.0e-8,
 })
 solver.Initialize(k_solver0)
 solver.Execute(k_solver0)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_materials.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_materials.lua
@@ -1,8 +1,8 @@
 --############################################### Create cross sections
 xss = {}
 
-for m=0,1 do
-    xss[tostring(m)] = xs.Create()
+for m = 0, 1 do
+  xss[tostring(m)] = xs.Create()
 end
 
 xs.Set(xss["0"], OPENSN_XSFILE, "xs_water_g2.xs")
@@ -13,8 +13,8 @@ num_groups = water_xs["num_groups"]
 
 --############################################### Create materials
 materials = {}
-for m=0,1 do
-    key = tostring(m)
-    materials[key] = mat.AddMaterial("Material_"..key)
-    mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
+for m = 0, 1 do
+  key = tostring(m)
+  materials[key] = mat.AddMaterial("Material_" .. key)
+  mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
@@ -1,18 +1,18 @@
 --############################################### Setup mesh
-nodes={}
-N=40
-L=14.0
+nodes = {}
+N = 40
+L = 14.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-1000.0,xmax=10.0,ymin=-1000.0,ymax=10.0, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 10.0, ymin = -1000.0, ymax = 10.0, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_mesh.lua
@@ -13,6 +13,11 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 10.0, ymin = -1000.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -1000.0,
+  xmax = 10.0,
+  ymin = -1000.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/reed_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/reed_balance.lua
@@ -1,7 +1,7 @@
 -- Standard Reed 1D 1-group problem
 -- Create Mesh
-widths = {2., 1., 2., 1., 2.}
-nrefs = {200, 200, 200, 200, 200}
+widths = { 2., 1., 2., 1., 2. }
+nrefs = { 200, 200, 200, 200, 200 }
 
 Nmat = #widths
 
@@ -16,7 +16,7 @@ for imat = 1, Nmat do
   end
 end
 
-meshgen = mesh.OrthogonalMeshGenerator.Create({node_sets = {nodes}})
+meshgen = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen)
 
 -- Set Material IDs
@@ -24,27 +24,29 @@ z_min = 0.0
 z_max = widths[1]
 for imat = 1, Nmat do
   z_max = z_min + widths[imat]
-  log.Log(LOG_0, 'imat=' .. imat .. ', zmin=' .. z_min .. ', zmax=' .. z_max)
-  lv = logvol.RPPLogicalVolume.Create({infx = true, infy = true, zmin = z_min, zmax = z_max})
+  log.Log(LOG_0, "imat=" .. imat .. ", zmin=" .. z_min .. ", zmax=" .. z_max)
+  lv = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, zmin = z_min, zmax = z_max })
   mesh.SetMaterialIDFromLogicalVolume(lv, imat - 1)
   z_min = z_max
 end
 
 -- Create materials
-mat_names = {"AbsoSrc", "Abso", "Void", "ScatSrc", "Scat"}
+mat_names = { "AbsoSrc", "Abso", "Void", "ScatSrc", "Scat" }
 materials = {}
-for imat = 1, Nmat do materials[imat] = mat.AddMaterial(mat_names[imat]) end
+for imat = 1, Nmat do
+  materials[imat] = mat.AddMaterial(mat_names[imat])
+end
 
 -- Add cross sections to materials
-total = {50., 5., 0., 1., 1.}
-c = {0., 0., 0., 0.9, 0.9}
+total = { 50., 5., 0., 1., 1. }
+c = { 0., 0., 0., 0.9, 0.9 }
 for imat = 1, Nmat do
   mat.SetProperty(materials[imat], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, total[imat], c[imat])
 end
 
 -- Create sources in 1st and 4th materials
-mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, {50.})
-mat.SetProperty(materials[4], ISOTROPIC_MG_SOURCE, FROM_ARRAY, {1.})
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 50. })
+mat.SetProperty(materials[4], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 1. })
 
 -- Angular Quadrature
 gl_quad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 64)
@@ -55,29 +57,28 @@ lbs_block = {
   num_groups = num_groups,
   groupsets = {
     {
-      groups_from_to = {0, num_groups - 1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = gl_quad,
       inner_linear_method = "gmres",
       l_abs_tol = 1.0e-9,
       l_max_its = 300,
-      gmres_restart_interval = 30
-    }
+      gmres_restart_interval = 30,
+    },
   },
   options = {
     scattering_order = 0,
     spatial_discretization = "pwld",
-    boundary_conditions = {{name = "zmin", type = "vacuum"}, {name = "zmax", type = "vacuum"}}
-  }
+    boundary_conditions = { { name = "zmin", type = "vacuum" }, { name = "zmax", type = "vacuum" } },
+  },
 }
 
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 
 -- Initialize and execute solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 -- compute particle balance
 lbs.ComputeBalance(phys)
-

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
@@ -3,30 +3,30 @@
 -- Test: Max-value=0.49903 and 7.18243e-4
 num_procs = 3
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=100
-L=30.0
+nodes = {}
+N = 100
+L = 30.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -34,15 +34,15 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -51,13 +51,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 40)
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 8,
@@ -67,7 +65,7 @@ lbs_block =
       gmres_restart_interval = 100,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 8,
@@ -76,24 +74,22 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/2
+bsrc[1] = 1.0 / 2
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "zmin",
       type = "isotropic",
-      group_strength = bsrc
-    }
+      group_strength = bsrc,
+    },
   },
   scattering_order = 5,
 }
@@ -102,60 +98,60 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Line plot
 --Testing consolidated interpolation
 cline = fieldfunc.FFInterpolationCreate(LINE)
-fieldfunc.SetProperty(cline,LINE_FIRSTPOINT,{x = 0.0, y = 0.0, z = 0.0001+xmin})
-fieldfunc.SetProperty(cline,LINE_SECONDPOINT,{x = 0.0, y = 0.0, z = 29.999+xmin})
-fieldfunc.SetProperty(cline,LINE_NUMBEROFPOINTS, 50)
+fieldfunc.SetProperty(cline, LINE_FIRSTPOINT, { x = 0.0, y = 0.0, z = 0.0001 + xmin })
+fieldfunc.SetProperty(cline, LINE_SECONDPOINT, { x = 0.0, y = 0.0, z = 29.999 + xmin })
+fieldfunc.SetProperty(cline, LINE_NUMBEROFPOINTS, 50)
 
-for k=165,165 do
-  fieldfunc.SetProperty(cline,ADD_FIELDFUNCTION,fflist[k])
+for k = 165, 165 do
+  fieldfunc.SetProperty(cline, ADD_FIELDFUNCTION, fflist[k])
 end
 
 fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 ffi2 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi2
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
+if master_export == nil then
   fieldfunc.ExportToCSV(cline)
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
+if location_id == 0 and master_export == nil then
   local handle = io.popen("python3 ZLFFI00.py")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
@@ -4,52 +4,52 @@
 -- and   WGS groups [63-167] Iteration    39 Residual 8.73816e-07 CONVERGED
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=1000
-L=100
+nodes = {}
+N = 1000
+L = 100
 --N=10
 --L=200e6
-xmin = -L/2
+xmin = -L / 2
 --xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, zmin=-10.0, zmax=10.0})
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, zmin = -10.0, zmax = 10.0 })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
@@ -61,13 +61,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2, false)
 --pquad1 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 8, 8, false)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -79,7 +77,7 @@ lbs_block =
       wgdsa_l_abs_tol = 1.0e-2,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -91,11 +89,10 @@ lbs_block =
       apply_tgdsa = true,
       wgdsa_l_abs_tol = 1.0e-2,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
 
@@ -103,17 +100,17 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_4_dsa_ortho_inf.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_4_dsa_ortho_inf.lua
@@ -4,50 +4,49 @@
 -- and   WGS groups [63-167] Iteration    59 Residual 4.73732e-07 CONVERGED
 num_procs = 1
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=1
-L=1e6
+nodes = {}
+N = 1
+L = 1e6
 --N=10
 --L=200e6
-xmin = -L/2
+xmin = -L / 2
 --xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
@@ -59,13 +58,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2, false)
 --pquad1 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 8, 8, false)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -77,7 +74,7 @@ lbs_block =
       wgdsa_l_abs_tol = 1.0e-2,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -89,11 +86,10 @@ lbs_block =
       apply_tgdsa = true,
       wgdsa_l_abs_tol = 1.0e-2,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
 
@@ -101,17 +97,17 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
@@ -5,11 +5,15 @@
 
 -- Check num_procs
 num_procs = 3
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 -- Setup mesh
@@ -17,8 +21,8 @@ N = 100
 L = 1.0
 nodes = {}
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = (i - 1) * L / N
+  k = i - 1
+  nodes[i] = (i - 1) * L / N
 end
 
 meshgen = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
@@ -30,43 +34,43 @@ num_groups = 1
 sigma_t = 1.0
 
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, sigma_t, 0.0)
 
 -- Setup Physics
 pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 128)
 lbs_block = {
-    num_groups = num_groups,
-    groupsets = {
-        {
-            groups_from_to = { 0, num_groups - 1 },
-            angular_quadrature_handle = pquad,
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 300,
-            gmres_restart_interval = 100,
-        }
-    }
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, num_groups - 1 },
+      angular_quadrature_handle = pquad,
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
 }
 
 bsrc = {}
 for g = 1, num_groups do
-    bsrc[g] = 0.0
+  bsrc[g] = 0.0
 end
 bsrc[1] = 1.0
 
 lbs_options = {
-    boundary_conditions = {
-        {
-            name = "zmin",
-            type = "isotropic",
-            group_strength = bsrc
-        }
+  boundary_conditions = {
+    {
+      name = "zmin",
+      type = "isotropic",
+      group_strength = bsrc,
     },
-    scattering_order = 0,
-    save_angular_flux =  true
+  },
+  scattering_order = 0,
+  save_angular_flux = true,
 }
 
 phys = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
@@ -81,5 +85,5 @@ solver.Execute(ss_solver)
 -- Compute the leakage
 leakage = lbs.ComputeLeakage(phys)
 for k, v in pairs(leakage) do
-    log.Log(LOG_0, string.format("%s=%.5e", k, v[1]))
+  log.Log(LOG_0, string.format("%s=%.5e", k, v[1]))
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -3,52 +3,50 @@
 -- Test: Max-value=0.50758 and 2.52527e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj",
     }),
   },
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0},
-  })
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
-
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -57,15 +55,13 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 1)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -75,7 +71,7 @@ lbs_block =
       gmres_restart_interval = 100,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -84,23 +80,21 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi
+bsrc[1] = 1.0 / 4.0 / math.pi
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "xmin",
       type = "isotropic",
-      group_strength = bsrc
-    }
+      group_strength = bsrc,
+    },
   },
   scattering_order = 1,
 }
@@ -109,36 +103,36 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
@@ -3,10 +3,6 @@
 -- Test: Max-value=0.50758 and 2.52527e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
 -- if (check_num_procs==nil and number_of_processes ~= num_procs) then
 --     log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
@@ -16,37 +12,46 @@ num_procs = 4
 -- end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=5
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 20
+L = 5
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
-vol1 = logvol.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
-
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
+vol1 = logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 0.0, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 1
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "tests/transport_steady/simple_scatter.xs")
-mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "tests/transport_steady/simple_scatter.xs")
+mat.SetProperty(
+  materials[1],
+  TRANSPORT_XSECTIONS,
+  OPENSN_XSFILE,
+  "tests/transport_steady/simple_scatter.xs"
+)
+mat.SetProperty(
+  materials[2],
+  TRANSPORT_XSECTIONS,
+  OPENSN_XSFILE,
+  "tests/transport_steady/simple_scatter.xs"
+)
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -54,17 +59,15 @@ src[1] = 1.0
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
-fac=1
-pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4*fac, 3*fac)
-aquad.OptimizeForPolarSymmetry(pquad, 4.0*math.pi)
+fac = 1
+pquad = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4 * fac, 3 * fac)
+aquad.OptimizeForPolarSymmetry(pquad, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 0},
+      groups_from_to = { 0, 0 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -73,23 +76,22 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi
+bsrc[1] = 1.0 / 4.0 / math.pi
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 0,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
@@ -97,12 +99,12 @@ solver.Execute(ss_solver)
 lbs.ComputeBalance(phys1)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 slice2 = fieldfunc.FFInterpolationCreate(SLICE)
-fieldfunc.SetProperty(slice2,SLICE_POINT,{x = 0.0, y = 0.0, z = 0.025})
-fieldfunc.SetProperty(slice2,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(slice2, SLICE_POINT, { x = 0.0, y = 0.0, z = 0.025 })
+fieldfunc.SetProperty(slice2, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(slice2)
 fieldfunc.Execute(slice2)
@@ -110,36 +112,36 @@ fieldfunc.Execute(slice2)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
   fieldfunc.ExportToPython(slice2)
-  ExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
+  ExportFieldFunctionToVTKG(fflist[1], "ZPhi3D", "Phi")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
+if location_id == 0 and master_export == nil then
   local handle = io.popen("python ZPFFI00.py")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
@@ -3,10 +3,6 @@
 -- Test: Max-value=0.50758 and 2.52527e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
 -- if (check_num_procs==nil and number_of_processes ~= num_procs) then
 --     log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
@@ -16,99 +12,94 @@ num_procs = 4
 -- end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=5.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-    k=i-1
-    nodes[i] = xmin + k*dx
+nodes = {}
+N = 20
+L = 5.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(SetMaterialIDFromLogicalVolumevol0,0)
-vol1 = logvol.RPPLogicalVolume.Create({xmin=-1000.0, xmax=0.0, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
-
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(SetMaterialIDFromLogicalVolumevol0, 0)
+vol1 = logvol.RPPLogicalVolume.Create({ xmin = -1000.0, xmax = 0.0, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
-    src[g] = 0.0
+src = {}
+for g = 1, num_groups do
+  src[g] = 0.0
 end
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 src[1] = 1.0
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
-fac=1
-pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4*fac, 3*fac)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+fac = 1
+pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4 * fac, 3 * fac)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
-    num_groups = num_groups,
-    groupsets =
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, 62},
-            angular_quadrature_handle = pquad0,
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-4,
-            l_max_its = 300,
-            gmres_restart_interval = 100,
-        },
-        {
-            groups_from_to = {63, num_groups-1},
-            angular_quadrature_handle = pquad0,
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 1,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-4,
-            l_max_its = 300,
-            gmres_restart_interval = 100,
-        },
-    }
-}
-bsrc={}
-for g=1,num_groups do
-    bsrc[g] = 0.0
-end
-bsrc[1] = 1.0/4.0/math.pi
-
-lbs_options =
-{
-    boundary_conditions =
-    {
-        {
-            name = "xmin",
-            type = "isotropic",
-            group_strength = bsrc
-        }
+      groups_from_to = { 0, 62 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-4,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
     },
-    scattering_order = 0,
+    {
+      groups_from_to = { 63, num_groups - 1 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-4,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+}
+bsrc = {}
+for g = 1, num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0 / 4.0 / math.pi
+
+lbs_options = {
+  boundary_conditions = {
+    {
+      name = "xmin",
+      type = "isotropic",
+      group_strength = bsrc,
+    },
+  },
+  scattering_order = 0,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
@@ -116,12 +107,12 @@ solver.Execute(ss_solver)
 lbs.ComputeBalance(phys1)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 slice2 = fieldfunc.FFInterpolationCreate(SLICE)
-fieldfunc.SetProperty(slice2,SLICE_POINT,{x = 0.0, y = 0.0, z = 0.025})
-fieldfunc.SetProperty(slice2,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(slice2, SLICE_POINT, { x = 0.0, y = 0.0, z = 0.025 })
+fieldfunc.SetProperty(slice2, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(slice2)
 fieldfunc.Execute(slice2)
@@ -129,36 +120,36 @@ fieldfunc.Execute(slice2)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-    fieldfunc.ExportToPython(slice2)
-    ExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
+  fieldfunc.ExportToPython(slice2)
+  ExportFieldFunctionToVTKG(fflist[1], "ZPhi3D", "Phi")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-    local handle = io.popen("python ZPFFI00.py")
+if location_id == 0 and master_export == nil then
+  local handle = io.popen("python ZPFFI00.py")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -4,51 +4,51 @@
 num_procs = 4
 --Unstructured mesh
 
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                       "Expected "..tostring(num_procs)..
-                       ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="../../../../resources/TestMeshes/TriangleMesh2x2Cuts.obj"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/TriangleMesh2x2Cuts.obj",
     }),
   },
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0},
-  })
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
-    src[g] = 0.0
+src = {}
+for g = 1, num_groups do
+  src[g] = 0.0
 end
 --src[1] = 1.0
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -56,88 +56,84 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 8, 4)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
-    num_groups = num_groups,
-    groupsets =
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
     {
-        {
-            groups_from_to = {0, 62},
-            angular_quadrature_handle = pquad0,
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 2,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 300,
-            gmres_restart_interval = 100,
-        },
-        {
-            groups_from_to = {63, num_groups-1},
-            angular_quadrature_handle = pquad0,
-            angle_aggregation_num_subsets = 1,
-            groupset_num_subsets = 2,
-            inner_linear_method = "gmres",
-            l_abs_tol = 1.0e-6,
-            l_max_its = 300,
-            gmres_restart_interval = 100,
-        },
-    }
-}
-bsrc={}
-for g=1,num_groups do
-    bsrc[g] = 0.0
-end
-bsrc[1] = 1.0/4.0/math.pi
-
-lbs_options =
-{
-    boundary_conditions =
-    {
-        {
-            name = "xmin",
-            type = "isotropic",
-            group_strength = bsrc
-        }
+      groups_from_to = { 0, 62 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 2,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
     },
-    scattering_order = 1,
+    {
+      groups_from_to = { 63, num_groups - 1 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 2,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+}
+bsrc = {}
+for g = 1, num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0 / 4.0 / math.pi
+
+lbs_options = {
+  boundary_conditions = {
+    {
+      name = "xmin",
+      type = "isotropic",
+      group_strength = bsrc,
+    },
+  },
+  scattering_order = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[10])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[10])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -3,51 +3,49 @@
 -- Test: Max-value=0.50758 and 2.52527e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename="../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj",
     }),
   },
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0},
-  })
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -56,15 +54,13 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 1)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -74,7 +70,7 @@ lbs_block =
       gmres_restart_interval = 100,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -83,23 +79,21 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi
+bsrc[1] = 1.0 / 4.0 / math.pi
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "xmin",
       type = "isotropic",
-      group_strength = bsrc
-    }
+      group_strength = bsrc,
+    },
   },
   scattering_order = 1,
 }
@@ -108,38 +102,38 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
@@ -4,53 +4,53 @@
 -- and   WGS groups [63-167] Iteration    59 Residual 5.96296e-07 CONVERGED
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=100
+nodes = {}
+N = 20
+L = 100
 --N=10
 --L=200e6
-xmin = -L/2
+xmin = -L / 2
 --xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
@@ -60,15 +60,13 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2, false)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -80,7 +78,7 @@ lbs_block =
       wgdsa_l_abs_tol = 1.0e-2,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -92,11 +90,10 @@ lbs_block =
       apply_tgdsa = true,
       wgdsa_l_abs_tol = 1.0e-2,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
 
@@ -104,17 +101,17 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
@@ -36,8 +36,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -10.0,
+  xmax = 10.0,
+  ymin = -10.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
@@ -36,8 +36,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -10.0,
+  xmax = 10.0,
+  ymin = -10.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
@@ -4,53 +4,53 @@
 -- and   WGS groups [63-167] Iteration    56 Residual 9.73954e-07 CONVERGED
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=100
+nodes = {}
+N = 20
+L = 100
 --N=10
 --L=200e6
-xmin = -L/2
+xmin = -L / 2
 --xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
@@ -60,15 +60,13 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2, false)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -80,7 +78,7 @@ lbs_block =
       wgdsa_l_abs_tol = 1.0e-2,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -92,15 +90,13 @@ lbs_block =
       apply_tgdsa = true,
       wgdsa_l_abs_tol = 1.0e-2,
     },
-  }
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions =
-  {
-   {name = "xmin",type = "reflecting"},
-   {name = "ymin",type = "reflecting"},
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "reflecting" },
+    { name = "ymin", type = "reflecting" },
   },
   scattering_order = 1,
 }
@@ -109,17 +105,17 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
@@ -3,43 +3,43 @@
 -- Test: Max-value1=3.18785
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=40
-L=10.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 40
+L = 10.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -47,15 +47,13 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 12, 2)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 0},
+      groups_from_to = { 0, 0 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -64,7 +62,7 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
 --int cell_global_id
@@ -79,48 +77,48 @@ lbs_block =
 --array<int>      group_indices
 
 --double          evaluation_time
-function luaBoundaryFunctionA(cell_global_id,
-                              material_id,
-                              location,
-                              normal,
-                              quadrature_angle_indices,
-                              quadrature_angle_vectors,
-                              quadrature_phi_theta_angles,
-                              group_indices,
-                              time)
-    num_angles = rawlen(quadrature_angle_vectors)
-    num_groups = rawlen(group_indices)
-    psi = {}
-    dof_count = 0
+function luaBoundaryFunctionA(
+  cell_global_id,
+  material_id,
+  location,
+  normal,
+  quadrature_angle_indices,
+  quadrature_angle_vectors,
+  quadrature_phi_theta_angles,
+  group_indices,
+  time
+)
+  num_angles = rawlen(quadrature_angle_vectors)
+  num_groups = rawlen(group_indices)
+  psi = {}
+  dof_count = 0
 
-    for ni=1,num_angles do
-        omega = quadrature_angle_vectors[ni]
-        phi_theta = quadrature_phi_theta_angles[ni]
-        for gi=1,num_groups do
-            g = group_indices[gi]
+  for ni = 1, num_angles do
+    omega = quadrature_angle_vectors[ni]
+    phi_theta = quadrature_phi_theta_angles[ni]
+    for gi = 1, num_groups do
+      g = group_indices[gi]
 
-            value = 1.0
-            if (location.y < 0.0 or omega.y < 0.0) then
-                value = 0.0
-            end
+      value = 1.0
+      if location.y < 0.0 or omega.y < 0.0 then
+        value = 0.0
+      end
 
-            dof_count = dof_count + 1
-            psi[dof_count] = value
-        end
+      dof_count = dof_count + 1
+      psi[dof_count] = value
     end
+  end
 
-    return psi
+  return psi
 end
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "xmin",
       type = "incident_anisotropic_heterogeneous",
-      function_name = "luaBoundaryFunctionA"
-    }
+      function_name = "luaBoundaryFunctionA",
+    },
   },
   scattering_order = 1,
 }
@@ -129,35 +127,35 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 slice2 = fieldfunc.FFInterpolationCreate(SLICE)
-fieldfunc.SetProperty(slice2,SLICE_POINT,{x = 0.0, y = 0.0, z = 0.025})
-fieldfunc.SetProperty(slice2,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(slice2, SLICE_POINT, { x = 0.0, y = 0.0, z = 0.025 })
+fieldfunc.SetProperty(slice2, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(slice2)
 fieldfunc.Execute(slice2)
 
 ----############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 ----############################################### Volume integrations
 --ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
@@ -178,6 +176,6 @@ if master_export == nil then
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
+if location_id == 0 and master_export == nil then
   local handle = io.popen("python ZPFFI00.py")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
@@ -3,72 +3,67 @@
 -- Test: Max-value=0.49903 and 7.18243e-4
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
 Nxy = 32
 nodesxy = {}
-dxy = 2/Nxy
-dz = 1.6/8
-for i=0,(Nxy) do
-  nodesxy[i+1] = -1.0 + i*dxy
+dxy = 2 / Nxy
+dz = 1.6 / 8
+for i = 0, Nxy do
+  nodesxy[i + 1] = -1.0 + i * dxy
 end
 nodesz = {}
-for k=0,8 do
-  nodesz[k+1] = 0.0 + k*dz
+for k = 0, 8 do
+  nodesz[k + 1] = 0.0 + k * dz
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodesxy,nodesxy,nodesz} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodesxy, nodesxy, nodesz } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
-
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
-
-
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -78,17 +73,17 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "zmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "zmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
 }
 
@@ -96,13 +91,13 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -121,36 +116,35 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -36,8 +36,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create({ xmin = -0.5 / 8, xmax = 0.5 / 8, ymin = -0.5 / 8, ymax = 0.5
-  / 8, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -0.5 / 8,
+  xmax = 0.5 / 8,
+  ymin = -0.5 / 8,
+  ymax = 0.5 / 8,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -3,56 +3,54 @@
 -- Test: Max-value=1.08320e-01 and 0.0
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5/8,xmax=0.5/8,ymin=-0.5/8,ymax=0.5/8, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 = logvol.RPPLogicalVolume.Create({ xmin = -0.5 / 8, xmax = 0.5 / 8, ymin = -0.5 / 8, ymax = 0.5
+  / 8, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
@@ -63,13 +61,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       --angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -79,11 +75,10 @@ lbs_block =
       l_max_its = 1,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
 
@@ -91,15 +86,15 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
-lbs.CreateAndWriteSourceMoments(phys1,"Qmoms")
+lbs.CreateAndWriteSourceMoments(phys1, "Qmoms")
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -118,36 +113,35 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -3,56 +3,54 @@
 -- Test: Max-value=1.01701e-04 and 9.14681e-06
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5/8,xmax=0.5/8,ymin=-0.5/8,ymax=0.5/8, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 = logvol.RPPLogicalVolume.Create({ xmin = -0.5 / 8, xmax = 0.5 / 8, ymin = -0.5 / 8, ymax = 0.5
+  / 8, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
@@ -63,13 +61,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       --angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -79,11 +75,10 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
   use_source_moments = true,
 }
@@ -92,14 +87,14 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 solver.Initialize(ss_solver)
-lbs.ReadSourceMoments(phys1,"Qmoms")
+lbs.ReadSourceMoments(phys1, "Qmoms")
 
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -118,42 +113,41 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi3DColl")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi3DColl")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")
   print("Execution completed")
 end
 MPIBarrier()
-if (location_id == 0) then
+if location_id == 0 then
   os.execute("rm Qmoms*")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -36,8 +36,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create({ xmin = -0.5 / 8, xmax = 0.5 / 8, ymin = -0.5 / 8, ymax = 0.5
-  / 8, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -0.5 / 8,
+  xmax = 0.5 / 8,
+  ymin = -0.5 / 8,
+  ymax = 0.5 / 8,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
@@ -3,84 +3,74 @@
 -- Test: Max-value=0.49903 and 7.18243e-4
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
 Nxy = 32
 nodesxy = {}
-dxy = 2/Nxy
-dz = 1.6/8
-for i=0,(Nxy) do
-  nodesxy[i+1] = -1.0 + i*dxy
+dxy = 2 / Nxy
+dz = 1.6 / 8
+for i = 0, Nxy do
+  nodesxy[i + 1] = -1.0 + i * dxy
 end
 nodesz = {}
-for k=0,8 do
-  nodesz[k+1] = 0.0 + k*dz
+for k = 0, 8 do
+  nodesz[k + 1] = 0.0 + k * dz
 end
 
-meshgen = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.OrthogonalMeshGenerator.Create
-    ({
-      node_sets = {nodesxy, nodesxy, nodesz}
+meshgen = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.OrthogonalMeshGenerator.Create({
+      node_sets = { nodesxy, nodesxy, nodesz },
     }),
   },
-  partitioner = mesh.PETScGraphPartitioner.Create({type="ptscotch"})
+  partitioner = mesh.PETScGraphPartitioner.Create({ type = "ptscotch" }),
 })
 mesh.MeshGenerator.Execute(meshgen)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
-
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
-mat.SetProperty(materials[1],TRANSPORT_XSECTIONS,
-  OPENSN_XSFILE,"xs_graphite_pure.xs")
-mat.SetProperty(materials[2],TRANSPORT_XSECTIONS,
-  OPENSN_XSFILE,"xs_graphite_pure.xs")
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
+mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
-mat.SetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
-mat.SetProperty(materials[2],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
-
-
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
-pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
+pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -90,17 +80,17 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "zmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "zmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
 }
 
@@ -108,35 +98,35 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
@@ -3,56 +3,55 @@
 -- Test: Max-value=5.27450e-01 and 3.76339e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2Quads.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
@@ -62,13 +61,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -77,17 +74,17 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
-    bsrc[g] = 0.0
+bsrc = {}
+for g = 1, num_groups do
+  bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "zmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "zmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
 }
 
@@ -95,13 +92,13 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -120,36 +117,35 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
@@ -2,55 +2,58 @@
 -- SDM: PWLD
 -- Test: Max-value=5.28310e-01 and 8.04576e-04
 num_procs = 4
-if (reflecting == nil) then reflecting = true end
-
-
-
+if reflecting == nil then
+  reflecting = true
+end
 
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=10
-L=5.0
-xmin = -L/2
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+nodes = {}
+N = 10
+L = 5.0
+xmin = -L / 2
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-znodes={}
-for i=1,(N/2+1) do
-  k=i-1
-  znodes[i] = xmin + k*dx
+znodes = {}
+for i = 1, (N / 2 + 1) do
+  k = i - 1
+  znodes[i] = xmin + k * dx
 end
 
-if (reflecting) then
-  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,znodes} })
+if reflecting then
+  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, znodes } })
 else
-  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,nodes} })
+  meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, nodes } })
 end
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -58,13 +61,11 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -74,35 +75,34 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
 }
-if (reflecting) then
-  table.insert(lbs_options.boundary_conditions,
-    {name = "zmin", type = "reflecting"})
+if reflecting then
+  table.insert(lbs_options.boundary_conditions, { name = "zmin", type = "reflecting" })
 end
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -121,40 +121,39 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  if (reflecting) then
-    fieldfunc.ExportToVTKMulti(fflist,"ZPhi3DReflected")
+if master_export == nil then
+  if reflecting then
+    fieldfunc.ExportToVTKMulti(fflist, "ZPhi3DReflected")
   else
-    fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
+    fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
   end
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
@@ -3,57 +3,54 @@
 -- Test: Max-value=5.41465e-01 and 3.78243e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/TriangleMesh2x2Cuts.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/TriangleMesh2x2Cuts.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
-
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
@@ -63,13 +60,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       --angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -79,17 +74,17 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "zmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "zmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
   save_angular_flux = true,
 }
@@ -98,13 +93,13 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -123,36 +118,35 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_restart.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_restart.lua
@@ -98,7 +98,7 @@ lbs_options = {
   save_angular_flux = true,
   --write_restart_time_interval = 60,
   --write_restart_path = "transport_3d_2_unstructured_restart/transport_3d_2_unstructured",
-  read_restart_path = "transport_3d_2_unstructured_restart/transport_3d_2_unstructured"
+  read_restart_path = "transport_3d_2_unstructured_restart/transport_3d_2_unstructured",
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
@@ -37,8 +37,13 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 =
-  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+vol1 = logvol.RPPLogicalVolume.Create({
+  xmin = -10.0,
+  xmax = 10.0,
+  ymin = -10.0,
+  ymax = 10.0,
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
@@ -4,54 +4,54 @@
 -- and   WGS groups [63-167] Iteration    63 Residual 8.1975e-07 CONVERGED
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=20
-L=100.0
+nodes = {}
+N = 20
+L = 100.0
 --N=10
 --L=200e6
-xmin = -L/2
+xmin = -L / 2
 --xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
-znodes = {0.0,10.0,20.0,30.0,40.0}
+znodes = { 0.0, 10.0, 20.0, 30.0, 40.0 }
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes,nodes,znodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes, znodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-10.0,xmax=10.0,ymin=-10.0,ymax=10.0, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -10.0, xmax = 10.0, ymin = -10.0, ymax = 10.0, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 src[1] = 1.0
@@ -62,13 +62,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -80,7 +78,7 @@ lbs_block =
       wgdsa_l_abs_tol = 1.0e-2,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 1,
@@ -92,11 +90,10 @@ lbs_block =
       apply_tgdsa = true,
       wgdsa_l_abs_tol = 1.0e-2,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 1,
 }
 
@@ -104,17 +101,17 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
@@ -3,56 +3,55 @@
 -- Test: Max-value=3.74343e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.ExtruderMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/Square2x2_partition_cyclic3.obj"
+meshgen1 = mesh.ExtruderMeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/Square2x2_partition_cyclic3.obj",
     }),
   },
-  layers = {{z=0.4,n=2},{z=0.8,n=2},{z=1.2,n=2},{z=1.6,n=2}}, -- layers
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  layers = { { z = 0.4, n = 2 }, { z = 0.8, n = 2 }, { z = 1.2, n = 2 }, { z = 1.6, n = 2 } }, -- layers
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
-vol1 = logvol.RPPLogicalVolume.Create
-({ xmin=-0.5,xmax=0.5,ymin=-0.5,ymax=0.5, infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol1,1)
+vol1 =
+  logvol.RPPLogicalVolume.Create({ xmin = -0.5, xmax = 0.5, ymin = -0.5, ymax = 0.5, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol1, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
@@ -62,13 +61,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       --angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -78,35 +75,34 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 30,
     },
-  }
+  },
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "zmax", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "zmax", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
 }
-if (reflecting) then
-  table.insert(lbs_options.boundary_conditions,
-    {name = "zmax", type = "reflecting"})
+if reflecting then
+  table.insert(lbs_options.boundary_conditions, { name = "zmax", type = "reflecting" })
 end
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -125,47 +121,46 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[20])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[20])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  ExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
+if master_export == nil then
+  ExportFieldFunctionToVTKG(fflist[1], "ZPhi3D", "Phi")
 
   line = fieldfunc.FFInterpolationCreate(LINE)
-  fieldfunc.SetProperty(line,LINE_FIRSTPOINT,{0.0,-1.0,0.5})
-  fieldfunc.SetProperty(line,LINE_SECONDPOINT,{0.0, 1.0,0.5})
-  fieldfunc.SetProperty(line,LINE_NUMBEROFPOINTS,1000)
-  fieldfunc.SetProperty(line,ADD_FIELDFUNCTION,fflist[2])
+  fieldfunc.SetProperty(line, LINE_FIRSTPOINT, { 0.0, -1.0, 0.5 })
+  fieldfunc.SetProperty(line, LINE_SECONDPOINT, { 0.0, 1.0, 0.5 })
+  fieldfunc.SetProperty(line, LINE_NUMBEROFPOINTS, 1000)
+  fieldfunc.SetProperty(line, ADD_FIELDFUNCTION, fflist[2])
 
   fieldfunc.Initialize(line)
   fieldfunc.Execute(line)
 
-  fieldfunc.ExportToCSV(line,"Line")
+  fieldfunc.ExportToCSV(line, "Line")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
-
+if location_id == 0 and master_export == nil then
   --os.execute("python ZPFFI00.py")
   ----os.execute("python ZPFFI11.py")
   --local handle = io.popen("python ZPFFI00.py")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
@@ -5,64 +5,61 @@
 
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/Sphere.case"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/Sphere.case",
     }),
   },
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2, nz=1,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    nz = 1,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 5
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
-src[1]=1.0
+src[1] = 1.0
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 2)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, num_groups-1},
+      groups_from_to = { 0, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "single",
       angle_aggregation_num_subsets = 1,
@@ -72,11 +69,10 @@ lbs_block =
       l_max_its = 300,
       gmres_restart_interval = 100,
     },
-  }
+  },
 }
 
-lbs_options =
-{
+lbs_options = {
   scattering_order = 0,
 }
 
@@ -84,13 +80,13 @@ phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Slice plot
 --slices = {}
@@ -107,38 +103,38 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --end
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5e", maxval))
 
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[2])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[2])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi3D")
-  fieldfunc.ExportToVTK(fflist[1],"ZPhi3D_g0")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi3D")
+  fieldfunc.ExportToVTK(fflist[1], "ZPhi3D_g0")
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
+if location_id == 0 and master_export == nil then
   print("Execution completed")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
@@ -5,23 +5,23 @@
 
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 -- Cells
 div = 8
-Nx = math.floor(128/div)
-Ny = math.floor(128/div)
-Nz = math.floor(256/div)
+Nx = math.floor(128 / div)
+Ny = math.floor(128 / div)
+Nz = math.floor(256 / div)
 
 -- Dimensions
 Lx = 10.0
@@ -30,33 +30,31 @@ Lz = 10.0
 
 xmesh = {}
 xmin = 0.0
-dx = Lx/Nx
-for i = 1, (Nx+1) do
-  k = i-1
-  xmesh[i] = xmin + k*dx
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
 end
 
 ymesh = {}
 ymin = 0.0
-dy = Ly/Ny
-for i = 1, (Ny+1) do
-  k = i-1
-  ymesh[i] = ymin + k*dy
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
 end
 
 zmesh = {}
 zmin = 0.0
-dz = Lz/Nz
-for i = 1, (Nz+1) do
-  k = i-1
-  zmesh[i] = zmin + k*dz
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
 end
 
-meshgen1 = mesh.SplitFileMeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh,zmesh} })
+meshgen1 = mesh.SplitFileMeshGenerator.Create({
+  inputs = {
+    mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh, zmesh } }),
   },
 })
 
@@ -66,13 +64,13 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 num_groups = 21
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE,"xs_graphite_pure.xs")
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -80,13 +78,11 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 4)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "polar",
       angle_aggregation_num_subsets = 1,
@@ -99,49 +95,47 @@ lbs_block =
   },
   sweep_type = "CBC",
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
-  save_angular_flux = true
+  save_angular_flux = true,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
-pp1 = post.CellVolumeIntegralPostProcessor.Create
-({
-  name="max-grp0",
+pp1 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp0",
   field_function = fflist[1],
   compute_volume_average = true,
-  print_numeric_format = "scientific"
+  print_numeric_format = "scientific",
 })
-pp2 = post.CellVolumeIntegralPostProcessor.Create
-({
-  name="max-grp19",
+pp2 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp19",
   field_function = fflist[20],
   compute_volume_average = true,
-  print_numeric_format = "scientific"
+  print_numeric_format = "scientific",
 })
 post.Execute({ pp1, pp2 })
 
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end
 
 log.PrintTimingGraph()

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
@@ -5,23 +5,23 @@
 
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 -- Cells
 div = 8
-Nx = math.floor(128/div)
-Ny = math.floor(128/div)
-Nz = math.floor(256/div)
+Nx = math.floor(128 / div)
+Ny = math.floor(128 / div)
+Nz = math.floor(256 / div)
 
 -- Dimensions
 Lx = 10.0
@@ -30,37 +30,35 @@ Lz = 10.0
 
 xmesh = {}
 xmin = 0.0
-dx = Lx/Nx
-for i = 1, (Nx+1) do
-  k = i-1
-  xmesh[i] = xmin + k*dx
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
 end
 
 ymesh = {}
 ymin = 0.0
-dy = Ly/Ny
-for i = 1, (Ny+1) do
-  k = i-1
-  ymesh[i] = ymin + k*dy
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
 end
 
 zmesh = {}
 zmin = 0.0
-dz = Lz/Nz
-for i = 1, (Nz+1) do
-  k = i-1
-  zmesh[i] = zmin + k*dz
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
 end
 
-meshgen1 = mesh.SplitFileMeshGenerator.Create
-({
+meshgen1 = mesh.SplitFileMeshGenerator.Create({
   inputs = {
-    mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh} }),
-    mesh.ExtruderMeshGenerator.Create
-    ({
-      layers = {{z=Lz, n=Nz}}
-    })
-  }
+    mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh } }),
+    mesh.ExtruderMeshGenerator.Create({
+      layers = { { z = Lz, n = Nz } },
+    }),
+  },
 })
 
 mesh.MeshGenerator.Execute(meshgen1)
@@ -69,13 +67,13 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -83,13 +81,11 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 4)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 20},
+      groups_from_to = { 0, 20 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "polar",
       angle_aggregation_num_subsets = 1,
@@ -102,47 +98,45 @@ lbs_block =
   },
   sweep_type = "CBC",
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi;
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "isotropic",
-                            group_strength=bsrc}},
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "isotropic", group_strength = bsrc },
+  },
   scattering_order = 1,
-  save_angular_flux = true
+  save_angular_flux = true,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
-pp1 = post.CellVolumeIntegralPostProcessor.Create
-({
-  name="max-grp0",
+pp1 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp0",
   field_function = fflist[1],
   compute_volume_average = true,
-  print_numeric_format = "scientific"
+  print_numeric_format = "scientific",
 })
-pp2 = post.CellVolumeIntegralPostProcessor.Create
-({
-  name="max-grp19",
+pp2 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp19",
   field_function = fflist[20],
   compute_volume_average = true,
-  print_numeric_format = "scientific"
+  print_numeric_format = "scientific",
 })
 post.Execute({ pp1, pp2 })
 
-if (master_export == nil) then
-  fieldfunc.ExportToVTKMulti(fflist,"ZPhi")
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
@@ -3,30 +3,30 @@
 -- Test: Max-value=0.49903 and 7.18243e-4
 num_procs = 3
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-nodes={}
-N=100
-L=30.0
+nodes = {}
+N = 100
+L = 30.0
 xmin = 0.0
-dx = L/N
-for i=1,(N+1) do
-  k=i-1
-  nodes[i] = xmin + k*dx
+dx = L / N
+for i = 1, (N + 1) do
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
@@ -34,15 +34,15 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -51,13 +51,11 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE, 40)
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 8,
@@ -67,7 +65,7 @@ lbs_block =
       gmres_restart_interval = 100,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 8,
@@ -77,87 +75,85 @@ lbs_block =
       gmres_restart_interval = 100,
     },
   },
-  sweep_type = "CBC"
+  sweep_type = "CBC",
 }
 
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/2
+bsrc[1] = 1.0 / 2
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "zmin",
       type = "isotropic",
-      group_strength = bsrc
-    }
+      group_strength = bsrc,
+    },
   },
   scattering_order = 5,
-  save_angular_flux = true
+  save_angular_flux = true,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Line plot
 --Testing consolidated interpolation
 cline = fieldfunc.FFInterpolationCreate(LINE)
-fieldfunc.SetProperty(cline,LINE_FIRSTPOINT,{x = 0.0, y = 0.0, z = 0.0001+xmin})
-fieldfunc.SetProperty(cline,LINE_SECONDPOINT,{x = 0.0, y = 0.0, z = 29.999+xmin})
-fieldfunc.SetProperty(cline,LINE_NUMBEROFPOINTS, 50)
+fieldfunc.SetProperty(cline, LINE_FIRSTPOINT, { x = 0.0, y = 0.0, z = 0.0001 + xmin })
+fieldfunc.SetProperty(cline, LINE_SECONDPOINT, { x = 0.0, y = 0.0, z = 29.999 + xmin })
+fieldfunc.SetProperty(cline, LINE_NUMBEROFPOINTS, 50)
 
-for k=165,165 do
-  fieldfunc.SetProperty(cline,ADD_FIELDFUNCTION,fflist[k])
+for k = 165, 165 do
+  fieldfunc.SetProperty(cline, ADD_FIELDFUNCTION, fflist[k])
 end
 
 fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 --############################################### Volume integrations
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 ffi2 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi2
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
-if (master_export == nil) then
+if master_export == nil then
   fieldfunc.ExportToCSV(cline)
 end
 
 --############################################### Plots
-if (location_id == 0 and master_export == nil) then
+if location_id == 0 and master_export == nil then
   local handle = io.popen("python3 ZLFFI00.py")
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -3,52 +3,49 @@
 -- Test: Max-value=0.50758 and 2.52527e-04
 num_procs = 4
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-  log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-    "Expected "..tostring(num_procs)..
-    ". Pass check_num_procs=false to override if possible.")
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
   os.exit(false)
 end
 
 --############################################### Setup mesh
-meshgen1 = mesh.MeshGenerator.Create
-({
-  inputs =
-  {
-    mesh.FromFileMeshGenerator.Create
-    ({
-      filename = "../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj"
+meshgen1 = mesh.MeshGenerator.Create({
+  inputs = {
+    mesh.FromFileMeshGenerator.Create({
+      filename = "../../../../resources/TestMeshes/SquareMesh2x2QuadsBlock.obj",
     }),
   },
-  partitioner = mesh.KBAGraphPartitioner.Create
-  ({
-    nx = 2, ny=2,
-    xcuts = {0.0}, ycuts = {0.0}
-  })
+  partitioner = mesh.KBAGraphPartitioner.Create({
+    nx = 2,
+    ny = 2,
+    xcuts = { 0.0 },
+    ycuts = { 0.0 },
+  }),
 })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create({infx=true, infy=true, infz=true})
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
-
+vol0 = logvol.RPPLogicalVolume.Create({ infx = true, infy = true, infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 
-src={}
-for g=1,num_groups do
+src = {}
+for g = 1, num_groups do
   src[g] = 0.0
 end
 --src[1] = 1.0
@@ -57,15 +54,13 @@ mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 1)
-aquad.OptimizeForPolarSymmetry(pquad0, 4.0*math.pi)
+aquad.OptimizeForPolarSymmetry(pquad0, 4.0 * math.pi)
 
-lbs_block =
-{
+lbs_block = {
   num_groups = num_groups,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, 62},
+      groups_from_to = { 0, 62 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -75,7 +70,7 @@ lbs_block =
       gmres_restart_interval = 100,
     },
     {
-      groups_from_to = {63, num_groups-1},
+      groups_from_to = { 63, num_groups - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_num_subsets = 1,
       groupset_num_subsets = 2,
@@ -85,62 +80,60 @@ lbs_block =
       gmres_restart_interval = 100,
     },
   },
-  sweep_type = "CBC"
+  sweep_type = "CBC",
 }
-bsrc={}
-for g=1,num_groups do
+bsrc = {}
+for g = 1, num_groups do
   bsrc[g] = 0.0
 end
-bsrc[1] = 1.0/4.0/math.pi
+bsrc[1] = 1.0 / 4.0 / math.pi
 
-lbs_options =
-{
-  boundary_conditions =
-  {
+lbs_options = {
+  boundary_conditions = {
     {
       name = "xmin",
       type = "isotropic",
-      group_strength = bsrc
-    }
+      group_strength = bsrc,
+    },
   },
   scattering_order = 1,
-  save_angular_flux = true
+  save_angular_flux = true,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
 
 --############################################### Get field functions
-fflist,count = lbs.GetScalarFieldFunctionList(phys1)
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[1])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-value1=%.5f", maxval))
 
 --############################################### Volume integrations
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[160])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[160])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
+log.Log(LOG_0, string.format("Max-value2=%.5e", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
@@ -34,8 +34,13 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 =
-  logvol.RPPLogicalVolume.Create({ xmin = 0.0, xmax = length[1], ymin = 0.0, ymax = length[2], infz = true })
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = 0.0,
+  xmax = length[1],
+  ymin = 0.0,
+  ymax = length[2],
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
@@ -5,37 +5,38 @@
 num_procs = 4
 --Structured mesh
 
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                      "Expected "..tostring(num_procs)..
-                      ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
 dim = 2
-length = {1.0, 2.0, }
-ncells = {50, 100, }
+length = { 1.0, 2.0 }
+ncells = { 50, 100 }
 nodes = {}
 for d = 1, dim do
-  delta = length[d]/ncells[d]
+  delta = length[d] / ncells[d]
   nodes[d] = {}
   for i = 0, ncells[d] do
-    nodes[d][i+1] = i*delta
+    nodes[d][i + 1] = i * delta
   end
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes[1],nodes[2]} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2] } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create
-({ xmin=0.0,xmax=length[1],ymin=0.0,ymax=length[2], infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 =
+  logvol.RPPLogicalVolume.Create({ xmin = 0.0, xmax = length[1], ymin = 0.0, ymax = length[2], infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials
 ngrp = 1
@@ -43,44 +44,40 @@ sigmat = 25.0
 ratioc = 0.1
 source = sigmat * (1 - ratioc)
 
-material0 = mat.AddMaterial("Material_0");
+material0 = mat.AddMaterial("Material_0")
 mat.SetProperty(material0, TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, sigmat, ratioc)
 mat.SetProperty(material0, ISOTROPIC_MG_SOURCE, SINGLE_VALUE, source)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateCylindricalProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 8)
 
-lbs_block =
-{
+lbs_block = {
   coord_system = 2,
   num_groups = ngrp,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, ngrp-1},
+      groups_from_to = { 0, ngrp - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "azimuthal",
       inner_linear_method = "gmres",
       l_max_its = 100,
       l_abs_tol = 1.0e-12,
-    }
-  }
+    },
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "reflecting"} },
+lbs_options = {
+  boundary_conditions = { { name = "xmin", type = "reflecting" } },
   scattering_order = 0,
 }
 phys1 = lbs.DiscreteOrdinatesCurvilinearSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
-
 
 --phys0 = LBSCurvilinearCreateSolver(LBSCurvilinear.CYLINDRICAL)
 --

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
@@ -34,8 +34,13 @@ meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 =
-  logvol.RPPLogicalVolume.Create({ xmin = 0.0, xmax = length[1], ymin = 0.0, ymax = length[2], infz = true })
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = 0.0,
+  xmax = length[1],
+  ymin = 0.0,
+  ymax = length[2],
+  infz = true,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
@@ -5,63 +5,62 @@
 num_procs = 4
 --Structured mesh
 
-
-
-
 --############################################### Check num_procs
-if (check_num_procs==nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR,"Incorrect amount of processors. " ..
-                      "Expected "..tostring(num_procs)..
-                      ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
 dim = 2
-length = {1.0, 2.0, }
-ncells = {50, 100, }
+length = { 1.0, 2.0 }
+ncells = { 50, 100 }
 nodes = {}
 for d = 1, dim do
-  delta = length[d]/ncells[d]
+  delta = length[d] / ncells[d]
   nodes[d] = {}
   for i = 0, ncells[d] do
-    nodes[d][i+1] = i*delta
+    nodes[d][i + 1] = i * delta
   end
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = {nodes[1],nodes[2]} })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2] } })
 mesh.MeshGenerator.Execute(meshgen1)
 
 --############################################### Set Material IDs
-vol0 = logvol.RPPLogicalVolume.Create
-({ xmin=0.0,xmax=length[1],ymin=0.0,ymax=length[2], infz=true })
-mesh.SetMaterialIDFromLogicalVolume(vol0,0)
+vol0 =
+  logvol.RPPLogicalVolume.Create({ xmin = 0.0, xmax = length[1], ymin = 0.0, ymax = length[2], infz = true })
+mesh.SetMaterialIDFromLogicalVolume(vol0, 0)
 
 --############################################### Add materials
 ngrp = 2
 sigmat = 20.0
 ratioc = 0.4
 source = {}
-source[1] = sigmat * (1 - 0.5*ratioc)
+source[1] = sigmat * (1 - 0.5 * ratioc)
 for g = 2, ngrp do
   source[g] = 0
 end
 
-material0 = mat.AddMaterial("Material_0");
+material0 = mat.AddMaterial("Material_0")
 mat.SetProperty(material0, TRANSPORT_XSECTIONS, OPENSN_XSFILE, "transport_2d_cyl_2_multigroup.xs")
 mat.SetProperty(material0, ISOTROPIC_MG_SOURCE, FROM_ARRAY, source)
 
 --############################################### Setup Physics
 pquad0 = aquad.CreateCylindricalProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 4, 8)
 
-lbs_block =
-{
+lbs_block = {
   coord_system = 2,
   num_groups = ngrp,
-  groupsets =
-  {
+  groupsets = {
     {
-      groups_from_to = {0, ngrp-1},
+      groups_from_to = { 0, ngrp - 1 },
       angular_quadrature_handle = pquad0,
       angle_aggregation_type = "azimuthal",
       inner_linear_method = "gmres",
@@ -69,14 +68,13 @@ lbs_block =
       l_abs_tol = 1.0e-12,
       apply_wgdsa = true,
       wgdsa_l_abs_tol = 1.0e-9,
-      wgdsa_l_max_its = 50
-    }
-  }
+      wgdsa_l_max_its = 50,
+    },
+  },
 }
 
-lbs_options =
-{
-  boundary_conditions = { { name = "xmin", type = "reflecting"} },
+lbs_options = {
+  boundary_conditions = { { name = "xmin", type = "reflecting" } },
   scattering_order = 0,
 }
 
@@ -84,7 +82,7 @@ phys1 = lbs.DiscreteOrdinatesCurvilinearSolver.Create(lbs_block)
 lbs.SetOptions(phys1, lbs_options)
 
 --############################################### Initialize and Execute Solver
-ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
 
 solver.Initialize(ss_solver)
 solver.Execute(ss_solver)
@@ -106,17 +104,17 @@ fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-valueG1=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-valueG1=%.5f", maxval))
 
 --  volume integrations - energy group 2
 ffi1 = fieldfunc.FFInterpolationCreate(VOLUME)
 curffi = ffi1
-fieldfunc.SetProperty(curffi,OPERATION,OP_MAX)
-fieldfunc.SetProperty(curffi,LOGICAL_VOLUME,vol0)
-fieldfunc.SetProperty(curffi,ADD_FIELDFUNCTION,fflist[2])
+fieldfunc.SetProperty(curffi, OPERATION, OP_MAX)
+fieldfunc.SetProperty(curffi, LOGICAL_VOLUME, vol0)
+fieldfunc.SetProperty(curffi, ADD_FIELDFUNCTION, fflist[2])
 
 fieldfunc.Initialize(curffi)
 fieldfunc.Execute(curffi)
 maxval = fieldfunc.GetValue(curffi)
 
-log.Log(LOG_0,string.format("Max-valueG2=%.5f", maxval))
+log.Log(LOG_0, string.format("Max-valueG2=%.5f", maxval))

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
@@ -3,16 +3,16 @@
 -- Test:
 num_procs = 2
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
@@ -22,8 +22,8 @@ L = 100.0
 xmin = 0.0
 dx = L / N
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = xmin + k * dx
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
 meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
@@ -34,8 +34,8 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
-materials[2] = mat.AddMaterial("Test Material2");
+materials[1] = mat.AddMaterial("Test Material")
+materials[2] = mat.AddMaterial("Test Material2")
 
 -- Define microscopic cross sections
 micro_xs = xs.Create()
@@ -52,7 +52,7 @@ mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, macro_xs)
 
 src = {}
 for g = 1, num_groups do
-    src[g] = 0.0
+  src[g] = 0.0
 end
 --src[1] = 1.0
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
@@ -64,7 +64,7 @@ phys1 = LBSCreateTransientSolver()
 --========== Groups
 grp = {}
 for g = 1, num_groups do
-    grp[g] = LBSCreateGroup(phys1)
+  grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
@@ -105,7 +105,6 @@ LBSSetProperty(phys1, USE_PRECURSORS, true)
 LBSSetProperty(phys1, VERBOSE_INNER_ITERATIONS, false)
 LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 
-
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
@@ -113,7 +112,7 @@ LBTSSetProperty(phys1, "TIMESTEP", 1e-1)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
-phys1name = solver.GetName(phys1);
+phys1name = solver.GetName(phys1)
 
 --for k=1,2 do
 --    --LBTSSetProperty(phys1, "INHIBIT_ADVANCE", true)
@@ -129,14 +128,24 @@ phys1name = solver.GetName(phys1);
 time = 0.0
 time_stop = 20.0
 k = 0
-while (time < time_stop) do
-    k = k + 1
-    solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1, "NEW")
-    FRi = lbs.ComputeFissionRate(phys1, "OLD")
-    dt = LBTSGetProperty(phys1, "TIMESTEP")
-    time = LBTSGetProperty(phys1, "TIME")
-    period = dt / math.log(FRf / FRi)
-    log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                                 phys1name, k, time, dt, period, FRf))
+while time < time_stop do
+  k = k + 1
+  solver.Step(phys1)
+  FRf = lbs.ComputeFissionRate(phys1, "NEW")
+  FRi = lbs.ComputeFissionRate(phys1, "OLD")
+  dt = LBTSGetProperty(phys1, "TIMESTEP")
+  time = LBTSGetProperty(phys1, "TIME")
+  period = dt / math.log(FRf / FRi)
+  log.Log(
+    LOG_0,
+    string.format(
+      "%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+      phys1name,
+      k,
+      time,
+      dt,
+      period,
+      FRf
+    )
+  )
 end

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
@@ -3,16 +3,16 @@
 -- Test:
 num_procs = 2
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
@@ -22,8 +22,8 @@ L = 100.0
 xmin = 0.0
 dx = L / N
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = xmin + k * dx
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
 meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
@@ -34,7 +34,7 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 -- Define microscopic cross sections
 xs_critical = xs.Create()
@@ -48,8 +48,8 @@ mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_critical)
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
-    mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
-    lbs.InitializeMaterials(solver_handle)
+  mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
+  lbs.InitializeMaterials(solver_handle)
 end
 
 --############################################### Setup Physics
@@ -58,7 +58,7 @@ phys1 = LBSCreateTransientSolver()
 --========== Groups
 grp = {}
 for g = 1, num_groups do
-    grp[g] = LBSCreateGroup(phys1)
+  grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
@@ -85,8 +85,8 @@ LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --    bsrc[g] = 0.0
 --end
 --bsrc[1] = 1.0/2
-LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMIN, LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMAX, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMIN, LBSBoundaryTypes.REFLECTING)
+LBSSetProperty(phys1, BOUNDARY_CONDITION, ZMAX, LBSBoundaryTypes.REFLECTING)
 --
 LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
 LBSSetProperty(phys1, SCATTERING_ORDER, 1)
@@ -100,7 +100,6 @@ LBSSetProperty(phys1, USE_PRECURSORS, true)
 LBSSetProperty(phys1, VERBOSE_INNER_ITERATIONS, false)
 LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 
-
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
@@ -108,7 +107,7 @@ LBTSSetProperty(phys1, "TIMESTEP", 1e-3)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
-phys1name = solver.GetName(phys1);
+phys1name = solver.GetName(phys1)
 initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
@@ -128,20 +127,30 @@ time = 0.0
 time_stop = 1.0
 k = 0
 swapped = false
-while (time < time_stop) do
-    k = k + 1
-    solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1, "NEW")
-    FRi = lbs.ComputeFissionRate(phys1, "OLD")
-    dt = LBTSGetProperty(phys1, "TIMESTEP")
-    time = LBTSGetProperty(phys1, "TIME")
-    period = dt / math.log(FRf / FRi)
-    log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                                 phys1name, k, time, dt, period, FRf / initial_FR))
-    if (time >= 0.2 and not swapped) then
-        SwapXS(phys1, xs_21cent)
-        swapped = true
-    end
+while time < time_stop do
+  k = k + 1
+  solver.Step(phys1)
+  FRf = lbs.ComputeFissionRate(phys1, "NEW")
+  FRi = lbs.ComputeFissionRate(phys1, "OLD")
+  dt = LBTSGetProperty(phys1, "TIMESTEP")
+  time = LBTSGetProperty(phys1, "TIME")
+  period = dt / math.log(FRf / FRi)
+  log.Log(
+    LOG_0,
+    string.format(
+      "%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+      phys1name,
+      k,
+      time,
+      dt,
+      period,
+      FRf / initial_FR
+    )
+  )
+  if time >= 0.2 and not swapped then
+    SwapXS(phys1, xs_21cent)
+    swapped = true
+  end
 
-    LBTSAdvanceTimeData(phys1)
+  LBTSAdvanceTimeData(phys1)
 end

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
@@ -3,16 +3,16 @@
 -- Test:
 num_procs = 2
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
@@ -22,8 +22,8 @@ L = 100.0
 xmin = -L / 2
 dx = L / N
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = xmin + k * dx
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
 meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes } })
@@ -37,8 +37,8 @@ mesh.SetMaterialIDFromLogicalVolume(vol0, 1)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Strong fuel");
-materials[2] = mat.AddMaterial("Weak fuel");
+materials[1] = mat.AddMaterial("Strong fuel")
+materials[2] = mat.AddMaterial("Weak fuel")
 
 -- Define microscopic cross sections
 xs_strong_fuel_micro = xs.Create()
@@ -51,7 +51,7 @@ xs.Set(xs_weak_fuelB_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_wea
 atom_density = 0.056559
 xs_strong_fuel = xs.MakeScaled(xs_strong_fuel_micro, atom_density) --critical
 xs_weak_fuelA = xs.MakeScaled(xs_weak_fuelA_micro, atom_density) --critical
-xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density)   --critical
+xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density) --critical
 
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_strong_fuel)
@@ -61,8 +61,8 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
-    mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
-    lbs.InitializeMaterials(solver_handle)
+  mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
+  lbs.InitializeMaterials(solver_handle)
 end
 
 --############################################### Setup Physics
@@ -71,7 +71,7 @@ phys1 = LBSCreateTransientSolver()
 --========== Groups
 grp = {}
 for g = 1, num_groups do
-    grp[g] = LBSCreateGroup(phys1)
+  grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
@@ -114,7 +114,6 @@ LBSSetProperty(phys1, USE_PRECURSORS, true)
 LBSSetProperty(phys1, VERBOSE_INNER_ITERATIONS, false)
 LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 
-
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
@@ -124,9 +123,8 @@ LBTSSetProperty(phys1, "MAX_TIMESTEPS", -1)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
-phys1name = solver.GetName(phys1);
+phys1name = solver.GetName(phys1)
 initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
-
 
 --time = 0.0
 --psi_t = psi_0
@@ -180,18 +178,27 @@ initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 --end
 swapped = false
 function MyCallBack()
-    FRf = lbs.ComputeFissionRate(phys1, "NEW")
-    FRi = lbs.ComputeFissionRate(phys1, "OLD")
-    dt = LBTSGetProperty(phys1, "TIMESTEP")
-    time = LBTSGetProperty(phys1, "TIME")
-    period = dt / math.log(FRf / FRi)
+  FRf = lbs.ComputeFissionRate(phys1, "NEW")
+  FRi = lbs.ComputeFissionRate(phys1, "OLD")
+  dt = LBTSGetProperty(phys1, "TIMESTEP")
+  time = LBTSGetProperty(phys1, "TIME")
+  period = dt / math.log(FRf / FRi)
 
-    if (time >= 0.2 and not swapped) then
-        SwapXS(phys1, xs_weak_fuelB)
-        swapped = true
-    end
-    log.Log(LOG_0, string.format("%s time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                                 phys1name, time, dt, period, FRf / initial_FR))
+  if time >= 0.2 and not swapped then
+    SwapXS(phys1, xs_weak_fuelB)
+    swapped = true
+  end
+  log.Log(
+    LOG_0,
+    string.format(
+      "%s time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+      phys1name,
+      time,
+      dt,
+      period,
+      FRf / initial_FR
+    )
+  )
 end
 LBTSSetProperty(phys1, "CALLBACK", "MyCallBack")
 solver.Execute(phys1)

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
@@ -3,16 +3,16 @@
 -- Test:
 num_procs = 2
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
@@ -22,8 +22,8 @@ L = 100.0
 xmin = 0.0
 dx = L / N
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = xmin + k * dx
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
 meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
@@ -34,7 +34,7 @@ mesh.SetUniformMaterialID(0)
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Test Material");
+materials[1] = mat.AddMaterial("Test Material")
 
 -- Define microscopic cross sections
 xs_critical = xs.Create()
@@ -48,8 +48,8 @@ mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_critical)
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
-    mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
-    lbs.InitializeMaterials(solver_handle)
+  mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, new_xs)
+  lbs.InitializeMaterials(solver_handle)
 end
 
 --############################################### Setup Physics
@@ -58,7 +58,7 @@ phys1 = LBSCreateTransientSolver()
 --========== Groups
 grp = {}
 for g = 1, num_groups do
-    grp[g] = LBSCreateGroup(phys1)
+  grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
@@ -87,10 +87,10 @@ LBSGroupsetSetGMRESRestartIntvl(phys1, cur_gs, 100)
 --    bsrc[g] = 0.0
 --end
 --bsrc[1] = 1.0/2
-LBSSetProperty(phys1, BOUNDARY_CONDITION, XMIN, LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1, BOUNDARY_CONDITION, XMAX, LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1, BOUNDARY_CONDITION, YMIN, LBSBoundaryTypes.REFLECTING);
-LBSSetProperty(phys1, BOUNDARY_CONDITION, YMAX, LBSBoundaryTypes.REFLECTING);
+LBSSetProperty(phys1, BOUNDARY_CONDITION, XMIN, LBSBoundaryTypes.REFLECTING)
+LBSSetProperty(phys1, BOUNDARY_CONDITION, XMAX, LBSBoundaryTypes.REFLECTING)
+LBSSetProperty(phys1, BOUNDARY_CONDITION, YMIN, LBSBoundaryTypes.REFLECTING)
+LBSSetProperty(phys1, BOUNDARY_CONDITION, YMAX, LBSBoundaryTypes.REFLECTING)
 --
 LBSSetProperty(phys1, DISCRETIZATION_METHOD, PWLD)
 LBSSetProperty(phys1, SCATTERING_ORDER, 1)
@@ -104,7 +104,6 @@ LBSSetProperty(phys1, USE_PRECURSORS, true)
 LBSSetProperty(phys1, VERBOSE_INNER_ITERATIONS, false)
 LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 
-
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
@@ -112,7 +111,7 @@ LBTSSetProperty(phys1, "TIMESTEP", 1e-3)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
-phys1name = solver.GetName(phys1);
+phys1name = solver.GetName(phys1)
 initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
@@ -132,20 +131,30 @@ time = 0.0
 time_stop = 1.0
 k = 0
 swapped = false
-while (time < time_stop) do
-    k = k + 1
-    solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1, "NEW")
-    FRi = lbs.ComputeFissionRate(phys1, "OLD")
-    dt = LBTSGetProperty(phys1, "TIMESTEP")
-    time = LBTSGetProperty(phys1, "TIME")
-    period = dt / math.log(FRf / FRi)
-    log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                                 phys1name, k, time, dt, period, FRf / initial_FR))
-    if (time >= 0.2 and not swapped) then
-        SwapXS(phys1, xs_21cent)
-        swapped = true
-    end
+while time < time_stop do
+  k = k + 1
+  solver.Step(phys1)
+  FRf = lbs.ComputeFissionRate(phys1, "NEW")
+  FRi = lbs.ComputeFissionRate(phys1, "OLD")
+  dt = LBTSGetProperty(phys1, "TIMESTEP")
+  time = LBTSGetProperty(phys1, "TIME")
+  period = dt / math.log(FRf / FRi)
+  log.Log(
+    LOG_0,
+    string.format(
+      "%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+      phys1name,
+      k,
+      time,
+      dt,
+      period,
+      FRf / initial_FR
+    )
+  )
+  if time >= 0.2 and not swapped then
+    SwapXS(phys1, xs_21cent)
+    swapped = true
+  end
 
-    LBTSAdvanceTimeData(phys1)
+  LBTSAdvanceTimeData(phys1)
 end

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
@@ -3,16 +3,16 @@
 -- Test:
 num_procs = 2
 
-
-
-
-
 --############################################### Check num_procs
-if (check_num_procs == nil and number_of_processes ~= num_procs) then
-    log.Log(LOG_0ERROR, "Incorrect amount of processors. " ..
-        "Expected " .. tostring(num_procs) ..
-        ". Pass check_num_procs=false to override if possible.")
-    os.exit(false)
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
 end
 
 --############################################### Setup mesh
@@ -22,8 +22,8 @@ L = 80.96897163
 xmin = -L / 2
 dx = L / N
 for i = 1, (N + 1) do
-    k = i - 1
-    nodes[i] = xmin + k * dx
+  k = i - 1
+  nodes[i] = xmin + k * dx
 end
 
 meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes, nodes } })
@@ -32,17 +32,22 @@ mesh.MeshGenerator.Execute(meshgen1)
 --############################################### Set Material IDs
 mesh.SetUniformMaterialID(0)
 
-vol0 = logvol.RPPLogicalVolume.Create({ xmin = -L / 16, xmax = L / 16,
-                                        ymin = -L / 16, ymax = L / 16,
-                                        zmin = -L / 16, zmax = L / 16 })
+vol0 = logvol.RPPLogicalVolume.Create({
+  xmin = -L / 16,
+  xmax = L / 16,
+  ymin = -L / 16,
+  ymax = L / 16,
+  zmin = -L / 16,
+  zmax = L / 16,
+})
 mesh.SetMaterialIDFromLogicalVolume(vol0, 1)
 
 mesh.ExportToPVTU("TheMesh")
 
 --############################################### Add materials
 materials = {}
-materials[1] = mat.AddMaterial("Strong fuel");
-materials[2] = mat.AddMaterial("Weak fuel");
+materials[1] = mat.AddMaterial("Strong fuel")
+materials[2] = mat.AddMaterial("Weak fuel")
 
 -- Define microscopic cross sections
 xs_strong_fuel_micro = xs.Create()
@@ -55,7 +60,7 @@ xs.Set(xs_weak_fuelB_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_wea
 atom_density = 0.056559
 xs_strong_fuel = xs.MakeScaled(xs_strong_fuel_micro, atom_density) --critical
 xs_weak_fuelA = xs.MakeScaled(xs_weak_fuelA_micro, atom_density) --critical
-xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density)   --critical
+xs_weak_fuelB = xs.MakeScaled(xs_weak_fuelB_micro, atom_density) --critical
 
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, EXISTING, xs_strong_fuel)
@@ -65,8 +70,8 @@ mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 mat.SetProperty(materials[2], ISOTROPIC_MG_SOURCE, FROM_ARRAY, { 0.0 })
 
 function SwapXS(solver_handle, new_xs)
-    mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
-    lbs.InitializeMaterials(solver_handle)
+  mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, EXISTING, new_xs)
+  lbs.InitializeMaterials(solver_handle)
 end
 
 --############################################### Setup Physics
@@ -75,7 +80,7 @@ phys1 = LBSCreateTransientSolver()
 --========== Groups
 grp = {}
 for g = 1, num_groups do
-    grp[g] = LBSCreateGroup(phys1)
+  grp[g] = LBSCreateGroup(phys1)
 end
 
 --========== ProdQuad
@@ -119,7 +124,6 @@ LBSSetProperty(phys1, USE_PRECURSORS, true)
 LBSSetProperty(phys1, VERBOSE_INNER_ITERATIONS, false)
 LBSSetProperty(phys1, VERBOSE_OUTER_ITERATIONS, true)
 
-
 --############################################### Initialize and Execute Solver
 solver.Initialize(phys1)
 
@@ -127,7 +131,7 @@ LBTSSetProperty(phys1, "TIMESTEP", 1e-3)
 LBTSSetProperty(phys1, "VERBOSITY_LEVEL", 0)
 LBTSSetProperty(phys1, "TIMESTEP_METHOD", "CRANK_NICHOLSON")
 
-phys1name = solver.GetName(phys1);
+phys1name = solver.GetName(phys1)
 initial_FR = lbs.ComputeFissionRate(phys1, "OLD")
 
 --time = 0.0
@@ -147,20 +151,30 @@ time = 0.0
 time_stop = 1.0
 k = 0
 swapped = false
-while (time < time_stop) do
-    k = k + 1
-    solver.Step(phys1)
-    FRf = lbs.ComputeFissionRate(phys1, "NEW")
-    FRi = lbs.ComputeFissionRate(phys1, "OLD")
-    dt = LBTSGetProperty(phys1, "TIMESTEP")
-    time = LBTSGetProperty(phys1, "TIME")
-    period = dt / math.log(FRf / FRi)
-    log.Log(LOG_0, string.format("%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
-                                 phys1name, k, time, dt, period, FRf / initial_FR))
-    if (time >= 0.2 and not swapped) then
-        SwapXS(phys1, xs_weak_fuelB)
-        swapped = true
-    end
+while time < time_stop do
+  k = k + 1
+  solver.Step(phys1)
+  FRf = lbs.ComputeFissionRate(phys1, "NEW")
+  FRi = lbs.ComputeFissionRate(phys1, "OLD")
+  dt = LBTSGetProperty(phys1, "TIMESTEP")
+  time = LBTSGetProperty(phys1, "TIME")
+  period = dt / math.log(FRf / FRi)
+  log.Log(
+    LOG_0,
+    string.format(
+      "%s %4d time=%10.3g dt=%10.4g period=%10.3g FR=%10.3e",
+      phys1name,
+      k,
+      time,
+      dt,
+      period,
+      FRf / initial_FR
+    )
+  )
+  if time >= 0.2 and not swapped then
+    SwapXS(phys1, xs_weak_fuelB)
+    swapped = true
+  end
 
-    LBTSAdvanceTimeData(phys1)
+  LBTSAdvanceTimeData(phys1)
 end

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,5 +5,6 @@ A description of each of the files in this directory is given in the table below
 
 | File | Description |
 | ---- | ----------- |
+| `lua-style.md`                 | Notes on the tools used for formatting input files | 
 | `developer/lsan.supp`          | Leak sanitizer suppression file |
 | `xs/create_openmc_xslib.ipynb` | Jupyter notebook for creating OpenMC multi-group cross-section libraries |

--- a/tools/lua-style.md
+++ b/tools/lua-style.md
@@ -1,0 +1,4 @@
+# StyLua
+We currently use [StyLua](https://github.com/JohnnyMorganz/StyLua) to format our input files. The
+OpenSn StyLua configuration file is named `.stylua.toml` and can be found in the topmost OpenSn
+directory. Usage information for StyLua can be found [here](https://github.com/JohnnyMorganz/StyLua?tab=readme-ov-file#usage).


### PR DESCRIPTION
This PR uses ~https://github.com/Koihik/LuaFormatter~ https://github.com/JohnnyMorganz/StyLua  to bring some consistency to the format of our input files. If we want to start enforcing format checks on our `*.lua` files using this tool or another, we can address that as a separate issue/PR.

`LuaFormatter` mangles some comment blocks, and I can't seem to prevent that from happening. Instead of adding `noformat` tags to all of the input files, I decided to switch to `stylua`. It has less configuration options, but I think the formatting is more consistent. It also seems to be the go-to Lua formatter.

I've added the style file as `.stylua.toml`.