### PR TITLE
Changing global variable `name`

### DIFF
--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -52,7 +52,7 @@ Initialize()
     cali_mgr.start();
   }
 
-  CALI_MARK_BEGIN(opensn::name.c_str());
+  CALI_MARK_BEGIN(opensn::program.c_str());
 
   SystemWideEventPublisher::GetInstance().PublishEvent(Event("ProgramStart"));
 
@@ -75,7 +75,7 @@ Finalize()
   function_stack.clear();
   object_stack.clear();
 
-  CALI_MARK_END(opensn::name.c_str());
+  CALI_MARK_END(opensn::program.c_str());
 }
 
 void

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -17,7 +17,7 @@ namespace mpi = mpicpp_lite;
 namespace opensn
 {
 
-const std::string name = "OpenSn";
+static const std::string program = "OpenSn";
 
 class MeshContinuum;
 class SurfaceMesh;

--- a/lua/framework/lua_app.cc
+++ b/lua/framework/lua_app.cc
@@ -47,10 +47,10 @@ LuaApp::Run(int argc, char** argv)
 {
   if (opensn::mpi_comm.rank() == 0)
   {
-    std::cout << opensn::name << " version " << GetVersionStr() << "\n"
-              << Timer::GetLocalDateTimeString() << " Running " << opensn::name << " with "
+    std::cout << opensn::program << " version " << GetVersionStr() << "\n"
+              << Timer::GetLocalDateTimeString() << " Running " << opensn::program << " with "
               << opensn::mpi_comm.size() << " processes.\n"
-              << opensn::name << " number of arguments supplied: " << argc - 1 << "\n"
+              << opensn::program << " number of arguments supplied: " << argc - 1 << "\n"
               << std::endl;
   }
 
@@ -76,8 +76,8 @@ LuaApp::Run(int argc, char** argv)
     {
       std::cout << "\n"
                 << "Elapsed execution time: " << program_timer.GetTimeString() << "\n"
-                << Timer::GetLocalDateTimeString() << " " << opensn::name << " finished execution."
-                << std::endl;
+                << Timer::GetLocalDateTimeString() << " " << opensn::program
+                << " finished execution." << std::endl;
     }
   }
 
@@ -93,7 +93,7 @@ LuaApp::ProcessArguments(int argc, char** argv)
 {
   try
   {
-    cxxopts::Options options(LowerCase(opensn::name), "");
+    cxxopts::Options options(LowerCase(opensn::program), "");
 
     /* clang-format off */
     options.add_options("User")


### PR DESCRIPTION
To avoid clashes, renaming the global variable `name` to a static variable named `program`. Please suggest alternatives if you have other ideas. 