### PR TITLE
Removed discretization requirement for `FieldFunctionGridBased`

### DIFF
--- a/framework/field_functions/field_function.cc
+++ b/framework/field_functions/field_function.cc
@@ -12,21 +12,17 @@ FieldFunction::GetInputParameters()
 {
   InputParameters params = Object::GetInputParameters();
 
-  params.AddRequiredParameter<std::string>("name",
-                                           "Named to be associated with this field function");
-
+  params.AddRequiredParameter<std::string>("name", "The field function name.");
   params.AddOptionalParameter(
     "unknown_type", "Scalar", "The type of the variable for this field function");
-
   params.AddOptionalParameter("num_components",
                               1,
                               "The number of components to attach to the variable. "
-                              "Only effective when \"type\" is VectorN.");
+                              "This is only valid for VectorN unknowns.");
 
   // Constrain values
   params.ConstrainParameterRange(
     "unknown_type", AllowableRangeList::New({"Scalar", "Vector2", "Vector3", "VectorN"}));
-
   params.ConstrainParameterRange("num_components", AllowableRangeLowLimit::New(1));
 
   return params;
@@ -34,7 +30,7 @@ FieldFunction::GetInputParameters()
 
 FieldFunction::FieldFunction(const InputParameters& params)
   : Object(params),
-    text_name_(params.GetParamValue<std::string>("name")),
+    name_(params.GetParamValue<std::string>("name")),
     unknown_(
       (params.GetParamValue<std::string>("unknown_type") == "Scalar") ? Unknown(UnknownType::SCALAR)
       : (params.GetParamValue<std::string>("unknown_type") == "Vector2")
@@ -48,8 +44,8 @@ FieldFunction::FieldFunction(const InputParameters& params)
 {
 }
 
-FieldFunction::FieldFunction(const std::string& text_name, Unknown unknown)
-  : text_name_(text_name), unknown_(std::move(unknown)), unknown_manager_({unknown_})
+FieldFunction::FieldFunction(std::string name, Unknown unknown)
+  : name_(std::move(name)), unknown_(std::move(unknown)), unknown_manager_({unknown_})
 {
 }
 

--- a/framework/field_functions/field_function.cc
+++ b/framework/field_functions/field_function.cc
@@ -35,21 +35,20 @@ FieldFunction::GetInputParameters()
 FieldFunction::FieldFunction(const InputParameters& params)
   : Object(params),
     text_name_(params.GetParamValue<std::string>("name")),
-    unknown_((params.GetParamValue<std::string>("unknown_type") == "Scalar")
-               ? opensn::Unknown(UnknownType::SCALAR)
-             : (params.GetParamValue<std::string>("unknown_type") == "Vector2")
-               ? opensn::Unknown(UnknownType::VECTOR_2)
-             : (params.GetParamValue<std::string>("unknown_type") == "Vector3")
-               ? opensn::Unknown(UnknownType::VECTOR_2)
-             : (params.GetParamValue<std::string>("unknown_type") == "VectorN")
-               ? opensn::Unknown(UnknownType::VECTOR_N,
-                                 params.GetParamValue<unsigned int>("num_components"))
-               : opensn::Unknown(UnknownType::SCALAR)),
+    unknown_(
+      (params.GetParamValue<std::string>("unknown_type") == "Scalar") ? Unknown(UnknownType::SCALAR)
+      : (params.GetParamValue<std::string>("unknown_type") == "Vector2")
+        ? Unknown(UnknownType::VECTOR_2)
+      : (params.GetParamValue<std::string>("unknown_type") == "Vector3")
+        ? Unknown(UnknownType::VECTOR_2)
+      : (params.GetParamValue<std::string>("unknown_type") == "VectorN")
+        ? Unknown(UnknownType::VECTOR_N, params.GetParamValue<unsigned int>("num_components"))
+        : Unknown(UnknownType::SCALAR)),
     unknown_manager_({unknown_})
 {
 }
 
-FieldFunction::FieldFunction(const std::string& text_name, opensn::Unknown unknown)
+FieldFunction::FieldFunction(const std::string& text_name, Unknown unknown)
   : text_name_(text_name), unknown_(std::move(unknown)), unknown_manager_({unknown_})
 {
 }

--- a/framework/field_functions/field_function.h
+++ b/framework/field_functions/field_function.h
@@ -15,7 +15,7 @@ class FieldFunction : public Object
 {
 private:
   std::string text_name_;
-  opensn::Unknown unknown_;
+  Unknown unknown_;
   UnknownManager unknown_manager_;
 
 public:
@@ -34,7 +34,7 @@ public:
   /**Returns the text name of the field function.*/
   const std::string& TextName() const { return text_name_; }
   /**Returns a reference to the unknown structure.*/
-  const opensn::Unknown& Unknown() const { return unknown_; }
+  const Unknown& GetUnknown() const { return unknown_; }
   /**Returns a reference to the unknown manager that can be used in
    * spatial discretizations.*/
   const UnknownManager& GetUnknownManager() const { return unknown_manager_; }

--- a/framework/field_functions/field_function.h
+++ b/framework/field_functions/field_function.h
@@ -13,40 +13,34 @@ class Cell;
 
 class FieldFunction : public Object
 {
-private:
-  std::string text_name_;
-  Unknown unknown_;
-  UnknownManager unknown_manager_;
-
 public:
-  /**Returns required input parameters.*/
   static InputParameters GetInputParameters();
-
-  /**ObjectMaker based constructor.*/
   explicit FieldFunction(const InputParameters& params);
 
-  /**Conventional constructor.*/
-  FieldFunction(const std::string& text_name, Unknown unknown);
+  FieldFunction(std::string name, Unknown unknown);
 
   virtual ~FieldFunction() = default;
 
-  // Getters
-  /**Returns the text name of the field function.*/
-  const std::string& TextName() const { return text_name_; }
+  /// Returns the text name of the field function.
+  const std::string& Name() const { return name_; }
   /**Returns a reference to the unknown structure.*/
   const Unknown& GetUnknown() const { return unknown_; }
-  /**Returns a reference to the unknown manager that can be used in
-   * spatial discretizations.*/
+  /// Returns a reference to the unknown manager that can be with spatial discretizations.
   const UnknownManager& GetUnknownManager() const { return unknown_manager_; }
 
-  /**\brief Overrides the stack placement so that FieldFunctions go
-   * to the field function stack.*/
+  /// Overrides the stack placement so that field functions go to the field function stack.*/
   void PushOntoStack(std::shared_ptr<Object>& new_object) override;
 
-  virtual double Evaluate(const Cell& cell, const Vector3& position, unsigned int component) const
+  /// Evaluate the field function on a given cell, at a given position, for the given component.
+  virtual double Evaluate(const Cell& cell, const Vector3& position, int component) const
   {
     return 0.0;
   }
+
+protected:
+  std::string name_;
+  Unknown unknown_;
+  UnknownManager unknown_manager_;
 };
 
 } // namespace opensn

--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -237,7 +237,7 @@ FieldFunctionGridBased::ExportMultipleToVTK(
     const auto field_vector = ff_ptr->GetGhostedFieldVector();
 
     const auto& uk_man = ff_ptr->GetUnknownManager();
-    const auto& unknown = ff_ptr->Unknown();
+    const auto& unknown = ff_ptr->GetUnknown();
     const auto& sdm = ff_ptr->sdm_;
     const size_t num_comps = unknown.NumComponents();
 

--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -28,21 +28,18 @@ FieldFunctionGridBased::GetInputParameters()
 
   params.SetDocGroup("DocFieldFunction");
 
-  params.AddRequiredParameter<std::string>("sdm_type",
-                                           "The spatial discretization type to be used");
-
+  params.AddOptionalParameter("discretization", "FV", "The spatial discretization type to be used");
   params.AddOptionalParameter(
-    "initial_value", 0.0, "The initial value to assign to the field function");
-
+    "coordinate_system", "cartesian", "Coordinate system to apply to element mappings");
   params.AddOptionalParameter("quadrature_order",
                               0,
                               "If supplied, will overwrite the default for the "
                               "specific discretization-coordinate system combination.");
 
   params.AddOptionalParameter(
-    "coordinate_system", "cartesian", "Coordinate system to apply to element mappings");
+    "initial_value", 0.0, "The initial value to assign to the field function");
 
