### PR TITLE
Forcing some multi-groupset tests to use only 1 AGS iteration

### DIFF
--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.lua
@@ -92,6 +92,7 @@ lbs_options = {
     },
   },
   scattering_order = 5,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_1d_3a_dsa_ortho.lua
@@ -94,6 +94,7 @@ lbs_block = {
 
 lbs_options = {
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.lua
@@ -97,6 +97,7 @@ lbs_options = {
     },
   },
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.lua
@@ -98,6 +98,7 @@ lbs_options = {
     },
   },
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.lua
@@ -96,6 +96,7 @@ lbs_options = {
     },
   },
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4a_dsa_ortho.lua
@@ -100,6 +100,7 @@ lbs_block = {
 
 lbs_options = {
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.lua
@@ -104,6 +104,7 @@ lbs_options = {
     { name = "ymin", type = "reflecting" },
   },
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_3a_dsa_ortho.lua
@@ -100,6 +100,7 @@ lbs_block = {
 
 lbs_options = {
   scattering_order = 1,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.lua
@@ -94,6 +94,7 @@ lbs_options = {
   },
   scattering_order = 5,
   save_angular_flux = true,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)

--- a/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.lua
@@ -98,6 +98,7 @@ lbs_options = {
   },
   scattering_order = 1,
   save_angular_flux = true,
+  max_ags_iterations = 1,
 }
 
 phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)


### PR DESCRIPTION
The default behavior of the AGS solver has changed, and we now attempt a pointwise convergence of the groupset-to-groupset scattering. The previous behavior was to only do 1 AGS iteration. For a handful of our regression tests, pointwise AGS convergence is not necessary (doesn't change the answer we are testing for) and significantly increases the run time. For those tests, this PR sets the number of AGS iterations to 1.