### PR TITLE
Removing unnecessary `typedefs`.  Converting remaining `typedefs` to `using`.

### DIFF
--- a/framework/field_functions/field_function_grid_based.h
+++ b/framework/field_functions/field_function_grid_based.h
@@ -21,7 +21,8 @@ class GhostedParallelSTLVector;
 class FieldFunctionGridBased : public FieldFunction
 {
 public:
-  typedef std::pair<Vector3, Vector3> BoundingBox;
+  using BoundingBox = std::pair<Vector3, Vector3>;
+  using FFList = std::vector<std::shared_ptr<const FieldFunctionGridBased>>;
 
   static InputParameters GetInputParameters();
   explicit FieldFunctionGridBased(const InputParameters& params);

--- a/framework/math/dynamic_matrix.h
+++ b/framework/math/dynamic_matrix.h
@@ -19,8 +19,6 @@ class DynamicMatrix;
 template <class NumberFormat>
 class DynamicMatrix
 {
-  typedef std::pair<size_t, size_t> MatDim;
-
 public:
   std::vector<std::vector<NumberFormat>> elements_;
 
@@ -141,7 +139,7 @@ public:
 
   size_t size() const { return elements_.size(); }
 
-  MatDim Dimensions() const
+  std::pair<size_t, size_t> Dimensions() const
   {
     if (elements_.empty())
       return {0, 0};
@@ -150,13 +148,15 @@ public:
   }
 
 private:
-  static void bounds_check_rows_cols(const MatDim a, const MatDim b)
+  static void bounds_check_rows_cols(const std::pair<size_t, size_t> a,
+                                     const std::pair<size_t, size_t> b)
   {
     if ((a.first != b.first) or (a.second != b.second))
       throw std::length_error("Mismatched square sizes of DynamicMatrix");
   }
 
-  static void bounds_check_colsA_rowsB(const MatDim a, const MatDim b)
+  static void bounds_check_colsA_rowsB(const std::pair<size_t, size_t> a,
+                                       const std::pair<size_t, size_t> b)
   {
     if (a.first != b.second)
       throw std::length_error("Mismatched matrix A rows with matrix B cols"

--- a/framework/math/functions/function_dimA_to_dimB.h
+++ b/framework/math/functions/function_dimA_to_dimB.h
@@ -9,8 +9,8 @@
 namespace opensn
 {
 
-typedef std::function<double(double)> ScalarScalarFunction;
-typedef std::function<double(double, double, double, double)> ScalarXYZTFunction;
+using ScalarScalarFunction = std::function<double(double)>;
+using ScalarXYZTFunction = std::function<double(double, double, double, double)>;
 
 class FunctionDimAToDimB : public Object
 {

--- a/framework/math/golub_fischer/golub_fischer.cc
+++ b/framework/math/golub_fischer/golub_fischer.cc
@@ -11,8 +11,8 @@
 namespace opensn
 {
 
-AnglePairs&
-GolubFischer::GetDiscreteScatAngles(Tvecdbl& mell)
+std::vector<std::pair<double, double>>&
+GolubFischer::GetDiscreteScatAngles(std::vector<double>& mell)
 {
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Getting Discrete Scattering Angles" << '\n';
 
@@ -33,11 +33,11 @@ GolubFischer::GetDiscreteScatAngles(Tvecdbl& mell)
     return xn_wn_;
 
   /* Legendre recurrence coefficients */
-  Tvecdbl a;
+  std::vector<double> a;
   a.resize(2 * n, 0.0);
-  Tvecdbl b;
+  std::vector<double> b;
   b.resize(2 * n, 0.0);
-  Tvecdbl c;
+  std::vector<double> c;
   c.resize(2 * n, 0.0);
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "a,b,c:\n";
@@ -65,7 +65,10 @@ GolubFischer::GetDiscreteScatAngles(Tvecdbl& mell)
 }
 
 void
-GolubFischer::MCA(Tvecdbl& mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
+GolubFischer::MCA(std::vector<double>& mell,
+                  std::vector<double>& a,
+                  std::vector<double>& b,
+                  std::vector<double>& c)
 {
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "MCA Start" << '\n';
 
@@ -119,7 +122,7 @@ GolubFischer::MCA(Tvecdbl& mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c)
 }
 
 void
-GolubFischer::RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta)
+GolubFischer::RootsOrtho(int& N, std::vector<double>& alpha, std::vector<double>& beta)
 {
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "RootsOrtho Start" << '\n';
 
@@ -129,9 +132,9 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta)
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Check 1: Init guess" << '\n';
 
-  Tvecdbl xn;
+  std::vector<double> xn;
   xn.resize(N, 0.0);
-  Tvecdbl wn;
+  std::vector<double> wn;
   wn.resize(N, 0.0);
 
   for (int i = 0; i < N; i++)
@@ -140,7 +143,7 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta)
     log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "x[" << i << "]=" << xn[i] << "\n";
   }
 
-  Tvecdbl norm;
+  std::vector<double> norm;
   norm.resize(N + 1, 0.0);
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Check 2 " << beta[0] << '\n';
   norm[0] = beta[0];
@@ -231,7 +234,7 @@ GolubFischer::RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta)
 }
 
 double
-GolubFischer::Ortho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta)
+GolubFischer::Ortho(int ell, double x, std::vector<double>& alpha, std::vector<double>& beta)
 {
   if (ell == 0)
   {
@@ -259,7 +262,7 @@ GolubFischer::Ortho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta)
 }
 
 double
-GolubFischer::dOrtho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta)
+GolubFischer::dOrtho(int ell, double x, std::vector<double>& alpha, std::vector<double>& beta)
 {
 
   double eps = 0.000001;

--- a/framework/math/golub_fischer/golub_fischer.h
+++ b/framework/math/golub_fischer/golub_fischer.h
@@ -37,9 +37,6 @@
 namespace opensn
 {
 
-typedef std::vector<std::pair<double, double>> AnglePairs;
-typedef std::vector<double> Tvecdbl;
-
 /**Implementation of the GolubFischer Modified ChebyShev Algorithm (MCA) to find
  * moment-preserving angles from a set of moments computed for the expansion of
  * an angular function in Legendre polynomials.
@@ -55,25 +52,28 @@ typedef std::vector<double> Tvecdbl;
 class GolubFischer
 {
 public:
-  AnglePairs xn_wn_;
-  Tvecdbl alpha_;
-  Tvecdbl beta_;
+  std::vector<std::pair<double, double>> xn_wn_;
+  std::vector<double> alpha_;
+  std::vector<double> beta_;
 
 public:
   /**Master callable function that will return a reference to the abscissae and
    * weights of the discrete angles.*/
-  AnglePairs& GetDiscreteScatAngles(Tvecdbl& mell);
+  std::vector<std::pair<double, double>>& GetDiscreteScatAngles(std::vector<double>& mell);
 
 private:
   /**Applies the Modified Chebyshev Algorithm contained in [1] to find the
    * recursion coefficients for the orthogonal polynomials.*/
-  void MCA(Tvecdbl& mell, Tvecdbl& a, Tvecdbl& b, Tvecdbl& c);
+  void MCA(std::vector<double>& mell,
+           std::vector<double>& a,
+           std::vector<double>& b,
+           std::vector<double>& c);
   /**Finds the roots of the orthogonal polynomial.*/
-  void RootsOrtho(int& N, Tvecdbl& alpha, Tvecdbl& beta);
+  void RootsOrtho(int& N, std::vector<double>& alpha, std::vector<double>& beta);
   /**Computes the derivative of the orthogonal polynomials.*/
-  double dOrtho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta);
+  double dOrtho(int ell, double x, std::vector<double>& alpha, std::vector<double>& beta);
   /**Computes the function evaluation of the orthogonal polynomials.*/
-  double Ortho(int ell, double x, Tvecdbl& alpha, Tvecdbl& beta);
+  double Ortho(int ell, double x, std::vector<double>& alpha, std::vector<double>& beta);
 };
 
 } // namespace opensn

--- a/framework/math/math.h
+++ b/framework/math/math.h
@@ -9,8 +9,6 @@
 #include "framework/math/unknown_manager/unknown_manager.h"
 #include <memory>
 
-typedef std::vector<std::vector<double>> MatDbl;
-
 namespace opensn
 {
 class SparseMatrix;
@@ -20,6 +18,9 @@ class SpatialDiscretization;
 class SpatialDiscretization_FV;
 class SpatialDiscretization_PWLD;
 class SpatialDiscretization_PWLC;
+
+using MatDbl = std::vector<std::vector<double>>;
+using MatVec3 = std::vector<std::vector<Vector3>>;
 
 /**
  * Coordinate system type.

--- a/framework/math/quadratures/angular/sldfe_sq_quadrature.cc
+++ b/framework/math/quadratures/angular/sldfe_sq_quadrature.cc
@@ -148,11 +148,11 @@ SimplifiedLDFESQ::Quadrature::GenerateReferenceFaceVertices(const Matrix3x3& rot
   GaussLegendreQuadrature legendre(QuadratureOrder::THIRTYSECOND);
 
   // Generate xy_tilde values
-  std::vector<std::vector<Vertex>> vertices_xy_tilde_ij;
-  vertices_xy_tilde_ij.resize(Np, std::vector<Vertex>(Np));
+  std::vector<std::vector<Vector3>> vertices_xy_tilde_ij;
+  vertices_xy_tilde_ij.resize(Np, std::vector<Vector3>(Np));
   for (int i = 0; i < Np; ++i)
     for (int j = 0; j < Np; ++j)
-      vertices_xy_tilde_ij[i][j] = Vertex(diagonal_vertices_[i].x, diagonal_vertices_[j].y, 0.0);
+      vertices_xy_tilde_ij[i][j] = Vector3(diagonal_vertices_[i].x, diagonal_vertices_[j].y, 0.0);
 
   // Generate SQs
   for (int i = 0; i < Ns; ++i)
@@ -215,7 +215,7 @@ void
 SimplifiedLDFESQ::Quadrature::EmpiricalQPOptimization(
   SphericalQuadrilateral& sq,
   GaussLegendreQuadrature& legendre,
-  Vertex& sq_xy_tilde_centroid,
+  Vector3& sq_xy_tilde_centroid,
   std::array<Vector3, 4>& radii_vectors_xy_tilde,
   std::array<double, 4>& sub_sub_sqr_areas)
 {
@@ -239,7 +239,7 @@ SimplifiedLDFESQ::Quadrature::EmpiricalQPOptimization(
 void
 SimplifiedLDFESQ::Quadrature::IsolatedQPOptimization(SphericalQuadrilateral& sq,
                                                      GaussLegendreQuadrature& legendre,
-                                                     Vertex& sq_xy_tilde_centroid,
+                                                     Vector3& sq_xy_tilde_centroid,
                                                      std::array<Vector3, 4>& radii_vectors_xy_tilde,
                                                      std::array<double, 4>& sub_sub_sqr_areas)
 {
@@ -329,7 +329,7 @@ SimplifiedLDFESQ::Quadrature::DevelopSQLDFEValues(SphericalQuadrilateral& sq,
                                                   GaussLegendreQuadrature& legendre)
 {
   // Determine sq tilde center
-  Vertex sq_tilde_center;
+  Vector3 sq_tilde_center;
   for (const auto& v : sq.vertices_xy_tilde)
     sq_tilde_center += v;
   sq_tilde_center /= 4;
@@ -341,8 +341,8 @@ SimplifiedLDFESQ::Quadrature::DevelopSQLDFEValues(SphericalQuadrilateral& sq,
     vctoi[v] = sq.vertices_xy_tilde[v] - vc;
 
   // Determine sub-sub-squares
-  std::array<std::array<Vertex, 4>, 4> sub_sub_square_xy_tilde;
-  std::map<std::string, Vertex> vm;
+  std::array<std::array<Vector3, 4>, 4> sub_sub_square_xy_tilde;
+  std::map<std::string, Vector3> vm;
 
   for (int v = 0; v < 4; ++v)
     vm[std::to_string(v)] = sq.vertices_xy_tilde[v];
@@ -360,7 +360,7 @@ SimplifiedLDFESQ::Quadrature::DevelopSQLDFEValues(SphericalQuadrilateral& sq,
   sst[3] = {vm["03"], vm["c"], vm["23"], vm["3"]};
 
   // Determine sub-sub-square xyz
-  std::array<std::array<Vertex, 4>, 4> sub_sub_square_xyz;
+  std::array<std::array<Vector3, 4>, 4> sub_sub_square_xyz;
   for (int i = 0; i < 4; ++i)
     for (int j = 0; j < 4; ++j)
       sub_sub_square_xyz[i][j] =
@@ -389,12 +389,13 @@ SimplifiedLDFESQ::Quadrature::DevelopSQLDFEValues(SphericalQuadrilateral& sq,
 }
 
 double
-SimplifiedLDFESQ::Quadrature::ComputeSphericalQuadrilateralArea(std::array<Vertex, 4>& vertices_xyz)
+SimplifiedLDFESQ::Quadrature::ComputeSphericalQuadrilateralArea(
+  std::array<Vector3, 4>& vertices_xyz)
 {
   const auto num_verts = 4;
 
   // Compute centroid
-  Vertex centroid_xyz;
+  Vector3 centroid_xyz;
   for (auto& v : vertices_xyz)
     centroid_xyz += v;
   centroid_xyz /= num_verts;
@@ -969,14 +970,14 @@ SimplifiedLDFESQ::Quadrature::SplitSQ(SphericalQuadrilateral& sq, GaussLegendreQ
   std::array<SphericalQuadrilateral, 4> new_sqs;
 
   // Determine sq tilde center
-  Vertex sq_tilde_center;
+  Vector3 sq_tilde_center;
   for (const auto& v : sq.vertices_xy_tilde)
     sq_tilde_center += v;
   sq_tilde_center /= 4;
 
   // Determine sub-sub-squares Tilde coordinates
-  std::array<std::array<Vertex, 4>, 4> sub_sub_square_xy_tilde;
-  std::map<std::string, Vertex> vm;
+  std::array<std::array<Vector3, 4>, 4> sub_sub_square_xy_tilde;
+  std::map<std::string, Vector3> vm;
 
   for (int v = 0; v < 4; ++v)
     vm[std::to_string(v)] = sq.vertices_xy_tilde[v];

--- a/framework/math/quadratures/angular/sldfe_sq_quadrature.h
+++ b/framework/math/quadratures/angular/sldfe_sq_quadrature.h
@@ -32,10 +32,10 @@ struct BaseFunctor
  * spherical quadrilateral (SQ).*/
 struct SimplifiedLDFESQ::SphericalQuadrilateral
 {
-  std::array<Vertex, 4> vertices_xy_tilde;  ///< On square
-  std::array<Vertex, 4> vertices_xyz_prime; ///< On cube face
-  std::array<Vertex, 4> vertices_xyz;       ///< On unit sphere
-  Vertex centroid_xyz;
+  std::array<Vector3, 4> vertices_xy_tilde;  ///< On square
+  std::array<Vector3, 4> vertices_xyz_prime; ///< On cube face
+  std::array<Vector3, 4> vertices_xyz;       ///< On unit sphere
+  Vector3 centroid_xyz;
 
   Matrix3x3 rotation_matrix;
   Vector3 translation_vector;
@@ -108,13 +108,13 @@ private:
    */
   void EmpiricalQPOptimization(SphericalQuadrilateral& sq,
                                GaussLegendreQuadrature& legendre,
-                               Vertex& sq_xy_tilde_centroid,
+                               Vector3& sq_xy_tilde_centroid,
                                std::array<Vector3, 4>& radii_vectors_xy_tilde,
                                std::array<double, 4>& sub_sub_sqr_areas);
 
   void IsolatedQPOptimization(SphericalQuadrilateral& sq,
                               GaussLegendreQuadrature& legendre,
-                              Vertex& sq_xy_tilde_centroid,
+                              Vector3& sq_xy_tilde_centroid,
                               std::array<Vector3, 4>& radii_vectors_xy_tilde,
                               std::array<double, 4>& sub_sub_sqr_areas);
 
@@ -122,7 +122,7 @@ private:
    * Computes the area of a cell. This routine uses Girard's theorem to get the area of a spherical
    * triangle using the spherical excess.
    */
-  static double ComputeSphericalQuadrilateralArea(std::array<Vertex, 4>& vertices_xyz);
+  static double ComputeSphericalQuadrilateralArea(std::array<Vector3, 4>& vertices_xyz);
 
   /**
    * Integrates shape functions to produce weights.
@@ -190,7 +190,7 @@ private:
 struct SimplifiedLDFESQ::FUNCTION_WEIGHT_FROM_RHO
 {
   Quadrature& sldfesq;
-  Vertex& centroid_xy_tilde;
+  Vector3& centroid_xy_tilde;
   std::array<Vector3, 4>& radii_vectors_xy_tilde;
   SphericalQuadrilateral& sq;
 
@@ -204,7 +204,7 @@ struct SimplifiedLDFESQ::FUNCTION_WEIGHT_FROM_RHO
   std::vector<double>& lqw;
 
   FUNCTION_WEIGHT_FROM_RHO(SimplifiedLDFESQ::Quadrature& sldfesq,
-                           Vertex& centroid_xy_tilde,
+                           Vector3& centroid_xy_tilde,
                            std::array<Vector3, 4>& radii_vectors_xy_tilde,
                            SphericalQuadrilateral& sq,
                            GaussLegendreQuadrature& legendre_quadrature)

--- a/framework/math/sparse_matrix/math_sparse_matrix.h
+++ b/framework/math/sparse_matrix/math_sparse_matrix.h
@@ -104,9 +104,6 @@ public:
     class RowIterator
     {
     private:
-      typedef RowIterator It;
-
-    private:
       RowIteratorContext& context_;
       size_t ref_entry_;
 
@@ -116,13 +113,13 @@ public:
       {
       }
 
-      It operator++()
+      RowIterator operator++()
       {
-        It i = *this;
+        RowIterator i = *this;
         ref_entry_++;
         return i;
       }
-      It operator++(int)
+      RowIterator operator++(int)
       {
         ref_entry_++;
         return *this;
@@ -134,8 +131,8 @@ public:
           context_.ref_row_, context_.ref_col_ids_[ref_entry_], context_.ref_col_vals_[ref_entry_]};
       }
 
-      bool operator==(const It& rhs) const { return ref_entry_ == rhs.ref_entry_; }
-      bool operator!=(const It& rhs) const { return ref_entry_ != rhs.ref_entry_; }
+      bool operator==(const RowIterator& rhs) const { return ref_entry_ == rhs.ref_entry_; }
+      bool operator!=(const RowIterator& rhs) const { return ref_entry_ != rhs.ref_entry_; }
     };
 
     RowIterator begin() { return {*this, 0}; }
@@ -162,9 +159,6 @@ public:
     class ConstRowIterator
     {
     private:
-      typedef ConstRowIterator It;
-
-    private:
       const ConstRowIteratorContext& context_;
       size_t ref_entry_;
 
@@ -174,13 +168,13 @@ public:
       {
       }
 
-      It operator++()
+      ConstRowIterator operator++()
       {
-        It i = *this;
+        ConstRowIterator i = *this;
         ref_entry_++;
         return i;
       }
-      It operator++(int)
+      ConstRowIterator operator++(int)
       {
         ref_entry_++;
         return *this;
@@ -192,8 +186,8 @@ public:
           context_.ref_row_, context_.ref_col_ids_[ref_entry_], context_.ref_col_vals_[ref_entry_]};
       }
 
-      bool operator==(const It& rhs) const { return ref_entry_ == rhs.ref_entry_; }
-      bool operator!=(const It& rhs) const { return ref_entry_ != rhs.ref_entry_; }
+      bool operator==(const ConstRowIterator& rhs) const { return ref_entry_ == rhs.ref_entry_; }
+      bool operator!=(const ConstRowIterator& rhs) const { return ref_entry_ != rhs.ref_entry_; }
     };
 
     ConstRowIterator begin() const { return {*this, 0}; }
@@ -205,9 +199,6 @@ public:
   /**Iterator to loop over all matrix entries.*/
   class EntriesIterator
   {
-  private:
-    typedef EntriesIterator EIt;
-
   private:
     SparseMatrix& sp_matrix;
     size_t ref_row_;
@@ -231,13 +222,13 @@ public:
       }
     }
 
-    EIt operator++()
+    EntriesIterator operator++()
     {
-      EIt i = *this;
+      EntriesIterator i = *this;
       Advance();
       return i;
     }
-    EIt operator++(int)
+    EntriesIterator operator++(int)
     {
       Advance();
       return *this;
@@ -249,11 +240,11 @@ public:
               sp_matrix.rowI_indices_[ref_row_][ref_col_],
               sp_matrix.rowI_values_[ref_row_][ref_col_]};
     }
