### PR TITLE
Remove densities from SetSourceFunction call signature

### DIFF
--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
@@ -47,7 +47,7 @@ DiffusionDFEMSolver::Initialize()
   // Initialize source func
   using namespace std::placeholders;
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
 
   // Initialize groupsets preconditioning
   for (auto& groupset : groupsets_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
@@ -59,7 +59,7 @@ DiscreteOrdinatesAdjointSolver::Initialize()
   using namespace std::placeholders;
   auto src_function = std::make_shared<SourceFunction>(*this);
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
 
   // Initialize groupsets for sweeping
   InitializeSweepDataStructures();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -154,11 +154,7 @@ SweepWGSContext::PostSolveCallback()
   {
     lbs_ss_solver_.ZeroOutflowBalanceVars(groupset_);
     const auto scope = lhs_src_scope_ | rhs_src_scope_;
-    set_source_function_(groupset_,
-                         lbs_solver_.QMomentsLocal(),
-                         lbs_solver_.PhiOldLocal(),
-                         lbs_solver_.DensitiesLocal(),
-                         scope);
+    set_source_function_(groupset_, lbs_solver_.QMomentsLocal(), lbs_solver_.PhiOldLocal(), scope);
     sweep_scheduler_.SetDestinationPhi(lbs_solver_.PhiNewLocal());
     ApplyInverseTransportOperator(scope);
     lbs_solver_.GSScopedCopyPrimarySTLvectors(

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -115,7 +115,7 @@ DiscreteOrdinatesSolver::Initialize()
   using namespace std::placeholders;
   auto src_function = std::make_shared<SourceFunction>(*this);
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
 
   // Initialize groupsets for sweeping
   InitializeSweepDataStructures();
@@ -631,7 +631,6 @@ DiscreteOrdinatesSolver::ComputeBalance()
     active_set_source_function_(groupset,
                                 q_moments_local_,
                                 phi_old_local_,
-                                densities_local_,
                                 APPLY_FIXED_SOURCES | APPLY_AGS_FISSION_SOURCES |
                                   APPLY_WGS_FISSION_SOURCES);
     LBSSolver::GSScopedCopyPrimarySTLvectors(groupset, q_moments_local_, mat_src);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_transient_solver/lbts_transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_transient_solver/lbts_transient_solver.cc
@@ -62,7 +62,7 @@ DiscOrdTransientSolver::Initialize()
 
   using namespace std::placeholders;
   active_set_source_function_ =
-    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4, _5);
+    std::bind(&SourceFunction::operator(), src_function, _1, _2, _3, _4);
 }
 
 void

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen.cc
@@ -179,11 +179,8 @@ PowerIterationKEigen::SetLBSFissionSource(const std::vector<double>& input, cons
 
   for (auto& groupset : groupsets_)
   {
-    active_set_source_function_(groupset,
-                                q_moments_local_,
-                                input,
-                                lbs_solver_.DensitiesLocal(),
-                                APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+    active_set_source_function_(
+      groupset, q_moments_local_, input, APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   }
 }
 
@@ -201,8 +198,7 @@ PowerIterationKEigen::SetLBSScatterSource(const std::vector<double>& input,
 
   for (auto& groupset : groupsets_)
   {
-    active_set_source_function_(
-      groupset, q_moments_local_, input, lbs_solver_.DensitiesLocal(), source_flags);
+    active_set_source_function_(groupset, q_moments_local_, input, source_flags);
   }
 }
 

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_smm.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_smm.cc
@@ -796,11 +796,8 @@ PowerIterationKEigenSMM::SetNodalDiffusionFissionSource(const std::vector<double
   TransferDiffusionToTransport(phi0, phi);
 
   std::vector<double> Sf(phi.size(), 0.0);
-  active_set_source_function_(front_gs_,
-                              Sf,
-                              phi,
-                              lbs_solver_.DensitiesLocal(),
-                              APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+  active_set_source_function_(
+    front_gs_, Sf, phi, APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   return Sf;
 }
 
@@ -824,7 +821,6 @@ PowerIterationKEigenSMM::SetNodalDiffusionScatterSource(const std::vector<double
   active_set_source_function_(front_gs_,
                               Ss,
                               phi,
-                              lbs_solver_.DensitiesLocal(),
                               APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES |
                                 SUPPRESS_WG_SCATTER);
   return Ss;

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/nl_keigen_acc_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/nl_keigen_acc_residual_func.cc
@@ -26,7 +26,6 @@ NLKEigenAccResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   auto& q_moments_local = lbs_solver.QMomentsLocal();
   auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto phi_temp = phi_old_local;
-  const auto& densities_local = lbs_solver.DensitiesLocal();
 
   const auto& phi_l = nl_context_ptr->phi_l_;
   const auto& phi_lph_i = nl_context_ptr->phi_lph_i_;
@@ -35,26 +34,23 @@ NLKEigenAccResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   const auto& Sf = nl_context_ptr->Sf_;
 
   // Lambdas
-  auto SetLBSFissionSource = [&active_set_source_function, &front_gs, &densities_local](
+  auto SetLBSFissionSource = [&active_set_source_function, &front_gs](
                                const std::vector<double>& input, std::vector<double>& output)
   {
     Set(output, 0.0);
-    active_set_source_function(front_gs,
-                               output,
-                               input,
-                               densities_local,
-                               APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+    active_set_source_function(
+      front_gs, output, input, APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   };
 
   auto SetLBSScatterSource =
-    [&active_set_source_function, &front_gs, &densities_local](
-      const std::vector<double>& input, std::vector<double>& output, bool suppress_wgs)
+    [&active_set_source_function,
+     &front_gs](const std::vector<double>& input, std::vector<double>& output, bool suppress_wgs)
   {
     Set(output, 0.0);
     SourceFlags source_flags = APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES;
     if (suppress_wgs)
       source_flags |= SUPPRESS_WG_SCATTER;
-    active_set_source_function(front_gs, output, input, densities_local, source_flags);
+    active_set_source_function(front_gs, output, input, source_flags);
   };
 
   auto SetPhi0FissionSource =

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/nl_keigen_ags_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/nl_keigen_ags_residual_func.cc
@@ -22,7 +22,6 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   auto& lbs_solver = nl_context_ptr->lbs_solver_;
   const auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto& q_moments_local = lbs_solver.QMomentsLocal();
-  const auto& densities_local = lbs_solver.DensitiesLocal();
 
   auto active_set_source_function = lbs_solver.GetActiveSetSourceFunction();
 
@@ -39,7 +38,6 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
     active_set_source_function(groupset,
                                q_moments_local,
                                phi_old_local,
-                               densities_local,
                                APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
 
   const double k_eff = lbs_solver.ComputeFissionProduction(phi_old_local);
@@ -53,8 +51,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
     SourceFlags source_flags = APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES;
     if (supress_wgs)
       source_flags |= SUPPRESS_WG_SCATTER;
-    active_set_source_function(
-      groupset, q_moments_local, phi_old_local, densities_local, source_flags);
+    active_set_source_function(groupset, q_moments_local, phi_old_local, source_flags);
   }
 
   // Sweep all the groupsets

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/power_iteration_keigen.cc
@@ -35,7 +35,6 @@ PowerIterationKEigen(LBSSolver& lbs_solver, double tolerance, int max_iterations
   auto& q_moments_local = lbs_solver.QMomentsLocal();
   auto& phi_old_local = lbs_solver.PhiOldLocal();
   auto& phi_new_local = lbs_solver.PhiNewLocal();
-  const auto& densities_local = lbs_solver.DensitiesLocal();
   auto primary_ags_solver = lbs_solver.GetPrimaryAGSSolver();
   auto& groupsets = lbs_solver.Groupsets();
   auto active_set_source_function = lbs_solver.GetActiveSetSourceFunction();
@@ -60,7 +59,6 @@ PowerIterationKEigen(LBSSolver& lbs_solver, double tolerance, int max_iterations
       active_set_source_function(groupset,
                                  q_moments_local,
                                  phi_old_local,
-                                 densities_local,
                                  APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
 
     Scale(q_moments_local, 1.0 / k_eff);

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.cc
@@ -43,11 +43,7 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
   // Setting the source using updated phi_old
   auto& q_moments_local = lbs_solver_.QMomentsLocal();
   q_moments_local.assign(q_moments_local.size(), 0.0);
-  set_source_function_(groupset,
-                       q_moments_local,
-                       lbs_solver.PhiOldLocal(),
-                       lbs_solver.DensitiesLocal(),
-                       lhs_src_scope_);
+  set_source_function_(groupset, q_moments_local, lbs_solver.PhiOldLocal(), lhs_src_scope_);
 
   // Apply transport operator
   gs_context_ptr->ApplyInverseTransportOperator(lhs_src_scope_);

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_linear_solver.cc
@@ -173,11 +173,8 @@ WGSLinearSolver::SetRHS()
   if (not single_richardson)
   {
     const auto scope = gs_context_ptr->rhs_src_scope_ | ZERO_INCOMING_DELAYED_PSI;
-    gs_context_ptr->set_source_function_(groupset,
-                                         lbs_solver.QMomentsLocal(),
-                                         lbs_solver.PhiOldLocal(),
-                                         lbs_solver.DensitiesLocal(),
-                                         scope);
+    gs_context_ptr->set_source_function_(
+      groupset, lbs_solver.QMomentsLocal(), lbs_solver.PhiOldLocal(), scope);
 
     // Apply transport operator
     gs_context_ptr->ApplyInverseTransportOperator(scope);
@@ -204,11 +201,8 @@ WGSLinearSolver::SetRHS()
   else
   {
     const auto scope = gs_context_ptr->rhs_src_scope_ | gs_context_ptr->lhs_src_scope_;
-    gs_context_ptr->set_source_function_(groupset,
-                                         lbs_solver.QMomentsLocal(),
-                                         lbs_solver.PhiOldLocal(),
-                                         lbs_solver.DensitiesLocal(),
-                                         scope);
+    gs_context_ptr->set_source_function_(
+      groupset, lbs_solver.QMomentsLocal(), lbs_solver.PhiOldLocal(), scope);
 
     // Apply transport operator
     gs_context_ptr->ApplyInverseTransportOperator(scope);

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -2379,7 +2379,6 @@ LBSSolver::MakeSourceMomentsFromPhi()
     active_set_source_function_(groupset,
                                 source_moments,
                                 phi_old_local_,
-                                densities_local_,
                                 APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES |
                                   APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   }

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
@@ -198,7 +198,6 @@ class AGSSchemeEntry;
 typedef std::function<void(const LBSGroupset& groupset,
                            std::vector<double>& q,
                            const std::vector<double>& phi,
-                           const std::vector<double>& densities,
                            const SourceFlags source_flags)>
   SetSourceFunction;
 

--- a/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.cc
@@ -19,7 +19,6 @@ void
 SourceFunction::operator()(const LBSGroupset& groupset,
                            std::vector<double>& q,
                            const std::vector<double>& phi,
-                           const std::vector<double>& densities,
                            const SourceFlags source_flags)
 {
   CALI_CXX_MARK_SCOPE("SourceFunction::operator");
@@ -33,6 +32,8 @@ SourceFunction::operator()(const LBSGroupset& groupset,
   apply_wgs_fission_src_ = (source_flags & APPLY_WGS_FISSION_SOURCES);
   apply_ags_fission_src_ = (source_flags & APPLY_AGS_FISSION_SOURCES);
   suppress_wg_scatter_src_ = (source_flags & SUPPRESS_WG_SCATTER);
+
+  const auto& densities = lbs_solver_.DensitiesLocal();
 
   // Get group setup
   gs_i_ = static_cast<size_t>(groupset.groups_.front().id_);

--- a/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.h
@@ -49,7 +49,6 @@ public:
    * \param groupset The groupset the under consideration.
    * \param q A vector to contribute the source to.
    * \param phi The primary STL vector to operate off.
-   * \param densities The densities of the local cells.
    * \param source_flags Flags for adding specific terms into the
    *        destination vector. Available flags are for applying
    *        the material source, across/within-group scattering,
@@ -59,7 +58,6 @@ public:
   virtual void operator()(const LBSGroupset& groupset,
                           std::vector<double>& q,
                           const std::vector<double>& phi,
-                          const std::vector<double>& densities,
                           SourceFlags source_flags);
 
   virtual double AddSourceMoments() const;


### PR DESCRIPTION
Because a getter exists for densities, it is now accessed via the solver within the `SetSourceFunction::operator()` call rather than being a part of the call signature.