### PR TITLE
Updating field function interpolations

### DIFF
--- a/framework/field_functions/interpolation/ffinter_line.cc
+++ b/framework/field_functions/interpolation/ffinter_line.cc
@@ -125,7 +125,6 @@ FieldFunctionInterpolationLine::Export(std::string base_name)
   std::vector<int> local_data_sizes(opensn::mpi_comm.size(), 0);
   int local_size = local_data.size();
   opensn::mpi_comm.gather(local_size, local_data_sizes, 0);
-  //MPI_Gather(&local_size, 1, MPI_INT, local_data_sizes.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
 
   // Compute global size of coordinate and interpolation data and each location's offset
   std::vector<double> global_data;
@@ -179,8 +178,8 @@ FieldFunctionInterpolationLine::Export(std::string base_name)
     ofile << "x,y,z," << ref_ff_->TextName() << "\n";
     for (auto point_data : values)
     {
-      auto [x, y, z, fv ] = point_data;
-      ofile << std::setprecision(5) << x << "," << y << "," << z << "," << fv << "\n";
+      auto [x, y, z, fv] = point_data;
+      ofile << std::setprecision(7) << x << "," << y << "," << z << "," << fv << "\n";
     }
     ofile.close();
 

--- a/framework/field_functions/interpolation/ffinter_line.cc
+++ b/framework/field_functions/interpolation/ffinter_line.cc
@@ -107,7 +107,7 @@ FieldFunctionInterpolationLine::Execute()
 }
 
 void
