### PR TITLE
fixing transfer and production matrices when reading them for openmc

### DIFF
--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.lua
@@ -1,5 +1,5 @@
 -- 3D 172G KEigenvalue::Solver test using power iteration and OpenMC MGXS library
--- Test: Final k-eigenvalue: 1.5030447
+-- Test: Final k-eigenvalue: 2.2800213
 num_procs = 4 
 
 --########## Mesh ##########
@@ -45,7 +45,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "uo2.h5", 294.0)
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "u235.h5", 294.0, "u235")
 mesh.SetUniformMaterialID(0)
 
 --########## Solver ##########

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.lua
@@ -1,5 +1,5 @@
 -- 3D 172G KEigenvalue::Solver test using power iteration and OpenMC MGXS library
--- Test: Final k-eigenvalue: 2.2800216
+-- Test: Final k-eigenvalue: 1.5029618
 num_procs = 4 
 
 --########## Mesh ##########
@@ -45,7 +45,7 @@ mesh.MeshGenerator.Execute(meshgen1)
 
 materials = {}
 materials[1] = mat.AddMaterial("Fissile Material")
-mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "u235.h5", 294.0, "u235")
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENMC_XSLIB, "uo2.h5", 294.0)
 mesh.SetUniformMaterialID(0)
 
 --########## Solver ##########

--- a/test/modules/linear_boltzmann_solvers/transport_keigen/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_keigen/tests.json
@@ -150,7 +150,7 @@
     ]
   },
   {
-    "file": "keigenvalue_transport_3d_openmcxs.lua",
+    "file": "keigenvalue_transport_3d_openmcxs_UO2.lua",
     "comment": "3D 172G KEigenvalue::Solver test using Power Iteration with OpenMC MGXS library",
     "num_procs": 4,
     "checks": [
@@ -158,13 +158,13 @@
         "type": "FloatCompare",
         "key": "Final k-eigenvalue",
         "wordnum": 4,
-        "gold": 1.5030447,
+        "gold": 1.5029618,
         "abs_tol": 1e-05
       }
     ]
   },
   {
-    "file": "keigenvalue_transport_3d_openmcxs_cset.lua",
+    "file": "keigenvalue_transport_3d_openmcxs_U235.lua",
     "comment": "3D 172G KEigenvalue::Solver test using Power Iteration with OpenMC MGXS library",
     "num_procs": 4,
     "checks": [
@@ -172,7 +172,7 @@
         "type": "FloatCompare",
         "key": "Final k-eigenvalue",
         "wordnum": 4,
-        "gold": 2.2800216,
+        "gold": 2.2800213,
         "abs_tol": 1e-05
       }
     ]


### PR DESCRIPTION
The transfer and production matrices read from OpenMC were transposed. This was discovered when running a source-driven problem. The test suite will be made more robust by adding such a test (in a subsequent PR).

The absorption XS should not be read from OpenMC as it is prone to statistical noise (i.e., total is not exactly equal to absorption + outscatter). It is better to just read total and transfer from OpenMC and compute ourselves absoprtion from that.