### PR TITLE
Updating processing order of cli options

### DIFF
--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -113,6 +113,7 @@ LuaApp::ProcessArguments(int argc, char** argv)
 
     auto result = options.parse(argc, argv);
 
+    // Note that the order of evaluation of the command-line options is important!
     if (result.count("help"))
     {
       if (opensn::mpi_comm.rank() == 0)
@@ -127,6 +128,12 @@ LuaApp::ProcessArguments(int argc, char** argv)
       return 1;
     }
 
+    if (result.count("verbose"))
+    {
+      int verbosity = result["verbose"].as<int>();
+      opensn::log.SetVerbosity(verbosity);
+    }
+
     if (result.count("allow-petsc-error-handler"))
       allow_petsc_error_handler_ = true;
 
@@ -138,12 +145,6 @@ LuaApp::ProcessArguments(int argc, char** argv)
       ObjectFactory::GetInstance().DumpRegister();
       console.DumpRegister();
       return 1;
-    }
-
-    if (result.count("verbose"))
-    {
-      int verbosity = result["verbose"].as<int>();
-      opensn::log.SetVerbosity(verbosity);
     }
 
     if (result.count("caliper"))


### PR DESCRIPTION
This PR updates the processing order of cli options so that verbosity is set before processing any other options (except help options).  This fixes a bug where `--dump-object-registry` wasn't honoring the verbosity level.