-FieldFunctionInterpolationLine::Export(std::string base_name)
+FieldFunctionInterpolationLine::ExportToCSV(std::string base_name)
 {
   // Populate local coordinate and interpolation data
   std::vector<double> local_data;

--- a/framework/field_functions/interpolation/ffinter_line.h
+++ b/framework/field_functions/interpolation/ffinter_line.h
@@ -55,7 +55,7 @@ public:
 
   double GetOpValue() { return op_value_; }
 
-  void Export(std::string base_name) override;
+  void ExportToCSV(std::string base_name) override;
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinter_line.h
+++ b/framework/field_functions/interpolation/ffinter_line.h
@@ -28,8 +28,7 @@ public:
       number_of_points_(2),
       op_value_(0.0),
       op_type_(FieldFunctionInterpolationOperation::OP_SUM)
-  {
-  }
+  {}
 
   virtual ~FieldFunctionInterpolationLine() {}
 
@@ -55,9 +54,7 @@ public:
 
   double GetOpValue() { return op_value_; }
 
-  std::string GetDefaultFileBaseName() const override { return "ZLFFI"; }
-
-  void ExportPython(std::string base_name) override;
+  void Export(std::string base_name) override;
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinter_line.h
+++ b/framework/field_functions/interpolation/ffinter_line.h
@@ -28,7 +28,8 @@ public:
       number_of_points_(2),
       op_value_(0.0),
       op_type_(FieldFunctionInterpolationOperation::OP_SUM)
-  {}
+  {
+  }
 
   virtual ~FieldFunctionInterpolationLine() {}
 

--- a/framework/field_functions/interpolation/ffinter_line.h
+++ b/framework/field_functions/interpolation/ffinter_line.h
@@ -6,51 +6,57 @@
 #include "framework/field_functions/interpolation/ffinterpolation.h"
 #include "framework/mesh/mesh.h"
 
-#include <petscksp.h>
-
 namespace opensn
 {
-
-struct FieldFunctionContext
-{
-  std::shared_ptr<FieldFunctionGridBased> ref_ff;
-  std::vector<double> interpolation_points_values;
-  std::vector<uint64_t> interpolation_points_ass_cell;
-  std::vector<bool> interpolation_points_has_ass_cell;
-};
 
 /** A line based interpolation function.*/
 class FieldFunctionInterpolationLine : public FieldFunctionInterpolation
 {
-protected:
-  int number_of_points_ = 2;
+private:
+  int number_of_points_;
+  double op_value_;
   Vector3 pi_, pf_;
-
-  std::vector<std::vector<double>> custom_arrays_;
-  std::vector<Vector3> interpolation_points_;
-  std::vector<FieldFunctionContext> ff_contexts_;
-
-  double delta_d_ = 1.0;
+  std::vector<uint64_t> local_cells_;
+  std::vector<Vector3> local_interpolation_points_;
+  std::vector<double> local_interpolation_values_;
+  std::shared_ptr<FieldFunctionGridBased> ref_ff_;
+  FieldFunctionInterpolationOperation op_type_;
 
 public:
   FieldFunctionInterpolationLine()
-    : FieldFunctionInterpolation(FieldFunctionInterpolationType::LINE)
+    : FieldFunctionInterpolation(FieldFunctionInterpolationType::LINE),
+      number_of_points_(2),
+      op_value_(0.0),
+      op_type_(FieldFunctionInterpolationOperation::OP_SUM)
   {
   }
 
   virtual ~FieldFunctionInterpolationLine() {}
 
   int& GetNumberOfPoints() { return number_of_points_; }
-  Vector3& GetInitialPoint() { return pi_; }
-  Vector3& GetFinalPoint() { return pf_; }
-  std::vector<std::vector<double>>& GetCustomArrays() { return custom_arrays_; }
-  std::vector<Vector3>& GetInterpolationPoints() { return interpolation_points_; }
-  std::vector<FieldFunctionContext>& GetFFContexts() { return ff_contexts_; }
+
+  void SetNumberOfPoints(int number) { number_of_points_ = number; }
+
+  Vector3 GetInitialPoint() { return pi_; }
+
+  void SetInitialPoint(Vector3 point) { pi_ = point; }
+
+  Vector3 GetFinalPoint() { return pf_; }
+
+  void SetFinalPoint(Vector3 point) { pf_ = point; }
+
   void Initialize() override;
+
   void Execute() override;
 
-public:
+  FieldFunctionInterpolationOperation& GetOperationType() { return op_type_; }
+
+  void SetOperationType(FieldFunctionInterpolationOperation type) { op_type_ = type; }
+
+  double GetOpValue() { return op_value_; }
+
   std::string GetDefaultFileBaseName() const override { return "ZLFFI"; }
+
   void ExportPython(std::string base_name) override;
 };
 

--- a/framework/field_functions/interpolation/ffinter_point.cc
+++ b/framework/field_functions/interpolation/ffinter_point.cc
@@ -5,7 +5,7 @@
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 
 namespace opensn
@@ -14,9 +14,13 @@ namespace opensn
 void
 FieldFunctionInterpolationPoint::Initialize()
 {
-  const std::string fname = "FieldFunctionInterpolationPoint::Initialize";
-  const auto& grid = field_functions_.front()->GetSpatialDiscretization().Grid();
+  log.Log0Verbose1() << "Initializing point interpolator.";
 
+  // Check for empty FF-list
+  if (field_functions_.empty())
+    throw std::logic_error("Unassigned field function in point field function interpolator.");
+
+  const auto& grid = field_functions_.front()->GetSpatialDiscretization().Grid();
   std::vector<uint64_t> cells_potentially_owning_point;
   for (const auto& cell : grid.local_cells)
   {
@@ -31,20 +35,24 @@ FieldFunctionInterpolationPoint::Initialize()
   mpi_comm.all_gather(cells_potentially_owning_point, recvbuf);
 
   if (recvbuf.empty())
-    throw std::logic_error(fname + ": No cell identified containing the point.");
+  {
+    throw std::logic_error("FieldFunctionInterpolationPoint::Initialize: No cell identified "
+                           "containing the specified point.");
+  }
 
   uint64_t owning_cell_gid = recvbuf.front();
   for (const uint64_t gid : recvbuf)
     owning_cell_gid = std::min(owning_cell_gid, gid);
-
   locally_owned_ = false;
   for (const uint64_t gid : cells_potentially_owning_point)
+  {
     if (gid == owning_cell_gid)
     {
       locally_owned_ = true;
       owning_cell_gid_ = owning_cell_gid;
       break;
     }
+  }
 }
 
 void
@@ -72,11 +80,10 @@ FieldFunctionInterpolationPoint::Execute()
   {
     const int64_t imap = sdm.MapDOFLocal(cell, i, uk_man, uid, cid);
     node_dof_values[i] = field_data[imap];
-  } // for i
+  }
 
   std::vector<double> shape_values(num_nodes, 0.0);
   cell_mapping.ShapeValues(point_of_interest_, shape_values);
-
   point_value_ = 0.0;
   for (size_t i = 0; i < num_nodes; ++i)
     point_value_ += node_dof_values[i] * shape_values[i];
@@ -87,7 +94,6 @@ FieldFunctionInterpolationPoint::GetPointValue() const
 {
   double global_point_value;
   mpi_comm.all_reduce(point_value_, global_point_value, mpi::op::sum<double>());
-
   return global_point_value;
 }
 

--- a/framework/field_functions/interpolation/ffinter_point.h
+++ b/framework/field_functions/interpolation/ffinter_point.h
@@ -14,28 +14,27 @@ class FieldFunctionInterpolationPoint : public FieldFunctionInterpolation
 {
 protected:
   Vector3 point_of_interest_;
-
-  bool locally_owned_ = false;
-  uint64_t owning_cell_gid_ = 0;
-  double point_value_ = 0.0;
+  bool locally_owned_;
+  uint64_t owning_cell_gid_;
+  double point_value_;
 
 public:
   FieldFunctionInterpolationPoint()
-    : FieldFunctionInterpolation(FieldFunctionInterpolationType::POINT)
-  {
-  }
+    : FieldFunctionInterpolation(FieldFunctionInterpolationType::POINT),
+      locally_owned_(false),
+      owning_cell_gid_(0),
+      point_value_(0.0)
+  {}
 
   virtual ~FieldFunctionInterpolationPoint() {}
 
   Vector3& GetPointOfInterest() { return point_of_interest_; }
 
   void Initialize() override;
+
   void Execute() override;
+
   /**Gets the value of the field function evaluation at the point.*/
   double GetPointValue() const;
-
-public:
-  std::string GetDefaultFileBaseName() const override { return ""; }
-  void ExportPython(std::string base_name) override{};
 };
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinter_point.h
+++ b/framework/field_functions/interpolation/ffinter_point.h
@@ -24,7 +24,8 @@ public:
       locally_owned_(false),
       owning_cell_gid_(0),
       point_value_(0.0)
-  {}
+  {
+  }
 
   virtual ~FieldFunctionInterpolationPoint() {}
 

--- a/framework/field_functions/interpolation/ffinter_slice.cc
+++ b/framework/field_functions/interpolation/ffinter_slice.cc
@@ -296,7 +296,7 @@ FieldFunctionInterpolationSlice::Execute()
 }
 
 void
-FieldFunctionInterpolationSlice::Export(std::string base_name)
+FieldFunctionInterpolationSlice::ExportToPython(std::string base_name)
 {
   std::ofstream ofile;
 

--- a/framework/field_functions/interpolation/ffinter_slice.cc
+++ b/framework/field_functions/interpolation/ffinter_slice.cc
@@ -296,7 +296,7 @@ FieldFunctionInterpolationSlice::Execute()
 }
 
 void
-FieldFunctionInterpolationSlice::ExportPython(std::string base_name)
+FieldFunctionInterpolationSlice::Export(std::string base_name)
 {
   std::ofstream ofile;
 

--- a/framework/field_functions/interpolation/ffinter_slice.h
+++ b/framework/field_functions/interpolation/ffinter_slice.h
@@ -71,9 +71,7 @@ public:
    */
   void Initialize() override;
   void Execute() override;
-
-  std::string GetDefaultFileBaseName() const override { return "ZPFFI"; }
-  void ExportPython(std::string base_name) override;
+  void Export(std::string base_name) override;
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinter_slice.h
+++ b/framework/field_functions/interpolation/ffinter_slice.h
@@ -71,7 +71,7 @@ public:
    */
   void Initialize() override;
   void Execute() override;
-  void Export(std::string base_name) override;
+  void ExportToPython(std::string base_name) override;
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinter_volume.cc
+++ b/framework/field_functions/interpolation/ffinter_volume.cc
@@ -7,8 +7,8 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/vector_ghost_communicator/vector_ghost_communicator.h"
 #include "framework/math/spatial_discretization/finite_element/finite_element_data.h"
-#include "framework/runtime.h"
 #include "framework/logging/log.h"
+#include "framework/runtime.h"
 
 namespace opensn
 {
@@ -24,14 +24,13 @@ void
 FieldFunctionInterpolationVolume::Initialize()
 {
   log.Log0Verbose1() << "Initializing volume interpolator.";
+
   // Check grid available
   if (field_functions_.empty())
-    throw std::logic_error("Unassigned field function in volume field "
-                           "function interpolator.");
+    throw std::logic_error("Unassigned field function in volume field function interpolator.");
 
   if (logical_volume_ == nullptr)
-    throw std::logic_error("Unassigned logical volume in volume field function"
-                           "interpolator.");
+    throw std::logic_error("Unassigned logical volume in volume field function interpolator.");
 
   const auto& grid = field_functions_.front()->GetSpatialDiscretization().Grid();
 
@@ -70,7 +69,7 @@ FieldFunctionInterpolationVolume::Execute()
     {
       const int64_t imap = sdm.MapDOFLocal(cell, i, uk_man, uid, cid);
       node_dof_values[i] = field_data[imap];
-    } // for i
+    }
 
     if (cell_local_id == cell_local_ids_inside_logvol_.front())
     {
@@ -99,16 +98,16 @@ FieldFunctionInterpolationVolume::Execute()
       local_sum += function_value * fe_vol_data.JxW(qp);
       local_max = std::fmax(ff_value, local_max);
       local_min = std::fmin(ff_value, local_min);
-    } // for qp
-  }   // for cell-id
+    }
+  }
 
   if (op_type_ == FieldFunctionInterpolationOperation::OP_SUM or
       op_type_ == FieldFunctionInterpolationOperation::OP_SUM_FUNC)
   {
     mpi_comm.all_reduce(local_sum, op_value_, mpi::op::sum<double>());
   }
