### PR TITLE
Material Property API

### DIFF
--- a/lua/framework/materials/lua_material.cc
+++ b/lua/framework/materials/lua_material.cc
@@ -86,6 +86,9 @@ MatAddMaterial(lua_State* L)
 int
 MatAddProperty(lua_State* L)
 {
+  opensn::log.Log0Warning() << "mat.AddProperty has been deprecated and may be removed soon. "
+                               "This functionality is now bundled within mat.SetProperty.";
+
   const std::string fname = "mat.AddProperty";
   LuaCheckArgs<int, int>(L, fname);
 
@@ -175,7 +178,7 @@ MatSetProperty(lua_State* L)
 {
   const std::string fname = "mat.SetProperty";
   const int num_args = lua_gettop(L);
-  
+
   if (num_args < 3)
     LuaPostArgAmountError(fname, L, 3, num_args);
 
@@ -184,7 +187,7 @@ MatSetProperty(lua_State* L)
   auto material = opensn::GetStackItemPtr(opensn::material_stack, material_handle, fname);
 
   // Get the material property type and its index, if applicable
-  int property_type = -1;
+  int property_type;
   int property_index = -1;
   if (lua_isnumber(L, 2))
   {

--- a/lua/framework/materials/lua_material.cc
+++ b/lua/framework/materials/lua_material.cc
@@ -175,246 +175,192 @@ MatSetProperty(lua_State* L)
 {
   const std::string fname = "mat.SetProperty";
   const int num_args = lua_gettop(L);
-
+  
   if (num_args < 3)
-  {
-    opensn::log.Log0Error() << "Invalid number of arguments when calling mat.SetProperty";
-    opensn::Exit(EXIT_FAILURE);
-  }
+    LuaPostArgAmountError(fname, L, 3, num_args);
 
-  auto material_index = LuaArg<int>(L, 1);
+  // Get a pointer to the material
+  auto material_handle = LuaArg<int>(L, 1);
+  auto material = opensn::GetStackItemPtr(opensn::material_stack, material_handle, fname);
+
+  // Get the material property type and its index, if applicable
+  int property_type = -1;
   int property_index = -1;
-  std::string property_index_name;
   if (lua_isnumber(L, 2))
-    property_index = LuaArg<int>(L, 2);
-  else
-    property_index_name = LuaArg<std::string>(L, 2);
-
-  auto operation_index = LuaArg<int>(L, 3);
-
-  // Get reference to material
-  auto cur_material = opensn::GetStackItemPtr(opensn::material_stack, material_index, fname);
-
-  // If user supplied name then find property index
-  if (not lua_isnumber(L, 2))
   {
-    for (auto& property : cur_material->properties)
-      if (property->property_name == property_index_name)
-        property_index = static_cast<int>(property->Type());
+    property_type = LuaArg<int>(L, 2);
+    for (int p = 0; p < material->properties.size(); ++p)
+    {
+      const auto& property = material->properties.at(p);
+      if (static_cast<int>(property->Type()) == property_type)
+      {
+        property_index = p;
+        break;
+      }
+    }
   }
+  else
+  {
+    const auto property_name = LuaArg<std::string>(L, 2);
+    for (int p = 0; p < material->properties.size(); ++p)
+    {
+      const auto& property = material->properties.at(p);
+      if (property->property_name == property_name)
+      {
+        property_type = static_cast<int>(property->Type());
+        property_index = p;
+        break;
+      }
+    }
+    OpenSnInvalidArgumentIf(property_index == -1,
+                            "No property with name " + property_name +
+                              " found on material at index " + std::to_string(material_handle) +
+                              ".");
+  }
+
+  // Get the operation index
+  auto op_type = LuaArg<int>(L, 3);
 
   // Process property
-  if (property_index == static_cast<int>(PropertyType::SCALAR_VALUE))
+  if (property_type == static_cast<int>(PropertyType::SCALAR_VALUE))
   {
-    int location_of_prop = -1;
-    // Check if the material has this property
-    if (lua_isnumber(L, 2))
+    // Create the property, if no location was found
+    if (property_index == -1)
     {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-        if (cur_material->properties[p]->Type() == PropertyType::SCALAR_VALUE)
-          location_of_prop = p;
+      auto property = std::make_shared<ScalarValue>();
+      material->properties.push_back(property);
+      property_index = static_cast<int>(material->properties.size()) - 1;
+    }
+    OpenSnLogicalErrorIf(property_index < 0, "Error creating or finding ScalarValue property.");
+
+    // Get the property
+    auto property = std::static_pointer_cast<ScalarValue>(material->properties.at(property_index));
+
+    // Process operation
+    if (op_type == static_cast<int>(OperationType::SINGLE_VALUE))
+    {
+      const auto value = LuaArg<double>(L, 4);
+      property->value_ = value;
+      opensn::log.Log0Verbose1() << "Scalar value for material at index " << material_handle
+                                 << " set to " << value;
     }
     else
-    {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-        if (cur_material->properties[p]->property_name == property_index_name)
-          location_of_prop = p;
-    }
-
-    // If the property is valid
-    if (location_of_prop >= 0)
-    {
-      auto prop = std::static_pointer_cast<ScalarValue>(cur_material->properties[location_of_prop]);
-
-      // Process operation
-      if (operation_index == static_cast<int>(OperationType::SINGLE_VALUE))
-      {
-        auto value = LuaArg<double>(L, 4);
-        prop->value_ = value;
-        opensn::log.Log0Verbose1()
-          << "Scalar value for material at index " << material_index << " set to " << value;
-      }
-      else
-      {
-        opensn::log.Log0Error() << "ERROR: Unsupported operation for SCALAR_VALUE." << std::endl;
-        opensn::Exit(EXIT_FAILURE);
-      }
-    }
-    else
-    {
-      opensn::log.Log0Error() << "ERROR: Material has no property SCALAR_VALUE." << std::endl;
-      opensn::Exit(EXIT_FAILURE);
-    }
+      OpenSnLogicalError("Unsupported operation for ScalarValue property.");
   } // if scalar value
-  else if (property_index == static_cast<int>(PropertyType::TRANSPORT_XSECTIONS))
+
+  else if (property_type == static_cast<int>(PropertyType::TRANSPORT_XSECTIONS))
   {
-    int location_of_prop = -1;
-    // Check if the material has this property
-    if (lua_isnumber(L, 2))
+    // Create the property, if no location was found
+    if (property_index == -1)
     {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-      {
-        if (cur_material->properties[p]->Type() == PropertyType::TRANSPORT_XSECTIONS)
-        {
-          location_of_prop = p;
-        }
-      }
+      auto property = std::make_shared<MultiGroupXS>();
+      material->properties.push_back(property);
+      property_index = static_cast<int>(material->properties.size()) - 1;
     }
+    OpenSnLogicalErrorIf(property_index < 0, "Error creating or finding MultiGroupXS property.");
+
+    // Get the property
+    auto property = std::static_pointer_cast<MultiGroupXS>(material->properties.at(property_index));
+
+    // Process operation
+    if (op_type == static_cast<int>(OperationType::SIMPLE_ONE_GROUP))
+    {
+      if (num_args != 5)
+        LuaPostArgAmountError(fname, L, 5, num_args);
+
+      const auto sigma_t = LuaArg<double>(L, 4);
+      const auto c = LuaArg<double>(L, 5);
+      property->Initialize(sigma_t, c);
+      opensn::log.Log0Verbose1() << "Simple one group cross sections with sigma_t=" << sigma_t
+                                 << ", c=" << c << " set on the material at index "
+                                 << material_handle << ".";
+    }
+
+    else if (op_type == static_cast<int>(OperationType::OPENSN_XSFILE))
+    {
+      if (num_args != 4)
+        LuaPostArgAmountError(fname, L, 4, num_args);
+
+      const auto file_name = LuaArg<std::string>(L, 4);
+      property->Initialize(file_name);
+      opensn::log.Log0Verbose1() << "Cross sections from OpenSn XS file " << file_name
+                                 << " set on the material at index " << material_handle << ".";
+    }
+
+    else if (op_type == static_cast<int>(OperationType::OPENMC_XSLIB))
+    {
+      if (num_args < 5)
+        LuaPostArgAmountError(fname, L, 5, num_args);
+
+      const auto file_name = LuaArg<std::string>(L, 4);
+      const auto temperature = LuaArg<double>(L, 5);
+      const auto dataset_name = LuaArgOptional<std::string>(L, 6, "set1");
+      property->Initialize(file_name, dataset_name, temperature);
+      opensn::log.Log0Verbose1() << "Cross sections from OpenMC library " << file_name
+                                 << ", dataset " << dataset_name << ", and temperature "
+                                 << temperature << " set on the material at index "
+                                 << material_handle << ".";
+    }
+
+    else if (op_type == static_cast<int>(OperationType::EXISTING))
+    {
+      if (num_args != 4)
+        LuaPostArgAmountError(fname, L, 4, num_args);
+
+      const auto xs_handle = LuaArg<int>(L, 4);
+      material->properties.at(property_index) = std::dynamic_pointer_cast<MultiGroupXS>(
+        GetStackItemPtr(multigroup_xs_stack, xs_handle, fname));
+
+      opensn::log.Log0Verbose1() << "Cross sections at index " << xs_handle
+                                 << " set on material at index " << material_handle << ".";
+    }
+
     else
-    {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-      {
-        if (cur_material->properties[p]->property_name == property_index_name)
-        {
-          location_of_prop = p;
-        }
-      }
-    }
+      OpenSnLogicalError("Unsupported operation for MultiGroupXS property.");
+  } // if transport xsections
 
-    // If the property is valid
-    if (location_of_prop >= 0)
-    {
-      auto prop =
-        std::static_pointer_cast<MultiGroupXS>(cur_material->properties[location_of_prop]);
-
-      // Process operation
-      if (operation_index == static_cast<int>(OperationType::SIMPLE_ONE_GROUP))
-      {
-        if (num_args != 5)
-          LuaPostArgAmountError("MatSetProperty", L, 5, num_args);
-
-        auto sigma_t = LuaArg<double>(L, 4);
-        auto c = LuaArg<double>(L, 5);
-
-        prop->Initialize(sigma_t, c);
-      }
-      else if (operation_index == static_cast<int>(OperationType::OPENSN_XSFILE))
-      {
-        if (num_args != 4)
-          LuaPostArgAmountError("MatSetProperty", L, 4, num_args);
-
-        const auto file_name = LuaArg<std::string>(L, 4);
-
-        prop->Initialize(file_name);
-      }
-      else if (operation_index == static_cast<int>(OperationType::OPENMC_XSLIB))
-      {
-        if (num_args < 5)
-          LuaPostArgAmountError("MatSetProperty", L, 5, num_args);
-
-        const auto file_name = LuaArg<std::string>(L, 4);
-        const auto temperature = LuaArg<double>(L, 5);
-        const auto dataset_name = LuaArgOptional<std::string>(L, 6, "set1");
-        prop->Initialize(file_name, dataset_name, temperature);
-      }
-      else if (operation_index == static_cast<int>(OperationType::EXISTING))
-      {
-        if (num_args != 4)
-          LuaPostArgAmountError("MatSetProperty", L, 4, num_args);
-
-        auto handle = LuaArg<int>(L, 4);
-
-        std::shared_ptr<MultiGroupXS> xs;
-        try
-        {
-          xs = std::dynamic_pointer_cast<MultiGroupXS>(
-            opensn::GetStackItemPtr(opensn::multigroup_xs_stack, handle, fname));
-        }
-        catch (const std::out_of_range& o)
-        {
-          opensn::log.LogAllError()
-            << "ERROR: Invalid cross-section handle in call to MatSetProperty." << std::endl;
-          opensn::Exit(EXIT_FAILURE);
-        }
-        //        auto old_prop = prop;
-        prop = xs;
-
-        cur_material->properties[location_of_prop] = prop;
-
-        //        delete old_prop; //Still debating if this should be deleted
-      }
-      else
-      {
-        opensn::log.LogAllError() << "Unsupported operation for TRANSPORT_XSECTIONS." << std::endl;
-        opensn::Exit(EXIT_FAILURE);
-      }
-    }
-    else
-    {
-      opensn::log.LogAllError() << "Material has no property TRANSPORT_XSECTIONS." << std::endl;
-      opensn::Exit(EXIT_FAILURE);
-    }
-  } // if thermal conductivity
-  else if (property_index == static_cast<int>(PropertyType::ISOTROPIC_MG_SOURCE))
+  else if (property_type == static_cast<int>(PropertyType::ISOTROPIC_MG_SOURCE))
   {
-    int location_of_prop = -1;
-    // Check if the material has this property
-    if (lua_isnumber(L, 2))
+    // Create the property, if no location was found
+    if (property_index == -1)
     {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-      {
-        if (cur_material->properties[p]->Type() == PropertyType::ISOTROPIC_MG_SOURCE)
-        {
-          location_of_prop = p;
-        }
-      }
+      auto property = std::make_shared<IsotropicMultiGrpSource>();
+      material->properties.push_back(property);
+      property_index = static_cast<int>(material->properties.size()) - 1;
+    }
+    OpenSnLogicalErrorIf(property_index < 0,
+                         "Error creating or finding IsotropicMultiGrpSource property.");
+
+    // Get the property
+    auto property =
+      std::static_pointer_cast<IsotropicMultiGrpSource>(material->properties.at(property_index));
+
+    // Process operation
+    if (op_type == static_cast<int>(OperationType::SINGLE_VALUE))
+    {
+      if (num_args != 4)
+        LuaPostArgAmountError(fname, L, 4, num_args);
+
+      const auto value = LuaArg<double>(L, 4);
+      property->source_value_g.resize(1, value);
+      opensn::log.Log0Verbose1() << "Isotropic multi-group source value for material at index "
+                                 << material_handle << " set to " << value << ".";
+    }
+    else if (op_type == static_cast<int>(OperationType::FROM_ARRAY))
+    {
+      if (num_args != 4)
+        LuaPostArgAmountError("MatSetProperty", L, 4, num_args);
+
+      property->source_value_g = LuaArg<std::vector<double>>(L, 4);
+      opensn::log.Log0Verbose1() << "Isotropic Multi-group Source populated with "
+                                 << property->source_value_g.size() << " values.";
     }
     else
-    {
-      for (int p = 0; p < cur_material->properties.size(); p++)
-      {
-        if (cur_material->properties[p]->property_name == property_index_name)
-        {
-          location_of_prop = p;
-        }
-      }
-    }
+      OpenSnInvalidArgument("Unsupported operation for IsotropicMultiGrpSource");
+  } // if isotropic multi-group source
 
-    // If the property is valid
-    if (location_of_prop >= 0)
-    {
-      auto prop = std::static_pointer_cast<IsotropicMultiGrpSource>(
-        cur_material->properties[location_of_prop]);
-
-      if (operation_index == static_cast<int>(OperationType::SINGLE_VALUE))
-      {
-        if (num_args != 4)
-          LuaPostArgAmountError("MatSetProperty", L, 4, num_args);
-
-        auto value = LuaArg<double>(L, 4);
-
-        prop->source_value_g.resize(1, value);
-        opensn::log.Log0Verbose1() << "Isotropic Multigroup Source value for material at index "
-                                   << material_index << " set to " << value;
-      }
-      else if (operation_index == static_cast<int>(OperationType::FROM_ARRAY))
-      {
-        if (num_args != 4)
-          LuaPostArgAmountError("MatSetProperty", L, 4, num_args);
-        prop->source_value_g = LuaArg<std::vector<double>>(L, 4);
-        opensn::log.Log0Verbose1() << "Isotropic Multigroup Source populated with "
-                                   << prop->source_value_g.size() << " values";
-      }
-      else
-      {
-        opensn::log.LogAllError() << "Unsupported operation for ISOTROPIC_MG_SOURCE." << std::endl;
-        opensn::Exit(EXIT_FAILURE);
-      }
-    }
-    else
-    {
-      opensn::log.LogAllError() << "Material \"" << cur_material->name
-                                << "\" has no property ISOTROPIC_MG_SOURCE." << std::endl;
-      opensn::Exit(EXIT_FAILURE);
-    }
-  }
   else
-  {
-    opensn::log.LogAllError()
-      << "Unsupported material property specified in call to MatSetProperty." << property_index
-      << std::endl;
-    opensn::Exit(EXIT_FAILURE);
-  }
+    OpenSnInvalidArgument("Unsupported material property type specified in call to " + fname + ".");
 
   return LuaReturn(L);
 }

--- a/lua/framework/materials/lua_material.h
+++ b/lua/framework/materials/lua_material.h
@@ -84,8 +84,8 @@ int MatAddProperty(lua_State* L);
  * Sets a material property for a given material.
  *
  * \param MaterialHandle int Index to the reference material.
- * \param PropertyIndex int Property index. Or name of property.
- * \param OperationIndex int Method used for setting the material property.
+ * \param PropertyType int Property type, or name of property.
+ * \param OperationType int Method used for setting the material property.
  * \param Information varying Varying information depending on the operation.
  *
  * ##_
@@ -143,37 +143,32 @@ int MatAddProperty(lua_State* L);
  * ##_
  *
  * ### Example 1
- * Simple temperature independent thermal conductivity:
+ * Simple scalar valued property:
  * \code
  * materials = {}
  * materials[1] = mat.AddMaterial("Test Material");
- * mat.AddProperty(materials[0],THERMAL_CONDUCTIVITY)
- * mat.SetProperty(materials[0],THERMAL_CONDUCTIVITY,SINGLE_VALUE,13.7)
+ * mat.SetProperty(materials[0], SCALAR_VALUE, SINGLE_VALUE, 13.7)
  * \endcode
  *
  * where the thermal conductivity has been set to 13.7.\n
  *
  * ### Example 2
- * Isotropic Multigroup source set from a lua table/array (12 groups):
+ * Isotropic multi-group source set from a lua table/array (12 groups):
  * \code
  * materials = {}
  * materials[1] = mat.AddMaterial("Test Material");
- *
- * mat.AddProperty(materials[1],ISOTROPIC_MG_SOURCE)
  *
  * num_groups = 12
  * src={}
  * for g=1,num_groups do
  *     src[g] = 0.0
  * end
- * mat.SetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+ * mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
  * \endcode
  *
  * ### Developer Info
  * Checklist for adding a new material property:
- *  - Make sure you followed the steps depicted in the developer info section for
- *    the MatAddProperty function.
- *  - Now under the "If user supplied name then find property index"-section
+ *  - Under the "If user supplied name then find property index"-section
  *    add the appropriate code for setting the property index.
  *  - Add an else-if block for your property similar to the others. It should be
  *    intuitive if you look at the others.

--- a/test/framework/tutorials/tutorial_93_raytracing.lua
+++ b/test/framework/tutorials/tutorial_93_raytracing.lua
@@ -27,8 +27,6 @@ unit_tests.SimTest93_RayTracing()
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 1.0, 0.0)
 

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_1d_1g.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/keigenvalue_mip_1d_1g.lua
@@ -60,8 +60,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
 xs_file = "../transport_keigen/simple_fissile.xs"
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_materials.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_keigen/utils/qblock_materials.lua
@@ -16,6 +16,5 @@ materials = {}
 for m=0,1 do
     key = tostring(m)
     materials[key] = mat.AddMaterial("Material_"..key)
