### PR TITLE
Removing naked pointers in favor of `std::shared_ptr`

### DIFF
--- a/framework/data_types/ndarray.h
+++ b/framework/data_types/ndarray.h
@@ -19,8 +19,8 @@ class NDArray
 {
 private:
   size_t rank_;
-  size_t* dimensions_;
-  size_t* strides_;
+  std::vector<size_t> dimensions_;
+  std::vector<size_t> strides_;
   size_t size_;
   T* base_;
 
@@ -47,29 +47,23 @@ public:
    */
   template <typename D>
   explicit NDArray(const std::vector<D>& dims)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(dims.size()), dimensions_(rank_), strides_(rank_), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
-    const size_t N = dims.size();
-
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
 
     // Populate dimensions
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
       dimensions_[i] = dims[i];
 
     // Populate strides and size
     size_ = 1;
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
     {
       assert(dimensions_[i] > 0);
       size_ *= dimensions_[i];
       strides_[i] = 1;
-      for (size_t j = i + 1; j < N; ++j)
+      for (size_t j = i + 1; j < rank_; ++j)
         strides_[i] *= dimensions_[j];
     }
 
@@ -89,15 +83,10 @@ public:
    */
   template <typename D, size_t N>
   explicit NDArray(const std::array<D, N>& dims)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(N), dimensions_(N), strides_(N), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have array of integral types.");
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
-
     // Populate dimensions
     for (size_t i = 0; i < N; ++i)
       dimensions_[i] = dims[i];
@@ -129,17 +118,10 @@ public:
    */
   template <typename D>
   NDArray(const std::initializer_list<D>& dims)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(dims.size()), dimensions_(rank_), strides_(rank_), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
-    const size_t N = dims.size();
-
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
-
     // Populate dimensions
     {
       size_t i = 0;
@@ -147,19 +129,19 @@ public:
       {
         dimensions_[i] = val;
         ++i;
-        if (i >= N)
+        if (i >= rank_)
           break;
       }
     }
 
     // Populate strides and size
     size_ = 1;
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
     {
       assert(dimensions_[i] > 0);
       size_ *= dimensions_[i];
       strides_[i] = 1;
-      for (size_t j = i + 1; j < N; ++j)
+      for (size_t j = i + 1; j < rank_; ++j)
         strides_[i] *= dimensions_[j];
     }
 
@@ -180,29 +162,22 @@ public:
    */
   template <typename D>
   explicit NDArray(const std::vector<D>& dims, T value)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(dims.size()), dimensions_(rank_), strides_(rank_), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
-    const size_t N = dims.size();
-
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
-
     // Populate dimensions
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
       dimensions_[i] = dims[i];
 
     // Populate strides and size
     size_ = 1;
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
     {
       assert(dimensions_[i] > 0);
       size_ *= dimensions_[i];
       strides_[i] = 1;
-      for (size_t j = i + 1; j < N; ++j)
+      for (size_t j = i + 1; j < rank_; ++j)
         strides_[i] *= dimensions_[j];
     }
 
@@ -223,15 +198,10 @@ public:
    */
   template <typename D, size_t N>
   explicit NDArray(const std::array<D, N>& dims, T value)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(N), dimensions_(N), strides_(N), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
-
     // Populate dimensions
     for (size_t i = 0; i < N; ++i)
       dimensions_[i] = dims[i];
@@ -265,17 +235,10 @@ public:
    */
   template <typename D>
   NDArray(const std::initializer_list<D>& dims, T value)
-    : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr)
+    : rank_(dims.size()), dimensions_(rank_), strides_(rank_), size_(0), base_(nullptr)
   {
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
-    const size_t N = dims.size();
-
-    rank_ = N;
-
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
-
     // Populate dimensions
     {
       size_t i = 0;
@@ -283,19 +246,19 @@ public:
       {
         dimensions_[i] = val;
         ++i;
-        if (i >= N)
+        if (i >= rank_)
           break;
       }
     }
 
     // Populate strides and size
     size_ = 1;
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
     {
       assert(dimensions_[i] > 0);
       size_ *= dimensions_[i];
       strides_[i] = 1;
-      for (size_t j = i + 1; j < N; ++j)
+      for (size_t j = i + 1; j < rank_; ++j)
         strides_[i] *= dimensions_[j];
     }
 
@@ -310,25 +273,21 @@ public:
    *  This constructor creates an empty array and initializes the reference
    * count to one.
    */
-  NDArray() : rank_(0), dimensions_(nullptr), strides_(nullptr), size_(0), base_(nullptr) {}
+  NDArray() : rank_(0), dimensions_(), strides_(), size_(0), base_(nullptr) {}
 
   /** Copy construct from another array.
    *  \param other The array to copy.
    */
   NDArray(NDArray<T> const& other)
     : rank_(other.rank_),
-      dimensions_(nullptr),
-      strides_(nullptr),
+      dimensions_(other.rank_),
+      strides_(other.rank_),
       size_(other.size_),
       base_(nullptr)
   {
-
-    const size_t N = rank_;
-    strides_ = new size_t[N];
-    dimensions_ = new size_t[N];
     base_ = new T[size_];
 
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < rank_; ++i)
     {
       dimensions_[i] = other.dimensions_[i];
       strides_[i] = other.strides_[i];
@@ -428,10 +387,8 @@ public:
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
 
-    delete[] dimensions_;
-    dimensions_ = nullptr;
-    delete[] strides_;
-    strides_ = nullptr;
+    dimensions_.clear();
+    strides_.clear();
     delete[] base_;
     base_ = nullptr;
 
@@ -453,10 +410,8 @@ public:
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
 
-    delete[] dimensions_;
-    dimensions_ = nullptr;
-    delete[] strides_;
-    strides_ = nullptr;
+    dimensions_.clear();
+    strides_.clear();
     delete[] base_;
     base_ = nullptr;
 
@@ -478,10 +433,8 @@ public:
     static_assert(std::is_integral<D>::value,
                   "NDArray dims argument must have vector of integral types.");
 
-    delete[] dimensions_;
-    dimensions_ = nullptr;
-    delete[] strides_;
-    strides_ = nullptr;
+    dimensions_.clear();
+    strides_.clear();
     delete[] base_;
     base_ = nullptr;
 
@@ -598,10 +551,6 @@ public:
    */
   ~NDArray()
   {
-    delete[] dimensions_;
-    dimensions_ = nullptr;
-    delete[] strides_;
-    strides_ = nullptr;
     delete[] base_;
     base_ = nullptr;
   }

--- a/framework/math/statistics/cdfsampler.cc
+++ b/framework/math/statistics/cdfsampler.cc
@@ -33,7 +33,7 @@ CDFSampler::SubIntvl::SubIntvl(std::string offset,
 
     if (intvl_size < final_res)
     {
-      sub_intvls.push_back(new SubIntvl(
+      sub_intvls.push_back(std::make_shared<SubIntvl>(
         offset + std::string("  "), ibin, fbin, ref_cdf, subdiv_factor, final_res, true));
     }
     else
@@ -52,8 +52,8 @@ CDFSampler::SubIntvl::SubIntvl(std::string offset,
         //          << "Sub-interval " << beg
         //          << " " << end;
 
-        sub_intvls[i] =
-          new SubIntvl(offset + std::string("  "), beg, end, ref_cdf, subdiv_factor, final_res);
+        sub_intvls[i] = std::make_shared<SubIntvl>(
+          offset + std::string("  "), beg, end, ref_cdf, subdiv_factor, final_res);
       }
     }
   }

--- a/framework/math/statistics/cdfsampler.cc
+++ b/framework/math/statistics/cdfsampler.cc
@@ -91,7 +91,7 @@ CDFSampler::CDFSampler(std::vector<double>& cdf, int subdiv_factor, int final_re
   size_t intvl_size = ceil(cdf_size / (double)this->subdiv_factor_);
 
   if (intvl_size < this->final_res_)
-    sub_intvls_.push_back(new SubIntvl(
+    sub_intvls_.push_back(std::make_shared<SubIntvl>(
       std::string("  "), 0, cdf_size - 1, ref_cdf_, this->subdiv_factor_, this->final_res_, true));
   else
   {
@@ -108,8 +108,8 @@ CDFSampler::CDFSampler(std::vector<double>& cdf, int subdiv_factor, int final_re
       //        << "Sub-interval " << beg
       //        << " " << end;
 
-      sub_intvls_[i] =
-        new SubIntvl(std::string("  "), beg, end, ref_cdf_, this->subdiv_factor_, this->final_res_);
+      sub_intvls_[i] = std::make_shared<SubIntvl>(
+        std::string("  "), beg, end, ref_cdf_, this->subdiv_factor_, this->final_res_);
     }
   }
 }

--- a/framework/math/statistics/cdfsampler.h
+++ b/framework/math/statistics/cdfsampler.h
@@ -36,7 +36,7 @@ private:
   int subdiv_factor_;
   int final_res_;
   std::vector<double>& ref_cdf_;
-  std::vector<SubIntvl*> sub_intvls_;
+  std::vector<std::shared_ptr<SubIntvl>> sub_intvls_;
 
 public:
   /** constructor.*/

--- a/framework/math/statistics/cdfsampler.h
+++ b/framework/math/statistics/cdfsampler.h
@@ -57,7 +57,7 @@ struct CDFSampler::SubIntvl
   std::vector<double>& ref_cdf;
   bool inhibited;
 
-  std::vector<SubIntvl*> sub_intvls;
+  std::vector<std::shared_ptr<SubIntvl>> sub_intvls;
 
   std::string offset;
 

--- a/framework/mesh/io/gmsh_io.cc
+++ b/framework/mesh/io/gmsh_io.cc
@@ -261,19 +261,20 @@ MeshIO::FromGmsh(const UnpartitionedMesh::Options& options)
     auto& raw_boundary_cells = mesh->RawBoundaryCells();
     auto& raw_cells = mesh->RawCells();
     // Make the cell on either the volume or the boundary
-    UnpartitionedMesh::LightWeightCell* raw_cell = nullptr;
+    std::shared_ptr<UnpartitionedMesh::LightWeightCell> raw_cell;
     if (mesh_is_2D_assumption)
     {
       if (IsElementType1D(elem_type))
       {
-        raw_cell = new UnpartitionedMesh::LightWeightCell(CellType::SLAB, CellType::SLAB);
+        raw_cell =
+          std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::SLAB, CellType::SLAB);
         raw_boundary_cells.push_back(raw_cell);
         log.Log0Verbose2() << "Added to raw_boundary_cells.";
       }
       else if (IsElementType2D(elem_type))
       {
-        raw_cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYGON,
-                                                          CellTypeFromMSHTypeID(elem_type));
+        raw_cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(
+          CellType::POLYGON, CellTypeFromMSHTypeID(elem_type));
         raw_cells.push_back(raw_cell);
         log.Log0Verbose2() << "Added to raw_cells.";
       }
@@ -282,15 +283,15 @@ MeshIO::FromGmsh(const UnpartitionedMesh::Options& options)
     {
       if (IsElementType2D(elem_type))
       {
-        raw_cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYGON,
-                                                          CellTypeFromMSHTypeID(elem_type));
+        raw_cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(
+          CellType::POLYGON, CellTypeFromMSHTypeID(elem_type));
         raw_boundary_cells.push_back(raw_cell);
         log.Log0Verbose2() << "Added to raw_boundary_cells.";
       }
       else if (IsElementType3D(elem_type))
       {
-        raw_cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYHEDRON,
-                                                          CellTypeFromMSHTypeID(elem_type));
+        raw_cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(
+          CellType::POLYHEDRON, CellTypeFromMSHTypeID(elem_type));
         raw_cells.push_back(raw_cell);
         log.Log0Verbose2() << "Added to raw_cells.";
       }

--- a/framework/mesh/io/obj_io.cc
+++ b/framework/mesh/io/obj_io.cc
@@ -33,7 +33,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
   struct BlockData
   {
     std::string name;
-    std::vector<UnpartitionedMesh::LightWeightCell*> cells;
+    std::vector<std::shared_ptr<UnpartitionedMesh::LightWeightCell>> cells;
     std::vector<Edge> edges;
   };
 
@@ -116,7 +116,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
       else if (number_of_verts == 4)
         sub_type = CellType::QUADRILATERAL;
 
-      auto cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYGON, sub_type);
+      auto cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYGON, sub_type);
       cell->material_id = material_id;
 
       // Populate vertex-ids

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -31,7 +31,7 @@ namespace opensn
 namespace
 {
 
-UnpartitionedMesh::LightWeightCell*
+std::shared_ptr<UnpartitionedMesh::LightWeightCell>
 CreateCellFromVTKPolyhedron(vtkCell* vtk_cell)
 {
   const std::string fname = "CreateCellFromVTKPolyhedron";
@@ -60,7 +60,8 @@ CreateCellFromVTKPolyhedron(vtkCell* vtk_cell)
     default:
       throw std::logic_error(fname + ": Unsupported 3D cell type encountered.");
   }
-  auto polyh_cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYHEDRON, sub_type);
+  auto polyh_cell =
+    std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYHEDRON, sub_type);
 
   auto num_cpoints = vtk_cell->GetNumberOfPoints();
   auto num_cfaces = vtk_cell->GetNumberOfFaces();