-  if (op_type_ == FieldFunctionInterpolationOperation::OP_AVG or
-      op_type_ == FieldFunctionInterpolationOperation::OP_AVG_FUNC)
+  else if (op_type_ == FieldFunctionInterpolationOperation::OP_AVG or
+           op_type_ == FieldFunctionInterpolationOperation::OP_AVG_FUNC)
   {
     double local_data[] = {local_volume, local_sum};
     double global_data[] = {0.0, 0.0};
@@ -118,8 +117,8 @@ FieldFunctionInterpolationVolume::Execute()
     double global_sum = global_data[1];
     op_value_ = global_sum / global_volume;
   }
-  if (op_type_ == FieldFunctionInterpolationOperation::OP_MAX or
-      op_type_ == FieldFunctionInterpolationOperation::OP_MAX_FUNC)
+  else if (op_type_ == FieldFunctionInterpolationOperation::OP_MAX or
+           op_type_ == FieldFunctionInterpolationOperation::OP_MAX_FUNC)
   {
     mpi_comm.all_reduce(local_max, op_value_, mpi::op::max<double>());
   }

--- a/framework/field_functions/interpolation/ffinter_volume.h
+++ b/framework/field_functions/interpolation/ffinter_volume.h
@@ -32,7 +32,8 @@ public:
       logical_volume_(nullptr),
       op_type_(FieldFunctionInterpolationOperation::OP_SUM),
       op_value_(0.0)
-  {}
+  {
+  }
 
   virtual ~FieldFunctionInterpolationVolume() {}
 

--- a/framework/field_functions/interpolation/ffinter_volume.h
+++ b/framework/field_functions/interpolation/ffinter_volume.h
@@ -7,8 +7,6 @@
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "framework/math/functions/scalar_material_function.h"
 