-    mat.AddProperty(materials[key], TRANSPORT_XSECTIONS)
     mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
@@ -45,11 +45,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "../transport_steady/xs_graphite_pure.xs")
 

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_3a_dsa_ortho.lua
@@ -48,12 +48,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "../transport_steady/xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "../transport_steady/xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.lua
@@ -73,13 +73,8 @@ materials[3] = mat.AddMaterial("Test Material3");
 
 -- Add cross sections to materials
 num_groups = 1
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.01, 0.01)
-
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.1 * 20, 0.8)
-
-mat.AddProperty(materials[3], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[3], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.3 * 20, 0.0)
 
 -- Create sources
@@ -91,7 +86,6 @@ for g = 1, num_groups do
         src[g] = 0.0
     end
 end
-mat.AddProperty(materials[3], ISOTROPIC_MG_SOURCE)
 mat.SetProperty(materials[3], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
 
 -- Setup physics

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.lua
@@ -63,10 +63,7 @@ materials[1] = mat.AddMaterial("Test Material1");
 materials[2] = mat.AddMaterial("Test Material2");
 
 -- Add cross sections
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.01, 0.01)
-
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, 0.1 * 20, 0.8)
 
 -- Add sources

--- a/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.lua
@@ -73,10 +73,7 @@ materials[2] = mat.AddMaterial("Test Material2");
 
 -- Add cross sections to materials
 num_groups = 10
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "response_2d_3_mat1.xs")
-
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "response_2d_3_mat2.xs")
 
 -- Create sources

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/materials/materials.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/c5g7/materials/materials.lua
@@ -24,6 +24,5 @@ materials = {}
 for m=0,6 do
     key = tostring(m)
     materials[key] = mat.AddMaterial("Material_"..key)