@@ -158,7 +159,7 @@ CreateCellFromVTKPolyhedron(vtkCell* vtk_cell)
   return polyh_cell;
 }
 
-UnpartitionedMesh::LightWeightCell*
+std::shared_ptr<UnpartitionedMesh::LightWeightCell>
 CreateCellFromVTKPolygon(vtkCell* vtk_cell)
 {
   const std::string fname = "CreateCellFromVTKPolygon";
@@ -180,7 +181,8 @@ CreateCellFromVTKPolygon(vtkCell* vtk_cell)
       throw std::logic_error(fname + ": Unsupported 2D cell type encountered.");
   }
 
-  auto poly_cell = new UnpartitionedMesh::LightWeightCell(CellType::POLYGON, sub_type);
+  auto poly_cell =
+    std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYGON, sub_type);
 
   auto num_cpoints = vtk_cell->GetNumberOfPoints();
   auto num_cfaces = num_cpoints;
@@ -211,7 +213,7 @@ CreateCellFromVTKPolygon(vtkCell* vtk_cell)
   return poly_cell;
 }
 
-UnpartitionedMesh::LightWeightCell*
+std::shared_ptr<UnpartitionedMesh::LightWeightCell>
 CreateCellFromVTKLine(vtkCell* vtk_cell)
 {
   const std::string fname = "CreateCellFromVTKPolygon";
@@ -226,7 +228,7 @@ CreateCellFromVTKLine(vtkCell* vtk_cell)
       throw std::logic_error(fname + ": Unsupported 1D cell type encountered.");
   }
 