-  params.ConstrainParameterRange("sdm_type", AllowableRangeList::New({"FV", "PWLC", "PWLD"}));
+  params.ConstrainParameterRange("discretization", AllowableRangeList::New({"FV", "PWLC", "PWLD"}));
   params.ConstrainParameterRange(
     "coordinate_system", AllowableRangeList::New({"cartesian", "cylindrical", "spherical"}));
 
@@ -51,32 +48,31 @@ FieldFunctionGridBased::GetInputParameters()
 
 FieldFunctionGridBased::FieldFunctionGridBased(const InputParameters& params)
   : FieldFunction(params),
-    sdm_(MakeSpatialDiscretization(params)),
-    ghosted_field_vector_(MakeFieldVector(*sdm_, GetUnknownManager())),
+    discretization_(MakeSpatialDiscretization(params)),
+    ghosted_field_vector_(MakeFieldVector(*discretization_, GetUnknownManager())),
     local_grid_bounding_box_(GetCurrentMesh()->GetLocalBoundingBox())
 {
   ghosted_field_vector_->Set(params.GetParamValue<double>("initial_value"));
 }
 
 FieldFunctionGridBased::FieldFunctionGridBased(
-  const std::string& text_name,
-  std::shared_ptr<SpatialDiscretization>& discretization_ptr,
-  opensn::Unknown unknown)
-  : FieldFunction(text_name, std::move(unknown)),
-    sdm_(discretization_ptr),
-    ghosted_field_vector_(MakeFieldVector(*sdm_, GetUnknownManager())),
-    local_grid_bounding_box_(sdm_->Grid().GetLocalBoundingBox())
+  std::string name, std::shared_ptr<SpatialDiscretization>& discretization_ptr, Unknown unknown)
+  : FieldFunction(std::move(name), std::move(unknown)),
+    discretization_(discretization_ptr),
+    ghosted_field_vector_(MakeFieldVector(*discretization_, GetUnknownManager())),
+    local_grid_bounding_box_(discretization_->Grid().GetLocalBoundingBox())
 {
 }
 
-FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
-                                               std::shared_ptr<SpatialDiscretization>& sdm_ptr,
-                                               opensn::Unknown unknown,
-                                               const std::vector<double>& field_vector)
-  : FieldFunction(text_name, std::move(unknown)),
-    sdm_(sdm_ptr),
-    ghosted_field_vector_(MakeFieldVector(*sdm_, GetUnknownManager())),
-    local_grid_bounding_box_(sdm_->Grid().GetLocalBoundingBox())
+FieldFunctionGridBased::FieldFunctionGridBased(
+  std::string name,
+  std::shared_ptr<SpatialDiscretization>& discretization_ptr,
+  Unknown unknown,
+  const std::vector<double>& field_vector)
+  : FieldFunction(std::move(name), std::move(unknown)),
+    discretization_(discretization_ptr),
+    ghosted_field_vector_(MakeFieldVector(*discretization_, GetUnknownManager())),
+    local_grid_bounding_box_(discretization_->Grid().GetLocalBoundingBox())
 {
   OpenSnInvalidArgumentIf(field_vector.size() != ghosted_field_vector_->LocalSize(),
                           "Constructor called with incompatible size field vector.");
@@ -84,14 +80,15 @@ FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
   ghosted_field_vector_->Set(field_vector);
 }
 
-FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
-                                               std::shared_ptr<SpatialDiscretization>& sdm_ptr,
-                                               opensn::Unknown unknown,
-                                               double field_value)
-  : FieldFunction(text_name, std::move(unknown)),
-    sdm_(sdm_ptr),
-    ghosted_field_vector_(MakeFieldVector(*sdm_, GetUnknownManager())),
-    local_grid_bounding_box_(sdm_->Grid().GetLocalBoundingBox())
+FieldFunctionGridBased::FieldFunctionGridBased(
+  std::string name,
+  std::shared_ptr<SpatialDiscretization>& discretization_ptr,
+  Unknown unknown,
+  double field_value)
+  : FieldFunction(std::move(name), std::move(unknown)),
+    discretization_(discretization_ptr),
+    ghosted_field_vector_(MakeFieldVector(*discretization_, GetUnknownManager())),
+    local_grid_bounding_box_(discretization_->Grid().GetLocalBoundingBox())
 {
   ghosted_field_vector_->Set(field_value);
 }
@@ -99,88 +96,25 @@ FieldFunctionGridBased::FieldFunctionGridBased(const std::string& text_name,
 const SpatialDiscretization&
 FieldFunctionGridBased::GetSpatialDiscretization() const
 {
-  return *sdm_;
-}
-
-const std::vector<double>&
-FieldFunctionGridBased::FieldVectorRead() const
-{
-  return ghosted_field_vector_->LocalSTLData();
+  return *discretization_;
 }
 
 std::vector<double>&
-FieldFunctionGridBased::FieldVector()
+FieldFunctionGridBased::GetLocalFieldVector()
 {
   return ghosted_field_vector_->LocalSTLData();
 }
 
-std::shared_ptr<SpatialDiscretization>
-FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
+const std::vector<double>&
+FieldFunctionGridBased::GetLocalFieldVector() const
 {
-  const auto& user_params = params.ParametersAtAssignment();
-  const auto& grid_ptr = GetCurrentMesh();
-  const auto sdm_type = params.GetParamValue<std::string>("sdm_type");
-
-  typedef FiniteVolume FV;
-  typedef PieceWiseLinearContinuous PWLC;
-  typedef PieceWiseLinearDiscontinuous PWLD;
-
-  if (sdm_type == "FV")
-    return FV::New(*grid_ptr);
-
-  CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN;
-  std::string cs = "cartesian";
-  if (user_params.Has("coordinate_system"))
-  {
-    cs = params.GetParamValue<std::string>("coordinate_system");
-
-    if (cs == "cartesian")
-      cs_type = CoordinateSystemType::CARTESIAN;
-    if (cs == "cylindrical")
-      cs_type = CoordinateSystemType::CYLINDRICAL;
-    if (cs == "spherical")
-      cs_type = CoordinateSystemType::SPHERICAL;
-  }
-
-  QuadratureOrder q_order = QuadratureOrder::SECOND;
-
-  if (user_params.Has("quadrature_order"))
-  {
-    const uint32_t max_order = static_cast<uint32_t>(QuadratureOrder::FORTYTHIRD);
-    const uint32_t q_order_int = params.GetParamValue<uint32_t>("quadrature_order");
-    OpenSnInvalidArgumentIf(q_order_int > max_order,
-                            "Invalid quadrature point order " + std::to_string(q_order_int));
-    q_order = static_cast<QuadratureOrder>(q_order_int);
-  }
-  else // Defaulted
-  {
-    if (cs == "cartesian")
-      q_order = QuadratureOrder::SECOND;
-    if (cs == "cylindrical")
-      q_order = QuadratureOrder::THIRD;
-    if (cs == "spherical")
-      q_order = QuadratureOrder::FOURTH;
-  }
-
-  if (sdm_type == "PWLC")
-    return PWLC::New(*grid_ptr, q_order, cs_type);
-  else if (sdm_type == "PWLD")
-    return PWLD::New(*grid_ptr, q_order, cs_type);
-
-  // If not returned by now
-  OpenSnInvalidArgument("Unsupported sdm_type \"" + sdm_type + "\"");
+  return ghosted_field_vector_->LocalSTLData();
 }
 
-std::unique_ptr<GhostedParallelSTLVector>
-FieldFunctionGridBased::MakeFieldVector(const SpatialDiscretization& discretization,
-                                        const UnknownManager& uk_man)
+std::vector<double>
+FieldFunctionGridBased::GetGhostedFieldVector() const
 {
-  auto field = std::make_unique<GhostedParallelSTLVector>(discretization.GetNumLocalDOFs(uk_man),
-                                                          discretization.GetNumGlobalDOFs(uk_man),
-                                                          discretization.GetGhostDOFIndices(uk_man),
-                                                          mpi_comm);
-
-  return field;
+  return ghosted_field_vector_->LocalSTLData();
 }
 
 void
@@ -190,7 +124,6 @@ FieldFunctionGridBased::UpdateFieldVector(const std::vector<double>& field_vecto
                           "Attempted update with a vector of insufficient size.");
 
   ghosted_field_vector_->Set(field_vector);
-
   ghosted_field_vector_->CommunicateGhostEntries();
 }
 