-    bool operator==(const EIt& rhs) const
+    bool operator==(const EntriesIterator& rhs) const
     {
       return (ref_row_ == rhs.ref_row_) and (ref_col_ == rhs.ref_col_);
     }
-    bool operator!=(const EIt& rhs) const
+    bool operator!=(const EntriesIterator& rhs) const
     {
       return (ref_row_ != rhs.ref_row_) or (ref_col_ != rhs.ref_col_);
     }

--- a/framework/math/spatial_discretization/cell_mappings/cell_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/cell_mapping.cc
@@ -15,7 +15,7 @@ CellMapping::CellMapping(const MeshContinuum& grid,
                          size_t num_nodes,
                          std::vector<Vector3> node_locations,
                          std::vector<std::vector<int>> face_node_mappings,
-                         const VandAFunction& volume_area_function)
+                         const VolumeAndAreaFunction& volume_area_function)
   : ref_grid_(grid),
     cell_(cell),
     num_nodes_(num_nodes),

--- a/framework/math/spatial_discretization/cell_mappings/cell_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/cell_mapping.h
@@ -80,15 +80,15 @@ protected:
    * used as this function. Otherwise (i.e. for higher order
    * elements, the child-class should
    * bind a different function to this.*/
-  typedef std::function<void(const MeshContinuum&, const Cell&, double&, std::vector<double>&)>
-    VandAFunction;
+  using VolumeAndAreaFunction =
+    std::function<void(const MeshContinuum&, const Cell&, double&, std::vector<double>&)>;
 
   CellMapping(const MeshContinuum& grid,
               const Cell& cell,
               size_t num_nodes,
               std::vector<Vector3> node_locations,
               std::vector<std::vector<int>> face_node_mappings,
-              const VandAFunction& volume_area_function);
+              const VolumeAndAreaFunction& volume_area_function);
 
   /**Static method that all child elements can use as a default.*/
   static void ComputeCellVolumeAndAreas(const MeshContinuum& grid,

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.h
@@ -18,9 +18,6 @@ class PieceWiseLinearBaseMapping : public CellMapping
 {
 protected:
 public:
-  typedef std::vector<Vector3> VecVec3;
-
-public:
   /** Constructor. */
   PieceWiseLinearBaseMapping(const MeshContinuum& grid,
                              const Cell& cell,

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.cc
@@ -31,7 +31,7 @@ PieceWiseLinearPolygonMapping::PieceWiseLinearPolygonMapping(
 
     const auto& v0 = ref_grid_.vertices[face.vertex_ids_[0]];
     const auto& v1 = ref_grid_.vertices[face.vertex_ids_[1]];
-    Vertex v2 = vc_;
+    Vector3 v2 = vc_;
 
     Vector3 sidev01 = v1 - v0;
     Vector3 sidev02 = v2 - v0;
@@ -319,9 +319,9 @@ PieceWiseLinearPolygonMapping::MakeVolumetricFiniteElementData() const
 
   // Declare necessary vars
   std::vector<unsigned int> V_quadrature_point_indices;
-  VecVec3 V_qpoints_xyz;
+  std::vector<Vector3> V_qpoints_xyz;
   std::vector<std::vector<double>> V_shape_value;
-  std::vector<VecVec3> V_shape_grad;
+  std::vector<std::vector<Vector3>> V_shape_grad;
   std::vector<double> V_JxW;
   size_t V_num_nodes;
 
@@ -335,7 +335,7 @@ PieceWiseLinearPolygonMapping::MakeVolumetricFiniteElementData() const
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_vol_qpoints);
     node_shape_grad.reserve(ttl_num_vol_qpoints);
@@ -389,11 +389,11 @@ PieceWiseLinearPolygonMapping::MakeSurfaceFiniteElementData(size_t face_index) c
   unsigned int s = face_index;
   // Declare necessary vars
   std::vector<unsigned int> F_quadrature_point_indices;
-  VecVec3 F_qpoints_xyz;
+  std::vector<Vector3> F_qpoints_xyz;
   std::vector<std::vector<double>> F_shape_value;
-  std::vector<VecVec3> F_shape_grad;
+  std::vector<std::vector<Vector3>> F_shape_grad;
   std::vector<double> F_JxW;
-  VecVec3 F_normals;
+  std::vector<Vector3> F_normals;
   size_t F_num_nodes;
 
   size_t ttl_num_face_qpoints = num_srf_qpoints;
@@ -411,7 +411,7 @@ PieceWiseLinearPolygonMapping::MakeSurfaceFiniteElementData(size_t face_index) c
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_face_qpoints);
     node_shape_grad.reserve(ttl_num_face_qpoints);

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.h
@@ -77,7 +77,7 @@ private:
 
   int num_of_subtris_;
   double beta_;
-  Vertex vc_;
+  Vector3 vc_;
   std::vector<std::vector<int>> node_to_side_map_;
 };
 

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.cc
@@ -20,7 +20,7 @@ PieceWiseLinearPolyhedronMapping::PieceWiseLinearPolyhedronMapping(
     surface_quadrature_(surface_quadrature)
 {
   // Assign cell centre
-  const Vertex& vcc = polyh_cell.centroid_;
+  const Vector3& vcc = polyh_cell.centroid_;
   alphac_ = 1.0 / static_cast<double>(polyh_cell.vertex_ids_.size());
 
   // For each face
@@ -36,7 +36,7 @@ PieceWiseLinearPolyhedronMapping::PieceWiseLinearPolyhedronMapping(
 
     face_betaf_.push_back(1.0 / static_cast<double>(face.vertex_ids_.size()));
 
-    const Vertex& vfc = face.centroid_;
+    const Vector3& vfc = face.centroid_;
 
     // For each edge
     const size_t num_edges = face.vertex_ids_.size();
@@ -583,9 +583,9 @@ PieceWiseLinearPolyhedronMapping::MakeVolumetricFiniteElementData() const
 
   // Declare necessary vars
   std::vector<unsigned int> V_quadrature_point_indices;
-  VecVec3 V_qpoints_xyz;
+  std::vector<Vector3> V_qpoints_xyz;
   std::vector<std::vector<double>> V_shape_value;
-  std::vector<VecVec3> V_shape_grad;
+  std::vector<std::vector<Vector3>> V_shape_grad;
   std::vector<double> V_JxW;
   size_t V_num_nodes;
 
@@ -599,7 +599,7 @@ PieceWiseLinearPolyhedronMapping::MakeVolumetricFiniteElementData() const
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_vol_qpoints);
     node_shape_grad.reserve(ttl_num_vol_qpoints);
@@ -661,11 +661,11 @@ PieceWiseLinearPolyhedronMapping::MakeSurfaceFiniteElementData(size_t face_index
   unsigned int f = face_index;
   // Declare necessary vars
   std::vector<unsigned int> F_quadrature_point_indices;
-  VecVec3 F_qpoints_xyz;
+  std::vector<Vector3> F_qpoints_xyz;
   std::vector<std::vector<double>> F_shape_value;
-  std::vector<VecVec3> F_shape_grad;
+  std::vector<std::vector<Vector3>> F_shape_grad;
   std::vector<double> F_JxW;
-  VecVec3 F_normals;
+  std::vector<Vector3> F_normals;
   size_t F_num_nodes;
 
   size_t num_tris = face_data_[f].sides.size();
@@ -684,7 +684,7 @@ PieceWiseLinearPolyhedronMapping::MakeSurfaceFiniteElementData(size_t face_index
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_face_qpoints);
     node_shape_grad.reserve(ttl_num_face_qpoints);

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
@@ -134,9 +134,9 @@ PieceWiseLinearSlabMapping::MakeVolumetricFiniteElementData() const
 
   // Declare necessary vars
   std::vector<unsigned int> V_quadrature_point_indices;
-  VecVec3 V_qpoints_xyz;
+  std::vector<Vector3> V_qpoints_xyz;
   std::vector<std::vector<double>> V_shape_value;
-  std::vector<VecVec3> V_shape_grad;
+  std::vector<std::vector<Vector3>> V_shape_grad;
   std::vector<double> V_JxW;
   size_t V_num_nodes;
 
@@ -150,7 +150,7 @@ PieceWiseLinearSlabMapping::MakeVolumetricFiniteElementData() const
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_vol_qpoints);
     node_shape_grad.reserve(ttl_num_vol_qpoints);
@@ -200,11 +200,11 @@ PieceWiseLinearSlabMapping::MakeSurfaceFiniteElementData(size_t face_index) cons
 
   // Declare necessary vars
   std::vector<unsigned int> F_quadrature_point_indices;
-  VecVec3 F_qpoints_xyz;
+  std::vector<Vector3> F_qpoints_xyz;
   std::vector<std::vector<double>> F_shape_value;
-  std::vector<VecVec3> F_shape_grad;
+  std::vector<std::vector<Vector3>> F_shape_grad;
   std::vector<double> F_JxW;
-  VecVec3 F_normals;
+  std::vector<Vector3> F_normals;
   size_t F_num_nodes;
 
   size_t ttl_num_face_qpoints = num_srf_qpoints;
@@ -222,7 +222,7 @@ PieceWiseLinearSlabMapping::MakeSurfaceFiniteElementData(size_t face_index) cons
   for (size_t i = 0; i < num_nodes_; i++)
   {
     std::vector<double> node_shape_value;
-    VecVec3 node_shape_grad;
+    std::vector<Vector3> node_shape_grad;
 
     node_shape_value.reserve(ttl_num_face_qpoints);
     node_shape_grad.reserve(ttl_num_face_qpoints);

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.h
@@ -50,7 +50,7 @@ private:
   Vector3 v0_;
   uint64_t v0i_;
   uint64_t v1i_;
-  std::array<Normal, 2> normals_;
+  std::array<Vector3, 2> normals_;
   const LineQuadrature& volume_quadrature_;
   double h_;
 };

--- a/framework/math/spatial_discretization/finite_element/finite_element_base.h
+++ b/framework/math/spatial_discretization/finite_element/finite_element_base.h
@@ -20,7 +20,7 @@ public:
 protected:
   explicit FiniteElementBase(const MeshContinuum& grid,
                              CoordinateSystemType cs_type,
-                             SDMType sdm_type,
+                             SpatialDiscretizationType sdm_type,
                              QuadratureOrder q_order)
     : SpatialDiscretization(grid, cs_type, sdm_type), q_order_(q_order)
   {

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
@@ -12,7 +12,7 @@ namespace opensn
 
 PieceWiseLinearBase::PieceWiseLinearBase(const MeshContinuum& grid,
                                          QuadratureOrder q_order,
-                                         SDMType sdm_type,
+                                         SpatialDiscretizationType sdm_type,
                                          CoordinateSystemType cs_type)
   : FiniteElementBase(grid, cs_type, sdm_type, q_order),
     line_quad_order_arbitrary_(q_order),
@@ -26,10 +26,6 @@ PieceWiseLinearBase::CreateCellMappings()
 {
   constexpr std::string_view fname = __PRETTY_FUNCTION__;
 
-  typedef PieceWiseLinearSlabMapping SlabSlab;
-  typedef PieceWiseLinearPolygonMapping Polygon;
-  typedef PieceWiseLinearPolyhedronMapping Polyhedron;
-
   auto MakeCellMapping = [this, fname](const Cell& cell)
   {
     using namespace std;
@@ -42,7 +38,7 @@ PieceWiseLinearBase::CreateCellMappings()
       {
         const auto& vol_quad = line_quad_order_arbitrary_;
 
-        mapping = make_unique<SlabSlab>(cell, ref_grid_, vol_quad);
+        mapping = make_unique<PieceWiseLinearSlabMapping>(cell, ref_grid_, vol_quad);
         break;
       }
       case CellType::POLYGON:
@@ -50,7 +46,7 @@ PieceWiseLinearBase::CreateCellMappings()
         const auto& vol_quad = tri_quad_order_arbitrary_;
         const auto& area_quad = line_quad_order_arbitrary_;
 
-        mapping = make_unique<Polygon>(cell, ref_grid_, vol_quad, area_quad);
+        mapping = make_unique<PieceWiseLinearPolygonMapping>(cell, ref_grid_, vol_quad, area_quad);
         break;
       }
       case CellType::POLYHEDRON:
@@ -58,7 +54,8 @@ PieceWiseLinearBase::CreateCellMappings()
         const auto& vol_quad = tet_quad_order_arbitrary_;
         const auto& area_quad = tri_quad_order_arbitrary_;
 
-        mapping = make_unique<Polyhedron>(cell, ref_grid_, vol_quad, area_quad);
+        mapping =
+          make_unique<PieceWiseLinearPolyhedronMapping>(cell, ref_grid_, vol_quad, area_quad);
         break;
       }
       default:

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.h
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.h
@@ -19,7 +19,7 @@ protected:
   /**Constructor*/
   explicit PieceWiseLinearBase(const MeshContinuum& grid,
                                QuadratureOrder q_order,
-                               SDMType sdm_type,
+                               SpatialDiscretizationType sdm_type,
                                CoordinateSystemType cs_type);
 
   LineQuadrature line_quad_order_arbitrary_;

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.cc
@@ -15,7 +15,8 @@ namespace opensn
 PieceWiseLinearContinuous::PieceWiseLinearContinuous(const MeshContinuum& grid,
                                                      QuadratureOrder q_order,
                                                      CoordinateSystemType cs_type)
-  : PieceWiseLinearBase(grid, q_order, SDMType::PIECEWISE_LINEAR_CONTINUOUS, cs_type)
+  : PieceWiseLinearBase(
+      grid, q_order, SpatialDiscretizationType::PIECEWISE_LINEAR_CONTINUOUS, cs_type)
 {
   CreateCellMappings();
 
@@ -74,8 +75,7 @@ PieceWiseLinearContinuous::OrderNodes()
   // node. We build this list here.
   // We start by adding the current location id
   // as the first subscription
-  typedef std::set<uint64_t> PSUBS;
-  std::map<uint64_t, PSUBS> ls_node_ids_psubs;
+  std::map<uint64_t, std::set<uint64_t>> ls_node_ids_psubs;
   for (const uint64_t node_id : ls_node_ids_set)
     ls_node_ids_psubs[node_id] = {static_cast<uint64_t>(opensn::mpi_comm.rank())};
 
@@ -303,7 +303,7 @@ PieceWiseLinearContinuous::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_
   // of ir-nodes that are not local. Each ir-node needs to
   // be furnished with the jr-nodes it links to.
 
-  typedef std::pair<int64_t, std::vector<int64_t>> ROWJLINKS;
+  using ROWJLINKS = std::pair<int64_t, std::vector<int64_t>>;
   std::vector<ROWJLINKS> ir_links;
 
   for (auto& cell : ref_grid_.local_cells)

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.cc
@@ -15,7 +15,8 @@ namespace opensn
 PieceWiseLinearDiscontinuous::PieceWiseLinearDiscontinuous(const MeshContinuum& grid,
                                                            QuadratureOrder q_order,
                                                            CoordinateSystemType cs_type)
-  : PieceWiseLinearBase(grid, q_order, SDMType::PIECEWISE_LINEAR_DISCONTINUOUS, cs_type)
+  : PieceWiseLinearBase(
+      grid, q_order, SpatialDiscretizationType::PIECEWISE_LINEAR_DISCONTINUOUS, cs_type)
 {
   CreateCellMappings();
 

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.cc
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.cc
@@ -14,7 +14,7 @@ namespace opensn
 {
 
 FiniteVolume::FiniteVolume(const MeshContinuum& grid, CoordinateSystemType cs_type)
-  : SpatialDiscretization(grid, cs_type, SDMType::FINITE_VOLUME)
+  : SpatialDiscretization(grid, cs_type, SpatialDiscretizationType::FINITE_VOLUME)
 {
   CreateCellMappings();
 
@@ -65,9 +65,8 @@ FiniteVolume::CreateCellMappings()
       case CellType::POLYGON:
       case CellType::POLYHEDRON:
       {
-        typedef std::vector<std::vector<int>> FaceDofMapping;
         mapping = make_unique<FiniteVolumeMapping>(
-          ref_grid_, cell, cell.centroid_, FaceDofMapping(cell.faces_.size(), {-1}));
+          ref_grid_, cell, cell.centroid_, std::vector<std::vector<int>>(cell.faces_.size(), {-1}));
         break;
       }
       default:

--- a/framework/math/spatial_discretization/spatial_discretization.cc
+++ b/framework/math/spatial_discretization/spatial_discretization.cc
@@ -13,7 +13,7 @@ namespace opensn
 
 SpatialDiscretization::SpatialDiscretization(const MeshContinuum& grid,
                                              CoordinateSystemType cs_type,
-                                             SDMType sdm_type)
+                                             SpatialDiscretizationType sdm_type)
   : UNITARY_UNKNOWN_MANAGER({std::make_pair(UnknownType::SCALAR, 0)}),
     ref_grid_(grid),
     coord_sys_type_(cs_type),
@@ -122,26 +122,22 @@ SpatialDiscretization::MakeCellInternalAndBndryNodeIDs(const Cell& cell) const
 std::vector<std::vector<std::vector<int>>>
 SpatialDiscretization::MakeInternalFaceNodeMappings(const double tolerance) const
 {
-  typedef std::vector<int> FaceAdjMapping;
-  typedef std::vector<FaceAdjMapping> PerFaceAdjMapping;
-  typedef std::vector<PerFaceAdjMapping> CellAdjMapping;
-
   const auto& grid = this->ref_grid_;
 
-  CellAdjMapping cell_adj_mapping;
+  std::vector<std::vector<std::vector<int>>> cell_adj_mapping;
   for (const auto& cell : grid.local_cells)
   {
     const auto& cell_mapping = this->GetCellMapping(cell);
     const auto& node_locations = cell_mapping.GetNodeLocations();
     const size_t num_faces = cell.faces_.size();
 
-    PerFaceAdjMapping per_face_adj_mapping;
+    std::vector<std::vector<int>> per_face_adj_mapping;
 
     for (size_t f = 0; f < num_faces; ++f)
     {
       const auto& face = cell.faces_[f];
       const auto num_face_nodes = cell_mapping.NumFaceNodes(f);
-      FaceAdjMapping face_adj_mapping(num_face_nodes, -1);
+      std::vector<int> face_adj_mapping(num_face_nodes, -1);
       if (face.has_neighbor_)
       {
         const auto& adj_cell = grid.cells[face.neighbor_id_];

--- a/framework/math/spatial_discretization/spatial_discretization.h
+++ b/framework/math/spatial_discretization/spatial_discretization.h
@@ -26,16 +26,12 @@ public:
   std::pair<std::set<uint32_t>, std::set<uint32_t>>
   MakeCellInternalAndBndryNodeIDs(const Cell& cell) const;
 
-  // 01 AddViewOfContinuum
   const CellMapping& GetCellMapping(const Cell& cell) const;
   SpatialDiscretizationType Type() const;
   /**Returns the reference grid on which this discretization is based.*/
   const MeshContinuum& Grid() const;
   CoordinateSystemType GetCoordinateSystemType() const;
 
-  // 02 OrderNodes
-
-  // 03
   /**Builds the sparsity pattern for a local block matrix compatible with
    * the given unknown manager. The modified vectors are: `nodal_nnz_in_diag`
    * which specifies for each row the number of non-zeros in the local diagonal
@@ -45,7 +41,6 @@ public:
                                     std::vector<int64_t>& nodal_nnz_off_diag,
                                     const UnknownManager& unknown_manager) const = 0;
 
-  // 04 Mappings
   /**Maps the global address of a degree of freedom.*/
   virtual int64_t MapDOF(const Cell& cell,
                          unsigned int node,
@@ -70,7 +65,6 @@ public:
    * here is a single scalar unknown.*/
   virtual int64_t MapDOFLocal(const Cell& cell, unsigned int node) const = 0;
 
-  // 05 Utils
   /**For the unknown structure in the unknown manager, returns the
    * number of local degrees-of-freedom.*/
   size_t GetNumLocalDOFs(const UnknownManager& unknown_manager) const;
@@ -175,7 +169,7 @@ public:
   /**Spherical coordinate system (1D Spherical) spatial weighting function.*/
   static double Spherical1DSpatialWeightFunction(const Vector3& point);
 
-  typedef std::function<double(const Vector3&)> SpatialWeightFunction;
+  using SpatialWeightFunction = std::function<double(const Vector3&)>;
 
   /**Returns the spatial weighting function appropriate to the discretization's
    * coordinate system.*/
@@ -184,9 +178,9 @@ public:
   virtual ~SpatialDiscretization() = default;
 
 protected:
-  typedef SpatialDiscretizationType SDMType;
-  // 00
-  SpatialDiscretization(const MeshContinuum& grid, CoordinateSystemType cs_type, SDMType sdm_type);
+  SpatialDiscretization(const MeshContinuum& grid,
+                        CoordinateSystemType cs_type,
+                        SpatialDiscretizationType sdm_type);
 
   const MeshContinuum& ref_grid_;
   std::vector<std::unique_ptr<CellMapping>> cell_mappings_;

--- a/framework/math/unknown_manager/unknown_manager.h
+++ b/framework/math/unknown_manager/unknown_manager.h
@@ -121,14 +121,13 @@ public:
   std::vector<Unknown> unknowns_;
   UnknownStorageType dof_storage_type_;
 
-  typedef std::pair<UnknownType, unsigned int> UnknownInfo;
   // Constructors
   explicit UnknownManager(UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
     : dof_storage_type_(storage_type)
   {
   }
 
-  UnknownManager(std::initializer_list<UnknownInfo> unknown_info_list,
+  UnknownManager(std::initializer_list<std::pair<UnknownType, unsigned int>> unknown_info_list,
                  UnknownStorageType storage_type = UnknownStorageType::NODAL) noexcept
     : dof_storage_type_(storage_type)
   {

--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -39,8 +39,8 @@ class CellFace
 {
 public:
   std::vector<uint64_t> vertex_ids_; /// A list of the vertices
-  Normal normal_;                    ///< The average/geometric normal
-  Vertex centroid_;                  ///< The face centroid
+  Vector3 normal_;                   ///< The average/geometric normal
+  Vector3 centroid_;                 ///< The face centroid
   bool has_neighbor_ = false;        ///< Flag indicating whether face has a neighbor
   uint64_t neighbor_id_ = 0;         ///< If face has neighbor, contains the global_id.
                                      ///< Otherwise contains boundary_id.
@@ -81,7 +81,7 @@ public:
   uint64_t global_id_ = 0;
   uint64_t local_id_ = 0;
   uint64_t partition_id_ = 0;
-  Vertex centroid_;
+  Vector3 centroid_;
   int material_id_ = -1;
 
   std::vector<uint64_t> vertex_ids_;

--- a/framework/mesh/io/obj_io.cc
+++ b/framework/mesh/io/obj_io.cc
@@ -29,16 +29,15 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
 
   std::shared_ptr<UnpartitionedMesh> mesh = std::make_shared<UnpartitionedMesh>();
 
-  typedef std::pair<uint64_t, uint64_t> Edge;
   struct BlockData
   {
     std::string name;
     std::vector<std::shared_ptr<UnpartitionedMesh::LightWeightCell>> cells;
-    std::vector<Edge> edges;
+    std::vector<std::pair<uint64_t, uint64_t>> edges;
   };
 
   std::vector<BlockData> block_data;
-  std::vector<Vertex> file_vertices;
+  std::vector<Vector3> file_vertices;
 
   // Reading every line
   std::string file_line;
@@ -71,7 +70,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
     // Keyword "v" for Vertex
     if (first_word == "v")
     {
-      Vertex newVertex;
+      Vector3 newVertex;
       for (int k = 1; k <= 3; k++)
       {
         // Extract sub word
@@ -178,7 +177,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
     // Keyword "l" for edge
     if (first_word == "l")
     {
-      Edge edge;
+      std::pair<uint64_t, uint64_t> edge;
       for (int k = 1; k <= 2; ++k)
       {
         // Extract sub word
@@ -249,7 +248,7 @@ MeshIO::FromOBJ(const UnpartitionedMesh::Options& options)
                            "\"selection only\"");
 
   // Process blocks
-  std::vector<Vertex> cell_vertices;
+  std::vector<Vector3> cell_vertices;
   {
     // Initial map is straight
     std::vector<size_t> vertex_map;

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -897,7 +897,7 @@ MeshIO::ToOBJ(const std::shared_ptr<MeshContinuum>& grid, const char* file_name,
       int node_g_index = node;
       node_mapping[node_g_index] = node_counter;
 
-      Vertex cur_v = grid->vertices[node_g_index];
+      Vector3 cur_v = grid->vertices[node_g_index];
 
       fprintf(of, "v %9.6f %9.6f %9.6f\n", cur_v.x, cur_v.y, cur_v.z);
     }
@@ -998,7 +998,7 @@ MeshIO::ToOBJ(const std::shared_ptr<MeshContinuum>& grid, const char* file_name,
         int node_g_index = node;
         node_mapping[node_g_index] = node_counter;
 
-        Vertex cur_v = grid->vertices[node_g_index];
+        Vector3 cur_v = grid->vertices[node_g_index];
 
         fprintf(of, "v %9.6f %9.6f %9.6f\n", cur_v.x, cur_v.y, cur_v.z);
       }

--- a/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
+++ b/framework/mesh/logical_volume/surface_mesh_logical_volume.cc
@@ -135,12 +135,12 @@ SurfaceMeshLogicalVolume::Inside(const Vector3& point) const
         int v0_i = surf_mesh->GetTriangles()[fi].v_index[0];
         int v1_i = surf_mesh->GetTriangles()[fi].v_index[1];
         int v2_i = surf_mesh->GetTriangles()[fi].v_index[2];
-        Vertex v0 = surf_mesh->GetVertices()[v0_i];
-        Vertex v1 = surf_mesh->GetVertices()[v1_i];
-        Vertex v2 = surf_mesh->GetVertices()[v2_i];
+        Vector3 v0 = surf_mesh->GetVertices()[v0_i];
+        Vector3 v1 = surf_mesh->GetVertices()[v1_i];
+        Vector3 v2 = surf_mesh->GetVertices()[v2_i];
 
         // Check if the line intersects plane
-        Vertex intp; // Intersection point
+        Vector3 intp; // Intersection point
         std::pair<double, double> weights;
         bool intersects_plane = CheckPlaneLineIntersect(
           surf_mesh->GetTriangles()[fi].geometric_normal, v0, point, fc, intp, &weights);

--- a/framework/mesh/mesh.h
+++ b/framework/mesh/mesh.h
@@ -16,11 +16,7 @@ namespace opensn
 {
 
 struct Vector3;
-typedef Vector3 Normal;
-typedef Vector3 Vertex;
-
 struct Matrix3x3;
-
 struct Face;
 struct Edge;
 struct PolyFace;

--- a/framework/mesh/mesh_continuum/grid_vtk_utils.h
+++ b/framework/mesh/mesh_continuum/grid_vtk_utils.h
@@ -43,8 +43,8 @@ void UploadFaceGeometry(const CellFace& cell_face,
                         const std::vector<uint64_t>& vertex_map,
                         vtkNew<vtkUnstructuredGrid>& ugrid);
 
-typedef vtkSmartPointer<vtkUnstructuredGrid> vtkUGridPtr;
-typedef std::pair<vtkUGridPtr, std::string> vtkUGridPtrAndName;
+using vtkUGridPtr = vtkSmartPointer<vtkUnstructuredGrid>;
+using vtkUGridPtrAndName = std::pair<vtkUGridPtr, std::string>;
 
 /**
  * Finds the highest dimension across all the grid blocks. This is useful when a vtk-read mesh

--- a/framework/mesh/mesh_continuum/mesh_continuum_vertex_handler.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum_vertex_handler.h
@@ -13,7 +13,7 @@ namespace opensn
 /**Manages a vertex map with custom calls.*/
 class VertexHandler
 {
-  typedef std::map<uint64_t, Vector3> GlobalIDMap;
+  using GlobalIDMap = std::map<uint64_t, Vector3>;
 
 private:
   std::map<uint64_t, Vector3> m_global_id_vertex_map;

--- a/framework/mesh/mesh_edge_loops.h
+++ b/framework/mesh/mesh_edge_loops.h
@@ -9,9 +9,9 @@ namespace opensn
 /**Structure containing edge properties*/
 struct Edge
 {
-  int v_index[2]{};   ///< Indices of the vertices
-  int f_index[4]{};   ///< Indices of faces adjoining it
-  Vertex vertices[2]; ///< Vector vertices
+  int v_index[2]{};    ///< Indices of the vertices
+  int f_index[4]{};    ///< Indices of faces adjoining it
+  Vector3 vertices[2]; ///< Vector vertices
 
   Edge()
   {

--- a/framework/mesh/mesh_face.h
+++ b/framework/mesh/mesh_face.h
@@ -14,9 +14,9 @@ struct Face
   int vt_index[3];
   int e_index[3][4];
 
-  Normal geometric_normal;
-  Normal assigned_normal;
-  Vertex face_centroid;
+  Vector3 geometric_normal;
+  Vector3 assigned_normal;
+  Vector3 face_centroid;
 
   bool invalidated;
 
@@ -96,8 +96,8 @@ struct PolyFace
   std::vector<std::vector<int>> edges;
   int face_indices[3];
 
-  Normal geometric_normal;
-  Vertex face_centroid;
+  Vector3 geometric_normal;
+  Vector3 face_centroid;
 
   bool invalidated;
 

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -170,9 +170,7 @@ MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh, int num_parti
   OpenSnLogicalErrorIf(num_raw_cells == 0, "No cells in final input mesh");
 
   // Build cell graph and centroids
-  typedef std::vector<uint64_t> CellGraphNode;
-  typedef std::vector<CellGraphNode> CellGraph;
-  CellGraph cell_graph;
+  std::vector<std::vector<uint64_t>> cell_graph;
   std::vector<Vector3> cell_centroids;
 
   cell_graph.reserve(num_raw_cells);
@@ -180,7 +178,7 @@ MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh, int num_parti
   {
     for (const auto& raw_cell_ptr : raw_cells)
     {
-      CellGraphNode cell_graph_node; // <-- Note A
+      std::vector<uint64_t> cell_graph_node; // <-- Note A
       for (auto& face : raw_cell_ptr->faces)
         if (face.has_neighbor)
           cell_graph_node.push_back(face.neighbor);
@@ -302,7 +300,7 @@ MeshGenerator::SetupCell(const UnpartitionedMesh::LightWeightCell& raw_cell,
     newFace.neighbor_id_ = raw_face.neighbor;
 
     newFace.vertex_ids_ = raw_face.vertex_ids;
-    auto vfc = Vertex(0.0, 0.0, 0.0);
+    auto vfc = Vector3(0.0, 0.0, 0.0);
     for (auto fvid : newFace.vertex_ids_)
       vfc = vfc + vertices.at(fvid);
     newFace.centroid_ = vfc / static_cast<double>(newFace.vertex_ids_.size());

--- a/framework/mesh/mesh_generator/mesh_generator.h
+++ b/framework/mesh/mesh_generator/mesh_generator.h
@@ -53,13 +53,13 @@ public:
 
   struct VertexListHelper
   {
-    virtual const Vertex& at(uint64_t vid) const = 0;
+    virtual const Vector3& at(uint64_t vid) const = 0;
   };
   template <typename T>
   struct STLVertexListHelper : public VertexListHelper
   {
     explicit STLVertexListHelper(const T& list) : list_(list) {}
-    const Vertex& at(uint64_t vid) const override { return list_.at(vid); };
+    const Vector3& at(uint64_t vid) const override { return list_.at(vid); };
     const T& list_;
   };
 

--- a/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
@@ -119,7 +119,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned1DOrthoMesh(const std::vector<double
   auto umesh = std::make_shared<UnpartitionedMesh>();
 
   // Reorient 1D vertices along z
-  std::vector<Vertex> zverts;
+  std::vector<Vector3> zverts;
   zverts.reserve(vertices.size());
   for (double z_coord : vertices)
     zverts.emplace_back(0.0, 0.0, z_coord);
@@ -200,8 +200,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned2DOrthoMesh(const std::vector<double
   umesh->AddBoundary(YMIN, "YMIN");
   umesh->AddBoundary(YMAX, "YMAX");
 
-  typedef std::vector<uint64_t> VecIDs;
-  std::vector<VecIDs> vertex_ij_to_i_map(Ny, VecIDs(Nx));
+  std::vector<std::vector<uint64_t>> vertex_ij_to_i_map(Ny, std::vector<uint64_t>(Nx));
   umesh->Vertices().reserve(Nx * Ny);
   {
     uint64_t k = 0;
@@ -215,7 +214,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned2DOrthoMesh(const std::vector<double
     }
   }
 
-  std::vector<VecIDs> cells_ij_to_i_map(Ny - 1, VecIDs(Nx - 1));
+  std::vector<std::vector<uint64_t>> cells_ij_to_i_map(Ny - 1, std::vector<uint64_t>(Nx - 1));
   {
     uint64_t k = 0;
     for (size_t i = 0; i < (Ny - 1); ++i)
@@ -326,11 +325,9 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
   // and the j-index refers to the jth row. We try to follow
   // the same logic here.
 
-  typedef std::vector<uint64_t> VecIDs;
-  typedef std::vector<VecIDs> VecVecIDs;
-  std::vector<VecVecIDs> vertex_ijk_to_i_map(Ny);
+  std::vector<std::vector<std::vector<uint64_t>>> vertex_ijk_to_i_map(Ny);
   for (auto& vec : vertex_ijk_to_i_map)
-    vec.resize(Nx, VecIDs(Nz));
+    vec.resize(Nx, std::vector<uint64_t>(Nz));
 
   umesh->Vertices().reserve(Nx * Ny * Nz);
   {
@@ -348,9 +345,9 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
     }
   }
 
-  std::vector<VecVecIDs> cells_ijk_to_i_map(Ny - 1);
+  std::vector<std::vector<std::vector<uint64_t>>> cells_ijk_to_i_map(Ny - 1);
   for (auto& vec : cells_ijk_to_i_map)
-    vec.resize(Nx - 1, VecIDs(Nz - 1));
+    vec.resize(Nx - 1, std::vector<uint64_t>(Nz - 1));
 
   {
     uint64_t c = 0;

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -372,7 +372,7 @@ SplitFileMeshGenerator::ReadSplitMesh()
       new_cell.faces.push_back(std::move(new_face));
     } // for f
 
-    cells.insert(std::make_pair(CellPIDGID(cell_pid, cell_gid), std::move(new_cell)));
+    cells.insert(std::make_pair(std::make_pair(cell_pid, cell_gid), std::move(new_cell)));
   } // for cell c
 
   // Read the vertices

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -26,11 +26,10 @@ protected:
                       int num_parts);
   static void SerializeCell(const UnpartitionedMesh::LightWeightCell& cell,
                             ByteArray& serial_buffer);
-  typedef std::pair<int, uint64_t> CellPIDGID;
   struct SplitMeshInfo
   {
     unsigned int dimension;
-    std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells;
+    std::map<std::pair<int, uint64_t>, UnpartitionedMesh::LightWeightCell> cells;
     std::map<uint64_t, Vector3> vertices;
     std::map<uint64_t, std::string> boundary_id_map;
     MeshType mesh_type;

--- a/framework/mesh/raytrace/raytracer.cc
+++ b/framework/mesh/raytrace/raytracer.cc
@@ -223,7 +223,7 @@ RayTracer::TraceSlab(const Cell& cell,
   for (int f = 0; f < num_faces; f++)
   {
     uint64_t fpi = cell.vertex_ids_[f]; // face point index
-    Vertex face_point = grid.vertices[fpi];
+    Vector3 face_point = grid.vertices[fpi];
 
     bool intersects = CheckPlaneLineIntersect(
       cell.faces_[f].normal_, face_point, pos_i, pos_f_line, intersection_point, &weights);
@@ -275,8 +275,8 @@ RayTracer::TracePolygon(const Cell& cell,
 
     uint64_t fpi = cell.faces_[f].vertex_ids_[0]; // face point index 0
     uint64_t fpf = cell.faces_[f].vertex_ids_[1]; // face point index 1
-    const Vertex& face_point_i = grid.vertices[fpi];
-    const Vertex& face_point_f = grid.vertices[fpf];
+    const Vector3& face_point_i = grid.vertices[fpi];
+    const Vector3& face_point_f = grid.vertices[fpf];
 
     bool intersects = CheckLineIntersectStrip(
       face_point_i, face_point_f, cell.faces_[f].normal_, pos_i, pos_f_line, ip);
@@ -400,7 +400,7 @@ RayTracer::TracePolyhedron(const Cell& cell,
 }
 
 bool
-CheckPlaneLineIntersect(const Normal& plane_normal,
+CheckPlaneLineIntersect(const Vector3& plane_normal,
                         const Vector3& plane_point,
                         const Vector3& line_point_0,
                         const Vector3& line_point_1,
@@ -532,7 +532,7 @@ CheckLineIntersectTriangle2(const Vector3& tri_point0,
 
 bool
 CheckPointInTriangle(
-  const Vector3& v0, const Vector3& v1, const Vector3& v2, const Normal& n, const Vector3& point)
+  const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& n, const Vector3& point)
 {
   auto v01 = v1 - v0;
   auto v12 = v2 - v1;
@@ -557,7 +557,7 @@ CheckPointInTriangle(
 }
 
 bool
-CheckPlaneTetIntersect(const Normal& plane_normal,
+CheckPlaneTetIntersect(const Vector3& plane_normal,
                        const Vector3& plane_point,
                        const std::vector<Vector3>& tet_points)
 {
@@ -621,7 +621,7 @@ PopulateRaySegmentLengths(const MeshContinuum& grid,
 
       auto n0 = (vc - v0).Cross(khat).Normalized();
 
-      Vertex intersection_point;
+      Vector3 intersection_point;
       double d = 0.0;
       bool intersects =
         CheckLineIntersectStrip(v0, vc, n0, line_point0, line_point1, intersection_point, &d);
@@ -647,7 +647,7 @@ PopulateRaySegmentLengths(const MeshContinuum& grid,
       {
         auto& vert = grid.vertices[vi];
 
-        Vertex intersection_point;
+        Vector3 intersection_point;
 
         double d = 0.0;
         bool intersects =
@@ -671,7 +671,7 @@ PopulateRaySegmentLengths(const MeshContinuum& grid,
         auto& v1 = grid.vertices[vid_1];
         auto& v2 = vcc;
 
-        Vertex intersection_point;
+        Vector3 intersection_point;
 
         double d = 0.0;
         bool intersects =

--- a/framework/mesh/raytrace/raytracer.h
+++ b/framework/mesh/raytrace/raytracer.h
@@ -130,7 +130,7 @@ private:
  *
  * \author Jan
  */
-bool CheckPlaneLineIntersect(const Normal& plane_normal,
+bool CheckPlaneLineIntersect(const Vector3& plane_normal,
                              const Vector3& plane_point,
                              const Vector3& line_point_0,
                              const Vector3& line_point_1,
@@ -169,7 +169,7 @@ bool CheckLineIntersectTriangle2(const Vector3& tri_point0,
  * Check whether a point lies in a triangle.
  */
 bool CheckPointInTriangle(
-  const Vector3& v0, const Vector3& v1, const Vector3& v2, const Normal& n, const Vector3& point);
+  const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& n, const Vector3& point);
 
 /**
  * This functions checks the intersection of a plane with a tetrahedron.
@@ -181,7 +181,7 @@ bool CheckPointInTriangle(
  * Therefore, if we encounter differing senses then the plane is indeed
  * intersecting.
  */
-bool CheckPlaneTetIntersect(const Normal& plane_normal,
+bool CheckPlaneTetIntersect(const Vector3& plane_normal,
                             const Vector3& plane_point,
                             const std::vector<Vector3>& tet_points);
 

--- a/framework/mesh/surface_mesh/surface_mesh.cc
+++ b/framework/mesh/surface_mesh/surface_mesh.cc
@@ -69,7 +69,7 @@ SurfaceMesh::CheckNegativeSense(double x, double y, double z)
   for (cur_face = this->faces_.begin(); cur_face != this->faces_.end(); cur_face++)
   {
     // Get a vertex (first one)
-    Vertex p;
+    Vector3 p;
     try
     {
       p = this->vertices_.at(cur_face->v_index[0]);
@@ -122,8 +122,8 @@ SurfaceMesh::ExtractOpenEdgesToObj(const char* fileName)
 
   for (auto vert_pair : edges)
   {
-    Vertex& v0 = vertices_[vert_pair.first];
-    Vertex& v1 = vertices_[vert_pair.second];
+    Vector3& v0 = vertices_[vert_pair.first];
+    Vector3& v1 = vertices_[vert_pair.second];
     outfile << "v " << v0.x << " " << v0.y << " " << v0.z << "\n"
             << "v " << v1.x << " " << v1.y << " " << v1.z << "\n";
   }
@@ -150,7 +150,7 @@ SurfaceMesh::UpdateInternalConnectivity()
     vert_sub.reserve(5);
 
   // Loop over cells and determine which cells subscribe to a vertex
-  //%%%%%% TRIANGLES %%%%%
+  // Triangles
   size_t num_tri_faces = faces_.size();
   for (size_t tf = 0; tf < num_tri_faces; tf++)
   {
@@ -158,7 +158,7 @@ SurfaceMesh::UpdateInternalConnectivity()
     for (int v = 0; v < 3; ++v)
       vertex_subscriptions[v].push_back(tf);
   }
-  //%%%%% POLYGONS %%%%%
+  // Polygons
   size_t num_poly_faces = poly_faces_.size();
   for (size_t pf = 0; pf < num_poly_faces; pf++)
   {
@@ -168,7 +168,7 @@ SurfaceMesh::UpdateInternalConnectivity()
   }
 
   // Loop over cells and determine connectivity
-  //%%%%%% TRIANGLES %%%%%
+  // Triangles
   for (auto curFace : faces_)
   {
     for (int e = 0; e < 3; e++)
@@ -212,7 +212,7 @@ SurfaceMesh::UpdateInternalConnectivity()
   }       // for faces
 
   // Loop over cells and determine connectivity
-  //%%%%% POLYGONS %%%%%
+  // Polygons
   for (auto curFace : poly_faces_)
   {
     for (auto& curface_edge : curFace->edges)
@@ -285,7 +285,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     // Keyword "v" for Vertex
     if (first_word == "v")
     {
-      Vertex newVertex;
+      Vector3 newVertex;
       for (int k = 1; k <= 3; k++)
       {
         // Extract sub word
@@ -324,7 +324,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     // Keyword "vt" for Vertex
     if (first_word.compare("vt") == 0)
     {
-      Vertex newVertex;
+      Vector3 newVertex;
       for (int k = 1; k <= 2; k++)
       {
         // Extract sub word
@@ -336,7 +336,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
         try
         {
           double numValue = std::stod(sub_word);
-          //*newVertex->value[k-1] = numValue;
           if (k == 1)
           {
             newVertex.x = numValue;
@@ -370,7 +369,7 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     // Keyword "vn" for normal
     if (first_word.compare("vn") == 0)
     {
-      Normal newNormal;
+      Vector3 newNormal;
       for (int k = 1; k <= 3; k++)
       {
         // Extract sub word
@@ -382,7 +381,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
         try
         {
           double numValue = std::stod(sub_word);
-          //*newNormal->value[k-1] = numValue;
           if (k == 1)
           {
             newNormal.x = numValue;
@@ -526,7 +524,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
           try
           {
             int numValue = std::stoi(norm_word);
-            // newFace->n_indices.push_back(numValue-1);
           }
           catch (const std::invalid_argument& ia)
           {
@@ -540,7 +537,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
             try
             {
               int numValue = std::stoi(tvert_word);
-              // newFace->vt_indices.push_back(numValue-1);
             }
             catch (const std::invalid_argument& ia)
             {
@@ -615,8 +611,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
       newEdge.vertices[1] = this->vertices_.at(newEdge.v_index[1]);
 
       this->lines_.push_back(newEdge);
-
-      // printf("line %d->%d\n",newEdge.v_index[0],newEdge.v_index[1]);
     }
   }
   file.close();
@@ -626,9 +620,9 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
   for (curFace = this->faces_.begin(); curFace != this->faces_.end(); curFace++)
   {
     // Calculate geometrical normal
-    Vertex vA = this->vertices_.at(curFace->v_index[0]);
-    Vertex vB = this->vertices_.at(curFace->v_index[1]);
-    Vertex vC = this->vertices_.at(curFace->v_index[2]);
+    Vector3 vA = this->vertices_.at(curFace->v_index[0]);
+    Vector3 vB = this->vertices_.at(curFace->v_index[1]);
+    Vector3 vC = this->vertices_.at(curFace->v_index[2]);
 
     Vector3 vAB = vB - vA;
     Vector3 vBC = vC - vB;
@@ -637,9 +631,9 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
     curFace->geometric_normal = curFace->geometric_normal / curFace->geometric_normal.Norm();
 
     // Calculate Assigned normal
-    Vertex nA = this->normals_.at(curFace->n_index[0]);
-    Vertex nB = this->normals_.at(curFace->n_index[1]);
-    Vertex nC = this->normals_.at(curFace->n_index[2]);
+    Vector3 nA = this->normals_.at(curFace->n_index[0]);
+    Vector3 nB = this->normals_.at(curFace->n_index[1]);
+    Vector3 nC = this->normals_.at(curFace->n_index[2]);
 
     Vector3 nAvg = (nA + nB + nC) / 3.0;
     nAvg = nAvg / nAvg.Norm();
@@ -672,7 +666,6 @@ SurfaceMesh::ImportFromOBJFile(const std::string& fileName, bool as_poly, const 
   // Check each vertex is accounted
   log.Log() << "Surface mesh loaded with " << this->faces_.size() << " triangle faces and "
             << this->poly_faces_.size() << " polygon faces.";
-  // Exit(EXIT_FAILURE);
 
   return 0;
 }
@@ -702,7 +695,7 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   for (int v = 1; v <= num_verts; v++)
   {
     int vert_index;
-    Vertex vertex;
+    Vector3 vertex;
     file >> vert_index >> vertex.x >> vertex.y;
     file.getline(line, 250);
 
@@ -769,9 +762,9 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   for (curFace = this->faces_.begin(); curFace != this->faces_.end(); curFace++)
   {
     // Calculate geometrical normal
-    Vertex vA = this->vertices_.at(curFace->v_index[0]);
-    Vertex vB = this->vertices_.at(curFace->v_index[1]);
-    Vertex vC = this->vertices_.at(curFace->v_index[2]);
+    Vector3 vA = this->vertices_.at(curFace->v_index[0]);
+    Vector3 vB = this->vertices_.at(curFace->v_index[1]);
+    Vector3 vC = this->vertices_.at(curFace->v_index[2]);
 
     Vector3 vAB = vB - vA;
     Vector3 vBC = vC - vB;
@@ -780,9 +773,9 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
     curFace->geometric_normal = curFace->geometric_normal / curFace->geometric_normal.Norm();
 
     // Calculate Assigned normal
-    Vertex nA = this->normals_.at(curFace->n_index[0]);
-    Vertex nB = this->normals_.at(curFace->n_index[1]);
-    Vertex nC = this->normals_.at(curFace->n_index[2]);
+    Vector3 nA = this->normals_.at(curFace->n_index[0]);
+    Vector3 nB = this->normals_.at(curFace->n_index[1]);
+    Vector3 nC = this->normals_.at(curFace->n_index[2]);
 
     Vector3 nAvg = (nA + nB + nC) / 3.0;
     nAvg = nAvg / nAvg.Norm();
@@ -815,7 +808,6 @@ SurfaceMesh::ImportFromTriangleFiles(const char* fileName, bool as_poly = false)
   // Check each vertex is accounted
   log.Log() << "Surface mesh loaded with " << this->faces_.size() << " triangle faces and "
             << this->poly_faces_.size() << " polygon faces.";
-  // Exit(EXIT_FAILURE);
 
   return 0;
 }
@@ -843,8 +835,8 @@ SurfaceMesh::CreateFromDivisions(std::vector<double>& vertices_1d_x,
   int Ncx = Nvx - 1;
   int Ncy = Nvy - 1;
 
-  std::vector<Vertex> vertices_x;
-  std::vector<Vertex> vertices_y;
+  std::vector<Vector3> vertices_x;
+  std::vector<Vector3> vertices_y;
 
   vertices_x.reserve(Nvx);
   vertices_y.reserve(Nvy);
@@ -967,7 +959,7 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
     std::getline(file, line);
     iss = std::istringstream(line);
 
-    Vertex vertex;
+    Vector3 vertex;
     int vert_index;
     if (not(iss >> vert_index))
     {
@@ -1118,12 +1110,6 @@ SurfaceMesh::ImportFromMshFiles(const char* fileName, bool as_poly = false)
 void
 SurfaceMesh::ExportToOBJFile(const char* fileName)
 {
-
-  //  if (this->faces.empty())
-  //  {
-  //    std::cout << "Cannot export empty SurfaceMesh\n";
-  //    return;
-  //  }
   FILE* outputFile = fopen(fileName, "w");
   if (outputFile == nullptr)
   {
@@ -1134,7 +1120,7 @@ SurfaceMesh::ExportToOBJFile(const char* fileName)
   fprintf(outputFile, "# Exported mesh file from triangulation script\n");
   fprintf(outputFile, "o %s\n", "OpenSnTriMesh");
 
-  std::vector<Vertex>::iterator cur_v;
+  std::vector<Vector3>::iterator cur_v;
   for (cur_v = this->vertices_.begin(); cur_v != this->vertices_.end(); cur_v++)
   {
     fprintf(outputFile, "v %9.6f %9.6f %9.6f\n", cur_v->x, cur_v->y, cur_v->z);
@@ -1260,15 +1246,13 @@ SurfaceMesh::CheckCyclicDependencies(int num_angles)
         int neighbor = face->edges[e][2];
         if ((mu > (0.0 + tolerance)) and (neighbor >= 0))
         {
-          //          boost::add_edge(c,neighbor,G);
           G.AddEdge(c, neighbor);
         } // if outgoing
       }   // for edge
     }     // for cell
 
-    // Generic topological
-    //                                                   sorting
-    //    typedef boost::graph_traits<CHI_D_GRAPH>::vertex_descriptor gVertex;
+    // Generic topological sorting
+    //    using gVertex = boost::graph_traits<CHI_D_GRAPH>::vertex_descriptor;
     //
     //    boost::property_map<CHI_D_GRAPH, boost::vertex_index_t>::type
     //      index_map = get(boost::vertex_index, G);
@@ -1459,29 +1443,28 @@ SurfaceMesh::ComputeLoadBalancing(std::vector<double>& x_cuts, std::vector<doubl
 void
 SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 {
-  typedef std::vector<Face> FaceList;
-  typedef std::vector<std::shared_ptr<FaceList>> FaceListCollection;
+  using FaceListCollection = std::vector<std::shared_ptr<std::vector<Face>>>;
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Copy all faces from surface
-  FaceList unsorted_faces;
-  FaceList::iterator cur_face;
+  // Copy all faces from surface
+  std::vector<Face> unsorted_faces;
+  std::vector<Face>::iterator cur_face;
   for (cur_face = this->faces_.begin(); cur_face != this->faces_.end(); cur_face++)
   {
     unsorted_faces.push_back((*cur_face));
   }
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Initialize co-planar
+  // Initialize co-planar
   // collection
   FaceListCollection co_planar_lists;
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Seed the first collection
-  auto first_list = std::make_shared<FaceList>();
+  // Seed the first collection
+  auto first_list = std::make_shared<std::vector<Face>>();
   co_planar_lists.push_back(first_list);
   first_list->push_back(unsorted_faces.back());
   unsorted_faces.pop_back();
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Reverse iterate over unsorted
-  FaceList::reverse_iterator us_face;
+  // Reverse iterate over unsorted
+  std::vector<Face>::reverse_iterator us_face;
   for (us_face = unsorted_faces.rbegin(); us_face != unsorted_faces.rend(); us_face++)
   {
     bool matchFound = false;
@@ -1493,8 +1476,8 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
     {
       for (cur_face = (*existing_list)->begin(); cur_face != (*existing_list)->end(); cur_face++)
       {
-        Normal n1 = cur_face->geometric_normal;
-        Normal n2 = us_face->geometric_normal;
+        Vector3 n1 = cur_face->geometric_normal;
+        Vector3 n2 = us_face->geometric_normal;
 
         if (fabs(n1.Dot(n2)) > (1.0 - 1.0e-4))
         {
@@ -1514,7 +1497,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
     if (not matchFound)
     {
       printf("New list created\n");
-      auto new_list = std::make_shared<FaceList>();
+      auto new_list = std::make_shared<std::vector<Face>>();
       new_list->push_back(unsorted_faces.back());
       unsorted_faces.pop_back();
       co_planar_lists.push_back(new_list);
@@ -1525,7 +1508,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 
   FaceListCollection patch_list_collection;
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Loop over co_planar lists
+  // Loop over co_planar lists
   FaceListCollection::iterator existing_list;
   for (existing_list = co_planar_lists.begin(); existing_list != co_planar_lists.end();
        existing_list++)
@@ -1534,14 +1517,14 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
     FaceListCollection inner_patch_list_collection;
 
     // Add all the faces of this collection to an unused list
-    FaceList unused_faces;
+    std::vector<Face> unused_faces;
     for (cur_face = (*existing_list)->begin(); cur_face != (*existing_list)->end(); cur_face++)
     {
       unused_faces.push_back((*cur_face));
     }
 
     // Seed the first patch list
-    auto first_patch_list = std::make_shared<FaceList>();
+    auto first_patch_list = std::make_shared<std::vector<Face>>();
     inner_patch_list_collection.push_back(first_patch_list);
     first_patch_list->push_back(unused_faces.back());
     unused_faces.pop_back();
@@ -1549,9 +1532,8 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
     // Loop over unused faces
     while (unused_faces.size() > 0)
     {
-      // printf("Unused faces=%d\n",unused_faces.size());
       bool updateMade = false;
-      FaceList::iterator us_face_f; // Forward iterator
+      std::vector<Face>::iterator us_face_f; // Forward iterator
       for (us_face_f = unused_faces.begin(); us_face_f != unused_faces.end(); us_face_f++)
       {
         // Try to to find a home
@@ -1602,7 +1584,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 
       if (not updateMade)
       {
-        auto new_patch_list = std::make_shared<FaceList>();
+        auto new_patch_list = std::make_shared<std::vector<Face>>();
         inner_patch_list_collection.push_back(new_patch_list);
         new_patch_list->push_back(unused_faces.back());
         unused_faces.pop_back();
@@ -1621,7 +1603,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
 
   printf("Number of patches = %lu\n", patch_list_collection.size());
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Create surfaces for each patch
+  // Create surfaces for each patch
   FaceListCollection::iterator outer_patch;
   for (outer_patch = patch_list_collection.begin(); outer_patch != patch_list_collection.end();
        outer_patch++)
@@ -1662,7 +1644,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
         else
         {
           // Copy vertex
-          Vertex v = this->vertices_.at(vi);
+          Vector3 v = this->vertices_.at(vi);
           std::vector<int> newMapping(2);
           newMapping[0] = vi;
           newMapping[1] = new_surface->vertices_.size();
@@ -1692,16 +1674,7 @@ SurfaceMesh::SplitByPatch(std::vector<std::shared_ptr<SurfaceMesh>>& patches)
       new_surface->faces_.push_back(newFace);
     }
     new_surface->UpdateInternalConnectivity();
-    // std::cout << (*new_surface);
     patches.push_back(new_surface);
-
-    //    std::string fileName = "ZZMesh";
-    //    fileName = fileName + std::to_string((int)patches.size());
-    //    fileName = fileName + ".obj";
-    //
-    //    std::cout <<fileName <<"\n";
-    //
-    //    new_surface->ExportToOBJFile(fileName.c_str());
   }
 }
 

--- a/framework/mesh/surface_mesh/surface_mesh.h
+++ b/framework/mesh/surface_mesh/surface_mesh.h
@@ -25,9 +25,9 @@ protected:
   explicit SurfaceMesh(const InputParameters& params);
 
 protected:
-  std::vector<Vertex> vertices_;
-  std::vector<Vertex> tex_vertices_; ///< Texture vertices
-  std::vector<Normal> normals_;
+  std::vector<Vector3> vertices_;
+  std::vector<Vector3> tex_vertices_; ///< Texture vertices
+  std::vector<Vector3> normals_;
   std::vector<Face> faces_;
   std::vector<Edge> lines_;
   std::vector<std::shared_ptr<PolyFace>> poly_faces_; ///< Polygonal faces
@@ -35,7 +35,7 @@ protected:
   std::vector<int> physical_region_map_;
 
 public:
-  const std::vector<Vertex>& GetVertices() const { return vertices_; }
+  const std::vector<Vector3>& GetVertices() const { return vertices_; }
 
   const std::vector<Face>& GetTriangles() const { return faces_; }
 
@@ -78,8 +78,8 @@ public:
    * The vertices along a dimension merely represents the divisions. They
    * are not the complete vertices defining a cell. For example:
    * \code
-   * std::vector<Vertex> vertices_x = {0.0,1.0,2.0};
-   * std::vector<Vertex> vertices_y = {0.0,1.0,2.0};
+   * std::vector<Vector3> vertices_x = {0.0,1.0,2.0};
+   * std::vector<Vector3> vertices_y = {0.0,1.0,2.0};
    * SurfaceMesh::CreateFromDivisions(vertices_x,vertices_y);
    * \endcode
    *

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.cc
@@ -47,7 +47,7 @@ UnpartitionedMesh::ComputeCentroids()
   log.Log0Verbose1() << "Computing cell-centroids.";
   for (auto cell : raw_cells_)
   {
-    cell->centroid = Vertex(0.0, 0.0, 0.0);
+    cell->centroid = Vector3(0.0, 0.0, 0.0);
     for (auto vid : cell->vertex_ids)
       cell->centroid += vertices_[vid];
 

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -33,7 +33,7 @@ public:
   {
     const CellType type;
     const CellType sub_type;
-    Vertex centroid;
+    Vector3 centroid;
     int material_id = -1;
     std::vector<uint64_t> vertex_ids;
     std::vector<LightWeightFace> faces;
@@ -90,8 +90,8 @@ public:
     return raw_boundary_cells_;
   }
 
-  const std::vector<Vertex>& Vertices() const { return vertices_; }
-  std::vector<Vertex>& Vertices() { return vertices_; }
+  const std::vector<Vector3>& Vertices() const { return vertices_; }
+  std::vector<Vector3>& Vertices() { return vertices_; }
 
   /**
    * Establishes neighbor connectivity for the light-weight mesh.
@@ -140,7 +140,7 @@ protected:
   BoundBox bound_box_;
   std::map<uint64_t, std::string> boundary_id_map_;
 
-  std::vector<Vertex> vertices_;
+  std::vector<Vector3> vertices_;
   std::vector<std::shared_ptr<LightWeightCell>> raw_cells_;
   std::vector<std::shared_ptr<LightWeightCell>> raw_boundary_cells_;
   std::vector<std::set<uint64_t>> vertex_cell_subscriptions_;

--- a/framework/post_processors/post_processor_printer.cc
+++ b/framework/post_processors/post_processor_printer.cc
@@ -166,8 +166,7 @@ PostProcessorPrinter::GetPrintedPostProcessors(
 {
   std::stringstream outstr;
 
-  typedef std::pair<std::string, std::string> PPNameAndVal;
-  std::vector<PPNameAndVal> scalar_ppnames_and_vals;
+  std::vector<std::pair<std::string, std::string>> scalar_ppnames_and_vals;
   for (const auto& pp : pp_list)
   {
     const auto& value = pp->GetValue();
@@ -196,8 +195,7 @@ PostProcessorPrinter::PrintPPsLatestValuesOnly(const std::string& pps_typename,
     return;
   std::stringstream outstr;
 
-  typedef std::pair<std::string, std::string> PPNameAndVal;
-  std::vector<PPNameAndVal> scalar_ppnames_and_vals;
+  std::vector<std::pair<std::string, std::string>> scalar_ppnames_and_vals;
   for (const auto& pp : pp_list)
   {
     const auto& value = pp->GetValue();
@@ -425,13 +423,12 @@ PostProcessorPrinter::PrintPPsTimeHistory(const std::string& pps_typename,
     sub_mat_sizes.push_back(col_counter);
 
     // Now actually build the sub-matrices
-    typedef std::vector<std::string> VecStr;
-    typedef std::vector<VecStr> MatStr;
-    std::vector<MatStr> sub_matrices;
+    std::vector<std::vector<std::vector<std::string>>> sub_matrices;
     size_t last_k = 1;
     for (const size_t k : sub_mat_sizes)
     {
-      MatStr sub_matrix(num_rows, VecStr(k - last_k + 1, ""));
+      std::vector<std::vector<std::string>> sub_matrix(
+        num_rows, std::vector<std::string>(k - last_k + 1, ""));
       // Copy time col
       for (size_t i = 0; i < num_rows; ++i)
         sub_matrix[i][0] = value_matrix[i][0];
@@ -673,9 +670,8 @@ PostProcessorPrinter::BuildPPHistoryMatrix(size_t timehistsize,
 
   const auto& front_time_hist = pp_sub_list.front()->GetTimeHistory();
 
-  typedef std::vector<std::string> VecStr;
-  typedef std::vector<VecStr> MatStr;
-  MatStr value_matrix(num_rows, VecStr(num_cols, ""));
+  std::vector<std::vector<std::string>> value_matrix(num_rows,
+                                                     std::vector<std::string>(num_cols, ""));
 
   // Do the header first
   value_matrix[0][0] = "Time";

--- a/framework/utils/utils.cc
+++ b/framework/utils/utils.cc
@@ -98,8 +98,6 @@ PrintIterationProgress(const size_t current_iteration,
                        const size_t total_num_iterations,
                        const unsigned int num_intvls)
 {
-  typedef unsigned int uint;
-
   // Creating shorthand symbols for arguments
   const auto& i = current_iteration;
   const auto& I = num_intvls;
@@ -129,7 +127,7 @@ PrintIterationProgress(const size_t current_iteration,
   double x2;
   std::modf(double(i) / dI, &x2);
 
-  if (uint(x2) != uint(x1))
+  if (static_cast<unsigned int>(x2) != static_cast<unsigned int>(x1))
   {
     output << x2 * (100.0 / I);
     return output.str();

--- a/lua/framework/interfaces/plugin.cc
+++ b/lua/framework/interfaces/plugin.cc
@@ -65,9 +65,9 @@ Plugin::Plugin(const InputParameters& params)
   if (user_params.Has("entry_function"))
   {
     const auto& entry_function = user_params.GetParamValue<std::string>("entry_function");
-    typedef void(some_func)();
 
-    auto func = (some_func*)dlsym(library_handle_, entry_function.c_str());
+    using func_ptr = void (*)();
+    auto func = (func_ptr)dlsym(library_handle_, entry_function.c_str());
 
     OpenSnLogicalErrorIf(not func, "Failed to call entry function \"" + entry_function + "\"");
 

--- a/modules/diffusion/dfem_diffusion_solver.cc
+++ b/modules/diffusion/dfem_diffusion_solver.cc
@@ -342,15 +342,13 @@ DFEMDiffusionSolver::Execute()
 
       const double hm = HPerpendicular(cell, f);
 
-      typedef MeshContinuum Grid;
-
       // interior face
       if (face.has_neighbor_)
       {
         const auto& adj_cell = grid.cells[face.neighbor_id_];
         const auto& adj_cell_mapping = sdm.GetCellMapping(adj_cell);
         const auto ac_nodes = adj_cell_mapping.GetNodeLocations();
-        const size_t acf = Grid::MapCellFace(cell, adj_cell, f);
+        const size_t acf = MeshContinuum::MapCellFace(cell, adj_cell, f);
         const double hp_neigh = HPerpendicular(adj_cell, acf);
 
         const auto imat_neigh = adj_cell.material_id_;

--- a/modules/diffusion/diffusion_solver.h
+++ b/modules/diffusion/diffusion_solver.h
@@ -40,8 +40,8 @@ public:
 protected:
   void InitFieldFunctions();
 
-  typedef std::pair<BoundaryType, std::vector<double>> BoundaryInfo;
-  typedef std::map<std::string, BoundaryInfo> BoundaryPreferences;
+  using BoundaryInfo = std::pair<BoundaryType, std::vector<double>>;
+  using BoundaryPreferences = std::map<std::string, BoundaryInfo>;
 
   std::shared_ptr<MeshContinuum> grid_ptr_;
   std::shared_ptr<SpatialDiscretization> sdm_ptr_;

--- a/modules/diffusion/mg_diffusion_solver.cc
+++ b/modules/diffusion/mg_diffusion_solver.cc
@@ -408,7 +408,7 @@ MGDiffusionSolver::InitializeMaterials(std::set<int>& material_ids)
 
   std::stringstream materials_list;
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Process materials found
+  // Process materials found
   const size_t num_physics_mats = material_stack.size();
   bool first_material_read = true;
 
@@ -502,7 +502,7 @@ MGDiffusionSolver::InitializeMaterials(std::set<int>& material_ids)
 
   opensn::mpi_comm.barrier();
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Compute last fast group
+  // Compute last fast group
   // initialize last fast group
   log.Log() << "Computing last fast group.";
   unsigned int lfg = num_groups_;
@@ -529,7 +529,7 @@ MGDiffusionSolver::InitializeMaterials(std::set<int>& material_ids)
 
   last_fast_group_ = lfg;
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Compute two-grid params
+  // Compute two-grid params
   do_two_grid_ = basic_options_("do_two_grid").BoolValue();
   if ((lfg == num_groups_) and do_two_grid_)
   {

--- a/modules/diffusion/mg_diffusion_solver.h
+++ b/modules/diffusion/mg_diffusion_solver.h
@@ -79,9 +79,8 @@ private:
   void SolveOneGroupProblem(unsigned int g, int64_t iverbose);
   void UpdateFluxWithTwoGrid(int64_t iverbose);
 
-  typedef std::pair<BoundaryType, std::array<std::vector<double>, 3>> BoundaryInfo;
-
-  typedef std::map<std::string, BoundaryInfo> BoundaryPreferences;
+  using BoundaryInfo = std::pair<BoundaryType, std::array<std::vector<double>, 3>>;
+  using BoundaryPreferences = std::map<std::string, BoundaryInfo>;
 
   std::shared_ptr<MeshContinuum> grid_ptr_;
 

--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context2.cc
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context2.cc
@@ -18,7 +18,7 @@
 namespace opensn
 {
 
-typedef PetscErrorCode (*PCShellPtr)(PC, Vec, Vec);
+using PCShellPtr = PetscErrorCode (*)(PC, Vec, Vec);
 
 MIPWGSContext2::MIPWGSContext2(DiffusionDFEMSolver& lbs_mip_ss_solver,
                                LBSGroupset& groupset,

--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
@@ -94,9 +94,7 @@ DiffusionDFEMSolver::InitializeWGSSolvers()
     } // for sweep-boundary
 
     // Make xs map
-    typedef Multigroup_D_and_sigR MultiGroupXS;
-    typedef std::map<int, Multigroup_D_and_sigR> MatID2XSMap;
-    MatID2XSMap matid_2_mgxs_map;
+    std::map<int, Multigroup_D_and_sigR> matid_2_mgxs_map;
     for (const auto& matid_xs_pair : matid_to_xs_map_)
     {
       const auto& mat_id = matid_xs_pair.first;
@@ -117,7 +115,7 @@ DiffusionDFEMSolver::InitializeWGSSolvers()
         ++g;
       } // for g
 
-      matid_2_mgxs_map.insert(std::make_pair(mat_id, MultiGroupXS{Dg, sigR}));
+      matid_2_mgxs_map.insert(std::make_pair(mat_id, Multigroup_D_and_sigR{Dg, sigR}));
     }
 
     // Create solver

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
@@ -212,13 +212,11 @@ DiscreteOrdinatesAdjointSolver::ExportImportanceMap(const std::string& file_name
 
   const auto& m_to_ell_em_map = groupsets_.front().quadrature_->GetMomentToHarmonicsIndexMap();
 
-  typedef VectorN<4> Arr4; // phi, J_x, J_y, J_z
-  typedef std::vector<Arr4> MGVec4;
-  typedef std::vector<MGVec4> VecOfMGVec4;
+  using MGVec4 = std::vector<VectorN<4>>; // 0 = phi, 1 = J_x, 2 = J_y, 3 = J_z
   const size_t num_groups = set_group_numbers.size();
   const size_t num_cells = grid_ptr_->local_cells.size();
 
-  VecOfMGVec4 cell_avg_p1_moments(num_cells, MGVec4(num_groups));
+  std::vector<MGVec4> cell_avg_p1_moments(num_cells, MGVec4(num_groups));
   {
 
     for (const auto& cell : grid_ptr_->local_cells)
@@ -227,7 +225,7 @@ DiscreteOrdinatesAdjointSolver::ExportImportanceMap(const std::string& file_name
       const int num_nodes = cell_view.NumNodes();
       const auto& fe_values = unit_cell_matrices_[cell.local_id_];
 
-      VecOfMGVec4 nodal_p1_moments(num_nodes);
+      std::vector<MGVec4> nodal_p1_moments(num_nodes);
       for (int i = 0; i < num_nodes; ++i)
       {
         // Get multigroup p1_moments
@@ -275,10 +273,9 @@ DiscreteOrdinatesAdjointSolver::ExportImportanceMap(const std::string& file_name
   }
 
   // Determine cell-based exponential-representations
-  typedef std::pair<double, double> ABCoeffsPair;
-  typedef std::vector<ABCoeffsPair> VecOfABCoeffsPair;
-  typedef std::vector<VecOfABCoeffsPair> ExpReps;
-  ExpReps cell_exp_reps(num_cells, VecOfABCoeffsPair(num_groups, {0.0, 0.0}));
+  using VecOfABCoeffsPair = std::vector<std::pair<double, double>>;
+  std::vector<VecOfABCoeffsPair> cell_exp_reps(num_cells,
+                                               VecOfABCoeffsPair(num_groups, {0.0, 0.0}));
   {
     for (const auto& cell : grid_ptr_->local_cells)
     {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_solver/lbs_curvilinear_solver.cc
@@ -126,9 +126,8 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
     {
       case CoordinateSystemType::CYLINDRICAL:
       {
-        typedef CylindricalQuadrature CylAngQuad;
         const auto curvilinear_angular_quad_ptr =
-          std::dynamic_pointer_cast<CylAngQuad>(angular_quad_ptr);
+          std::dynamic_pointer_cast<CylindricalQuadrature>(angular_quad_ptr);
         if (curvilinear_angular_quad_ptr == nullptr)
         {
           log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "
@@ -141,9 +140,8 @@ DiscreteOrdinatesCurvilinearSolver::PerformInputChecks()
       }
       case CoordinateSystemType::SPHERICAL:
       {
-        typedef SphericalQuadrature SphAngQuad;
         const auto curvilinear_angular_quad_ptr =
-          std::dynamic_pointer_cast<SphAngQuad>(angular_quad_ptr);
+          std::dynamic_pointer_cast<SphericalQuadrature>(angular_quad_ptr);
         if (curvilinear_angular_quad_ptr == nullptr)
         {
           log.LogAllError() << "D_DO_RZ_SteadyState::SteadyStateSolver::PerformInputChecks : "
@@ -287,8 +285,7 @@ DiscreteOrdinatesCurvilinearSolver::InitializeSpatialDiscretization()
     }
   }
 
-  typedef PieceWiseLinearDiscontinuous SDM_PWLD;
-  discretization_ = SDM_PWLD::New(*grid_ptr_, qorder, system);
+  discretization_ = PieceWiseLinearDiscontinuous::New(*grid_ptr_, qorder, system);
 
   ComputeUnitIntegrals();
 
@@ -321,7 +318,7 @@ DiscreteOrdinatesCurvilinearSolver::InitializeSpatialDiscretization()
     }
   }
 
-  discretization_secondary_ = SDM_PWLD::New(*grid_ptr_, qorder, system);
+  discretization_secondary_ = PieceWiseLinearDiscontinuous::New(*grid_ptr_, qorder, system);
 
   ComputeSecondaryUnitIntegrals();
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -13,7 +13,7 @@
 namespace opensn
 {
 
-typedef PetscErrorCode (*PCShellPtr)(PC, Vec, Vec);
+using PCShellPtr = PetscErrorCode (*)(PC, Vec, Vec);
 
 SweepWGSContext::SweepWGSContext(DiscreteOrdinatesSolver& lbs_solver,
                                  LBSGroupset& groupset,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -1062,8 +1062,7 @@ DiscreteOrdinatesSolver::AssociateSOsAndDirections(const MeshContinuum& grid,
       // Process Product Quadrature
       try
       {
-        typedef ProductQuadrature ProdQuadType;
-        const auto& product_quad = dynamic_cast<const ProdQuadType&>(quadrature);
+        const auto& product_quad = dynamic_cast<const ProductQuadrature&>(quadrature);
 
         const auto num_azi = product_quad.azimu_ang_.size();
         const auto num_pol = product_quad.polar_ang_.size();
@@ -1128,8 +1127,7 @@ DiscreteOrdinatesSolver::AssociateSOsAndDirections(const MeshContinuum& grid,
       // Process Product Quadrature
       try
       {
-        typedef ProductQuadrature ProdQuadType;
-        const auto& product_quad = dynamic_cast<const ProdQuadType&>(quadrature);
+        const auto& product_quad = dynamic_cast<const ProductQuadrature&>(quadrature);
 
         for (const auto& dir_set : product_quad.GetDirectionMap())
         {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.h
@@ -18,7 +18,7 @@ class CBC_ASynchronousCommunicator;
 class DiscreteOrdinatesSolver : public LBSSolver
 {
 protected:
-  typedef std::pair<UniqueSOGroupings, DirIDToSOMap> SwpOrderGroupingInfo;
+  using SweepOrderGroupingInfo = std::pair<UniqueSOGroupings, DirIDToSOMap>;
 
 public:
   /**
@@ -121,7 +121,7 @@ protected:
    */
   virtual std::shared_ptr<SweepChunk> SetSweepChunk(LBSGroupset& groupset);
 
-  std::map<std::shared_ptr<AngularQuadrature>, SwpOrderGroupingInfo>
+  std::map<std::shared_ptr<AngularQuadrature>, SweepOrderGroupingInfo>
     quadrature_unq_so_grouping_map_;
   std::map<std::shared_ptr<AngularQuadrature>, std::vector<std::shared_ptr<SPDS>>>
     quadrature_spds_map_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.cc
@@ -39,10 +39,8 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
 {
   CALI_CXX_MARK_SCOPE("CBC_AngleSet::AngleSetAdvance");
 
-  typedef AngleSetStatus Status;
-
   if (executed_)
-    return Status::FINISHED;
+    return AngleSetStatus::FINISHED;
 
   if (current_task_list_.empty())
     current_task_list_ = cbc_spds_.TaskList();
@@ -59,7 +57,7 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
   // Check if boundaries allow for execution
   for (auto& [bid, boundary] : boundaries_)
     if (not boundary->CheckAnglesReadyStatus(angles_, group_subset_))
-      return Status::NOT_FINISHED;
+      return AngleSetStatus::NOT_FINISHED;
 
   bool all_tasks_completed = true;
   bool a_task_executed = true;
@@ -94,10 +92,10 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
     for (auto& [bid, boundary] : boundaries_)
       boundary->UpdateAnglesReadyStatus(angles_, group_subset_);
     executed_ = true;
-    return Status::FINISHED;
+    return AngleSetStatus::FINISHED;
   }
 
-  return Status::NOT_FINISHED;
+  return AngleSetStatus::NOT_FINISHED;
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/arbitrary_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/arbitrary_boundary.cc
@@ -51,11 +51,9 @@ ArbitraryBoundary::Setup(const MeshContinuum& grid, const AngularQuadrature& qua
 
   size_t num_angles = quadrature.omegas_.size();
 
-  typedef std::pair<double, double> PhiTheta;
-
   std::vector<int> angle_indices;
   std::vector<Vector3> angle_vectors;
-  std::vector<PhiTheta> phi_theta_angles;
+  std::vector<std::pair<double, double>> phi_theta_angles;
   std::vector<int> group_indices;
 
   angle_indices.reserve(num_angles);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/arbitrary_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/arbitrary_boundary.h
@@ -21,10 +21,8 @@ private:
   std::unique_ptr<BoundaryFunction> boundary_function_;
   const uint64_t boundary_id_;
 
-  typedef std::vector<double> FaceNodeData;
-  typedef std::vector<FaceNodeData> FaceData;
-  typedef std::vector<FaceData> CellData;
-
+  using FaceData = std::vector<std::vector<double>>;
+  using CellData = std::vector<FaceData>;
   std::vector<CellData> local_cell_data_;
 
 public:

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/reflecting_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/boundary/reflecting_boundary.h
@@ -16,29 +16,22 @@ namespace opensn
 class ReflectingBoundary : public SweepBoundary
 {
 protected:
-  const opensn::Normal normal_;
+  const Vector3 normal_;
   bool opposing_reflected_ = false;
 
-  /// Groups per DOF
-  typedef std::vector<double> DOFVec;
-  /// DOFs per face
-  typedef std::vector<DOFVec> FaceVec;
-  /// Faces per cell
-  typedef std::vector<FaceVec> CellVec;
-  /// Cell per angle
-  typedef std::vector<CellVec> AngVec;
-
-  // angle,cell,face,dof,group
   // Populated by angle aggregation
-  std::vector<AngVec> boundary_flux_;
-  std::vector<AngVec> boundary_flux_old_;
+  // AngularFluxData indices are: angle, cell per angle, faces per cell, DOFs per face, groups per
+  // DOF
+  using AngularFluxData = std::vector<std::vector<std::vector<std::vector<std::vector<double>>>>>;
+  AngularFluxData boundary_flux_;
+  AngularFluxData boundary_flux_old_;
 
   std::vector<int> reflected_anglenum_;
   std::vector<std::vector<bool>> angle_readyflags_;
 
 public:
   ReflectingBoundary(size_t num_groups,
-                     const Normal& normal,
+                     const Vector3& normal,
                      CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN)
     : SweepBoundary(BoundaryType::REFLECTING, num_groups, coord_type), normal_(normal)
   {
@@ -50,9 +43,9 @@ public:
 
   void SetOpposingReflected(bool value) { opposing_reflected_ = value; }
 
-  std::vector<AngVec>& GetBoundaryFluxNew() { return boundary_flux_; }
+  AngularFluxData& GetBoundaryFluxNew() { return boundary_flux_; }
 
-  std::vector<AngVec>& GetBoundaryFluxOld() { return boundary_flux_old_; }
+  AngularFluxData& GetBoundaryFluxOld() { return boundary_flux_old_; }
 
   std::vector<int>& GetReflectedAngleIndexMap() { return reflected_anglenum_; }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/cbc_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/cbc_async_comm.cc
@@ -32,18 +32,16 @@ CBC_ASynchronousCommunicator::SendData()
 {
   CALI_CXX_MARK_SCOPE("CBC_ASynchronousCommunicator::SendData");
 
-  typedef int MPIRank;
-
   // First we convert any new outgoing messages from the queue into
   // buffer messages. We aggregate these messages per location-id
   // they need to be sent to
   if (not outgoing_message_queue_.empty())
   {
-    std::map<MPIRank, BufferItem> locI_buffer_map;
+    std::map<int, BufferItem> locI_buffer_map;
 
     for (const auto& [msg_key, data] : outgoing_message_queue_)
     {
-      const MPIRank locI = std::get<0>(msg_key);
+      const int locI = std::get<0>(msg_key);
       const uint64_t cell_global_id = std::get<1>(msg_key);
       const unsigned int face_id = std::get<2>(msg_key);
       const size_t data_size = data.size();
@@ -95,8 +93,7 @@ CBC_ASynchronousCommunicator::ReceiveData()
 {
   CALI_CXX_MARK_SCOPE("CBC_ASynchronousCommunicator::ReceiveData");
 
-  typedef std::pair<uint64_t, unsigned int> CellFaceKey; // cell_gid + face_id
-
+  using CellFaceKey = std::pair<uint64_t, unsigned int>; // cell_gid + face_id
   std::map<CellFaceKey, std::vector<double>> received_messages;
   std::vector<uint64_t> cells_who_received_data;
   auto& location_dependencies = fluds_.GetSPDS().GetLocationDependencies();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/aah_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/aah_fluds_common_data.cc
@@ -13,7 +13,7 @@
 namespace opensn
 {
 
-typedef std::vector<std::pair<int, short>> LockBox;
+using LockBox = std::vector<std::pair<int, short>>;
 
 AAH_FLUDSCommonData::AAH_FLUDSCommonData(
   const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/aah_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/aah_fluds_common_data.h
@@ -16,10 +16,10 @@ class Cell;
 class CellFace;
 
 // face_slot index, vertex ids
-typedef std::pair<int, std::vector<uint64_t>> CompactFaceView;
+using CompactFaceView = std::pair<int, std::vector<uint64_t>>;
 
 // cell_global_id, faces
-typedef std::pair<int, std::vector<CompactFaceView>> CompactCellView;
+using CompactCellView = std::pair<int, std::vector<CompactFaceView>>;
 
 class SPDS;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.h
@@ -69,9 +69,8 @@ public:
     return delayed_prelocI_outgoing_psi_old_;
   }
 
-  // cell_global_id
-  // face_id
-  typedef std::pair<uint64_t, unsigned int> CellFaceKey;
+  // cell_global_id, face_id
+  using CellFaceKey = std::pair<uint64_t, unsigned int>;
 
   std::map<CellFaceKey, std::vector<double>>& DeplocsOutgoingMessages()
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/fluds_common_data.h
@@ -29,7 +29,7 @@ struct FaceNodalMapping
   {
   }
 };
-typedef std::vector<FaceNodalMapping> CellFaceNodalMapping;
+using CellFaceNodalMapping = std::vector<FaceNodalMapping>;
 
 class FLUDSCommonData
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
@@ -61,7 +61,7 @@ SweepScheduler::InitializeAlgoDOG()
   // Loop over angleset groups
   for (size_t q = 0; q < angle_agg_.angle_set_groups.size(); q++)
   {
-    TAngleSetGroup& angleset_group = angle_agg_.angle_set_groups[q];
+    AngleSetGroup& angleset_group = angle_agg_.angle_set_groups[q];
 
     // Loop over anglesets in group
     size_t num_anglesets = angleset_group.AngleSets().size();
@@ -70,7 +70,7 @@ SweepScheduler::InitializeAlgoDOG()
       auto angleset = angleset_group.AngleSets()[as];
       const auto& spds = dynamic_cast<const SPDS_AdamsAdamsHawkins&>(angleset->GetSPDS());
 
-      const TLEVELED_GRAPH& leveled_graph = spds.GetGlobalSweepPlanes();
+      const std::vector<STDG>& leveled_graph = spds.GetGlobalSweepPlanes();
 
       // Find location depth
       int loc_depth = -1;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.h
@@ -17,12 +17,6 @@ enum class SchedulingAlgorithm
   DEPTH_OF_GRAPH = 2      ///< DOG
 };
 
-typedef AngleSetGroup TAngleSetGroup;
-typedef AngleSet TAngleSet;
-typedef STDG TGSPO;
-
-typedef std::vector<TGSPO> TLEVELED_GRAPH;
-
 class SweepScheduler
 {
 private:
@@ -31,14 +25,14 @@ private:
 
   struct RULE_VALUES
   {
-    std::shared_ptr<TAngleSet> angle_set;
+    std::shared_ptr<AngleSet> angle_set;
     int depth_of_graph;
     int sign_of_omegax;
     int sign_of_omegay;
     int sign_of_omegaz;
     size_t set_index;
 
-    explicit RULE_VALUES(std::shared_ptr<TAngleSet>& ref_as) : angle_set(ref_as)
+    explicit RULE_VALUES(std::shared_ptr<AngleSet>& ref_as) : angle_set(ref_as)
     {
       depth_of_graph = 0;
       set_index = 0;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
@@ -22,11 +22,16 @@ public:
   const Vector3& Omega() const { return omega_; }
   const SPLS& GetSPLS() const { return spls_; }
 
-  typedef std::vector<int> VecInt;
-  const VecInt& GetLocationDependencies() const { return location_dependencies_; }
-  const VecInt& GetLocationSuccessors() const { return location_successors_; }
-  const VecInt& GetDelayedLocationDependencies() const { return delayed_location_dependencies_; }
-  const VecInt& GetDelayedLocationSuccessors() const { return delayed_location_successors_; }
+  const std::vector<int>& GetLocationDependencies() const { return location_dependencies_; }
+  const std::vector<int>& GetLocationSuccessors() const { return location_successors_; }
+  const std::vector<int>& GetDelayedLocationDependencies() const
+  {
+    return delayed_location_dependencies_;
+  }
+  const std::vector<int>& GetDelayedLocationSuccessors() const
+  {
+    return delayed_location_successors_;
+  }
   const std::vector<std::pair<int, int>>& GetLocalCyclicDependencies() const
   {
     return local_cyclic_dependencies_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -18,15 +18,15 @@ public:
   /**
    * Convenient typdef for the moment call back function. See moment_callbacks.
    */
-  typedef std::function<void(SweepChunk* sweeper, AngleSet* angle_set)> MomentCallbackF;
+  using MomentCallbackFunc = std::function<void(SweepChunk* sweeper, AngleSet* angle_set)>;
 
   /**
-   * Functions of type MomentCallbackF can be added to the moment_callbacks
+   * Functions of type MomentCallbackFunc can be added to the moment_callbacks
    * vector and these can be called from within functions taking a
    * LBSGroupset instance. The intention is that this function can
    * be used as a general interface to retrieve angular flux values
    */
-  std::vector<MomentCallbackF> moment_callbacks;
+  std::vector<MomentCallbackFunc> moment_callbacks;
 
   SweepChunk(std::vector<double>& destination_phi,
              std::vector<double>& destination_psi,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_transient_solver/sweep_chunks/lbts_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_transient_solver/sweep_chunks/lbts_sweep_chunk_pwl.cc
@@ -111,7 +111,6 @@ SweepChunkPWLTransientTheta::Sweep(opensn::AngleSet* angle_set)
   auto const& m2d_op = groupset_.quadrature_->GetMomentToDiscreteOperator();
 
   const auto& psi_uk_man = groupset_.psi_uk_man_;
-  typedef const int64_t cint64_t;
 
   const bool fixed_src_active = surface_source_active;
   //  const bool fixed_src_active = true;
@@ -239,7 +238,7 @@ SweepChunkPWLTransientTheta::Sweep(opensn::AngleSet* angle_set)
             const size_t ir = transport_view.MapDOF(i, m, g);
             temp_src += m2d_op[m][angle_num] * q_moments_[ir];
           } // for m
-          cint64_t imap = grid_fe_view_.MapDOFLocal(cell, i, psi_uk_man, angle_num, 0);
+          const int64_t imap = grid_fe_view_.MapDOFLocal(cell, i, psi_uk_man, angle_num, 0);
           if (fixed_src_active) temp_src += tau_gsg[gsg] * psi_prev_[imap + gsg];
           source_[i] = temp_src;
         } // for i
@@ -284,7 +283,7 @@ SweepChunkPWLTransientTheta::Sweep(opensn::AngleSet* angle_set)
       {
         for (int i = 0; i < num_nodes; ++i)
         {
-          cint64_t imap = grid_fe_view_.MapDOFLocal(cell, i, psi_uk_man, angle_num, gs_ss_begin);
+          const int64_t imap = grid_fe_view_.MapDOFLocal(cell, i, psi_uk_man, angle_num, gs_ss_begin);
           for (int gsg = 0; gsg < gs_ss_size; ++gsg)
             output_psi[imap + gsg] = b_[gsg][i];
           // inv_theta*(b_[gsg][i] + (theta_ - 1.0) * psi_prev_[imap + gsg]);

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/acceleration.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/acceleration.cc
@@ -39,9 +39,7 @@ PackGroupsetXS(const std::map<int, std::shared_ptr<MultiGroupXS>>& matid_to_xs_m
   const int num_gs_groups = last_group_index - first_grp_index + 1;
   OpenSnInvalidArgumentIf(num_gs_groups < 0, "last_grp_index must be >= first_grp_index");
 
-  typedef Multigroup_D_and_sigR MultiGroupXS;
-  typedef std::map<int, Multigroup_D_and_sigR> MatID2XSMap;
-  MatID2XSMap matid_2_mgxs_map;
+  std::map<int, Multigroup_D_and_sigR> matid_2_mgxs_map;
   for (const auto& matid_xs_pair : matid_to_xs_map)
   {
     const auto& mat_id = matid_xs_pair.first;
@@ -60,7 +58,7 @@ PackGroupsetXS(const std::map<int, std::shared_ptr<MultiGroupXS>>& matid_to_xs_m
       ++g;
     } // for g
 
-    matid_2_mgxs_map.insert(std::make_pair(mat_id, MultiGroupXS{D, sigma_r}));
+    matid_2_mgxs_map.insert(std::make_pair(mat_id, Multigroup_D_and_sigR{D, sigma_r}));
   }
 
   return matid_2_mgxs_map;

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion.h
@@ -22,7 +22,7 @@ struct Multigroup_D_and_sigR;
 class DiffusionSolver
 {
 protected:
-  typedef std::map<int, Multigroup_D_and_sigR> MatID2XSMap;
+  using MatID2XSMap = std::map<int, Multigroup_D_and_sigR>;
 
   const std::string text_name_;
   const MeshContinuum& grid_;

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
@@ -130,14 +130,12 @@ DiffusionMIPSolver::AssembleAand_b_wQpoints(const std::vector<double>& q_vector)
 
         const double hm = HPerpendicular(cell, f);
 
-        typedef MeshContinuum Grid;
-
         if (face.has_neighbor_)
         {
           const auto& adj_cell = grid_.cells[face.neighbor_id_];
           const auto& adj_cell_mapping = sdm_.GetCellMapping(adj_cell);
           const auto ac_nodes = adj_cell_mapping.GetNodeLocations();
-          const size_t acf = Grid::MapCellFace(cell, adj_cell, f);
+          const size_t acf = MeshContinuum::MapCellFace(cell, adj_cell, f);
           const double hp = HPerpendicular(adj_cell, acf);
 
           const auto& adj_xs = mat_id_2_xs_map_.at(adj_cell.material_id_);
@@ -658,14 +656,12 @@ DiffusionMIPSolver::AssembleAand_b(const std::vector<double>& q_vector)
 
         const double hm = HPerpendicular(cell, f);
 
-        typedef MeshContinuum Grid;
-
         if (face.has_neighbor_)
         {
           const auto& adj_cell = grid_.cells[face.neighbor_id_];
           const auto& adj_cell_mapping = sdm_.GetCellMapping(adj_cell);
           const auto ac_nodes = adj_cell_mapping.GetNodeLocations();
-          const size_t acf = Grid::MapCellFace(cell, adj_cell, f);
+          const size_t acf = MeshContinuum::MapCellFace(cell, adj_cell, f);
           const double hp = HPerpendicular(adj_cell, acf);
 
           const auto& adj_xs = mat_id_2_xs_map_.at(adj_cell.material_id_);

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_pwlc_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_pwlc_solver.cc
@@ -69,8 +69,7 @@ DiffusionPWLCSolver::AssembleAand_b(const std::vector<double>& q_vector)
     const auto& xs = mat_id_2_xs_map_.at(cell.material_id_);
 
     // Mark dirichlet nodes
-    typedef std::pair<bool, double> DirichFlagVal;
-    std::vector<DirichFlagVal> node_is_dirichlet(num_nodes, {false, 0.0});
+    std::vector<std::pair<bool, double>> node_is_dirichlet(num_nodes, {false, 0.0});
     for (size_t f = 0; f < num_faces; ++f)
     {
       const auto& face = cell.faces_[f];
@@ -268,8 +267,7 @@ DiffusionPWLCSolver::Assemble_b(const std::vector<double>& q_vector)
     const auto& xs = mat_id_2_xs_map_.at(cell.material_id_);
 
     // Mark dirichlet nodes
-    typedef std::pair<bool, double> DirichFlagVal;
-    std::vector<DirichFlagVal> node_is_dirichlet(num_nodes, {false, 0.0});
+    std::vector<std::pair<bool, double>> node_is_dirichlet(num_nodes, {false, 0.0});
     for (size_t f = 0; f < num_faces; ++f)
     {
       const auto& face = cell.faces_[f];

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -1833,17 +1833,15 @@ LBSSolver::InitTGDSA(LBSGroupset& groupset)
     }
 
     // Make xs map
-    typedef Multigroup_D_and_sigR MultiGroupXS;
-    typedef std::map<int, MultiGroupXS> MatID2MGDXSMap;
-    MatID2MGDXSMap matid_2_mgxs_map;
+    std::map<int, Multigroup_D_and_sigR> matid_2_mgxs_map;
     for (const auto& matid_xs_pair : matid_to_xs_map_)
     {
       const auto& mat_id = matid_xs_pair.first;
 
       const auto& tg_info = groupset.tg_acceleration_info_.map_mat_id_2_tginfo.at(mat_id);
 
-      matid_2_mgxs_map.insert(
-        std::make_pair(mat_id, MultiGroupXS{{tg_info.collapsed_D}, {tg_info.collapsed_sig_a}}));
+      matid_2_mgxs_map.insert(std::make_pair(
+        mat_id, Multigroup_D_and_sigR{{tg_info.collapsed_D}, {tg_info.collapsed_sig_a}}));
     }
 
     // Create solver

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
@@ -15,7 +15,6 @@ namespace opensn
 using DirIDs = std::vector<size_t>; ///< Direction-IDs
 using UniqueSOGroupings = std::vector<DirIDs>;
 using DirIDToSOMap = std::map<size_t, size_t>;
-using MatVec3 = std::vector<std::vector<Vector3>>;
 
 enum class SolverType
 {
@@ -194,12 +193,11 @@ enum class PhiSTLOption
 
 class LBSGroupset;
 
-typedef std::function<void(const LBSGroupset& groupset,
-                           std::vector<double>& q,
-                           const std::vector<double>& phi,
-                           const std::vector<double>& densities,
-                           const SourceFlags source_flags)>
-  SetSourceFunction;
+using SetSourceFunction = std::function<void(const LBSGroupset& groupset,
+                                             std::vector<double>& q,
+                                             const std::vector<double>& phi,
+                                             const std::vector<double>& densities,
+                                             const SourceFlags source_flags)>;
 
 /**Struct for storing LBS options.*/
 struct LBSOptions

--- a/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.h
@@ -64,7 +64,7 @@ public:
 
   virtual double AddSourceMoments() const;
 
-  typedef std::vector<MultiGroupXS::Precursor> PrecursorList;
+  using PrecursorList = std::vector<MultiGroupXS::Precursor>;
   /**Adds delayed particle precursor sources.*/
   virtual double AddDelayedFission(const PrecursorList& precursors,
                                    const double& rho,

--- a/test/framework/math/math_test_01_wdd_ijk_sweep.cc
+++ b/test/framework/math/math_test_01_wdd_ijk_sweep.cc
@@ -20,14 +20,12 @@ RegisterWrapperFunctionInNamespace(unit_tests,
                                    nullptr,
                                    math_Test01_WDD_IJK_Sweep);
 
-typedef NDArray<double> IJKArrayDbl;
-
-IJKArrayDbl
+NDArray<double>
 WDD_IJK_Sweep2(const std::array<size_t, 3>& mesh_divs,
                const std::array<double, 3>& mesh_lengths,
                const std::array<double, 6>& bcs,
-               const IJKArrayDbl& sigma_t,
-               const IJKArrayDbl& q,
+               const NDArray<double>& sigma_t,
+               const NDArray<double>& q,
                const AngularQuadrature& quad,
                bool verbose = false)
 {
@@ -39,7 +37,7 @@ WDD_IJK_Sweep2(const std::array<size_t, 3>& mesh_divs,
   const double dy = mesh_lengths[1] / Ny;
   const double dz = mesh_lengths[2] / Nz;
 
-  IJKArrayDbl phi_0(mesh_divs);
+  NDArray<double> phi_0(mesh_divs);
   phi_0.set(0.0);
 
   auto iorder = Range<int>(0, Nx);
@@ -71,9 +69,9 @@ WDD_IJK_Sweep2(const std::array<size_t, 3>& mesh_divs,
       korder = Range<int>(Nz - 1, -1, -1);
 
     // Sweep cells
-    IJKArrayDbl psi_ds_x(mesh_divs);
-    IJKArrayDbl psi_ds_y(mesh_divs);
-    IJKArrayDbl psi_ds_z(mesh_divs);
+    NDArray<double> psi_ds_x(mesh_divs);
+    NDArray<double> psi_ds_y(mesh_divs);
+    NDArray<double> psi_ds_z(mesh_divs);
     for (auto k : korder)
       for (auto j : jorder)
         for (auto i : iorder)
@@ -136,8 +134,8 @@ math_Test01_WDD_IJK_Sweep(const InputParameters&)
   const std::array<double, 3> mesh_lengths = {1.0, 1.0, 10.0};
   const std::array<double, 6> bcs = {0.0, 0.0, 0.0, 0.0, 0.5, 0.0};
 
-  IJKArrayDbl sigma_t(mesh_divisions, 0.2);
-  IJKArrayDbl q(mesh_divisions, 0.0);
+  NDArray<double> sigma_t(mesh_divisions, 0.2);
+  NDArray<double> q(mesh_divisions, 0.0);
 
   //  sigma_t.Set(0.2);
   //  q.Set(0.0);

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -147,14 +147,12 @@ math_SDM_Test02_DisContinuous(const InputParameters& input_parameters)
 
       const double hm = HPerpendicular(cell_mapping, f);
 
-      typedef MeshContinuum Grid;
-
       if (face.has_neighbor_)
       {
         const auto& adj_cell = grid.cells[face.neighbor_id_];
         const auto& adj_cell_mapping = sdm.GetCellMapping(adj_cell);
         const auto ac_nodes = adj_cell_mapping.GetNodeLocations();
-        const size_t acf = Grid::MapCellFace(cell, adj_cell, f);
+        const size_t acf = MeshContinuum::MapCellFace(cell, adj_cell, f);
         const double hp = HPerpendicular(adj_cell_mapping, acf);
 
         // Compute kappa

--- a/test/framework/tutorials/tutorial_06_wdd.cc
+++ b/test/framework/tutorials/tutorial_06_wdd.cc
@@ -14,7 +14,6 @@ using namespace opensn;
 
 namespace unit_sim_tests
 {
-typedef AngularQuadrature::HarmonicIndices YlmIndices;
 double ComputeRelativePWChange(const MeshContinuum& grid,
                                const SpatialDiscretization& sdm,
                                const UnknownManager& phi_uk_man,
@@ -27,7 +26,7 @@ std::vector<double> SetSource(const MeshContinuum& grid,
                               const std::vector<double>& q_source,
                               const std::vector<double>& phi_old,
                               const MultiGroupXS& xs,
-                              const std::vector<YlmIndices>& m_ell_em_map);
+                              const std::vector<AngularQuadrature::HarmonicIndices>& m_ell_em_map);
 
 /**WDD Sweep. */
 ParameterBlock SimTest06_WDD(const InputParameters&);
@@ -153,10 +152,9 @@ SimTest06_WDD(const InputParameters&)
   }     // for cell
 
   // Define sweep chunk
-  typedef NDArray<double> IJKArrayDbl;
-  IJKArrayDbl psi_ds_x(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
-  IJKArrayDbl psi_ds_y(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
-  IJKArrayDbl psi_ds_z(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
+  NDArray<double> psi_ds_x(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
+  NDArray<double> psi_ds_y(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
+  NDArray<double> psi_ds_z(std::array<int64_t, 4>{Nx, Ny, Nz, num_groups});
 
   auto SweepChunk = [&ijk_info,
                      &ijk_mapping,
@@ -392,7 +390,7 @@ SetSource(const MeshContinuum& grid,
           const std::vector<double>& q_source,
           const std::vector<double>& phi_old,
           const MultiGroupXS& xs,
-          const std::vector<YlmIndices>& m_ell_em_map)
+          const std::vector<AngularQuadrature::HarmonicIndices>& m_ell_em_map)
 {
   const size_t num_local_phi_dofs = sdm.GetNumLocalDOFs(phi_uk_man);
   std::vector<double> source_moments(num_local_phi_dofs, 0.0);

--- a/test/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/framework/tutorials/tutorial_91a_pwld.cc
@@ -138,10 +138,9 @@ SimTest91_PWLD(const InputParameters&)
   }
 
   // Precompute cell matrices
-  typedef std::vector<Vector3> VecVec3;
-  typedef std::vector<VecVec3> MatVec3;
-  typedef std::vector<std::vector<double>> MatDbl;
-  typedef std::vector<MatDbl> VecMatDbl;
+  using MatVec3 = std::vector<std::vector<Vector3>>;
+  using MatDbl = std::vector<std::vector<double>>;
+  using VecMatDbl = std::vector<MatDbl>;
 
   std::vector<MatVec3> cell_Gmatrices;
   std::vector<MatDbl> cell_Mmatrices;
@@ -153,7 +152,7 @@ SimTest91_PWLD(const InputParameters&)
     const size_t num_nodes = cell_mapping.NumNodes();
     const auto fe_vol_data = cell_mapping.MakeVolumetricFiniteElementData();
 
-    MatVec3 IntV_shapeI_gradshapeJ(num_nodes, VecVec3(num_nodes, Vector3(0, 0, 0)));
+    MatVec3 IntV_shapeI_gradshapeJ(num_nodes, std::vector<Vector3>(num_nodes, Vector3(0, 0, 0)));
     MatDbl IntV_shapeI_shapeJ(num_nodes, std::vector<double>(num_nodes, 0.0));
 
     for (unsigned int i = 0; i < num_nodes; ++i)

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
@@ -23,7 +23,7 @@ RegisterWrapperFunctionInNamespace(unit_tests,
 ParameterBlock
 acceleration_Diffusion_CFEM(const InputParameters&)
 {
-  typedef std::map<int, Multigroup_D_and_sigR> MatID2XSMap;
+  using MatID2XSMap = std::map<int, Multigroup_D_and_sigR>;
   opensn::log.Log() << "SimTest92_DSA";
 
   // Get grid
@@ -45,14 +45,7 @@ acceleration_Diffusion_CFEM(const InputParameters&)
   opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
 
   // Make Boundary conditions
-  typedef BoundaryCondition BC;
-  std::map<uint64_t, BC> bcs;
-  // bcs[0] = {BCType::DIRICHLET,{1.0,0,0}},
-  // bcs[1] = {BCType::DIRICHLET,{1.0,0,0}},
-  // bcs[2] = {BCType::DIRICHLET,{1.0,0,0}},
-  // bcs[3] = {BCType::DIRICHLET,{1.0,0,0}},
-  // bcs[4] = {BCType::DIRICHLET,{1.0,0,0}},
-  // bcs[5] = {BCType::DIRICHLET,{1.0,0,0}};
+  std::map<uint64_t, BoundaryCondition> bcs;
   bcs[0] = {BCType::ROBIN, {0.25, 0.5, 0}}, bcs[1] = {BCType::ROBIN, {0.25, 0.5, 0}},
   bcs[2] = {BCType::ROBIN, {0.25, 0.5, 0}}, bcs[3] = {BCType::ROBIN, {0.25, 0.5, 0}},
   bcs[4] = {BCType::ROBIN, {0.25, 0.5, 0}}, bcs[5] = {BCType::ROBIN, {0.25, 0.5, 0}};
@@ -64,8 +57,7 @@ acceleration_Diffusion_CFEM(const InputParameters&)
   unit_cell_matrices.resize(grid.local_cells.size());
 
   // Build unit integrals
-  typedef std::vector<Vector3> VecVec3;
-  typedef std::vector<VecVec3> MatVec3;
+  using MatVec3 = std::vector<std::vector<Vector3>>;
   for (const auto& cell : grid.local_cells)
   {
     const auto& cell_mapping = sdm.GetCellMapping(cell);
@@ -110,7 +102,7 @@ acceleration_Diffusion_CFEM(const InputParameters&)
       const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
       IntS_shapeI_shapeJ[f].resize(cell_num_nodes, std::vector<double>(cell_num_nodes));
       IntS_shapeI[f].resize(cell_num_nodes);
-      IntS_shapeI_gradshapeJ[f].resize(cell_num_nodes, VecVec3(cell_num_nodes));
+      IntS_shapeI_gradshapeJ[f].resize(cell_num_nodes, std::vector<Vector3>(cell_num_nodes));
 
       for (unsigned int i = 0; i < cell_num_nodes; ++i)
       {

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
@@ -40,7 +40,7 @@ RegisterWrapperFunctionInNamespace(unit_tests,
 ParameterBlock
 acceleration_Diffusion_DFEM(const InputParameters&)
 {
-  typedef std::map<int, Multigroup_D_and_sigR> MatID2XSMap;
+  using MatID2XSMap = std::map<int, Multigroup_D_and_sigR>;
   opensn::log.Log() << "SimTest92_DSA";
 
   // Get grid
@@ -62,8 +62,7 @@ acceleration_Diffusion_DFEM(const InputParameters&)
   opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
 
   // Make Boundary conditions
-  typedef BoundaryCondition BC;
-  std::map<uint64_t, BC> bcs;
+  std::map<uint64_t, BoundaryCondition> bcs;
   bcs[0] = {BCType::DIRICHLET, {2, 0, 0}}, bcs[1] = {BCType::DIRICHLET, {2, 0, 0}},
   bcs[2] = {BCType::DIRICHLET, {2, 0, 0}}, bcs[3] = {BCType::DIRICHLET, {2, 0, 0}},
   bcs[4] = {BCType::DIRICHLET, {2, 0, 0}}, bcs[5] = {BCType::DIRICHLET, {2, 0, 0}};
@@ -75,8 +74,7 @@ acceleration_Diffusion_DFEM(const InputParameters&)
   unit_cell_matrices.resize(grid.local_cells.size());
 
   // Build unit integrals
-  typedef std::vector<Vector3> VecVec3;
-  typedef std::vector<VecVec3> MatVec3;
+  using MatVec3 = std::vector<std::vector<Vector3>>;
   for (const auto& cell : grid.local_cells)
   {
     const auto& cell_mapping = sdm.GetCellMapping(cell);
@@ -121,7 +119,7 @@ acceleration_Diffusion_DFEM(const InputParameters&)
       const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
       IntS_shapeI_shapeJ[f].resize(cell_num_nodes, std::vector<double>(cell_num_nodes));
       IntS_shapeI[f].resize(cell_num_nodes);
-      IntS_shapeI_gradshapeJ[f].resize(cell_num_nodes, VecVec3(cell_num_nodes));
+      IntS_shapeI_gradshapeJ[f].resize(cell_num_nodes, std::vector<Vector3>(cell_num_nodes));
 
       for (unsigned int i = 0; i < cell_num_nodes; ++i)
       {


### PR DESCRIPTION
This PR removes unnecessary `typedefs` throughout the code base. `typedefs` that promoted code readability have been converted to `using` statements.

I apologize for the size of the PR. A small handful of `typedef` removals touched a large number of files, but it didn't seem practical to try to split the PR into multiple small ones.

Closes #86