### PR TITLE
Bug fixes for multi-groupset, k-eigenvalue problems with reflecting boundaries

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -1194,9 +1194,8 @@ DiscreteOrdinatesSolver::InitFluxDataStructures(LBSGroupset& groupset)
 
   // Passing the sweep boundaries
   //                                            to the angle aggregation
-  typedef AngleAggregation AngleAgg;
-  groupset.angle_agg_ = std::make_shared<AngleAgg>(
-    sweep_boundaries_, gs_num_grps, gs_num_ss, groupset.quadrature_, grid_ptr_);
+  groupset.angle_agg_ = std::make_shared<AngleAggregation>(
+    sweep_boundaries_, num_groups_, gs_num_ss, groupset.quadrature_, grid_ptr_);
 
   AngleSetGroup angle_set_group;
   size_t angle_set_id = 0;

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.cc
@@ -70,6 +70,9 @@ PowerIterationKEigenSCDSA::PowerIterationKEigenSCDSA(const InputParameters& para
     diff_accel_diffusion_petsc_options_(
       params.GetParamValue<std::string>("diff_accel_diffusion_petsc_options"))
 {
+  if (lbs_solver_.Groupsets().size() != 1)
+    throw std::logic_error("The SCDSA k-eigenvalue executor is only implemented for "
+                           "problems with a single groupset.");
 }
 
 void

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -876,8 +876,8 @@ LBSSolver::PrintSimHeader()
           outstr << "\n";
         }
       }
-      log.Log() << outstr.str() << "\n" << std::endl;
     }
+    log.Log() << outstr.str() << "\n" << std::endl;
   }
 }
 


### PR DESCRIPTION
This PR fixes multiple issues with multi-groupset k-eigenvalue problems with reflecting boundaries. The default k-eigenvalue solver was incorrectly setting active sources for only the first groupset. In addition, angular flux storage for reflecting boundaries was not sized properly for the current implementation (the implementation can be improved, but that is beyond the scope of this PR).  Resolves issue #321.