### PR TITLE
Forcing the use of node16 for regressions workflow.

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -9,6 +9,9 @@ jobs:
   build:
     name: "${{ matrix.compiler }}"
     runs-on: [self-hosted]
+    env:
+        ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -13,6 +13,9 @@ on:
 jobs:
   test:
     runs-on: [self-hosted]
+    env:
+        ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: build

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: [self-hosted]
+    env:
+        ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
       - name: build


### PR DESCRIPTION
Github workflows have migrated to node20 for actions. node20 does not work on older OS's like our CI machine. Trying to force node16 to get things working again. 

Update: It looks like forcing node16 works... for now. Hopefully Github leaves it be for a while. 