### PR TITLE
Materials Lua Interface Refactor

### DIFF
--- a/framework/math/math_vector_nx.h
+++ b/framework/math/math_vector_nx.h
@@ -114,7 +114,7 @@ struct VectorNX
     return *this;
   }
 
-  /**Component-wise shift by scalar-value.
+  /**Component-wise shift by scalar value.
    * \f$ \vec{w} = \vec{x} + \alpha \f$*/
   VectorNX Shifted(const NumberFormat value) const
   {
@@ -125,7 +125,7 @@ struct VectorNX
     return newVector;
   }
 
-  /**In-place component-wise shift by scalar-value.
+  /**In-place component-wise shift by scalar value.
    * \f$ \vec{x} = \vec{x} + \alpha \f$*/
   VectorNX& Shift(const NumberFormat value)
   {

--- a/framework/mesh/mesh_vector.h
+++ b/framework/mesh/mesh_vector.h
@@ -172,7 +172,7 @@ struct Vector3
     return newVector;
   }
 
-  /**In-place component-wise shift by scalar-value.
+  /**In-place component-wise shift by scalar value.
    * \f$ \vec{x} = \vec{x} + \alpha \f$*/
   Vector3& Shift(const double value)
   {

--- a/lua/framework/materials/lua_material.cc
+++ b/lua/framework/materials/lua_material.cc
@@ -92,47 +92,24 @@ MatSetProperty(lua_State* L)
   if (num_args < 3)
     LuaPostArgAmountError(fname, L, 3, num_args);
 
+  const auto material_handle = LuaArg<int>(L, 1);
+  const auto property_type = LuaArg<int>(L, 2);
+  const auto op_type = LuaArg<int>(L, 3);
+
   // Get a pointer to the material
-  auto material_handle = LuaArg<int>(L, 1);
   auto material = opensn::GetStackItemPtr(opensn::material_stack, material_handle, fname);
 
-  // Get the material property type and its index, if applicable
-  int property_type;
+  // Find the index of the material property on the material
   int property_index = -1;
-  if (lua_isnumber(L, 2))
+  for (int p = 0; p < material->properties.size(); ++p)
   {
-    property_type = LuaArg<int>(L, 2);
-    for (int p = 0; p < material->properties.size(); ++p)
+    const auto& property = material->properties.at(p);
+    if (static_cast<int>(property->Type()) == property_type)
     {
-      const auto& property = material->properties.at(p);
-      if (static_cast<int>(property->Type()) == property_type)
-      {
-        property_index = p;
-        break;
-      }
+      property_index = p;
+      break;
     }
   }
-  else
-  {
-    const auto property_name = LuaArg<std::string>(L, 2);
-    for (int p = 0; p < material->properties.size(); ++p)
-    {
-      const auto& property = material->properties.at(p);
-      if (property->property_name == property_name)
-      {
-        property_type = static_cast<int>(property->Type());
-        property_index = p;
-        break;
-      }
-    }
-    OpenSnInvalidArgumentIf(property_index == -1,
-                            "No property with name " + property_name +
-                              " found on material at index " + std::to_string(material_handle) +
-                              ".");
-  }
-
-  // Get the operation index
-  auto op_type = LuaArg<int>(L, 3);
 
   // Process property
   if (property_type == static_cast<int>(PropertyType::SCALAR_VALUE))

--- a/lua/framework/materials/lua_material.h
+++ b/lua/framework/materials/lua_material.h
@@ -95,7 +95,7 @@ int MatAddMaterial(lua_State* L);
  * ##_
  *
  * ### Example 1
- * Simple scalar valued property:
+ * Simple scalar-valued property:
  * \code
  * materials = {}
  * materials[1] = mat.AddMaterial("Test Material");

--- a/lua/framework/materials/lua_material.h
+++ b/lua/framework/materials/lua_material.h
@@ -33,58 +33,10 @@ namespace opensnlua
 int MatAddMaterial(lua_State* L);
 
 /**
- * Adds a material property to a material.
- *
- * \param MaterialHandle int Index to the reference material.
- * \param PropertyIndex int Property index.
- *
- * ##_
- *
- * ###PropertyIndex\n
- *
- * SCALAR_VALUE\n
- *  Simple scalar value property.\n\n
- *
- * TRANSPORT_XSECTIONS\n
- *  Multi-group transport cross section supporting numerous features.\n\n
- *
- * ISOTROPIC_MG_SOURCE\n
- *  Isotropic Multigroup Source.\n\n
- *
- * ### Developer Info
- * Checklist for adding a new material property:
- *  - Create your property class in its own header file. i.e.
- *    "physics/PhysicsMaterial/property_xx_myproperty.h"
- *  - Add the property to the physics namespace
- *    ("physics/chi_physics_namespace.h"). Make sure to derive from the base
- *    class.
- *  - Go define the integer to be associated with your new property in
- *    chi_physicsmaterial.h
- *  - Include the header file for your property in this file (i.e. at the top).
- *  - Add this property integer in the lua register (ChiLua/chi_lua_register.h).
- *    For testing you can just use the integer value but eventually you'd want
- *    to supply an easier way for users to enter it.
- *  - Add another else-if for your property. Just have a look at how the others
- *    were done, it should be intuitive enough.
- *
- * ##_
- *
- * ### Example\n
- * Example lua code:
- * \code
- * mat.AddProperty(materials[i],TRANSPORT_XSECTIONS)
- * \endcode
- *
- * \ingroup LuaPhysicsMaterials
- * \author Jan
- */
-int MatAddProperty(lua_State* L);
-
-/**
  * Sets a material property for a given material.
  *
  * \param MaterialHandle int Index to the reference material.
- * \param PropertyType int Property type, or name of property.
+ * \param PropertyType int Property type.
  * \param OperationType int Method used for setting the material property.
  * \param Information varying Varying information depending on the operation.
  *

--- a/test/modules/linear_boltzmann_solvers/transport_steady/reed_balance.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/reed_balance.lua
@@ -39,15 +39,11 @@ for imat = 1, Nmat do materials[imat] = mat.AddMaterial(mat_names[imat]) end
 total = {50., 5., 0., 1., 1.}
 c = {0., 0., 0., 0.9, 0.9}
 for imat = 1, Nmat do
-  mat.AddProperty(materials[imat], TRANSPORT_XSECTIONS)
   mat.SetProperty(materials[imat], TRANSPORT_XSECTIONS, SIMPLE_ONE_GROUP, total[imat], c[imat])
 end
 
 -- Create sources in 1st and 4th materials
-mat.AddProperty(materials[1], ISOTROPIC_MG_SOURCE)
 mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, {50.})
-
-mat.AddProperty(materials[4], ISOTROPIC_MG_SOURCE)
 mat.SetProperty(materials[4], ISOTROPIC_MG_SOURCE, FROM_ARRAY, {1.})
 
 -- Angular Quadrature


### PR DESCRIPTION
This PR is a follow-up to #257 that continues the Lua materials interface refactor.

- Removes `mat.AddProperty` from the Lua interface
- Eliminates material property name options within `mat.SetProperty`
- Only allows one property of a given type per material

Closes #252 