@@ -200,6 +133,91 @@ FieldFunctionGridBased::UpdateFieldVector(const Vec& field_vector)
   ghosted_field_vector_->CopyLocalValues(field_vector);
 
   ghosted_field_vector_->CommunicateGhostEntries();
+}
+
+std::vector<double>
+FieldFunctionGridBased::GetPointValue(const Vector3& point) const
+{
+  const auto& uk_man = GetUnknownManager();
+  const size_t num_components = uk_man.GetTotalUnknownStructureSize();
+
+  size_t local_num_point_hits = 0;
+  std::vector<double> local_point_value(num_components, 0.0);
+
+  const auto& xyz_min = local_grid_bounding_box_.first;
+  const auto& xyz_max = local_grid_bounding_box_.second;
+
+  const auto xmin = xyz_min.x;
+  const auto ymin = xyz_min.y;
+  const auto zmin = xyz_min.z;
+
+  const auto xmax = xyz_max.x;
+  const auto ymax = xyz_max.y;
+  const auto zmax = xyz_max.z;
+
+  const auto& field_vector = *ghosted_field_vector_;
+
+  if (point.x >= xmin and point.x <= xmax and point.y >= ymin and point.y <= ymax and
+      point.z >= zmin and point.z <= zmax)
+  {
+    const auto& grid = discretization_->Grid();
+    for (const auto& cell : grid.local_cells)
+    {
+      if (grid.CheckPointInsideCell(cell, point))
+      {
+        const auto& cell_mapping = discretization_->GetCellMapping(cell);
+        std::vector<double> shape_values;
+        cell_mapping.ShapeValues(point, shape_values);
+
+        local_num_point_hits += 1;
+
+        const auto num_nodes = cell_mapping.NumNodes();
+        for (size_t c = 0; c < num_components; ++c)
+        {
+          for (size_t j = 0; j < num_nodes; ++j)
+          {
+            const auto dof_map = discretization_->MapDOFLocal(cell, j, uk_man, 0, c);
+            const double dof_value = field_vector[dof_map];
+
+            local_point_value[c] += dof_value * shape_values[j];
+          } // for node i
+        }   // for component c
+      }     // if inside cell
+    }       // for cell
+  }         // if in bounding box
+
+  // Communicate number of point hits
+  size_t globl_num_point_hits;
+  mpi_comm.all_reduce(local_num_point_hits, globl_num_point_hits, mpi::op::sum<size_t>());
+
+  std::vector<double> globl_point_value(num_components, 0.0);
+  mpi_comm.all_reduce(
+    local_point_value.data(), 1, globl_point_value.data(), mpi::op::sum<double>());
+
+  Scale(globl_point_value, 1.0 / static_cast<double>(globl_num_point_hits));
+
+  return globl_point_value;
+}
+
+double
+FieldFunctionGridBased::Evaluate(const Cell& cell, const Vector3& position, int component) const
+{
+  const auto& field_vector = *ghosted_field_vector_;
+
+  const auto& cell_mapping = discretization_->GetCellMapping(cell);
+
+  std::vector<double> shape_values;
+  cell_mapping.ShapeValues(position, shape_values);
+
+  double value = 0.0;
+  const size_t num_nodes = cell_mapping.NumNodes();
+  for (size_t j = 0; j < num_nodes; ++j)
+  {
+    const auto dof_map = discretization_->MapDOFLocal(cell, j, GetUnknownManager(), 0, component);
+    value += field_vector[dof_map] * shape_values[j];
+  }
+
+  return value;
 }
 
 void
