### PR TITLE
IsotropicMultiGrpSource -> IsotropicMultiGroupSource

### DIFF
--- a/framework/materials/isotropic_multigroup_source.h
+++ b/framework/materials/isotropic_multigroup_source.h
@@ -8,13 +8,13 @@
 namespace opensn
 {
 
-/** Basic thermal conductivity material property.*/
-class IsotropicMultiGrpSource : public MaterialProperty
+/** Basic isotropic multi-group source material property. */
+class IsotropicMultiGroupSource : public MaterialProperty
 {
 public:
   std::vector<double> source_value_g;
 
-  IsotropicMultiGrpSource() : MaterialProperty(PropertyType::ISOTROPIC_MG_SOURCE) {}
+  IsotropicMultiGroupSource() : MaterialProperty(PropertyType::ISOTROPIC_MG_SOURCE) {}
 };
 
 } // namespace opensn

--- a/framework/materials/scalar_value.h
+++ b/framework/materials/scalar_value.h
@@ -8,7 +8,7 @@
 namespace opensn
 {
 
-/**Simple scalar material property.*/
+/** Simple scalar-valued material property. */
 class ScalarValue : public MaterialProperty
 {
 public:

--- a/lua/framework/materials/lua_material.cc
+++ b/lua/framework/materials/lua_material.cc
@@ -5,8 +5,8 @@
 #include "framework/lua.h"
 #include "framework/materials/material.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
-#include "framework/materials/material_property_scalar_value.h"
-#include "framework/materials/material_property_isotropic_mg_src.h"
+#include "framework/materials/scalar_value.h"
+#include "framework/materials/isotropic_multigroup_source.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/console/console.h"
@@ -38,7 +38,8 @@ ScalarPropertyPushTable(lua_State* L, std::shared_ptr<MaterialProperty> property
 }
 
 void
-IsotropicMGSourcePropertyPushTable(lua_State* L, std::shared_ptr<IsotropicMultiGrpSource> property)
+IsotropicMGSourcePropertyPushTable(lua_State* L,
+                                   std::shared_ptr<IsotropicMultiGroupSource> property)
 {
   lua_newtable(L);
   LuaPushTableKey(L, "is_empty", false);
@@ -60,7 +61,7 @@ PropertyPushLuaTable(lua_State* L, std::shared_ptr<MaterialProperty> property)
     ScalarPropertyPushTable(L, property);
   else if (property->Type() == PropertyType::ISOTROPIC_MG_SOURCE)
     IsotropicMGSourcePropertyPushTable(
-      L, std::dynamic_pointer_cast<IsotropicMultiGrpSource>(property));
+      L, std::dynamic_pointer_cast<IsotropicMultiGroupSource>(property));
   else
     MaterialPropertyPushLuaTable(L);
 }
@@ -156,7 +157,7 @@ MatAddProperty(lua_State* L)
       }
     }
 
-    auto prop = std::make_shared<IsotropicMultiGrpSource>();
+    auto prop = std::make_shared<IsotropicMultiGroupSource>();
 
     prop->property_name = provided_name;
 
@@ -327,7 +328,7 @@ MatSetProperty(lua_State* L)
     // Create the property, if no location was found
     if (property_index == -1)
     {
-      auto property = std::make_shared<IsotropicMultiGrpSource>();
+      auto property = std::make_shared<IsotropicMultiGroupSource>();
       material->properties.push_back(property);
       property_index = static_cast<int>(material->properties.size()) - 1;
     }
@@ -336,7 +337,7 @@ MatSetProperty(lua_State* L)
 
     // Get the property
     auto property =
-      std::static_pointer_cast<IsotropicMultiGrpSource>(material->properties.at(property_index));
+      std::static_pointer_cast<IsotropicMultiGroupSource>(material->properties.at(property_index));
 
     // Process operation
     if (op_type == static_cast<int>(OperationType::SINGLE_VALUE))

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -225,7 +225,7 @@ LBSSolver::GetMatID2XSMap() const
   return matid_to_xs_map_;
 }
 