-  auto slab_cell = new UnpartitionedMesh::LightWeightCell(CellType::SLAB, sub_type);
+  auto slab_cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::SLAB, sub_type);
 
   auto vtk_line = vtkLine::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_line->GetNumberOfPoints();
@@ -256,10 +258,11 @@ CreateCellFromVTKLine(vtkCell* vtk_cell)
   return slab_cell;
 }
 
-UnpartitionedMesh::LightWeightCell*
+std::shared_ptr<UnpartitionedMesh::LightWeightCell>
 CreateCellFromVTKVertex(vtkCell* vtk_cell)
 {
-  auto point_cell = new UnpartitionedMesh::LightWeightCell(CellType::GHOST, CellType::POINT);
+  auto point_cell =
+    std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::GHOST, CellType::POINT);
 
   auto vtk_vertex = vtkVertex::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_vertex->GetNumberOfPoints();
@@ -301,7 +304,7 @@ CopyUGridCellsAndPoints(std::shared_ptr<UnpartitionedMesh> mesh,
 
   if (has_global_ids)
   {
-    std::vector<UnpartitionedMesh::LightWeightCell*> cells(total_cell_count, nullptr);
+    std::vector<std::shared_ptr<UnpartitionedMesh::LightWeightCell>> cells(total_cell_count);
     std::vector<Vector3*> vertices(total_point_count, nullptr);
 
     auto cell_gids_ptr = ugrid.GetCellData()->GetGlobalIds();
@@ -343,7 +346,7 @@ CopyUGridCellsAndPoints(std::shared_ptr<UnpartitionedMesh> mesh,
       if (vtk_celldim != dimension_to_copy)
         continue;
 
-      UnpartitionedMesh::LightWeightCell* raw_cell;
+      std::shared_ptr<UnpartitionedMesh::LightWeightCell> raw_cell;
       if (vtk_celldim == 3)
         raw_cell = CreateCellFromVTKPolyhedron(vtk_cell);
       else if (vtk_celldim == 2)

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -305,7 +305,7 @@ CopyUGridCellsAndPoints(std::shared_ptr<UnpartitionedMesh> mesh,
   if (has_global_ids)
   {
     std::vector<std::shared_ptr<UnpartitionedMesh::LightWeightCell>> cells(total_cell_count);
-    std::vector<Vector3*> vertices(total_point_count, nullptr);
+    std::vector<std::shared_ptr<Vector3>> vertices(total_point_count);
 
     auto cell_gids_ptr = ugrid.GetCellData()->GetGlobalIds();
     auto pnts_gids_ptr = ugrid.GetPointData()->GetGlobalIds();
@@ -379,7 +379,7 @@ CopyUGridCellsAndPoints(std::shared_ptr<UnpartitionedMesh> mesh,
       auto point = ugrid.GetPoint(static_cast<vtkIdType>(p));
       const vtkIdType point_gid = pnts_gids->GetValue(p) + pid_offset;
 
-      auto vertex = new Vector3(point[0], point[1], point[2]);
+      auto vertex = std::make_shared<Vector3>(point[0], point[1], point[2]);
 
       *vertex *= scale;
 

--- a/framework/mesh/mesh_face.h
+++ b/framework/mesh/mesh_face.h
@@ -93,7 +93,7 @@ struct Face
 struct PolyFace
 {
   std::vector<int> v_indices;
-  std::vector<int*> edges;
+  std::vector<std::vector<int>> edges;
   int face_indices[3];
 
   Normal geometric_normal;
@@ -102,12 +102,6 @@ struct PolyFace
   bool invalidated;
 
   PolyFace() { invalidated = false; }
-
-  ~PolyFace()
-  {
-    for (auto edge : edges)
-      delete[] edge;
-  }
 };
 
 } // namespace opensn

--- a/framework/mesh/mesh_generator/extruder_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/extruder_mesh_generator.cc
@@ -193,8 +193,8 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
         }
 
         // Create new cell
-        auto new_cell_ptr =
-          new UnpartitionedMesh::LightWeightCell(CellType::POLYHEDRON, extruded_subtype);
+        auto new_cell_ptr = std::make_shared<UnpartitionedMesh::LightWeightCell>(
+          CellType::POLYHEDRON, extruded_subtype);
         auto& new_cell = *new_cell_ptr;
 
         new_cell.material_id = template_cell->material_id;

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -227,9 +227,6 @@ MeshGenerator::SetupMesh(std::shared_ptr<UnpartitionedMesh> input_umesh,
       grid_ptr->cells.push_back(std::move(cell));
     }
 
-    delete raw_cell;
-    raw_cell = nullptr;
-
     ++cell_globl_id;
   } // for raw_cell
 

--- a/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
@@ -141,7 +141,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned1DOrthoMesh(const std::vector<double
   const size_t max_cz = zverts.size() - 2;
   for (size_t c = 0; c < (zverts.size() - 1); ++c)
   {
-    auto cell = new UnpartitionedMesh::LightWeightCell(CellType::SLAB, CellType::SLAB);
+    auto cell =
+      std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::SLAB, CellType::SLAB);
 
     cell->vertex_ids = {c, c + 1};
 
@@ -231,8 +232,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned2DOrthoMesh(const std::vector<double
   {
     for (size_t j = 0; j < (Nx - 1); ++j)
     {
-      auto cell =
-        new UnpartitionedMesh::LightWeightCell(CellType::POLYGON, CellType::QUADRILATERAL);
+      auto cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYGON,
+                                                                       CellType::QUADRILATERAL);
 
       // vertex ids:   face ids:
       //                 2
@@ -371,8 +372,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
     {
       for (size_t k = 0; k < (Nz - 1); ++k)
       {
-        auto cell =
-          new UnpartitionedMesh::LightWeightCell(CellType::POLYHEDRON, CellType::HEXAHEDRON);
+        auto cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYHEDRON,
+                                                                         CellType::HEXAHEDRON);
 
         cell->vertex_ids = std::vector<uint64_t>{vmap[i][j][k],
                                                  vmap[i][j + 1][k],

--- a/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/framework/mesh/surface_mesh/surface_mesh.cc
@@ -1632,7 +1632,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 
     auto new_surface = std::make_shared<SurfaceMesh>();
 
-    std::vector<int*> vertex_mapping;
+    std::vector<std::vector<int>> vertex_mapping;
 
     for (cur_face = (*outer_patch)->begin(); cur_face != (*outer_patch)->end(); cur_face++)
     {
@@ -1646,9 +1646,8 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 
         // Check if vertex already there
         bool already_there = false;
-        int* already_there_mapping;
-        std::vector<int*>::iterator cur_map;
-        for (cur_map = vertex_mapping.begin(); cur_map != vertex_mapping.end(); cur_map++)
+        std::vector<int> already_there_mapping;
+        for (auto cur_map = vertex_mapping.begin(); cur_map != vertex_mapping.end(); cur_map++)
         {
           if ((*cur_map)[0] == vi)
           {
@@ -1667,7 +1666,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
         {
           // Copy vertex
           Vertex v = this->vertices_.at(vi);
-          int* newMapping = new int[2];
+          std::vector<int> newMapping(2);
           newMapping[0] = vi;
           newMapping[1] = new_surface->vertices_.size();
 

--- a/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/framework/mesh/surface_mesh/surface_mesh.cc
@@ -30,11 +30,6 @@ SurfaceMesh::SurfaceMesh()
 
 SurfaceMesh::~SurfaceMesh()
 {
-  for (auto poly_face : poly_faces_)
-  {
-    delete poly_face;
-  }
-
   poly_faces_.clear();
 }
 
@@ -427,7 +422,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
       int number_of_verts = std::count(file_line.begin(), file_line.end(), '/') / 2;
       if ((number_of_verts == 3) and (not as_poly))
       {
-        Face* newFace = new Face;
+        auto newFace = std::make_shared<Face>();
 
         for (int k = 1; k <= 3; k++)
         {
@@ -502,7 +497,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
       }
       else
       {
-        PolyFace* newFace = new PolyFace;
+        auto newFace = std::make_shared<PolyFace>();
 
         for (int k = 1; k <= number_of_verts; k++)
         {
@@ -565,7 +560,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
 
         for (int v = 0; v < (newFace->v_indices.size()); v++)
         {
-          int* side_indices = new int[4];
+          std::vector<int> side_indices(4);
 
           side_indices[0] = newFace->v_indices[v];
           if ((v + 1) >= newFace->v_indices.size())
@@ -657,8 +652,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     // Compute face center
     curFace->face_centroid = (vA + vB + vC) / 3.0;
   }
-  std::vector<PolyFace*>::iterator curPFace;
-  for (curPFace = this->poly_faces_.begin(); curPFace != this->poly_faces_.end(); curPFace++)
+  for (auto curPFace = this->poly_faces_.begin(); curPFace != this->poly_faces_.end(); curPFace++)
   {
     Vector3 centroid;
     int num_verts = (*curPFace)->v_indices.size();
@@ -736,7 +730,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   for (int v = 1; v <= num_tris; v++)
   {
     int tri_index;
-    PolyFace* newFace = new PolyFace;
+    auto newFace = std::make_shared<PolyFace>();
 
     int v0, v1, v2;
     file >> tri_index >> v0 >> v1 >> v2;
@@ -749,7 +743,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
 
     for (int e = 0; e < 3; e++)
     {
-      int* side_indices = new int[4];
+      std::vector<int> side_indices(4);
 
       if (e < 2)
       {
@@ -801,8 +795,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
     // Compute face center
     curFace->face_centroid = (vA + vB + vC) / 3.0;
   }
-  std::vector<PolyFace*>::iterator curPFace;
-  for (curPFace = this->poly_faces_.begin(); curPFace != this->poly_faces_.end(); curPFace++)
+  for (auto curPFace = this->poly_faces_.begin(); curPFace != this->poly_faces_.end(); curPFace++)
   {
     Vector3 centroid;
     int num_verts = (*curPFace)->v_indices.size();
@@ -830,7 +823,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   return 0;
 }
 
-SurfaceMesh*
+std::shared_ptr<SurfaceMesh>
 SurfaceMesh::CreateFromDivisions(std::vector<double>& vertices_1d_x,
                                  std::vector<double>& vertices_1d_y)
 {
@@ -866,7 +859,7 @@ SurfaceMesh::CreateFromDivisions(std::vector<double>& vertices_1d_x,
     vertices_y.emplace_back(0.0, v, 0.0);
 
   // Create surface mesh
-  auto surf_mesh = new SurfaceMesh();
+  auto surf_mesh = std::make_shared<SurfaceMesh>();
 
   // Populate vertices
   std::vector<std::vector<int>> vert_ij_map(Nvx, std::vector<int>(Nvx, -1));
@@ -884,7 +877,7 @@ SurfaceMesh::CreateFromDivisions(std::vector<double>& vertices_1d_x,
   {
     for (int j = 0; j < Ncx; ++j)
     {
-      auto new_face = new PolyFace();
+      auto new_face = std::make_shared<PolyFace>();
       new_face->v_indices.push_back(vert_ij_map[i][j]);
       new_face->v_indices.push_back(vert_ij_map[i][j + 1]);
       new_face->v_indices.push_back(vert_ij_map[i + 1][j + 1]);
@@ -892,8 +885,7 @@ SurfaceMesh::CreateFromDivisions(std::vector<double>& vertices_1d_x,
 
       for (int v = 0; v < (new_face->v_indices.size()); v++)
       {
-        int* side_indices = new int[4];
-
+        std::vector<int> side_indices(4);
         side_indices[0] = new_face->v_indices[v];
         side_indices[1] = new_face->v_indices[v + 1];
         side_indices[2] = -1;
@@ -1015,7 +1007,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
   for (int n = 0; n < num_elems; n++)
   {
     int elem_type, num_tags, physical_reg, tag, element_index;
-    PolyFace* newFace = new PolyFace;
+    auto newFace = std::make_shared<PolyFace>();
     std::getline(file, line);
     iss = std::istringstream(line);
 
@@ -1080,7 +1072,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
 
     for (size_t e = 0; e < total_nodes; e++)
     {
-      int* side_indices = new int[total_nodes];
+      std::vector<int> side_indices(total_nodes);
       side_indices[0] = newFace->v_indices[e];
 
       if (e < total_nodes - 1)
@@ -1178,7 +1170,7 @@ SurfaceMesh::ExportToOBJFile(const char* fileName)
   }
   if (not poly_faces_.empty())
   {
-    PolyFace* first_face = this->poly_faces_.front();
+    auto first_face = this->poly_faces_.front();
     fprintf(outputFile,
             "vn %.4f %.4f %.4f\n",
             first_face->geometric_normal.x,
@@ -1255,7 +1247,7 @@ SurfaceMesh::CheckCyclicDependencies(int num_angles)
     // Now construct dependencies
     for (size_t c = 0; c < num_loc_cells; c++)
     {
-      PolyFace* face = poly_faces_[c];
+      auto face = poly_faces_[c];
 
       size_t num_edges = face->edges.size();
       for (size_t e = 0; e < num_edges; e++)
@@ -1327,7 +1319,7 @@ SurfaceMesh::GetMeshStats()
   double max_area = 0.0;
   for (size_t c = 0; c < num_loc_cells; c++)
   {
-    PolyFace* face = poly_faces_[c];
+    auto face = poly_faces_[c];
 
     size_t num_edges = face->edges.size();
     double area = 0.0;
@@ -1468,10 +1460,10 @@ SurfaceMesh::ComputeLoadBalancing(std::vector<double>& x_cuts, std::vector<doubl
 }
 
 void
-SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
+SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 {
   typedef std::vector<Face> FaceList;
-  typedef std::vector<FaceList*> FaceListCollection;
+  typedef std::vector<std::shared_ptr<FaceList>> FaceListCollection;
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Copy all faces from surface
   FaceList unsorted_faces;
@@ -1486,7 +1478,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
   FaceListCollection co_planar_lists;
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Seed the first collection
-  FaceList* first_list = new FaceList;
+  auto first_list = std::make_shared<FaceList>();
   co_planar_lists.push_back(first_list);
   first_list->push_back(unsorted_faces.back());
   unsorted_faces.pop_back();
@@ -1525,7 +1517,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
     if (not matchFound)
     {
       printf("New list created\n");
-      FaceList* new_list = new FaceList;
+      auto new_list = std::make_shared<FaceList>();
       new_list->push_back(unsorted_faces.back());
       unsorted_faces.pop_back();
       co_planar_lists.push_back(new_list);
@@ -1552,7 +1544,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
     }
 
     // Seed the first patch list
-    FaceList* first_patch_list = new FaceList;
+    auto first_patch_list = std::make_shared<FaceList>();
     inner_patch_list_collection.push_back(first_patch_list);
     first_patch_list->push_back(unused_faces.back());
     unused_faces.pop_back();
@@ -1613,7 +1605,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
 
       if (not updateMade)
       {
-        FaceList* new_patch_list = new FaceList;
+        auto new_patch_list = std::make_shared<FaceList>();
         inner_patch_list_collection.push_back(new_patch_list);
         new_patch_list->push_back(unused_faces.back());
         unused_faces.pop_back();
@@ -1638,7 +1630,7 @@ SurfaceMesh::SplitByPatch(std::vector<SurfaceMesh*>& patches)
        outer_patch++)
   {
 
-    SurfaceMesh* new_surface = new SurfaceMesh;
+    auto new_surface = std::make_shared<SurfaceMesh>();
 
     std::vector<int*> vertex_mapping;
 

--- a/framework/mesh/surface_mesh/surface_mesh.h
+++ b/framework/mesh/surface_mesh/surface_mesh.h
@@ -30,7 +30,7 @@ protected:
   std::vector<Normal> normals_;
   std::vector<Face> faces_;
   std::vector<Edge> lines_;
-  std::vector<PolyFace*> poly_faces_; ///< Polygonal faces
+  std::vector<std::shared_ptr<PolyFace>> poly_faces_; ///< Polygonal faces
 
   std::vector<int> physical_region_map_;
 
@@ -39,7 +39,7 @@ public:
 
   const std::vector<Face>& GetTriangles() const { return faces_; }
 
-  const std::vector<PolyFace*>& GetPolygons() const { return poly_faces_; }
+  const std::vector<std::shared_ptr<PolyFace>>& GetPolygons() const { return poly_faces_; }
 
   SurfaceMesh();
   ~SurfaceMesh();
@@ -85,8 +85,8 @@ public:
    *
    * This code will create a 2x2 mesh with \f$ \vec{x} \in [0,2]^2 \f$.
    */
-  static SurfaceMesh* CreateFromDivisions(std::vector<double>& vertices_1d_x,
-                                          std::vector<double>& vertices_1d_y);
+  static std::shared_ptr<SurfaceMesh> CreateFromDivisions(std::vector<double>& vertices_1d_x,
+                                                          std::vector<double>& vertices_1d_y);
 
   /**
    * Runs over the faces of the surfacemesh and determines
@@ -102,7 +102,7 @@ public:
   /**
    * Splits the surface by patch.
    */
-  void SplitByPatch(std::vector<SurfaceMesh*>& patches);
+  void SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches);
 
   /**
    * Extract open edges to wavefront obj format.

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -18,10 +18,6 @@ UnpartitionedMesh::UnpartitionedMesh() : dim_(0), mesh_type_(UNSTRUCTURED), extr
 
 UnpartitionedMesh::~UnpartitionedMesh()
 {
-  for (auto& cell : raw_cells_)
-    delete cell;
-  for (auto& cell : raw_boundary_cells_)
-    delete cell;
   log.Log0Verbose1() << "Unpartitioned Mesh destructor called";
 }
 
@@ -301,7 +297,7 @@ UnpartitionedMesh::BuildMeshConnectivity()
 
   // Establish boundary connectivity
   // Make list of internal cells on the boundary
-  std::vector<LightWeightCell*> internal_cells_on_boundary;
+  std::vector<std::shared_ptr<LightWeightCell>> internal_cells_on_boundary;
   for (auto& cell : raw_cells_)
   {
     bool cell_on_boundary = false;
@@ -405,7 +401,7 @@ UnpartitionedMesh::PushProxyCell(const std::string& type_str,
   else
     throw std::logic_error(fname + ": Unsupported cell secondary type.");
 
-  auto cell = new LightWeightCell(type, sub_type);
+  auto cell = std::make_shared<LightWeightCell>(type, sub_type);
 
   cell->material_id = cell_material_id;
 
@@ -440,10 +436,6 @@ UnpartitionedMesh::PushProxyCell(const std::string& type_str,
 void
 UnpartitionedMesh::CleanUp()
 {
-  for (auto& cell : raw_cells_)
-    delete cell;
-  for (auto& cell : raw_boundary_cells_)
-    delete cell;
   vertices_.clear();
   vertices_.shrink_to_fit();
   raw_cells_.clear();

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -78,14 +78,17 @@ public:
     return vertex_cell_subscriptions_;
   }
 
-  void AddCell(LightWeightCell*& cell) { raw_cells_.push_back(cell); }
+  void AddCell(std::shared_ptr<LightWeightCell> cell) { raw_cells_.push_back(cell); }
   size_t GetNumberOfCells() const { return raw_cells_.size(); }
 
-  std::vector<LightWeightCell*>& RawCells() { return raw_cells_; }
-  const std::vector<LightWeightCell*>& RawCells() const { return raw_cells_; }
+  std::vector<std::shared_ptr<LightWeightCell>>& RawCells() { return raw_cells_; }
+  const std::vector<std::shared_ptr<LightWeightCell>>& RawCells() const { return raw_cells_; }
 
-  std::vector<LightWeightCell*>& RawBoundaryCells() { return raw_boundary_cells_; }
-  const std::vector<LightWeightCell*>& RawBoundaryCells() const { return raw_boundary_cells_; }
+  std::vector<std::shared_ptr<LightWeightCell>>& RawBoundaryCells() { return raw_boundary_cells_; }
+  const std::vector<std::shared_ptr<LightWeightCell>>& RawBoundaryCells() const
+  {
+    return raw_boundary_cells_;
+  }
 
   const std::vector<Vertex>& Vertices() const { return vertices_; }
   std::vector<Vertex>& Vertices() { return vertices_; }
@@ -138,8 +141,8 @@ protected:
   std::map<uint64_t, std::string> boundary_id_map_;
 
   std::vector<Vertex> vertices_;
-  std::vector<LightWeightCell*> raw_cells_;
-  std::vector<LightWeightCell*> raw_boundary_cells_;
+  std::vector<std::shared_ptr<LightWeightCell>> raw_cells_;
+  std::vector<std::shared_ptr<LightWeightCell>> raw_boundary_cells_;
   std::vector<std::set<uint64_t>> vertex_cell_subscriptions_;
 };
 

--- a/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
+++ b/lua/framework/math/quadratures/sldfesq/create_sldfesq_quadrature.cc
@@ -23,13 +23,10 @@ CreateSLDFESQAngularQuadrature(lua_State* L)
 
   auto init_refinement_level = LuaArg<int>(L, 1);
 
-  auto sldfesq = new SimplifiedLDFESQ::Quadrature;
+  auto sldfesq = std::make_shared<SimplifiedLDFESQ::Quadrature>();
   sldfesq->GenerateInitialRefinement(init_refinement_level);
 
-  std::shared_ptr<AngularQuadrature> new_ang_quad =
-    std::shared_ptr<SimplifiedLDFESQ::Quadrature>(sldfesq);
-
-  opensn::angular_quadrature_stack.push_back(new_ang_quad);
+  opensn::angular_quadrature_stack.push_back(sldfesq);
   const size_t index = opensn::angular_quadrature_stack.size() - 1;
   return LuaReturn(L, index);
 }

--- a/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
+++ b/lua/framework/mesh/field_function_interpolation/ffinterpol_create.cc
@@ -28,7 +28,7 @@ FFInterpolationCreate(lua_State* L)
   auto ffitype = LuaArg<int>(L, 1);
   if (ffitype == static_cast<int>(FieldFunctionInterpolationType::POINT))
   {
-    auto new_ffi = new FieldFunctionInterpolationPoint;
+    auto new_ffi = std::make_shared<FieldFunctionInterpolationPoint>();
 
     opensn::field_func_interpolation_stack.emplace_back(new_ffi);
     const size_t index = opensn::field_func_interpolation_stack.size() - 1;
@@ -37,7 +37,7 @@ FFInterpolationCreate(lua_State* L)
   }
   else if (ffitype == static_cast<int>(FieldFunctionInterpolationType::LINE))
   {
-    auto new_ffi = new FieldFunctionInterpolationLine;
+    auto new_ffi = std::make_shared<FieldFunctionInterpolationLine>();
 
     opensn::field_func_interpolation_stack.emplace_back(new_ffi);
     const size_t index = opensn::field_func_interpolation_stack.size() - 1;
@@ -46,7 +46,7 @@ FFInterpolationCreate(lua_State* L)
   }
   else if (ffitype == static_cast<int>(FieldFunctionInterpolationType::VOLUME))
   {
-    auto new_ffi = new FieldFunctionInterpolationVolume;
+    auto new_ffi = std::make_shared<FieldFunctionInterpolationVolume>();
 
     opensn::field_func_interpolation_stack.emplace_back(new_ffi);
     const size_t index = opensn::field_func_interpolation_stack.size() - 1;

--- a/lua/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/lua/framework/mesh/surface_mesh/surface_mesh.cc
@@ -25,7 +25,7 @@ RegisterLuaFunctionInNamespace(MeshSurfaceMeshImportFromTriangleFiles,
 int
 MeshSurfaceMeshCreate(lua_State* L)
 {
-  auto new_mesh = new SurfaceMesh;
+  auto new_mesh = std::make_shared<SurfaceMesh>();
 
   opensn::object_stack.emplace_back(new_mesh);
 


### PR DESCRIPTION
- Use `make_shared` in `CreateSLDFESQAngularQuadrature`
- Use `make_shared` in `FFInterpolationCreate`
- Use `make_shared` in `MeshSurfaceMeshCreate`
- `LightWeightCell`s in `UnpartitionedMesh` are `shared_ptr`s
- `sub_intvls` in `CDFSampler::SubIntvl` are `shared_ptr`s
- `sub_intvls` in `CDFSampler::SubIntvl` are `shared_ptr`s
- Using `shared_ptr`s in `CopyUGridCellsAndPoints`
- Using `shared_ptr`s in `SurfaceMesh`
- Use `std::vector` instead of C-style arrays in `SurfaceMesh`
- Use `std::vector` instead of C-style arrays in `NDArray`

Closes #95