@@ -220,12 +238,12 @@ FieldFunctionGridBased::ExportMultipleToVTK(
 
   for (const auto& ff_ptr : ff_list)
     if (ff_ptr != master_ff_ptr)
-      if (&ff_ptr->sdm_->Grid() != &master_ff_ptr->sdm_->Grid())
+      if (&ff_ptr->discretization_->Grid() != &master_ff_ptr->discretization_->Grid())
         throw std::logic_error(fname +
                                ": Cannot be used with field functions based on different grids.");
 
   // Get grid
-  const auto& grid = master_ff.sdm_->Grid();
+  const auto& grid = master_ff.discretization_->Grid();
 
   auto ugrid = PrepareVtkUnstructuredGrid(grid);
 
@@ -238,12 +256,12 @@ FieldFunctionGridBased::ExportMultipleToVTK(
 
     const auto& uk_man = ff_ptr->GetUnknownManager();
     const auto& unknown = ff_ptr->GetUnknown();
-    const auto& sdm = ff_ptr->sdm_;
+    const auto& sdm = ff_ptr->discretization_;
     const size_t num_comps = unknown.NumComponents();
 
     for (uint c = 0; c < num_comps; ++c)
     {
-      std::string component_name = ff_ptr->TextName() + unknown.text_name_;
+      std::string component_name = ff_ptr->Name() + unknown.text_name_;
       if (num_comps > 1)
         component_name += unknown.component_text_names_[c];
 
@@ -304,100 +322,69 @@ FieldFunctionGridBased::ExportMultipleToVTK(
   opensn::mpi_comm.barrier();
 }
 
-std::vector<double>
-FieldFunctionGridBased::GetGhostedFieldVector() const
+std::shared_ptr<SpatialDiscretization>
+FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
 {
-  return ghosted_field_vector_->LocalSTLData();
-}
+  const auto& user_params = params.ParametersAtAssignment();
+  const auto& grid_ptr = GetCurrentMesh();
+  const auto sdm_type = params.GetParamValue<std::string>("discretization");
 
-std::vector<double>
-FieldFunctionGridBased::GetPointValue(const Vector3& point) const
-{
-  typedef const int64_t cint64_t;
-  const auto& uk_man = GetUnknownManager();
-  const size_t num_components = uk_man.GetTotalUnknownStructureSize();
+  if (sdm_type == "FV")
+    return FiniteVolume::New(*grid_ptr);
 
-  size_t local_num_point_hits = 0;
-  std::vector<double> local_point_value(num_components, 0.0);
-
-  const auto& xyz_min = local_grid_bounding_box_.first;
-  const auto& xyz_max = local_grid_bounding_box_.second;
-
-  const double xmin = xyz_min.x;
-  const double ymin = xyz_min.y;
-  const double zmin = xyz_min.z;
-
-  const double xmax = xyz_max.x;
-  const double ymax = xyz_max.y;
-  const double zmax = xyz_max.z;
-
-  const auto& field_vector = *ghosted_field_vector_;
-
-  if (point.x >= xmin and point.x <= xmax and point.y >= ymin and point.y <= ymax and
-      point.z >= zmin and point.z <= zmax)
+  CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN;
+  std::string cs = "cartesian";
+  if (user_params.Has("coordinate_system"))
   {
-    const auto& grid = sdm_->Grid();
-    for (const auto& cell : grid.local_cells)
-    {
-      if (grid.CheckPointInsideCell(cell, point))
-      {
-        const auto& cell_mapping = sdm_->GetCellMapping(cell);
-        std::vector<double> shape_values;
-        cell_mapping.ShapeValues(point, shape_values);
+    cs = params.GetParamValue<std::string>("coordinate_system");
 
-        local_num_point_hits += 1;
-
-        const size_t num_nodes = cell_mapping.NumNodes();
-        for (size_t c = 0; c < num_components; ++c)
-        {
-          for (size_t j = 0; j < num_nodes; ++j)
-          {
-            cint64_t dof_map_j = sdm_->MapDOFLocal(cell, j, uk_man, 0, c);
-            const double dof_value_j = field_vector[dof_map_j];
-
-            local_point_value[c] += dof_value_j * shape_values[j];
-          } // for node i
-        }   // for component c
-      }     // if inside cell
-    }       // for cell
-  }         // if in bounding box
-
-  // Communicate number of point hits
-  size_t globl_num_point_hits;
-  mpi_comm.all_reduce(local_num_point_hits, globl_num_point_hits, mpi::op::sum<size_t>());
-
-  std::vector<double> globl_point_value(num_components, 0.0);
-  mpi_comm.all_reduce(
-    local_point_value.data(), 1, globl_point_value.data(), mpi::op::sum<double>());
-
-  Scale(globl_point_value, 1.0 / static_cast<double>(globl_num_point_hits));
-
-  return globl_point_value;
-}
-
-double
-FieldFunctionGridBased::Evaluate(const Cell& cell,
-                                 const Vector3& position,
-                                 unsigned int component) const
-{
-  const auto& field_vector = *ghosted_field_vector_;
-
-  typedef const int64_t cint64_t;
-  const auto& cell_mapping = sdm_->GetCellMapping(cell);
-
-  std::vector<double> shape_values;
-  cell_mapping.ShapeValues(position, shape_values);
-
-  double value = 0.0;
-  const size_t num_nodes = cell_mapping.NumNodes();
-  for (size_t j = 0; j < num_nodes; ++j)
-  {
-    cint64_t dof_map = sdm_->MapDOFLocal(cell, j, GetUnknownManager(), 0, component);
-
-    value += field_vector[dof_map] * shape_values[j];
+    if (cs == "cartesian")
+      cs_type = CoordinateSystemType::CARTESIAN;
+    if (cs == "cylindrical")
+      cs_type = CoordinateSystemType::CYLINDRICAL;
+    if (cs == "spherical")
+      cs_type = CoordinateSystemType::SPHERICAL;
   }
 
-  return value;
+  QuadratureOrder q_order = QuadratureOrder::SECOND;
+
+  if (user_params.Has("quadrature_order"))
+  {
+    const auto max_order = static_cast<uint32_t>(QuadratureOrder::FORTYTHIRD);
+    const auto q_order_int = params.GetParamValue<uint32_t>("quadrature_order");
+    OpenSnInvalidArgumentIf(q_order_int > max_order,
+                            "Invalid quadrature point order " + std::to_string(q_order_int));
+    q_order = static_cast<QuadratureOrder>(q_order_int);
+  }
+  else // Defaulted
+  {
+    if (cs == "cartesian")
+      q_order = QuadratureOrder::SECOND;
+    if (cs == "cylindrical")
+      q_order = QuadratureOrder::THIRD;
+    if (cs == "spherical")
+      q_order = QuadratureOrder::FOURTH;
+  }
+
+  if (sdm_type == "PWLC")
+    return PieceWiseLinearContinuous::New(*grid_ptr, q_order, cs_type);
+  else if (sdm_type == "PWLD")
+    return PieceWiseLinearDiscontinuous::New(*grid_ptr, q_order, cs_type);
+
+  // If not returned by now
+  OpenSnInvalidArgument("Unsupported discretization \"" + sdm_type + "\"");
+}
+
+std::unique_ptr<GhostedParallelSTLVector>
+FieldFunctionGridBased::MakeFieldVector(const SpatialDiscretization& discretization,
+                                        const UnknownManager& uk_man)
+{
+  auto field = std::make_unique<GhostedParallelSTLVector>(discretization.GetNumLocalDOFs(uk_man),
+                                                          discretization.GetNumGlobalDOFs(uk_man),
+                                                          discretization.GetGhostDOFIndices(uk_man),
+                                                          mpi_comm);
+
+  return field;
 }
 
 } // namespace opensn

--- a/framework/field_functions/field_function_grid_based.h
+++ b/framework/field_functions/field_function_grid_based.h
@@ -33,20 +33,20 @@ public:
   /**Creates a field function, filling it with zeros.*/
   FieldFunctionGridBased(const std::string& text_name,
                          std::shared_ptr<SpatialDiscretization>& discretization_ptr,
-                         opensn::Unknown unknown);
+                         Unknown unknown);
 
   /**Creates a field function with an associated field vector.
    * The field's data vector is set to the incoming field vector.*/
   FieldFunctionGridBased(const std::string& text_name,
                          std::shared_ptr<SpatialDiscretization>& sdm_ptr,
-                         opensn::Unknown unknown,
+                         Unknown unknown,
                          const std::vector<double>& field_vector);
 
   /**Creates a field function where all the values are assigned to
    * the single supplied value.*/
   FieldFunctionGridBased(const std::string& text_name,
                          std::shared_ptr<SpatialDiscretization>& sdm_ptr,
-                         opensn::Unknown unknown,
+                         Unknown unknown,
                          double field_value);
 
   virtual ~FieldFunctionGridBased() = default;

--- a/framework/field_functions/field_function_grid_based.h
+++ b/framework/field_functions/field_function_grid_based.h
@@ -18,109 +18,78 @@ namespace opensn
 class SpatialDiscretization;
 class GhostedParallelSTLVector;
 
-/***/
 class FieldFunctionGridBased : public FieldFunction
 {
 public:
   typedef std::pair<Vector3, Vector3> BoundingBox;
 
-  /**Returns required input parameters.*/
   static InputParameters GetInputParameters();
-
-  /**ObjectMaker based constructor.*/
   explicit FieldFunctionGridBased(const InputParameters& params);
 
-  /**Creates a field function, filling it with zeros.*/
-  FieldFunctionGridBased(const std::string& text_name,
+  /// Creates a field function, filling it with zeros.
+  FieldFunctionGridBased(std::string name,
                          std::shared_ptr<SpatialDiscretization>& discretization_ptr,
                          Unknown unknown);
 
-  /**Creates a field function with an associated field vector.
-   * The field's data vector is set to the incoming field vector.*/
-  FieldFunctionGridBased(const std::string& text_name,
-                         std::shared_ptr<SpatialDiscretization>& sdm_ptr,
+  /**
+   * Creates a field function with an associated field vector. The field's data vector is set to the
+   * incoming field vector.
+   */
+  FieldFunctionGridBased(std::string name,
+                         std::shared_ptr<SpatialDiscretization>& discretization_ptr,
                          Unknown unknown,
                          const std::vector<double>& field_vector);
 
-  /**Creates a field function where all the values are assigned to
-   * the single supplied value.*/
-  FieldFunctionGridBased(const std::string& text_name,
-                         std::shared_ptr<SpatialDiscretization>& sdm_ptr,
+  /// Creates a field function where all the values are assigned to the single supplied value.
+  FieldFunctionGridBased(std::string name,
+                         std::shared_ptr<SpatialDiscretization>& discretization_ptr,
                          Unknown unknown,
                          double field_value);
 
   virtual ~FieldFunctionGridBased() = default;
 
-  /**
-   * Returns the spatial discretization method.
-   */
+  /// Returns the spatial discretization method.
   const SpatialDiscretization& GetSpatialDiscretization() const;
 
-  /**
-   * Returns a read-only reference to the locally stored field data.
-   */
-  const std::vector<double>& FieldVectorRead() const;
-
-  /**
-   * Returns a reference to the locally stored field data.
-   */
-  std::vector<double>& FieldVector();
-
-  /**
-   * Updates the field vector with a local STL vector.
-   */
-  void UpdateFieldVector(const std::vector<double>& field_vector);
-
-  /**
-   * Updates the field vector with a PETSc vector. This only operates locally.
-   */
-  void UpdateFieldVector(const Vec& field_vector);
-
-  /**
-   * Static method to export multiple grid-based field functions.
-   */
-  typedef std::vector<std::shared_ptr<const FieldFunctionGridBased>> FFList;
-
-  /**
-   * Export multiple field functions to VTK.
-   */
-  static void ExportMultipleToVTK(const std::string& file_base_name, const FFList& ff_list);
-
-  /**
-   * Makes a copy of the locally stored data with ghost access.
-   */
+  /// Returns a reference to the locally stored field data.
+  std::vector<double>& GetLocalFieldVector();
+  /// Returns a read-only reference to the locally stored field data.
+  const std::vector<double>& GetLocalFieldVector() const;
+  /// Makes a copy of the locally stored data with ghost access.
   std::vector<double> GetGhostedFieldVector() const;
 
-  /**
-   * Returns the component values at requested point.
-   */
+  /// Updates the field vector with a local STL vector.
+  void UpdateFieldVector(const std::vector<double>& field_vector);
+  /// Updates the field vector with a PETSc vector. This only operates locally.
+  void UpdateFieldVector(const Vec& field_vector);
+
+  /// Returns the component values at requested point.
   virtual std::vector<double> GetPointValue(const Vector3& point) const;
 
-  /**Evaluates the field function, on a cell, at the specified point.*/
-  double Evaluate(const Cell& cell, const Vector3& position, unsigned int component) const override;
+  /// Evaluates the field function, on a cell, at the specified point, for the given component.
+  double Evaluate(const Cell& cell, const Vector3& position, int component) const override;
 
 protected:
-  std::shared_ptr<SpatialDiscretization> sdm_;
+  std::shared_ptr<SpatialDiscretization> discretization_;
   std::unique_ptr<GhostedParallelSTLVector> ghosted_field_vector_;
 
 private:
-  /**
-   * Static method for making the GetSpatialDiscretization for the constructors.
-   */
+  const BoundingBox local_grid_bounding_box_;
+
+public:
+  /// Export multiple field functions to VTK.
+  static void
+  ExportMultipleToVTK(const std::string& file_base_name,
+                      const std::vector<std::shared_ptr<const FieldFunctionGridBased>>& ff_list);
+
+private:
+  /// Static method for making the GetSpatialDiscretization for the constructors.
   static std::shared_ptr<SpatialDiscretization>
   MakeSpatialDiscretization(const InputParameters& params);
 
-  /**
-   * Static method for making the ghosted vector for the constructors.
-   */
+  /// Private method for creating the field vector.
   static std::unique_ptr<GhostedParallelSTLVector>
-
-  /**
-   * Private method for creating the field vector.
-   */
   MakeFieldVector(const SpatialDiscretization& discretization, const UnknownManager& uk_man);
-
-  const BoundingBox local_grid_bounding_box_;
 };
 
 } // namespace opensn

--- a/framework/field_functions/field_function_interface.cc
+++ b/framework/field_functions/field_function_interface.cc
@@ -33,7 +33,7 @@ FieldFunctionInterface::GetFieldFunction() const
   {
     const auto name = field_function_param_.GetValue<std::string>();
     for (const auto& ff_ptr : field_function_stack)
-      if (ff_ptr->TextName() == name)
+      if (ff_ptr->Name() == name)
         ref_ff_ptr = ff_ptr;
 
     OpenSnInvalidArgumentIf(ref_ff_ptr == nullptr, "Field function \"" + name + "\" not found.");

--- a/framework/field_functions/interpolation/ffinter_line.cc
+++ b/framework/field_functions/interpolation/ffinter_line.cc
@@ -173,9 +173,9 @@ FieldFunctionInterpolationLine::ExportToCSV(std::string base_name)
 
     // Write sorted data to CSV file
     std::ofstream ofile;
-    std::string filename = base_name + "_" + ref_ff_->TextName() + std::string(".csv");
+    std::string filename = base_name + "_" + ref_ff_->Name() + std::string(".csv");
     ofile.open(filename);
-    ofile << "x,y,z," << ref_ff_->TextName() << "\n";
+    ofile << "x,y,z," << ref_ff_->Name() << "\n";
     for (auto point_data : values)
     {
       auto [x, y, z, fv] = point_data;
@@ -183,8 +183,8 @@ FieldFunctionInterpolationLine::ExportToCSV(std::string base_name)
     }
     ofile.close();
 
-    log.Log() << "Exported CSV file for field func \"" << ref_ff_->TextName() << "\" to \""
-              << filename << "\"";
+    log.Log() << "Exported CSV file for field func \"" << ref_ff_->Name() << "\" to \"" << filename
+              << "\"";
   }
 }
 

--- a/lua/framework/physics/field_function/physics_get_field_func_list.cc
+++ b/lua/framework/physics/field_function/physics_get_field_func_list.cc
@@ -28,7 +28,7 @@ GetFieldFunctionHandleByName(lua_State* L)
   std::vector<size_t> handles_that_matched;
   for (const auto& pff : opensn::field_function_stack)
   {
-    if (pff->TextName() == ff_name)
+    if (pff->Name() == ff_name)
       handles_that_matched.emplace_back(ff_handle_counter);
     ++ff_handle_counter;
   }

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -2737,8 +2737,8 @@ LBSSolver::SetPhiFromFieldFunctions(PhiSTLOption which_phi,
     for (const size_t g : g_ids_to_copy)
     {
       const size_t ff_index = phi_field_functions_local_map_.at({g, m});
-      auto& ff_ptr = field_functions_.at(ff_index);
-      auto& ff_data = ff_ptr->FieldVector();
+      const auto& ff_ptr = field_functions_.at(ff_index);
+      const auto& ff_data = ff_ptr->GetLocalFieldVector();
 
       for (const auto& cell : grid_ptr_->local_cells)
       {

--- a/test/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/framework/tutorials/tutorial_91a_pwld.cc
@@ -517,7 +517,7 @@ SimTest91_PWLD(const InputParameters&)
   ff_list[3]->UpdateFieldVector(mz_phi);
 
   // Update field function
-  FieldFunctionGridBased::FFList const_ff_list;
+  std::vector<std::shared_ptr<const FieldFunctionGridBased>> const_ff_list;
   for (const auto& ff_ptr : ff_list)
     const_ff_list.push_back(ff_ptr);
   FieldFunctionGridBased::ExportMultipleToVTK("SimTest_91a_PWLD", const_ff_list);

--- a/test/framework/tutorials/tutorial_93_raytracing.cc
+++ b/test/framework/tutorials/tutorial_93_raytracing.cc
@@ -328,7 +328,7 @@ SimTest93_RayTracing(const InputParameters&)
   ff_list[0]->UpdateFieldVector(m0_phi);
 
   // Update field function
-  FieldFunctionGridBased::FFList const_ff_list;
+  std::vector<std::shared_ptr<const FieldFunctionGridBased>> const_ff_list;
   for (const auto& ff_ptr : ff_list)
     const_ff_list.push_back(ff_ptr);
   FieldFunctionGridBased::ExportMultipleToVTK("SimTest_93", const_ff_list);


### PR DESCRIPTION
This PR adds constructors and input options to make the default behavior of `FieldFunctionGridBased` default to a finite volume representation. The `discretization` input parameter is now defaulted to "FV" and constructors which require a grid instead of a discretization. 

Due to a lack of coordinate system information on the mesh, this currently only works for Cartesian grids. This will be changed with the resolution of #330.