### PR TITLE
Use full path in #includes

### DIFF
--- a/framework/math/functions/function.cc
+++ b/framework/math/functions/function.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "function.h"
+#include "framework/math/functions/function.h"
 
 namespace opensn
 {

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(libopensnlua
     $<INSTALL_INTERFACE:include/opensn>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/external
     ${LUA_INCLUDE_DIR}
 )

--- a/lua/framework/console/console.cc
+++ b/lua/framework/console/console.cc
@@ -3,7 +3,7 @@
 
 #include "lua/framework/console/console.h"
 #include "lua/modules/modules.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "config.h"
 #include "framework/object_factory.h"
 #include "framework/runtime.h"

--- a/lua/framework/interfaces/plugin.cc
+++ b/lua/framework/interfaces/plugin.cc
@@ -1,14 +1,12 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/interfaces/plugin.h"
-
+#include "lua/framework/interfaces/plugin.h"
 #include "framework/object_factory.h"
-
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/utils.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 #include <dlfcn.h>
 

--- a/lua/framework/logging/log.cc
+++ b/lua/framework/logging/log.cc
@@ -3,8 +3,8 @@
 
 #include "lua/framework/logging/log.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
-#include "framework/lua.h"
+#include "lua/framework/console/console.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 
 using namespace opensn;

--- a/lua/framework/logging/log.cc
+++ b/lua/framework/logging/log.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "log.h"
+#include "lua/framework/logging/log.h"
 #include "framework/logging/log.h"
 #include "framework/console/console.h"
 #include "framework/lua.h"

--- a/lua/framework/logging/log.h
+++ b/lua/framework/logging/log.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/materials/material.cc
+++ b/lua/framework/materials/material.cc
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/materials/material.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/materials/material.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include "framework/materials/scalar_value.h"
 #include "framework/materials/isotropic_multigroup_source.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include <iostream>
 
 using namespace opensn;

--- a/lua/framework/materials/material.cc
+++ b/lua/framework/materials/material.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "material.h"
+#include "lua/framework/materials/material.h"
 #include "framework/lua.h"
 #include "framework/materials/material.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"

--- a/lua/framework/materials/material.h
+++ b/lua/framework/materials/material.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
+++ b/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "multi_group_xs_lua_utils.h"
+#include "lua/framework//materials/multi_group_xs/multi_group_xs_lua_utils.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include "framework/materials/material.h"
 #include "framework/logging/log.h"

--- a/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
+++ b/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.cc
@@ -5,7 +5,7 @@
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include "framework/materials/material.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include <iostream>
 

--- a/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.h
+++ b/lua/framework/materials/multi_group_xs/multi_group_xs_lua_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/math/functions/lua_dim_a_to_dim_b.cc
+++ b/lua/framework/math/functions/lua_dim_a_to_dim_b.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/math/functions/lua_dim_a_to_dim_b.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/logging/log_exceptions.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 #include "framework/object_factory.h"
 

--- a/lua/framework/math/functions/lua_dim_a_to_dim_b.cc
+++ b/lua/framework/math/functions/lua_dim_a_to_dim_b.cc
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lua_dim_a_to_dim_b.h"
-
+#include "lua/framework/math/functions/lua_dim_a_to_dim_b.h"
 #include "framework/console/console.h"
 #include "framework/logging/log_exceptions.h"
 #include "framework/lua.h"

--- a/lua/framework/math/functions/lua_scalar_material_function.cc
+++ b/lua/framework/math/functions/lua_scalar_material_function.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/math/functions/lua_scalar_material_function.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/object_factory.h"
 
 using namespace opensn;

--- a/lua/framework/math/functions/lua_scalar_spatial_function.cc
+++ b/lua/framework/math/functions/lua_scalar_spatial_function.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/math/functions/lua_scalar_spatial_function.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/object_factory.h"
 
 using namespace opensn;

--- a/lua/framework/math/functions/lua_scalar_spatial_material_function.cc
+++ b/lua/framework/math/functions/lua_scalar_spatial_material_function.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/math/functions/lua_scalar_spatial_material_function.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/object_factory.h"
 
 using namespace opensn;

--- a/lua/framework/math/functions/lua_spatial_material_function.cc
+++ b/lua/framework/math/functions/lua_spatial_material_function.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/math/functions/lua_spatial_material_function.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/object_factory.h"
 
 using namespace opensn;

--- a/lua/framework/math/functions/math_function.cc
+++ b/lua/framework/math/functions/math_function.cc
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
-
-#include "framework/console/console.h"
-
+#include "lua/framework/lua.h"
+#include "lua/framework/console/console.h"
 #include "framework/math/functions/function_dimA_to_dimB.h"
-
 #include "framework/logging/log_exceptions.h"
 
 using namespace opensn;

--- a/lua/framework/math/quadratures/angular_quadrature_polar_opt.cc
+++ b/lua/framework/math/quadratures/angular_quadrature_polar_opt.cc
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/math/quadratures/angular/angular_quadrature.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "lua/framework/math/quadratures/quadratures.h"

--- a/lua/framework/math/quadratures/angular_quadrature_polar_opt.cc
+++ b/lua/framework/math/quadratures/angular_quadrature_polar_opt.cc
@@ -6,7 +6,7 @@
 #include "framework/console/console.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 
 using namespace opensn;
 

--- a/lua/framework/math/quadratures/create_angular_quadrature.cc
+++ b/lua/framework/math/quadratures/create_angular_quadrature.cc
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/math/quadratures/angular/angular_quadrature.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "lua/framework/math/quadratures/quadratures.h"
 

--- a/lua/framework/math/quadratures/create_angular_quadrature.cc
+++ b/lua/framework/math/quadratures/create_angular_quadrature.cc
@@ -6,7 +6,7 @@
 #include "framework/logging/log.h"
 #include "framework/console/console.h"
 #include "framework/runtime.h"
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 
 namespace opensnlua
 {

--- a/lua/framework/math/quadratures/create_curvilinear_product_quadrature.cc
+++ b/lua/framework/math/quadratures/create_curvilinear_product_quadrature.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/gausschebyshev_quadrature.h"
 #include "framework/math/quadratures/gausslegendre_quadrature.h"
 #include "framework/math/quadratures/angular/cylindrical_quadrature.h"

--- a/lua/framework/math/quadratures/create_curvilinear_product_quadrature.cc
+++ b/lua/framework/math/quadratures/create_curvilinear_product_quadrature.cc
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/gausschebyshev_quadrature.h"
 #include "framework/math/quadratures/gausslegendre_quadrature.h"
 #include "framework/math/quadratures/angular/cylindrical_quadrature.h"
 #include "framework/math/quadratures/angular/spherical_quadrature.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 
 using namespace opensn;

--- a/lua/framework/math/quadratures/create_line_quadrature.cc
+++ b/lua/framework/math/quadratures/create_line_quadrature.cc
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/object_factory.h"
 #include "lua/framework/math/quadratures/quadratures.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/math/quadratures/create_line_quadrature.cc
+++ b/lua/framework/math/quadratures/create_line_quadrature.cc
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-
 #include "framework/object_factory.h"
-
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/math/quadratures/create_prod_quadrature.cc
+++ b/lua/framework/math/quadratures/create_prod_quadrature.cc
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include <memory>
 

--- a/lua/framework/math/quadratures/create_prod_quadrature.cc
+++ b/lua/framework/math/quadratures/create_prod_quadrature.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/logging/log.h"
 #include "framework/console/console.h"

--- a/lua/framework/math/quadratures/get_prod_quadrature.cc
+++ b/lua/framework/math/quadratures/get_prod_quadrature.cc
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 
 using namespace opensn;

--- a/lua/framework/math/quadratures/get_prod_quadrature.cc
+++ b/lua/framework/math/quadratures/get_prod_quadrature.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-#include "quadratures.h"
+#include "lua/framework/math/quadratures/quadratures.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/logging/log.h"
 #include "framework/console/console.h"

--- a/lua/framework/math/quadratures/legendre_poly/legendre.cc
+++ b/lua/framework/math/quadratures/legendre_poly/legendre.cc
@@ -4,7 +4,7 @@
 #include "framework/lua.h"
 #include "framework/math/quadratures/angular/legendre_poly/legendrepoly.h"
 #include "framework/console/console.h"
-#include "legendre.h"
+#include "lua/framework/math/quadratures/legendre_poly/legendre.h"
 
 using namespace opensn;
 

--- a/lua/framework/math/quadratures/legendre_poly/legendre.cc
+++ b/lua/framework/math/quadratures/legendre_poly/legendre.cc
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/math/quadratures/angular/legendre_poly/legendrepoly.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "lua/framework/math/quadratures/legendre_poly/legendre.h"
 
 using namespace opensn;

--- a/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
+++ b/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/math/quadratures/angular/sldfe_sq_quadrature.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "lua/framework/math/quadratures/sldfesq/sldfe.h"
 

--- a/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
+++ b/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
@@ -5,7 +5,7 @@
 #include "framework/math/quadratures/angular/sldfe_sq_quadrature.h"
 #include "framework/console/console.h"
 #include "framework/runtime.h"
-#include "sldfe.h"
+#include "lua/framework/math/quadratures/sldfesq/sldfe.h"
 
 using namespace opensn;
 

--- a/lua/framework/math/quadratures/sldfesq/locally_refine_sldfesq.cc
+++ b/lua/framework/math/quadratures/sldfesq/locally_refine_sldfesq.cc
@@ -6,7 +6,7 @@
 #include "framework/console/console.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "sldfe.h"
+#include "lua/framework/math/quadratures/sldfesq/sldfe.h"
 
 using namespace opensn;
 

--- a/lua/framework/math/quadratures/sldfesq/locally_refine_sldfesq.cc
+++ b/lua/framework/math/quadratures/sldfesq/locally_refine_sldfesq.cc
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/math/quadratures/angular/sldfe_sq_quadrature.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "lua/framework/math/quadratures/sldfesq/sldfe.h"

--- a/lua/framework/mesh/export/mesh_export.cc
+++ b/lua/framework/mesh/export/mesh_export.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/mesh/mesh.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/mesh/io/mesh_io.h"

--- a/lua/framework/mesh/export/mesh_export.h
+++ b/lua/framework/mesh/export/mesh_export.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol.h
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/field_functions/interpolation/ffinter_point.h"
 #include "framework/field_functions/interpolation/ffinter_slice.h"
 #include "framework/field_functions/interpolation/ffinter_line.h"
@@ -9,7 +9,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
@@ -8,7 +8,7 @@
 #include "framework/field_functions/interpolation/ffinter_volume.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "ffinterpol.h"
+#include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/field_functions/interpolation/ffinterpolation.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_export.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-#include "ffinterpol.h"
+#include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/field_functions/interpolation/ffinterpolation.h"
 #include "framework/console/console.h"
 #include "framework/logging/log.h"

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/field_functions/interpolation/ffinter_point.h"
 #include "framework/field_functions/interpolation/ffinter_line.h"
 #include "framework/field_functions/interpolation/ffinter_volume.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_get_value.cc
@@ -7,7 +7,7 @@
 #include "framework/field_functions/interpolation/ffinter_volume.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "ffinterpol.h"
+#include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_operations.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_operations.cc
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/field_functions/interpolation/ffinterpolation.h"
 #include "framework/runtime.h"
 #include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_operations.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_operations.cc
@@ -4,7 +4,7 @@
 #include "framework/lua.h"
 #include "framework/field_functions/interpolation/ffinterpolation.h"
 #include "framework/runtime.h"
-#include "ffinterpol.h"
+#include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/console/console.h"
 
 namespace opensnlua

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/field_functions/interpolation/ffinter_point.h"
 #include "framework/field_functions/interpolation/ffinter_slice.h"
@@ -11,7 +11,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_set_property.cc
@@ -10,7 +10,7 @@
 #include "lua/framework/math/functions/lua_scalar_material_function.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "ffinterpol.h"
+#include "lua/framework/mesh/field_function_interpolation/ffinterpol.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/logical_volume/logic_volume.cc
+++ b/lua/framework/mesh/logical_volume/logic_volume.cc
@@ -4,7 +4,7 @@
 #include "lua/framework/mesh/logical_volume/logic_volume.h"
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/logical_volume/logic_volume.cc
+++ b/lua/framework/mesh/logical_volume/logic_volume.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "logic_volume.h"
+#include "lua/framework/mesh/logical_volume/logic_volume.h"
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "framework/runtime.h"
 #include "framework/console/console.h"

--- a/lua/framework/mesh/logical_volume/logic_volume.h
+++ b/lua/framework/mesh/logical_volume/logic_volume.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/mesh_generator/mesh_generator_execute.cc
+++ b/lua/framework/mesh/mesh_generator/mesh_generator_execute.cc
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
-
+#include "lua/framework/lua.h"
 #include "framework/mesh/mesh_generator/mesh_generator.h"
-
-#include "framework/console/console.h"
-
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/mesh_set_ids.cc
+++ b/lua/framework/mesh/mesh_set_ids.cc
@@ -6,7 +6,7 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/mesh/logical_volume/logical_volume.h"
 
 namespace opensnlua

--- a/lua/framework/mesh/mesh_set_ids.h
+++ b/lua/framework/mesh/mesh_set_ids.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/ortho_grids/mesh_ortho_macros.cc
+++ b/lua/framework/mesh/ortho_grids/mesh_ortho_macros.cc
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/data_types/varying.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "lua/framework/mesh/ortho_grids/mesh_ortho_macros.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/ortho_grids/mesh_ortho_macros.cc
+++ b/lua/framework/mesh/ortho_grids/mesh_ortho_macros.cc
@@ -7,7 +7,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
-#include "mesh_ortho_macros.h"
+#include "lua/framework/mesh/ortho_grids/mesh_ortho_macros.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/lua/framework/mesh/surface_mesh/surface_mesh.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "surface_mesh.h"
+#include "lua/framework/mesh/surface_mesh/surface_mesh.h"
 #include "framework/lua.h"
 #include "framework/mesh/surface_mesh/surface_mesh.h"
 #include "framework/runtime.h"

--- a/lua/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/lua/framework/mesh/surface_mesh/surface_mesh.cc
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/framework/mesh/surface_mesh/surface_mesh.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/mesh/surface_mesh/surface_mesh.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/surface_mesh/surface_mesh.h
+++ b/lua/framework/mesh/surface_mesh/surface_mesh.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mesh/unpartitioned_mesh/create.cc
+++ b/lua/framework/mesh/unpartitioned_mesh/create.cc
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/mesh/io/mesh_io.h"
 #include "lua/framework/mesh/unpartitioned_mesh/unpartition_mesh_lua_utils.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/mesh/unpartitioned_mesh/create.cc
+++ b/lua/framework/mesh/unpartitioned_mesh/create.cc
@@ -6,7 +6,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/mesh/io/mesh_io.h"
-#include "unpartition_mesh_lua_utils.h"
+#include "lua/framework/mesh/unpartitioned_mesh/unpartition_mesh_lua_utils.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/mesh/unpartitioned_mesh/unpartition_mesh_lua_utils.h
+++ b/lua/framework/mesh/unpartitioned_mesh/unpartition_mesh_lua_utils.h
@@ -4,8 +4,7 @@
 #pragma once
 
 #include "framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h"
-
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mpi/mpi_barrier.cc
+++ b/lua/framework/mpi/mpi_barrier.cc
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 #include "lua/framework/mpi/mpi_barrier.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 namespace opensnlua
 {

--- a/lua/framework/mpi/mpi_barrier.cc
+++ b/lua/framework/mpi/mpi_barrier.cc
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/lua.h"
-
 #include "framework/runtime.h"
-#include "mpi_barrier.h"
+#include "lua/framework/mpi/mpi_barrier.h"
 #include "framework/console/console.h"
 
 namespace opensnlua

--- a/lua/framework/mpi/mpi_barrier.h
+++ b/lua/framework/mpi/mpi_barrier.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/physics/field_function/field_functions.h
+++ b/lua/framework/physics/field_function/field_functions.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/physics/field_function/physics_export_field_func.cc
+++ b/lua/framework/physics/field_function/physics_export_field_func.cc
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/physics/field_function/field_functions.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/physics/field_function/physics_export_field_func.cc
+++ b/lua/framework/physics/field_function/physics_export_field_func.cc
@@ -5,7 +5,7 @@
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "field_functions.h"
+#include "lua/framework/physics/field_function/field_functions.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/physics/field_function/physics_get_field_func_list.cc
+++ b/lua/framework/physics/field_function/physics_get_field_func_list.cc
@@ -6,7 +6,7 @@
 #include "framework/physics/solver_base/solver.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/logging/log.h"
-#include "field_functions.h"
+#include "lua/framework/physics/field_function/field_functions.h"
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/framework/physics/field_function/physics_get_field_func_list.cc
+++ b/lua/framework/physics/field_function/physics_get_field_func_list.cc
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 #include "framework/physics/solver_base/solver.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/logging/log.h"
 #include "lua/framework/physics/field_function/field_functions.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/physics/solver/solver.cc
+++ b/lua/framework/physics/solver/solver.cc
@@ -8,7 +8,7 @@
 #include "framework/object_factory.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/framework/physics/solver/solver.cc
+++ b/lua/framework/physics/solver/solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "solver.h"
+#include "lua/framework/physics/solver/solver.h"
 #include "framework/physics/solver_base/solver.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/event_system/physics_event_publisher.h"

--- a/lua/framework/physics/solver/solver.h
+++ b/lua/framework/physics/solver/solver.h
@@ -8,7 +8,7 @@ namespace opensn
 class InputParameters;
 }
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/framework/post_processors/execute_post_processors.cc
+++ b/lua/framework/post_processors/execute_post_processors.cc
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/post_processors/post_processor.h"
-
-#include "framework/console/console.h"
-
+#include "lua/framework/console/console.h"
 #include "framework/event_system/event.h"
 
 namespace opensn

--- a/lua/framework/post_processors/post_processor_get_value.cc
+++ b/lua/framework/post_processors/post_processor_get_value.cc
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/post_processors/post_processor.h"
-
-#include "framework/console/console.h"
-
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/framework/post_processors/pp_printer_set_options.cc
+++ b/lua/framework/post_processors/pp_printer_set_options.cc
@@ -5,10 +5,8 @@
 
 #include "framework/parameters/input_parameters.h"
 #include "framework/utils/utils.h"
-
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/object_factory.h"
-
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/framework/post_processors/print_post_processors.cc
+++ b/lua/framework/post_processors/print_post_processors.cc
@@ -3,9 +3,7 @@
 
 #include "framework/post_processors/post_processor_printer.h"
 #include "framework/post_processors/post_processor.h"
-
-#include "framework/console/console.h"
-
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/framework/utils/exit.cc
+++ b/lua/framework/utils/exit.cc
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/console/console.h"
-
-#include "framework/lua.h"
-
+#include "lua/framework/console/console.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 
 namespace opensnlua

--- a/lua/framework/utils/program_timer.cc
+++ b/lua/framework/utils/program_timer.cc
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/console/console.h"
-
-#include "framework/lua.h"
-
+#include "lua/framework/console/console.h"
+#include "lua/framework/lua.h"
 #include "framework/runtime.h"
 #include "framework/utils/timer.h"
 

--- a/lua/framework/utils/sleep.cc
+++ b/lua/framework/utils/sleep.cc
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/console/console.h"
-
-#include "framework/lua.h"
-
+#include "lua/framework/console/console.h"
+#include "lua/framework/lua.h"
 #include "framework/utils/timer.h"
 
 namespace opensnlua

--- a/lua/modules/cfem_diffusion/cfem_diff_solver.cc
+++ b/lua/modules/cfem_diffusion/cfem_diff_solver.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/cfem_diffusion/cfem_diffusion_solver.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/math/functions/lua_scalar_spatial_material_function.h"

--- a/lua/modules/dfem_diffusion/dfem_diff_solver.cc
+++ b/lua/modules/dfem_diffusion/dfem_diff_solver.cc
@@ -3,7 +3,7 @@
 
 #include "lua/modules/dfem_diffusion/dfem_diff_solver.h"
 #include "modules/dfem_diffusion/dfem_diffusion_solver.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "lua/framework/math/functions/lua_scalar_spatial_material_function.h"

--- a/lua/modules/dfem_diffusion/dfem_diff_solver.cc
+++ b/lua/modules/dfem_diffusion/dfem_diff_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "dfem_diff_solver.h"
+#include "lua/modules/dfem_diffusion/dfem_diff_solver.h"
 #include "modules/dfem_diffusion/dfem_diffusion_solver.h"
 #include "framework/console/console.h"
 #include "framework/runtime.h"

--- a/lua/modules/dfem_diffusion/dfem_diff_solver.h
+++ b/lua/modules/dfem_diffusion/dfem_diff_solver.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/modules/fv_diffusion/fv_diff_solver.cc
+++ b/lua/modules/fv_diffusion/fv_diff_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "fv_diff_solver.h"
+#include "lua/modules/fv_diffusion/fv_diff_solver.h"
 #include "modules/fv_diffusion/fv_diffusion_solver.h"
 #include "lua/framework/console/console.h"
 #include "framework/runtime.h"

--- a/lua/modules/fv_diffusion/fv_diff_solver.h
+++ b/lua/modules/fv_diffusion/fv_diff_solver.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_export_impmap_binary.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_export_impmap_binary.cc
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbsadj_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.h"
-
 #include "framework/runtime.h"
-
 #include "framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_export_impmap_binary.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_export_impmap_binary.cc
@@ -4,7 +4,7 @@
 #include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 
 using namespace opensn;
 

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_make_exp_rep_from_p1.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_make_exp_rep_from_p1.cc
@@ -1,13 +1,10 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbsadj_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adjoint.h"
-
-#include <stdexcept>
-
 #include "framework/console/console.h"
+#include <stdexcept>
 
 using namespace opensn;
 

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_make_exp_rep_from_p1.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_make_exp_rep_from_p1.cc
@@ -3,7 +3,7 @@
 
 #include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adjoint.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include <stdexcept>
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_adjoint_solver/lbsadj_lua_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua::lbs
 {

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_balance.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_balance.cc
@@ -3,7 +3,7 @@
 
 #include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 
 namespace opensnlua::lbs

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_balance.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_balance.cc
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_do_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.h"
-
 #include "framework/console/console.h"
-
 #include "framework/runtime.h"
 
 namespace opensnlua::lbs

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_do_lua_utils.h"
+#include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h"
 #include "framework/runtime.h"
 #include "framework/console/console.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_compute_leakage.cc
@@ -3,7 +3,7 @@
 
 #include "lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.h"
 

--- a/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h
+++ b/lua/modules/linear_bolzmann_solvers/discrete_ordinates_solver/lbs_do_lua_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua::lbs
 {

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua::lbs
 {

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_compute_fiss_rates.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_compute_fiss_rates.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_common_lua_functions.h"
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
 #include "framework/lua.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_compute_fiss_rates.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_compute_fiss_rates.cc
@@ -4,7 +4,7 @@
 #include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
@@ -6,7 +6,7 @@
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_common_lua_functions.h"
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/runtime.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_common_lua_functions.h"
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
 #include "framework/lua.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_init_materials.cc
@@ -4,7 +4,7 @@
 #include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_angular_fluxes.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_angular_fluxes.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_common_lua_functions.h"
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_angular_fluxes.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_angular_fluxes.cc
@@ -6,7 +6,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/groupset/lbs_groupset.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_flux_moments.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_flux_moments.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_common_lua_functions.h"
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_flux_moments.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_io_flux_moments.cc
@@ -5,7 +5,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"
 
 using namespace opensn;

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_options.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_options.cc
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
-
 #include "framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_options.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_options.cc
@@ -3,7 +3,7 @@
 
 #include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_phi_from_ff.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_phi_from_ff.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_phi_from_ff.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_set_phi_from_ff.cc
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
 #include "framework/lua.h"
-
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
-
 #include "framework/console/console.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 #include "framework/parameters/input_parameters.h"
 
 namespace lbs

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_sources.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_sources.cc
@@ -3,9 +3,9 @@
 
 #include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
 #include "framework/runtime.h"
-#include "framework/console/console.h"
+#include "lua/framework/console/console.h"
 #include "framework/logging/log.h"
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "lua/framework/math/functions/lua_spatial_material_function.h"

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_sources.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_sources.cc
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "lbs_lua_utils.h"
-
+#include "lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_lua_utils.h"
 #include "framework/runtime.h"
 #include "framework/console/console.h"
 #include "framework/logging/log.h"

--- a/lua/modules/linear_bolzmann_solvers/response_evaluator/response_evaluator.cc
+++ b/lua/modules/linear_bolzmann_solvers/response_evaluator/response_evaluator.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "response_evaluator.h"
+#include "lua/modules/linear_bolzmann_solvers/response_evaluator/response_evaluator.h"
 #include "modules/linear_boltzmann_solvers/response_evaluator/response_evaluator.h"
 #include "lua/framework/console/console.h"
 

--- a/lua/modules/mg_diffusion/mg_diff_solver.cc
+++ b/lua/modules/mg_diffusion/mg_diff_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "mg_diff_solver.h"
+#include "lua/modules/mg_diffusion/mg_diff_solver.h"
 #include "lua/framework/console/console.h"
 #include "modules/mg_diffusion/mg_diffusion_solver.h"
 #include "framework/runtime.h"

--- a/lua/modules/mg_diffusion/mg_diff_solver.h
+++ b/lua/modules/mg_diffusion/mg_diff_solver.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua
 {

--- a/lua/modules/modules.cc
+++ b/lua/modules/modules.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "modules.h"
+#include "lua/modules/modules.h"
 #include "framework/object_factory.h"
 #include "lua/framework/lua.h"
 #include "lua/framework/console/console.h"

--- a/lua/modules/point_reactor_kinetics/prk_lua_utils.cc
+++ b/lua/modules/point_reactor_kinetics/prk_lua_utils.cc
@@ -3,10 +3,8 @@
 
 #include "framework/lua.h"
 #include "framework/console/console.h"
-
 #include "modules/point_reactor_kinetics/point_reactor_kinetics.h"
-#include "prk_lua_utils.h"
-
+#include "lua/modules/point_reactor_kinetics/prk_lua_utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 

--- a/lua/modules/point_reactor_kinetics/prk_lua_utils.cc
+++ b/lua/modules/point_reactor_kinetics/prk_lua_utils.cc
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/lua.h"
-#include "framework/console/console.h"
+#include "lua/framework/lua.h"
+#include "lua/framework/console/console.h"
 #include "modules/point_reactor_kinetics/point_reactor_kinetics.h"
 #include "lua/modules/point_reactor_kinetics/prk_lua_utils.h"
 #include "framework/runtime.h"

--- a/lua/modules/point_reactor_kinetics/prk_lua_utils.h
+++ b/lua/modules/point_reactor_kinetics/prk_lua_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "framework/lua.h"
+#include "lua/framework/lua.h"
 
 namespace opensnlua::prk
 {

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "diffusion_mip_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/acceleration/acceleration.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/finite_element/finite_element_data.h"

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_pwlc_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_pwlc_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "diffusion_pwlc_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_pwlc_solver.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/acceleration/acceleration.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"

--- a/modules/linear_boltzmann_solvers/lbs_solver/distributed_source/distributed_source.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/distributed_source/distributed_source.cc
@@ -1,15 +1,12 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "distributed_source.h"
-
+#include "modules/linear_boltzmann_solvers/lbs_solver/distributed_source/distributed_source.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
-
 #include "framework/mesh/cell/cell.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "framework/math/functions/spatial_material_function.h"
-
 #include "framework/runtime.h"
 #include "framework/object_factory.h"
 

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_linear_solver.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "ags_linear_solver.h"
+#include "modules//linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_linear_solver.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/math/linear_solver/linear_matrix_action_Ax.h"
 #include "framework/math/petsc_utils/petsc_utils.h"

--- a/modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.cc
@@ -1,15 +1,12 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "point_source.h"
-
-#include <numeric>
-
+#include "modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/object_factory.h"
 #include "framework/logging/log.h"
-
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
+#include <numeric>
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/response_evaluator/response_evaluator.cc
+++ b/modules/linear_boltzmann_solvers/response_evaluator/response_evaluator.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "response_evaluator.h"
+#include "modules/linear_boltzmann_solvers/response_evaluator/response_evaluator.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/distributed_source/distributed_source.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"

--- a/test/framework/parameters/params_test_01.cc
+++ b/test/framework/parameters/params_test_01.cc
@@ -1,7 +1,5 @@
-#include "params_test_01.h"
-
+#include "test/framework/parameters/params_test_01.h"
 #include "framework/object_factory.h"
-
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 


### PR DESCRIPTION
- Use full relative path from the repo root in #includes
- Don't include `lua` dir into include dir search

Closes #283