-    mat.AddProperty(key, TRANSPORT_XSECTIONS)
     mat.SetProperty(key, TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.lua
@@ -60,8 +60,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
 xs_file = "simple_fissile.xs"
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.lua
@@ -60,8 +60,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
 xs_file = "simple_fissile.xs"
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, xs_file)
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs.lua
@@ -45,7 +45,6 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "uo2.h5", 294.0)
 mesh.SetUniformMaterialID(0)
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_cset.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_cset.lua
@@ -45,7 +45,6 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "u235.h5", 294.0, "u235")
 mesh.SetUniformMaterialID(0)
 

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_materials.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/utils/qblock_materials.lua
@@ -16,6 +16,5 @@ materials = {}
 for m=0,1 do
     key = tostring(m)
     materials[key] = mat.AddMaterial("Material_"..key)
-    mat.AddProperty(materials[key], TRANSPORT_XSECTIONS)
     mat.SetProperty(materials[key], TRANSPORT_XSECTIONS, EXISTING, xss[key])
 end

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
@@ -37,12 +37,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
@@ -44,12 +44,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_4_dsa_ortho_inf.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_4_dsa_ortho_inf.lua
@@ -42,12 +42,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.lua
@@ -31,8 +31,6 @@ sigma_t = 1.0
 
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, sigma_t, 0.0)
 
 -- Setup Physics

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -43,12 +43,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
@@ -41,12 +41,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "tests/transport_steady/simple_scatter.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "tests/transport_steady/simple_scatter.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
@@ -41,12 +41,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -42,12 +42,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -42,12 +42,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
@@ -45,12 +45,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
@@ -45,12 +45,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
@@ -35,11 +35,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 1
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
@@ -45,13 +45,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -47,13 +47,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -47,13 +47,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.lua
@@ -55,13 +55,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1],TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2],TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1],ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2],ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1],TRANSPORT_XSECTIONS,
   OPENSN_XSFILE,"xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