-#include <petscksp.h>
-
 namespace opensn
 {
 
@@ -17,30 +15,24 @@ namespace opensn
  *
  * This interpolator allows the user to obtain quantities by logical
  * volume. If no logical volume is assigned to the method it will
- * default to operating over the entire volume.\n
- * \n
- * The method also supports a few primitive operations:
- *  - OP_VOLUME_AVG. Obtains the volume average of the field function
- *    of interest.
- *  - OP_VOLUME_SUM. Obtains the volume integral of the field function
- *    of interest.
+ * default to operating over the entire volume.
  */
 class FieldFunctionInterpolationVolume : public FieldFunctionInterpolation
 {
-protected:
-  std::shared_ptr<LogicalVolume> logical_volume_ = nullptr;
-  FieldFunctionInterpolationOperation op_type_ = FieldFunctionInterpolationOperation::OP_SUM;
-  double op_value_ = 0.0;
-  std::shared_ptr<ScalarMaterialFunction> oper_function_;
-
 private:
+  std::shared_ptr<LogicalVolume> logical_volume_;
+  FieldFunctionInterpolationOperation op_type_;
+  double op_value_;
+  std::shared_ptr<ScalarMaterialFunction> oper_function_;
   std::vector<uint64_t> cell_local_ids_inside_logvol_;
 
 public:
   FieldFunctionInterpolationVolume()
-    : FieldFunctionInterpolation(FieldFunctionInterpolationType::VOLUME)
-  {
-  }
+    : FieldFunctionInterpolation(FieldFunctionInterpolationType::VOLUME),
+      logical_volume_(nullptr),
+      op_type_(FieldFunctionInterpolationOperation::OP_SUM),
+      op_value_(0.0)
+  {}
 
   virtual ~FieldFunctionInterpolationVolume() {}
 
@@ -53,10 +45,8 @@ public:
   void SetOperationFunction(std::shared_ptr<ScalarMaterialFunction> function);
 
   void Initialize() override;
-  void Execute() override;
 
-  std::string GetDefaultFileBaseName() const override { return "ZVFFI"; }
-  void ExportPython(std::string base_name) override {}
+  void Execute() override;
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinterpolation.h
+++ b/framework/field_functions/interpolation/ffinterpolation.h
@@ -46,7 +46,6 @@ enum class FieldFunctionInterpolationProperty : int
   CUSTOM_ARRAY = 14,
 };
 
-// ###################################################################
 /** Base class for field-function interpolation objects.*/
 class FieldFunctionInterpolation
 {
@@ -72,7 +71,9 @@ public:
 
   virtual void Execute(){};
 
-  virtual void Export(std::string base_name){};
+  virtual void ExportToCSV(std::string base_name){};
+
+  virtual void ExportToPython(std::string base_name){};
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinterpolation.h
+++ b/framework/field_functions/interpolation/ffinterpolation.h
@@ -57,9 +57,9 @@ protected:
 
 public:
   explicit FieldFunctionInterpolation(FieldFunctionInterpolationType type)
-    : type_(type),
-      ref_component_(0)
-  {}
+    : type_(type), ref_component_(0)
+  {
+  }
 
   std::vector<std::shared_ptr<FieldFunctionGridBased>>& GetFieldFunctions()
   {
@@ -68,11 +68,11 @@ public:
 
   FieldFunctionInterpolationType Type() const { return type_; }
 
-  virtual void Initialize() {};
+  virtual void Initialize(){};
 
-  virtual void Execute() {};
+  virtual void Execute(){};
 
-  virtual void Export(std::string base_name) {};
+  virtual void Export(std::string base_name){};
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinterpolation.h
+++ b/framework/field_functions/interpolation/ffinterpolation.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 namespace opensn
 {
@@ -56,9 +57,9 @@ protected:
 
 public:
   explicit FieldFunctionInterpolation(FieldFunctionInterpolationType type)
-    : type_(type), ref_component_(0)
-  {
-  }
+    : type_(type),
+      ref_component_(0)
+  {}
 
   std::vector<std::shared_ptr<FieldFunctionGridBased>>& GetFieldFunctions()
   {
@@ -67,13 +68,11 @@ public:
 
   FieldFunctionInterpolationType Type() const { return type_; }
 
-  virtual void Initialize(){};
+  virtual void Initialize() {};
 
-  virtual void Execute(){};
+  virtual void Execute() {};
 
-  virtual std::string GetDefaultFileBaseName() const = 0;
-
-  virtual void ExportPython(std::string base_name) = 0;
+  virtual void Export(std::string base_name) {};
 };
 
 } // namespace opensn

--- a/framework/field_functions/interpolation/ffinterpolation.h
+++ b/framework/field_functions/interpolation/ffinterpolation.h
@@ -37,10 +37,8 @@ enum class FieldFunctionInterpolationProperty : int
   SLICEBINORM = 4,
   OPERATION = 5,
   LOGICAL_VOLUME = 8,
-
   ADD_FIELD_FUNCTION = 9,
   SET_FIELD_FUNCTIONS = 10,
-
   FIRSTPOINT = 11,
   SECONDPOINT = 12,
   NUMBEROFPOINTS = 13,
@@ -53,11 +51,14 @@ class FieldFunctionInterpolation
 {
 protected:
   FieldFunctionInterpolationType type_;
-  unsigned int ref_component_ = 0;
+  unsigned int ref_component_;
   std::vector<std::shared_ptr<FieldFunctionGridBased>> field_functions_;
 
 public:
-  explicit FieldFunctionInterpolation(FieldFunctionInterpolationType type) : type_(type) {}
+  explicit FieldFunctionInterpolation(FieldFunctionInterpolationType type)
+    : type_(type), ref_component_(0)
+  {
+  }
 
   std::vector<std::shared_ptr<FieldFunctionGridBased>>& GetFieldFunctions()
   {
@@ -66,12 +67,12 @@ public:
 
   FieldFunctionInterpolationType Type() const { return type_; }
 
-  /**Initializes the point interpolator.*/
   virtual void Initialize(){};
-  /**Executes the point interpolator.*/
+
   virtual void Execute(){};
 
   virtual std::string GetDefaultFileBaseName() const = 0;
+
   virtual void ExportPython(std::string base_name) = 0;
 };
 

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -954,19 +954,8 @@ MeshContinuum::CheckPointInsideCell(const Cell& cell, const Vector3& point) cons
     const auto& v0 = grid_ref.vertices[cell.vertex_ids_[0]];
     const auto& v1 = grid_ref.vertices[cell.vertex_ids_[1]];
 
-    if (not((point.z > v0.z) and (point.z < v1.z)))
-      return false;
-
     if (((v0.z - point.z) * (v1.z - point.z)) > 0.0)
       return false;
-
-    /*const auto v01 = v1 - v0;
-    const auto v0p = point - v0;
-
-    const double v0p_dot_v01 = v0p.Dot(v01);
-
-    if (not(v0p_dot_v01 >= 0.0 and v0p_dot_v01 < v01.Norm()))
-      inside = false;*/
   } // slab
 
   else if (cell.Type() == CellType::POLYGON)

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -954,13 +954,19 @@ MeshContinuum::CheckPointInsideCell(const Cell& cell, const Vector3& point) cons
     const auto& v0 = grid_ref.vertices[cell.vertex_ids_[0]];
     const auto& v1 = grid_ref.vertices[cell.vertex_ids_[1]];
 
-    const auto v01 = v1 - v0;
+    if (not((point.z > v0.z) and (point.z < v1.z)))
+      return false;
+
+    if (((v0.z - point.z) * (v1.z - point.z)) > 0.0)
+      return false;
+
+    /*const auto v01 = v1 - v0;
     const auto v0p = point - v0;
 
     const double v0p_dot_v01 = v0p.Dot(v01);
 
-    if (not(v0p_dot_v01 >= 0 and v0p_dot_v01 < v01.Norm()))
-      inside = false;
+    if (not(v0p_dot_v01 >= 0.0 and v0p_dot_v01 < v01.Norm()))
+      inside = false;*/
   } // slab
 
   else if (cell.Type() == CellType::POLYGON)

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
@@ -64,10 +64,8 @@ FFInterpolationCreate(lua_State* L)
     return LuaReturn(L, index);
   }
   else // Fall back
-  {
-    opensn::log.LogAllError() << "Invalid FFITypeIndex used in FFInterpolationCreate.";
-    opensn::Exit(EXIT_FAILURE);
-  }
+    throw std::logic_error("Invalid FFITypeIndex used in FFInterpolationCreate.");
+
   return LuaReturn(L);
 }
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
@@ -20,9 +20,8 @@ FFInterpolationExport(lua_State* L)
 
   // Get handle to field function
   const auto ffihandle = LuaArg<size_t>(L, 1);
