### PR TITLE
MeshAttributes are no longer bit-wise flags

### DIFF
--- a/framework/mesh/io/gmsh_io.cc
+++ b/framework/mesh/io/gmsh_io.cc
@@ -396,7 +396,7 @@ MeshIO::FromGmsh(const UnpartitionedMesh::Options& options)
     dimension = 3;
 
   mesh->SetDimension(dimension);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/io/gmsh_io.cc
+++ b/framework/mesh/io/gmsh_io.cc
@@ -396,7 +396,7 @@ MeshIO::FromGmsh(const UnpartitionedMesh::Options& options)
     dimension = 3;
 
   mesh->SetDimension(dimension);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/io/obj_io.cc
+++ b/framework/mesh/io/obj_io.cc
@@ -334,7 +334,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(2);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/io/obj_io.cc
+++ b/framework/mesh/io/obj_io.cc
@@ -334,7 +334,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(2);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -648,7 +648,7 @@ MeshIO::FromExodusII(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -706,7 +706,7 @@ MeshIO::FromVTU(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -761,7 +761,7 @@ MeshIO::FromPVTU(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -834,7 +834,7 @@ MeshIO::FromEnsightGold(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->SetAttributes(UNSTRUCTURED);
+  mesh->SetType(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -648,7 +648,7 @@ MeshIO::FromExodusII(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -706,7 +706,7 @@ MeshIO::FromVTU(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -761,7 +761,7 @@ MeshIO::FromPVTU(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();
@@ -834,7 +834,7 @@ MeshIO::FromEnsightGold(const UnpartitionedMesh::Options& options)
 
   // Always do this
   mesh->SetDimension(max_dimension);
-  mesh->Attributes() = UNSTRUCTURED;
+  mesh->SetAttributes(UNSTRUCTURED);
 
   mesh->ComputeCentroids();
   mesh->CheckQuality();

--- a/framework/mesh/mesh.h
+++ b/framework/mesh/mesh.h
@@ -55,10 +55,10 @@ class VolumeMesherPredefinedUnpartitioned;
 
 enum MeshAttributes : int
 {
-  NONE = 0,
-  ORTHOGONAL = (1 << 3),
-  EXTRUDED = (1 << 4),
-  UNSTRUCTURED = (1 << 5)
+  NONE,
+  ORTHOGONAL,
+  EXTRUDED,
+  UNSTRUCTURED
 };
 
 enum BoundaryID : int
@@ -70,12 +70,6 @@ enum BoundaryID : int
   ZMIN = 4,
   ZMAX = 5
 };
-
-inline MeshAttributes
-operator|(const MeshAttributes f1, const MeshAttributes f2)
-{
-  return static_cast<MeshAttributes>(static_cast<int>(f1) | static_cast<int>(f2));
-}
 
 struct OrthoMeshAttributes
 {

--- a/framework/mesh/mesh.h
+++ b/framework/mesh/mesh.h
@@ -53,11 +53,9 @@ class VolumeMesher;
 class VolumeMesherExtruder;
 class VolumeMesherPredefinedUnpartitioned;
 
-enum MeshAttributes : int
+enum MeshType : int
 {
-  NONE,
   ORTHOGONAL,
-  EXTRUDED,
   UNSTRUCTURED
 };
 

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -24,7 +24,8 @@ MeshContinuum::MeshContinuum()
           global_cell_id_to_local_id_map_,
           global_cell_id_to_nonlocal_id_map_),
     dim_(0),
-    attributes_(NONE),
+    mesh_type_(UNSTRUCTURED),
+    extruded_(false),
     global_vertex_count_(0)
 {
 }
@@ -483,7 +484,7 @@ std::array<size_t, 3>
 MeshContinuum::GetIJKInfo() const
 {
   const std::string fname = "GetIJKInfo";
-  if (this->Attributes() != MeshAttributes::ORTHOGONAL)
+  if (Type() != MeshType::ORTHOGONAL)
     throw std::logic_error(fname + " can only be run on orthogonal meshes.");
 
   return {ortho_attributes_.Nx, ortho_attributes_.Ny, ortho_attributes_.Nz};
@@ -493,7 +494,7 @@ NDArray<uint64_t>
 MeshContinuum::MakeIJKToGlobalIDMapping() const
 {
   const std::string fname = "MakeIJKToGlobalIDMapping";
-  if (this->Attributes() != MeshAttributes::ORTHOGONAL)
+  if (Type() != MeshType::ORTHOGONAL)
     throw std::logic_error(fname + " can only be run on orthogonal meshes.");
 
   const auto ijk_info = this->GetIJKInfo();
@@ -668,18 +669,6 @@ MeshContinuum::SetBoundaryIDFromLogical(const LogicalVolume& log_vol,
 
   if (global_num_faces_modified > 0 and grid_bndry_id_map.count(bndry_id) == 0)
     grid_bndry_id_map[bndry_id] = boundary_name;
-}
-
-void
-MeshContinuum::SetAttributes(MeshAttributes new_attribs)
-{
-  attributes_ = new_attribs;
-}
-
-void
-MeshContinuum::SetOrthoAttributes(const OrthoMeshAttributes& attrs)
-{
-  ortho_attributes_ = attrs;
 }
 
 } // namespace opensn

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -483,7 +483,7 @@ std::array<size_t, 3>
 MeshContinuum::GetIJKInfo() const
 {
   const std::string fname = "GetIJKInfo";
-  if (not(this->Attributes() & MeshAttributes::ORTHOGONAL))
+  if (this->Attributes() != MeshAttributes::ORTHOGONAL)
     throw std::logic_error(fname + " can only be run on orthogonal meshes.");
 
   return {ortho_attributes_.Nx, ortho_attributes_.Ny, ortho_attributes_.Nz};
@@ -493,7 +493,7 @@ NDArray<uint64_t>
 MeshContinuum::MakeIJKToGlobalIDMapping() const
 {
   const std::string fname = "MakeIJKToGlobalIDMapping";
-  if (not(this->Attributes() & MeshAttributes::ORTHOGONAL))
+  if (this->Attributes() != MeshAttributes::ORTHOGONAL)
     throw std::logic_error(fname + " can only be run on orthogonal meshes.");
 
   const auto ijk_info = this->GetIJKInfo();
@@ -673,7 +673,7 @@ MeshContinuum::SetBoundaryIDFromLogical(const LogicalVolume& log_vol,
 void
 MeshContinuum::SetAttributes(MeshAttributes new_attribs)
 {
-  attributes_ = attributes_ | new_attribs;
+  attributes_ = new_attribs;
 }
 
 void

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -143,7 +143,13 @@ public:
    */
   bool CheckPointInsideCell(const Cell& cell, const Vector3& point) const;
 
-  MeshAttributes Attributes() const { return attributes_; }
+  MeshType Type() const { return mesh_type_; }
+
+  void SetType(MeshType type) { mesh_type_ = type; }
+
+  bool Extruded() const { return extruded_; }
+
+  void SetExtruded(bool extruded) { extruded_ = extruded; }
 
   /**
    * Gets and orthogonal mesh interface object.
@@ -180,9 +186,7 @@ public:
                                 bool sense,
                                 const std::string& boundary_name);
 
-  void SetAttributes(MeshAttributes new_attribs);
-
-  void SetOrthoAttributes(const OrthoMeshAttributes& attrs);
+  void SetOrthoAttributes(const OrthoMeshAttributes& attrs) { ortho_attributes_ = attrs; }
 
 public:
   VertexHandler vertices;
@@ -192,7 +196,8 @@ public:
 private:
   /// Spatial dimension
   unsigned int dim_;
-  MeshAttributes attributes_;
+  MeshType mesh_type_;
+  bool extruded_;
   OrthoMeshAttributes ortho_attributes_;
   std::map<uint64_t, std::string> boundary_id_map_;
 

--- a/framework/mesh/mesh_generator/extruder_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/extruder_mesh_generator.cc
@@ -286,7 +286,7 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
   }   // for layer
 
   umesh->SetDimension(3);
-  umesh->SetAttributes(EXTRUDED);
+  umesh->SetExtruded(true);
 
   umesh->ComputeCentroids();
   umesh->CheckQuality();

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -234,7 +234,8 @@ MeshGenerator::SetupMesh(std::shared_ptr<UnpartitionedMesh> input_umesh,
   } // for raw_cell
 
   grid_ptr->SetDimension(input_umesh->Dimension());
-  grid_ptr->SetAttributes(input_umesh->Attributes());
+  grid_ptr->SetType(input_umesh->Type());
+  grid_ptr->SetExtruded(input_umesh->Extruded());
   grid_ptr->SetOrthoAttributes(input_umesh->OrthoAttributes());
 
   grid_ptr->SetGlobalVertexCount(input_umesh->Vertices().size());

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -300,8 +300,8 @@ SplitFileMeshGenerator::ReadSplitMesh()
     dir_path.string() + "/" + file_prefix_ + "_" + std::to_string(pid) + ".cmesh";
 
   SplitMeshInfo info_block;
-  auto& cells = info_block.cells_;
-  auto& vertices = info_block.vertices_;
+  auto& cells = info_block.cells;
+  auto& vertices = info_block.vertices;
   std::ifstream ifile(file_path, std::ios_base::binary | std::ios_base::in);
 
   OpenSnLogicalErrorIf(not ifile.is_open(), "Failed to open " + file_path.string());
@@ -321,7 +321,7 @@ SplitFileMeshGenerator::ReadSplitMesh()
   info_block.ortho_attributes.Ny = ReadBinaryValue<size_t>(ifile);
   info_block.ortho_attributes.Nz = ReadBinaryValue<size_t>(ifile);
 
-  info_block.num_global_vertices_ = ReadBinaryValue<size_t>(ifile);
+  info_block.num_global_vertices = ReadBinaryValue<size_t>(ifile);
 
   // Read boundary map
   const size_t num_bndries = ReadBinaryValue<size_t>(ifile);
@@ -332,7 +332,7 @@ SplitFileMeshGenerator::ReadSplitMesh()
     std::string bname(num_chars, ' ');
     ifile.read(bname.data(), static_cast<int>(num_chars));
 
-    info_block.boundary_id_map_.insert(std::make_pair(bid, bname));
+    info_block.boundary_id_map.insert(std::make_pair(bid, bname));
   }
 
   // Write how many cells and vertices in file
@@ -391,10 +391,10 @@ SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
 {
   auto grid_ptr = MeshContinuum::New();
 
-  grid_ptr->GetBoundaryIDMap() = mesh_info.boundary_id_map_;
+  grid_ptr->GetBoundaryIDMap() = mesh_info.boundary_id_map;
 
-  auto& cells = mesh_info.cells_;
-  auto& vertices = mesh_info.vertices_;
+  auto& cells = mesh_info.cells;
+  auto& vertices = mesh_info.vertices;
 
   for (const auto& [vid, vertex] : vertices)
     grid_ptr->vertices.Insert(vid, vertex);
@@ -411,7 +411,7 @@ SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
   grid_ptr->SetAttributes(mesh_info.mesh_attributes);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);
 
-  grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices_);
+  grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices);
 
   ComputeAndPrintStats(*grid_ptr);
 

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -316,7 +316,7 @@ SplitFileMeshGenerator::ReadSplitMesh()
                          std::to_string(opensn::mpi_comm.size()) + " processes.");
 
   info_block.dimension = ReadBinaryValue<unsigned int>(ifile);
-  info_block.mesh_attributes_ = ReadBinaryValue<int>(ifile);
+  info_block.mesh_attributes = static_cast<MeshAttributes>(ReadBinaryValue<int>(ifile));
   info_block.ortho_attributes.Nx = ReadBinaryValue<size_t>(ifile);
   info_block.ortho_attributes.Ny = ReadBinaryValue<size_t>(ifile);
   info_block.ortho_attributes.Nz = ReadBinaryValue<size_t>(ifile);
@@ -408,7 +408,7 @@ SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
   }
 
   grid_ptr->SetDimension(mesh_info.dimension);
-  grid_ptr->SetAttributes(static_cast<MeshAttributes>(mesh_info.mesh_attributes_));
+  grid_ptr->SetAttributes(mesh_info.mesh_attributes);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);
 
   grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices_);

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -192,7 +192,8 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
     WriteBinaryValue(ofile, num_parts); // int
     WriteBinaryValue<unsigned int>(ofile, umesh.Dimension());
 
-    WriteBinaryValue(ofile, static_cast<int>(umesh.Attributes())); // int
+    WriteBinaryValue(ofile, static_cast<int>(umesh.Type()));
+    WriteBinaryValue(ofile, umesh.Extruded());
     auto& ortho_attrs = umesh.OrthoAttributes();
     WriteBinaryValue(ofile, ortho_attrs.Nx); // size_t
     WriteBinaryValue(ofile, ortho_attrs.Ny); // size_t
@@ -316,7 +317,8 @@ SplitFileMeshGenerator::ReadSplitMesh()
                          std::to_string(opensn::mpi_comm.size()) + " processes.");
 
   info_block.dimension = ReadBinaryValue<unsigned int>(ifile);
-  info_block.mesh_attributes = static_cast<MeshAttributes>(ReadBinaryValue<int>(ifile));
+  info_block.mesh_type = static_cast<MeshType>(ReadBinaryValue<int>(ifile));
+  info_block.extruded = ReadBinaryValue<bool>(ifile);
   info_block.ortho_attributes.Nx = ReadBinaryValue<size_t>(ifile);
   info_block.ortho_attributes.Ny = ReadBinaryValue<size_t>(ifile);
   info_block.ortho_attributes.Nz = ReadBinaryValue<size_t>(ifile);
@@ -408,7 +410,8 @@ SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
   }
 
   grid_ptr->SetDimension(mesh_info.dimension);
-  grid_ptr->SetAttributes(mesh_info.mesh_attributes);
+  grid_ptr->SetType(mesh_info.mesh_type);
+  grid_ptr->SetExtruded(mesh_info.extruded);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);
 
   grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices);

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -33,7 +33,8 @@ protected:
     std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells;
     std::map<uint64_t, Vector3> vertices;
     std::map<uint64_t, std::string> boundary_id_map;
-    MeshAttributes mesh_attributes;
+    MeshType mesh_type;
+    bool extruded;
     OrthoMeshAttributes ortho_attributes;
     size_t num_global_vertices;
   };

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -33,7 +33,7 @@ protected:
     std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells_;
     std::map<uint64_t, Vector3> vertices_;
     std::map<uint64_t, std::string> boundary_id_map_;
-    int mesh_attributes_;
+    MeshAttributes mesh_attributes;
     OrthoMeshAttributes ortho_attributes;
     size_t num_global_vertices_;
   };

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -30,12 +30,12 @@ protected:
   struct SplitMeshInfo
   {
     unsigned int dimension;
-    std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells_;
-    std::map<uint64_t, Vector3> vertices_;
-    std::map<uint64_t, std::string> boundary_id_map_;
+    std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells;
+    std::map<uint64_t, Vector3> vertices;
+    std::map<uint64_t, std::string> boundary_id_map;
     MeshAttributes mesh_attributes;
     OrthoMeshAttributes ortho_attributes;
-    size_t num_global_vertices_;
+    size_t num_global_vertices;
   };
   SplitMeshInfo ReadSplitMesh();
 

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -199,13 +199,13 @@ UnpartitionedMesh::AddBoundary(uint64_t id, const std::string& name)
 void
 UnpartitionedMesh::SetAttributes(MeshAttributes new_attribs)
 {
-  attributes_ = attributes_ | new_attribs;
+  attributes_ = new_attribs;
 }
 
 void
 UnpartitionedMesh::SetOrthoAttributes(size_t nx, size_t ny, size_t nz)
 {
-  attributes_ = attributes_ | ORTHOGONAL;
+  attributes_ = ORTHOGONAL;
   ortho_attrs_.Nx = nx;
   ortho_attrs_.Ny = ny;
   ortho_attrs_.Nz = nz;

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -197,12 +197,6 @@ UnpartitionedMesh::AddBoundary(uint64_t id, const std::string& name)
 }
 
 void
-UnpartitionedMesh::SetAttributes(MeshAttributes new_attribs)
-{
-  attributes_ = new_attribs;
-}
-
-void
 UnpartitionedMesh::SetOrthoAttributes(size_t nx, size_t ny, size_t nz)
 {
   attributes_ = ORTHOGONAL;

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -12,7 +12,7 @@
 namespace opensn
 {
 
-UnpartitionedMesh::UnpartitionedMesh() : dim_(0), attributes_(NONE)
+UnpartitionedMesh::UnpartitionedMesh() : dim_(0), mesh_type_(UNSTRUCTURED), extruded_(false)
 {
 }
 
@@ -199,7 +199,7 @@ UnpartitionedMesh::AddBoundary(uint64_t id, const std::string& name)
 void
 UnpartitionedMesh::SetOrthoAttributes(size_t nx, size_t ny, size_t nz)
 {
-  attributes_ = ORTHOGONAL;
+  mesh_type_ = ORTHOGONAL;
   ortho_attrs_.Nx = nx;
   ortho_attrs_.Ny = ny;
   ortho_attrs_.Nz = nz;
@@ -434,7 +434,7 @@ UnpartitionedMesh::PushProxyCell(const std::string& type_str,
   if (type == CellType::POLYHEDRON)
     SetDimension(3);
 
-  attributes_ = UNSTRUCTURED;
+  mesh_type_ = UNSTRUCTURED;
 }
 
 void

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -67,8 +67,11 @@ public:
   void SetMeshOptions(const Options& opts) { mesh_options_ = opts; }
   const Options& MeshOptions() const { return mesh_options_; }
 
-  void SetAttributes(MeshAttributes attrs) { attributes_ = attrs; }
-  const MeshAttributes& Attributes() const { return attributes_; }
+  void SetType(MeshType type) { mesh_type_ = type; }
+  const MeshType& Type() const { return mesh_type_; }
+
+  void SetExtruded(bool extruded) { extruded_ = extruded; }
+  bool Extruded() const { return extruded_; }
 
   const std::vector<std::set<uint64_t>>& GetVertextCellSubscriptions() const
   {
@@ -127,7 +130,8 @@ public:
 protected:
   /// Spatial mesh dimension
   unsigned int dim_;
-  MeshAttributes attributes_;
+  MeshType mesh_type_;
+  bool extruded_;
   OrthoMeshAttributes ortho_attrs_;
   Options mesh_options_;
   BoundBox bound_box_;

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -64,10 +64,10 @@ public:
   const BoundBox& BoundingBox() const { return bound_box_; }
   void ComputeBoundingBox();
 
-  Options& MeshOptions() { return mesh_options_; }
+  void SetMeshOptions(const Options& opts) { mesh_options_ = opts; }
   const Options& MeshOptions() const { return mesh_options_; }
 
-  MeshAttributes& Attributes() { return attributes_; }
+  void SetAttributes(MeshAttributes attrs) { attributes_ = attrs; }
   const MeshAttributes& Attributes() const { return attributes_; }
 
   const std::vector<std::set<uint64_t>>& GetVertextCellSubscriptions() const
@@ -111,8 +111,6 @@ public:
 
   const std::map<uint64_t, std::string>& BoundaryIDMap() const { return boundary_id_map_; }
   std::map<uint64_t, std::string>& BoundaryIDMap() { return boundary_id_map_; }
-
-  void SetAttributes(MeshAttributes new_attribs);
 
   void SetOrthoAttributes(size_t nx, size_t ny, size_t nz);
   const OrthoMeshAttributes& OrthoAttributes() const { return ortho_attrs_; }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -1042,7 +1042,7 @@ DiscreteOrdinatesSolver::AssociateSOsAndDirections(const MeshContinuum& grid,
     {
       // Check geometry types
       const auto grid_attribs = grid.Attributes();
-      if (not(grid_attribs & ORTHOGONAL or grid.Dimension() == 2 or grid_attribs & EXTRUDED))
+      if (not(grid_attribs == ORTHOGONAL or grid.Dimension() == 2 or grid_attribs == EXTRUDED))
         throw std::logic_error(
           fname + ": The simulation is using polar angle aggregation for which only certain "
                   "geometry types are supported, i.e., ORTHOGONAL, 2D or 3D EXTRUDED.");

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -1041,8 +1041,7 @@ DiscreteOrdinatesSolver::AssociateSOsAndDirections(const MeshContinuum& grid,
     case AngleAggregationType::POLAR:
     {
       // Check geometry types
-      const auto grid_attribs = grid.Attributes();
-      if (not(grid_attribs == ORTHOGONAL or grid.Dimension() == 2 or grid_attribs == EXTRUDED))
+      if (not(grid.Type() == ORTHOGONAL or grid.Dimension() == 2 or grid.Extruded()))
         throw std::logic_error(
           fname + ": The simulation is using polar angle aggregation for which only certain "
                   "geometry types are supported, i.e., ORTHOGONAL, 2D or 3D EXTRUDED.");


### PR DESCRIPTION
- MeshAttributes are not bit-wise flags
- Removing trailing underscores from public member variables in SplitMeshInfo
- Creating setters according to code standards in `UnpartitionedMesh`

Closes #286 