@@ -47,13 +47,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
@@ -46,11 +46,6 @@ mesh.SetMaterialIDFromLogicalVolume(vol0,0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
@@ -48,13 +48,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
@@ -46,12 +46,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_air50RH.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
@@ -47,13 +47,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
@@ -40,12 +40,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 5
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.lua
@@ -68,11 +68,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE,"xs_graphite_pure.xs")
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.lua
@@ -71,11 +71,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
-
 num_groups = 21
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
@@ -37,12 +37,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -43,12 +43,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 num_groups = 168
 mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")
 mat.SetProperty(materials[2], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_3_170.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
@@ -44,8 +44,6 @@ ratioc = 0.1
 source = sigmat * (1 - ratioc)
 
 material0 = mat.AddMaterial("Material_0");
-mat.AddProperty(material0, TRANSPORT_XSECTIONS)
-mat.AddProperty(material0, ISOTROPIC_MG_SOURCE)
 mat.SetProperty(material0, TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, sigmat, ratioc)
 mat.SetProperty(material0, ISOTROPIC_MG_SOURCE, SINGLE_VALUE, source)
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
@@ -48,8 +48,6 @@ for g = 2, ngrp do
 end
 
 material0 = mat.AddMaterial("Material_0");
-mat.AddProperty(material0, TRANSPORT_XSECTIONS)
-mat.AddProperty(material0, ISOTROPIC_MG_SOURCE)
 mat.SetProperty(material0, TRANSPORT_XSECTIONS, OPENSN_XSFILE, "transport_2d_cyl_2_multigroup.xs")
 mat.SetProperty(material0, ISOTROPIC_MG_SOURCE, FROM_ARRAY, source)
 

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_1.lua
@@ -37,12 +37,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 materials[2] = mat.AddMaterial("Test Material2");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 -- Define microscopic cross sections
 micro_xs = xs.Create()
 xs_file = "tests/transport_transient/subcritical_1g.xs"

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_2.lua
@@ -36,9 +36,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
 -- Define microscopic cross sections
 xs_critical = xs.Create()
 xs.Set(xs_critical, OPENSN_XSFILE, "tests/transport_transient/xs_inf_critical_1g.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_1d_3.lua
@@ -40,11 +40,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Strong fuel");
 materials[2] = mat.AddMaterial("Weak fuel");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 -- Define microscopic cross sections
 xs_strong_fuel_micro = xs.Create()
 xs.Set(xs_strong_fuel_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_k1_6_1g.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_2.lua
@@ -36,9 +36,6 @@ mesh.SetUniformMaterialID(0)
 materials = {}
 materials[1] = mat.AddMaterial("Test Material");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-
 -- Define microscopic cross sections
 xs_critical = xs.Create()
 xs.Set(xs_critical, OPENSN_XSFILE, "tests/transport_transient/xs_inf_critical_1g.xs")

--- a/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_transient/transient_transport_2d_3.lua
@@ -44,11 +44,6 @@ materials = {}
 materials[1] = mat.AddMaterial("Strong fuel");
 materials[2] = mat.AddMaterial("Weak fuel");
 
-mat.AddProperty(materials[1], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[2], TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
-mat.AddProperty(materials[2], ISOTROPIC_MG_SOURCE)
-
 -- Define microscopic cross sections
 xs_strong_fuel_micro = xs.Create()
 xs.Set(xs_strong_fuel_micro, OPENSN_XSFILE, "tests/transport_transient/xs_inf_k1_6_1g.xs")

--- a/tutorials/lbs/first/first_example.lua
+++ b/tutorials/lbs/first/first_example.lua
@@ -99,9 +99,6 @@ We create a material and add two properties to it:
 materials = {}
 materials[1] = mat.AddMaterial("Material_A");
 
-mat.AddProperty(materials[1],TRANSPORT_XSECTIONS)
-mat.AddProperty(materials[1],ISOTROPIC_MG_SOURCE)
-
 --[[ @doc
 ## Cross Sections
 We assign the cross sections to the material by loading the file containing the cross sections. See the tutorials'

--- a/tutorials/material/mg_xs.lua
+++ b/tutorials/material/mg_xs.lua
@@ -47,8 +47,6 @@ Recall that lua indexing starts at 1.
 -- Add materials
 materials = {}
 materials[1] = mat.AddMaterial("Material_A");
-
-mat.AddProperty(materials[1],TRANSPORT_XSECTIONS)
 --[[ @doc
 
 ## Cross Sections


### PR DESCRIPTION
- Modifies the functionality of `mat.SetProperty`.
    - If the specified property type lives on the material already, the property is overwritten.
    - If the specified property type does not live on the material, it is created.
- Eliminated the use of `mat.AddProperty` throughout the tests. 
- Deprecates `mat.AddProperty` to avoid breaking existing scripts.

Refs #252 