### PR TITLE
Groupset solver doesn't honor GMRES restart parameter

### DIFF
--- a/modules/linear_boltzmann_solvers/lbs_solver/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/groupset/lbs_groupset.cc
@@ -188,6 +188,7 @@ LBSGroupset::LBSGroupset(const InputParameters& params, const int id, const LBSS
   else if (inner_linear_method == "bicgstab")
     iterative_method_ = IterativeMethod::KRYLOV_BICGSTAB;
 
+  gmres_restart_intvl_ = params.GetParamValue<int>("gmres_restart_interval");
   allow_cycles_ = params.GetParamValue<bool>("allow_cycles");
   residual_tolerance_ = params.GetParamValue<double>("l_abs_tol");
   max_iterations_ = params.GetParamValue<int>("l_max_its");

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/tests.json
@@ -13,7 +13,7 @@
       {
         "type": "KeyValuePair",
         "key": "[0]  Max-value2=",
-        "goldvalue": 7.18231e-04,
+        "goldvalue": 7.18243e-04,
         "abs_tol": 1.0e-8
       }
     ]


### PR DESCRIPTION
The GMRES restart parameter specified in groupset options was never assigned to the corresponding member variable, leading to the solver always using the default value of 30.