-  auto p_ffi = opensn::GetStackItemPtr(opensn::field_func_interpolation_stack,
-                                       ffihandle,
-                                       "fieldfunc.Export");
+  auto p_ffi =
+    opensn::GetStackItemPtr(opensn::field_func_interpolation_stack, ffihandle, "fieldfunc.Export");
   auto base_name = LuaArgOptional<std::string>(L, 2, opensn::input_path.stem());
   p_ffi->Export(base_name);
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
@@ -11,19 +11,39 @@
 namespace opensnlua
 {
 
-RegisterLuaFunctionInNamespace(FFInterpolationExport, fieldfunc, Export);
+RegisterLuaFunctionInNamespace(FFInterpolationExportToCSV, fieldfunc, ExportToCSV);
+RegisterLuaFunctionInNamespace(FFInterpolationExportToPython, fieldfunc, ExportToPython);
 
 int
-FFInterpolationExport(lua_State* L)
+FFInterpolationExportToCSV(lua_State* L)
 {
-  LuaCheckArgs<int>(L, "fieldfunc.Export");
-
   // Get handle to field function
   const auto ffihandle = LuaArg<size_t>(L, 1);
-  auto p_ffi =
-    opensn::GetStackItemPtr(opensn::field_func_interpolation_stack, ffihandle, "fieldfunc.Export");
+  auto p_ffi = opensn::GetStackItemPtr(
+    opensn::field_func_interpolation_stack, ffihandle, "fieldfunc.ExportToCSV");
+  if (p_ffi->Type() != opensn::FieldFunctionInterpolationType::LINE)
+    opensn::log.Log0Warning() << "ExportToCSV is only supported for LINE interpolators.";
+
+  LuaCheckArgs<int>(L, "fieldfunc.ExportToCSV");
   auto base_name = LuaArgOptional<std::string>(L, 2, opensn::input_path.stem());
-  p_ffi->Export(base_name);
+  p_ffi->ExportToCSV(base_name);
+
+  return LuaReturn(L);
+}
+
+int
+FFInterpolationExportToPython(lua_State* L)
+{
+  // Get handle to field function
+  const auto ffihandle = LuaArg<size_t>(L, 1);
+  auto p_ffi = opensn::GetStackItemPtr(
+    opensn::field_func_interpolation_stack, ffihandle, "fieldfunc.ExportToPython");
+  if (p_ffi->Type() != opensn::FieldFunctionInterpolationType::SLICE)
+    opensn::log.Log0Warning() << "ExportToPython is only supported for SLICEinterpolators.";
+
+  LuaCheckArgs<int>(L, "fieldfunc.ExportToPython");
+  auto base_name = LuaArgOptional<std::string>(L, 2, opensn::input_path.stem());
+  p_ffi->ExportToPython(base_name);
 
   return LuaReturn(L);
 }

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
@@ -2,32 +2,29 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-#include "framework/field_functions/interpolation/ffinterpolation.h"
-#include "framework/runtime.h"
-#include "framework/logging/log.h"
 #include "ffinterpol_lua.h"
+#include "framework/field_functions/interpolation/ffinterpolation.h"
 #include "framework/console/console.h"
+#include "framework/logging/log.h"
+#include "framework/runtime.h"
 
 namespace opensnlua
 {
 
-RegisterLuaFunctionInNamespace(FFInterpolationExportPython, fieldfunc, ExportPython);
+RegisterLuaFunctionInNamespace(FFInterpolationExport, fieldfunc, Export);
 
 int
-FFInterpolationExportPython(lua_State* L)
+FFInterpolationExport(lua_State* L)
 {
-  const std::string fname = "fieldfunc.ExportPython";
-  LuaCheckArgs<int>(L, fname);
+  LuaCheckArgs<int>(L, "fieldfunc.Export");
 
   // Get handle to field function
   const auto ffihandle = LuaArg<size_t>(L, 1);
-
-  auto p_ffi = opensn::GetStackItemPtr(opensn::field_func_interpolation_stack, ffihandle, fname);
-
-  auto base_name =
-    LuaArgOptional<std::string>(L, 2, p_ffi->GetDefaultFileBaseName() + std::to_string(ffihandle));
-
-  p_ffi->ExportPython(base_name);
+  auto p_ffi = opensn::GetStackItemPtr(opensn::field_func_interpolation_stack,
+                                       ffihandle,
+                                       "fieldfunc.Export");
+  auto base_name = LuaArgOptional<std::string>(L, 2, opensn::input_path.stem());
+  p_ffi->Export(base_name);
 
   return LuaReturn(L);
 }

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
@@ -37,15 +37,8 @@ FFInterpolationGetValue(lua_State* L)
   else if (p_ffi->Type() == FieldFunctionInterpolationType::LINE)
   {
     auto& cur_ffi_line = dynamic_cast<opensn::FieldFunctionInterpolationLine&>(*p_ffi);
-
-    std::vector<std::vector<double>> vals;
-    vals.resize(cur_ffi_line.GetFieldFunctions().size());
-    for (int ff = 0; ff < cur_ffi_line.GetFieldFunctions().size(); ff++)
-    {
-      const auto& ff_ctx = cur_ffi_line.GetFFContexts()[ff];
-      vals[ff] = ff_ctx.interpolation_points_values;
-    }
-    return LuaReturn(L, vals);
+    double value = cur_ffi_line.GetOpValue();
+    return LuaReturn(L, value);
   }
   else if (p_ffi->Type() == FieldFunctionInterpolationType::VOLUME)
   {

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_lua.h
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_lua.h
@@ -130,16 +130,25 @@ int FFInterpolationInitialize(lua_State* L);
  */
 int FFInterpolationExecute(lua_State* L);
 
-/** Export interpolation to a file. This is only valid for
+/** Export interpolation to a CSV file. This is only valid for
  * line interpolators.
  *
  * \param FFIHandle int Handle to the field function interpolation.
  * \param BaseName char Base name to be used for exported files.
  *
  * \ingroup LuaFFInterpol
- * \author Jan
  */
-int FFInterpolationExport(lua_State* L);
+int FFInterpolationExportToCSV(lua_State* L);
+
+/** Export interpolation to a Python file. This is only valid for
+ * slice interpolators.
+ *
+ * \param FFIHandle int Handle to the field function interpolation.
+ * \param BaseName char Base name to be used for exported files.
+ *
+ * \ingroup LuaFFInterpol
+ */
+int FFInterpolationExportToPython(lua_State* L);
 
 /** Gets the value(s) associated with an interpolation provided the
  * interpolation type has an associated value.

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_lua.h
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_lua.h
@@ -46,7 +46,6 @@ int FFInterpolationCreate(lua_State* L);
  * LINE_SECONDPOINT  = Line end point.\n
  * LINE_NUMBEROFPOINTS = Number of points to put in the line interpolator.
  *                           Minimum 2.\n
- * LINE_CUSTOM_ARRAY = Adds custom array to line interpolator.\n
  * OPERATION  =  Some interpolations support operation types. See OpTypes.\n
  * LOGICAL_VOLUME = To be followed by a handle to a logical volume to be
  *                  used by the interpolator.\n
@@ -131,8 +130,8 @@ int FFInterpolationInitialize(lua_State* L);
  */
 int FFInterpolationExecute(lua_State* L);
 
-/** Export interpolation to python line,contour plot depending on the
- * type of interpolation.
+/** Export interpolation to a file. This is only valid for
+ * line interpolators.
  *
  * \param FFIHandle int Handle to the field function interpolation.
  * \param BaseName char Base name to be used for exported files.
@@ -140,7 +139,7 @@ int FFInterpolationExecute(lua_State* L);
  * \ingroup LuaFFInterpol
  * \author Jan
  */
-int FFInterpolationExportPython(lua_State* L);
+int FFInterpolationExport(lua_State* L);
 
 /** Gets the value(s) associated with an interpolation provided the
  * interpolation type has an associated value.

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -164,9 +164,9 @@ FFInterpolationSetProperty(lua_State* L)
     LuaCheckArgs<size_t, int, int>(L, fname);
     auto op_type = LuaArg<int>(L, 3);
 
-    int OP_SUM      = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
-    int OP_AVG      = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
-    int OP_MAX      = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
+    int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
+    int OP_AVG = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
+    int OP_MAX = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
     int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
     int OP_AVG_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG_FUNC);
     int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -95,7 +95,6 @@ FFInterpolationSetProperty(lua_State* L)
     auto ffhandle = LuaArg<size_t>(L, 3);
     auto cur_ff_base = opensn::GetStackItemPtr(opensn::field_function_stack, ffhandle, fname);
     auto cur_ff = std::dynamic_pointer_cast<FieldFunctionGridBased>(cur_ff_base);
-
     p_ffi->GetFieldFunctions().push_back(cur_ff);
   }
   else if (property == FieldFunctionInterpolationProperty::SET_FIELD_FUNCTIONS)
@@ -106,7 +105,6 @@ FFInterpolationSetProperty(lua_State* L)
       const auto ffhandle = static_cast<int>(handle_d);
       auto cur_ff_base = opensn::GetStackItemPtr(opensn::field_function_stack, ffhandle, fname);
       auto cur_ff = std::dynamic_pointer_cast<FieldFunctionGridBased>(cur_ff_base);
-
       p_ffi->GetFieldFunctions().push_back(cur_ff);
     } // for handle
   }
@@ -140,99 +138,105 @@ FFInterpolationSetProperty(lua_State* L)
     LuaCheckArgs<size_t, int, Vector3>(L, fname);
 
     auto& cur_ffi_line = dynamic_cast<FieldFunctionInterpolationLine&>(*p_ffi);
-    cur_ffi_line.GetInitialPoint() = LuaArg<Vector3>(L, 3);
+    cur_ffi_line.SetInitialPoint(LuaArg<Vector3>(L, 3));
   }
   else if (property == FieldFunctionInterpolationProperty::SECONDPOINT)
   {
     LuaCheckArgs<size_t, int, Vector3>(L, fname);
 
     auto& cur_ffi_line = dynamic_cast<FieldFunctionInterpolationLine&>(*p_ffi);
-    cur_ffi_line.GetFinalPoint() = LuaArg<Vector3>(L, 3);
+    cur_ffi_line.SetFinalPoint(LuaArg<Vector3>(L, 3));
   }
   else if (property == FieldFunctionInterpolationProperty::NUMBEROFPOINTS)
   {
     LuaCheckArgs<size_t, int, int>(L, fname);
 
     auto& cur_ffi_line = dynamic_cast<FieldFunctionInterpolationLine&>(*p_ffi);
-
     auto num_points = LuaArg<int>(L, 3);
-
     if (num_points < 2)
     {
-      opensn::log.LogAllError() << "Line property FFI_LINE_NUMBEROFPOINTS"
-                                << " used in FFInterpolationSetProperty. Number of points must"
-                                << " be greater than or equal to 2.";
-      opensn::Exit(EXIT_FAILURE);
+      throw std::logic_error("Line property FFI_LINE_NUMBEROFPOINTS used in "
+                             "FFInterpolationSetProperty. Number of points must be greater than or "
+                             "equal to 2.");
     }
-    cur_ffi_line.GetNumberOfPoints() = num_points;
-  }
-  else if (property == FieldFunctionInterpolationProperty::CUSTOM_ARRAY)
-  {
-    LuaCheckArgs<size_t, int, std::vector<double>>(L, fname);
-
-    auto& cur_ffi_line = dynamic_cast<FieldFunctionInterpolationLine&>(*p_ffi);
-    auto new_array = LuaArg<std::vector<double>>(L, 3);
-    cur_ffi_line.GetCustomArrays().push_back(new_array);
+    cur_ffi_line.SetNumberOfPoints(num_points);
   }
   else if (property == FieldFunctionInterpolationProperty::OPERATION)
   {
     LuaCheckArgs<size_t, int, int>(L, fname);
-
-    if (p_ffi->Type() != FieldFunctionInterpolationType::VOLUME)
-      throw std::logic_error("Volume property FFI_PROP_OPERATION"
-                             " used in FFInterpolationSetProperty can only be used with "
-                             "Volume type interpolations.");
-
-    auto& cur_ffi_volume = dynamic_cast<FieldFunctionInterpolationVolume&>(*p_ffi);
-
     auto op_type = LuaArg<int>(L, 3);
 
-    int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
-    int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);
-    int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
-
-    if (not((op_type >= OP_SUM) and (op_type <= OP_MAX_FUNC)))
+    if (p_ffi->Type() == FieldFunctionInterpolationType::VOLUME)
     {
-      opensn::log.LogAllError() << "Volume property FFI_PROP_OPERATION"
-                                << " used in FFInterpolationSetProperty. Unsupported OPERATON."
-                                << " Supported types are OP_AVG and OP_SUM. " << op_type;
-      opensn::Exit(EXIT_FAILURE);
-    }
+      int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
+      int OP_AVG = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
+      int OP_MAX = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
+      int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
+      int OP_AVG_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG_FUNC);
+      int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);
 
-    if ((op_type >= OP_SUM_FUNC) and (op_type <= OP_MAX_FUNC))
+      if (op_type != OP_SUM && op_type != OP_AVG && op_type != OP_MAX && op_type != OP_SUM_FUNC &&
+          op_type != OP_AVG_FUNC && op_type != OP_MAX_FUNC)
+      {
+        throw std::logic_error("FFI_PROP_OPERATION used in FFInterpolationSetProperty. Unsupported "
+                               "operation type. Supported types are OP_SUM, OP_AVG, OP_MAX, "
+                               "OP_SUM_FUNC, OP_AVG_FUNC and OP_MAX_FUNC.");
+      }
+
+      if (op_type == OP_SUM_FUNC or op_type == OP_AVG_FUNC or op_type == OP_MAX_FUNC)
+      {
+        LuaCheckArgs<size_t, int, int, std::string>(L, fname);
+        const auto func_name = LuaArg<std::string>(L, 4);
+        auto operation_function = CreateFunction(func_name);
+        opensn::function_stack.push_back(operation_function);
+        auto& cur_ffi_volume = dynamic_cast<FieldFunctionInterpolationVolume&>(*p_ffi);
+        cur_ffi_volume.SetOperationFunction(operation_function);
+      }
+
+      auto& cur_ffi_volume = dynamic_cast<FieldFunctionInterpolationVolume&>(*p_ffi);
+      cur_ffi_volume.GetOperationType() = static_cast<FieldFunctionInterpolationOperation>(op_type);
+    }
+    else if (p_ffi->Type() == FieldFunctionInterpolationType::LINE)
     {
-      LuaCheckArgs<size_t, int, int, std::string>(L, fname);
-      const auto func_name = LuaArg<std::string>(L, 4);
-      auto operation_function = CreateFunction(func_name);
-      opensn::function_stack.push_back(operation_function);
-      cur_ffi_volume.SetOperationFunction(operation_function);
-    }
+      int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
+      int OP_AVG = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
+      int OP_MAX = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
 
-    cur_ffi_volume.GetOperationType() = static_cast<FieldFunctionInterpolationOperation>(op_type);
+      if (op_type != OP_SUM && op_type != OP_AVG && op_type != OP_MAX)
+      {
+        throw std::logic_error("FFI_PROP_OPERATION used in FFInterpolationSetProperty. Unsupported "
+                               "operation type. Supported types are OP_SUM, OP_AVG, or OP_MAX.");
+      }
+
+      auto& cur_ffi_line = dynamic_cast<FieldFunctionInterpolationLine&>(*p_ffi);
+      cur_ffi_line.SetOperationType(static_cast<FieldFunctionInterpolationOperation>(op_type));
+    }
+    else
+    {
+      throw std::logic_error("FFI_PROP_OPERATION used in FFInterpolationSetProperty can only be "
+                             "used with volume or line interpolations.");
+    }
   }
   else if (property == FieldFunctionInterpolationProperty::LOGICAL_VOLUME)
   {
     LuaCheckArgs<size_t, int, int>(L, fname);
 
     auto logvol_hndle = LuaArg<int>(L, 3);
-
     auto p_logical_volume = std::dynamic_pointer_cast<LogicalVolume>(
       opensn::GetStackItemPtr(opensn::object_stack, logvol_hndle, fname));
 
     if (p_ffi->Type() != FieldFunctionInterpolationType::VOLUME)
-      throw std::logic_error("Volume property FFI_PROP_LOGICAL_VOLUME"
-                             " used in FFInterpolationSetProperty can only be used with "
-                             "Volume type interpolations.");
+    {
+      throw std::logic_error("Volume property FFI_PROP_LOGICAL_VOLUME use in "
+                             "FFInterpolationSetProperty can only be used with volume type "
+                             "interpolations.");
+    }
 
     auto& cur_ffi_volume = dynamic_cast<FieldFunctionInterpolationVolume&>(*p_ffi);
-
     cur_ffi_volume.GetLogicalVolume() = p_logical_volume;
   }
-  else // Fall back
-  {
-    opensn::log.LogAllError() << "Invalid PropertyIndex used in FFInterpolationSetProperty.";
-    opensn::Exit(EXIT_FAILURE);
-  }
+  else
+    throw std::logic_error("Invalid PropertyIndex used in FFInterpolationSetProperty.");
 
   return LuaReturn(L);
 }

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -32,10 +32,8 @@ RegisterLuaConstant(OP_SUM_FUNC, Varying(13));
 RegisterLuaConstant(OP_AVG_FUNC, Varying(14));
 RegisterLuaConstant(OP_MAX_FUNC, Varying(15));
 RegisterLuaConstant(LOGICAL_VOLUME, Varying(8));
-
 RegisterLuaConstant(ADD_FIELDFUNCTION, Varying(9));
 RegisterLuaConstant(SET_FIELDFUNCTIONS, Varying(10));
-
 RegisterLuaConstant(LINE_FIRSTPOINT, Varying(11));
 RegisterLuaConstant(LINE_SECONDPOINT, Varying(12));
 RegisterLuaConstant(LINE_NUMBEROFPOINTS, Varying(13));
@@ -166,24 +164,23 @@ FFInterpolationSetProperty(lua_State* L)
     LuaCheckArgs<size_t, int, int>(L, fname);
     auto op_type = LuaArg<int>(L, 3);
 
+    int OP_SUM      = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
+    int OP_AVG      = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
+    int OP_MAX      = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
+    int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
+    int OP_AVG_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG_FUNC);
+    int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);
+
     if (p_ffi->Type() == FieldFunctionInterpolationType::VOLUME)
     {
-      int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
-      int OP_AVG = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
-      int OP_MAX = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
-      int OP_SUM_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM_FUNC);
-      int OP_AVG_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG_FUNC);
-      int OP_MAX_FUNC = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX_FUNC);
-
-      if (op_type != OP_SUM && op_type != OP_AVG && op_type != OP_MAX && op_type != OP_SUM_FUNC &&
-          op_type != OP_AVG_FUNC && op_type != OP_MAX_FUNC)
+      if (op_type < OP_SUM or op_type > OP_MAX_FUNC)
       {
         throw std::logic_error("FFI_PROP_OPERATION used in FFInterpolationSetProperty. Unsupported "
                                "operation type. Supported types are OP_SUM, OP_AVG, OP_MAX, "
                                "OP_SUM_FUNC, OP_AVG_FUNC and OP_MAX_FUNC.");
       }
 
-      if (op_type == OP_SUM_FUNC or op_type == OP_AVG_FUNC or op_type == OP_MAX_FUNC)
+      if (op_type >= OP_SUM_FUNC)
       {
         LuaCheckArgs<size_t, int, int, std::string>(L, fname);
         const auto func_name = LuaArg<std::string>(L, 4);
@@ -198,11 +195,7 @@ FFInterpolationSetProperty(lua_State* L)
     }
     else if (p_ffi->Type() == FieldFunctionInterpolationType::LINE)
     {
-      int OP_SUM = static_cast<int>(FieldFunctionInterpolationOperation::OP_SUM);
-      int OP_AVG = static_cast<int>(FieldFunctionInterpolationOperation::OP_AVG);
-      int OP_MAX = static_cast<int>(FieldFunctionInterpolationOperation::OP_MAX);
-
-      if (op_type != OP_SUM && op_type != OP_AVG && op_type != OP_MAX)
+      if (op_type < OP_SUM && op_type > OP_MAX)
       {
         throw std::logic_error("FFI_PROP_OPERATION used in FFInterpolationSetProperty. Unsupported "
                                "operation type. Supported types are OP_SUM, OP_AVG, or OP_MAX.");

--- a/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
+++ b/test/modules/cfem_diffusion/c_diffusion_2d_1a_linear.lua
@@ -79,7 +79,7 @@ fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 if (master_export == nil) then
-    fieldfunc.ExportPython(cline)
+    fieldfunc.Export(cline)
 end
 
 --############################################### Volume integrations

--- a/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
+++ b/test/modules/dfem_diffusion/d_diffusion_2d_1a_linear.lua
@@ -79,7 +79,7 @@ fieldfunc.Initialize(cline)
 fieldfunc.Execute(cline)
 
 if (master_export == nil) then
-    fieldfunc.ExportPython(cline)
+    fieldfunc.Export(cline)
 end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/mg_diffusion_steady/mip_diffusion_3d_1b_ortho.lua
@@ -108,7 +108,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
@@ -152,7 +152,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if (master_export == nil) then
-  fieldfunc.ExportPython(cline)
+  fieldfunc.Export(cline)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -153,7 +153,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-  fieldfunc.ExportPython(slice2)
+  fieldfunc.Export(slice2)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance.lua
@@ -135,7 +135,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-  fieldfunc.ExportPython(slice2)
+  fieldfunc.Export(slice2)
   ExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
 end
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.lua
@@ -154,7 +154,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-    fieldfunc.ExportPython(slice2)
+    fieldfunc.Export(slice2)
     ExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
 end
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -152,7 +152,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-    fieldfunc.ExportPython(slice2)
+    fieldfunc.Export(slice2)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -154,7 +154,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-  fieldfunc.ExportPython(slice2)
+  fieldfunc.Export(slice2)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_5_poly_a_ani_hetero_bndry.lua
@@ -174,7 +174,7 @@ log.Log(LOG_0,string.format("Max-value1=%.5f", maxval))
 
 --############################################### Exports
 if master_export == nil then
-  fieldfunc.ExportPython(slice2)
+  fieldfunc.Export(slice2)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.lua
@@ -115,7 +115,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part1.lua
@@ -112,7 +112,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_qmom_part2.lua
@@ -112,7 +112,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.lua
@@ -114,7 +114,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.lua
@@ -115,7 +115,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.lua
@@ -117,7 +117,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, y = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.lua
@@ -119,7 +119,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, y = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations
@@ -160,7 +160,7 @@ if (master_export == nil) then
   fieldfunc.Initialize(line)
   fieldfunc.Execute(line)
 
-  fieldfunc.ExportPython(line,"Line")
+  fieldfunc.Export(line,"Line")
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_5_cycles_2.lua
@@ -103,7 +103,7 @@ fflist,count = lbs.GetScalarFieldFunctionList(phys1)
 --    --fieldfunc.SetProperty(slices[k],SLICE_BINORM,{x = 0.0, y = 0.0, z = 1.0})
 --    fieldfunc.Initialize(slices[k])
 --    fieldfunc.Execute(slices[k])
---    fieldfunc.ExportPython(slices[k])
+--    fieldfunc.Export(slices[k])
 --end
 
 --############################################### Volume integrations

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
@@ -154,7 +154,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if (master_export == nil) then
-  fieldfunc.ExportPython(cline)
+  fieldfunc.Export(cline)
 end
 
 --############################################### Plots

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -155,7 +155,7 @@ log.Log(LOG_0,string.format("Max-value2=%.5e", maxval))
 
 --############################################### Exports
 if master_export == nil then
-  fieldfunc.ExportPython(slice2)
+  fieldfunc.Export(slice2)
 end
 
 --############################################### Plots


### PR DESCRIPTION
This commit updates the field function interpolation routines and includes a rewrite of the line interpolator. The line interpolator now implements the collective MAX, SUM, and AVG operations that are also defined for the volume interpolator. The ExportPython() routine has been replaced with an export routine that generates a CSV file. Other refactoring for style and coding standards. 

The slice field function is still present in this PR, but has not been updated for style, etc. It is scheduled for removal shortly.