-const std::map<int, std::shared_ptr<IsotropicMultiGrpSource>>&
+const std::map<int, std::shared_ptr<IsotropicMultiGroupSource>>&
 LBSSolver::GetMatID2IsoSrcMap() const
 {
   return matid_to_src_map_;
@@ -968,12 +968,12 @@ LBSSolver::InitializeMaterials()
 
       if (property->Type() == PropertyType::ISOTROPIC_MG_SOURCE)
       {
-        const auto& src = std::static_pointer_cast<IsotropicMultiGrpSource>(property);
+        const auto& src = std::static_pointer_cast<IsotropicMultiGroupSource>(property);
 
         // Check for a valid source
         if (src->source_value_g.size() < groups_.size())
         {
-          log.LogAllWarning() << __FUNCTION__ << ": IsotropicMultiGrpSource specified in "
+          log.LogAllWarning() << __FUNCTION__ << ": IsotropicMultiGroupSource specified in "
                               << "material \"" << current_material->name << "\" has fewer "
                               << "energy groups than called for in the simulation. "
                               << "Source will be ignored.";

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
@@ -143,7 +143,7 @@ public:
   /**
    * Returns a reference to the map of material ids to Isotropic Srcs.
    */
-  const std::map<int, std::shared_ptr<IsotropicMultiGrpSource>>& GetMatID2IsoSrcMap() const;
+  const std::map<int, std::shared_ptr<IsotropicMultiGroupSource>>& GetMatID2IsoSrcMap() const;
 
   /**
    * Obtains a reference to the grid.
@@ -536,7 +536,7 @@ protected:
   std::vector<LBSGroupset> groupsets_;
 
   std::map<int, std::shared_ptr<MultiGroupXS>> matid_to_xs_map_;
-  std::map<int, std::shared_ptr<IsotropicMultiGrpSource>> matid_to_src_map_;
+  std::map<int, std::shared_ptr<IsotropicMultiGroupSource>> matid_to_src_map_;
 
   std::vector<PointSource> point_sources_;
   std::vector<DistributedSource> distributed_sources_;

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
-#include "framework/materials/material_property_isotropic_mg_src.h"
+#include "framework/materials/isotropic_multigroup_source.h"
 #include "framework/math/math.h"
 #include <functional>
 #include <map>

--- a/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.cc
@@ -64,7 +64,7 @@ SourceFunction::operator()(const LBSGroupset& groupset,
     // Obtain xs
     const auto& xs = transport_view.XS();
 
-    std::shared_ptr<IsotropicMultiGrpSource> P0_src = nullptr;
+    std::shared_ptr<IsotropicMultiGroupSource> P0_src = nullptr;
     if (matid_to_src_map.count(cell.material_id_) > 0)
       P0_src = matid_to_src_map.at(cell.material_id_);
 

--- a/modules/mg_diffusion/mg_diffusion_solver.cc
+++ b/modules/mg_diffusion/mg_diffusion_solver.cc
@@ -5,7 +5,7 @@
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
 #include "framework/math/spatial_discretization/finite_element/finite_element_data.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
-#include "framework/materials/material_property_isotropic_mg_src.h"
+#include "framework/materials/isotropic_multigroup_source.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/materials/material.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
@@ -240,7 +240,7 @@ Solver::Initialize_Materials(std::set<int>& material_ids)
       } // transport xs
       if (property->Type() == MatProperty::ISOTROPIC_MG_SOURCE)
       {
-        auto mg_source = std::static_pointer_cast<IsotropicMultiGrpSource>(property);
+        auto mg_source = std::static_pointer_cast<IsotropicMultiGroupSource>(property);
 
         if (mg_source->source_value_g.size() < num_groups_)
         {

--- a/modules/mg_diffusion/mg_diffusion_solver.h
+++ b/modules/mg_diffusion/mg_diffusion_solver.h
@@ -5,7 +5,7 @@
 
 #include "modules/mg_diffusion/mg_diffusion_bndry.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
-#include "framework/materials/material_property_isotropic_mg_src.h"
+#include "framework/materials/isotropic_multigroup_source.h"
 #include "framework/physics/solver_base/solver.h"
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/utils/timer.h"
@@ -107,7 +107,7 @@ public:
 protected:
   std::map<int, std::shared_ptr<MultiGroupXS>> matid_to_xs_map;
 
-  std::map<int, std::shared_ptr<IsotropicMultiGrpSource>> matid_to_src_map;
+  std::map<int, std::shared_ptr<IsotropicMultiGroupSource>> matid_to_src_map;
 
   std::map<int, TwoGridCollapsedInfo> map_mat_id_2_tginfo;
   //  std::map<int, Multigroup_D_and_sigR> map_mat_id_2_tgXS;


### PR DESCRIPTION
This simple PR just spells out "Group" in `IsotropicMultiGrpSource` and renames the header file.