### PR TITLE
Routine to access power field function from Lua

### DIFF
--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_common_lua_functions.h
@@ -19,6 +19,15 @@ namespace opensnlua
 int LBSGetScalarFieldFunctionList(lua_State* L);
 
 /**
+ * Obtain the power field function handle.
+ *
+ * \param SolverIndex int Handle to the solver for which the list is to be obtained.
+ *
+ * \return ff_handle The power field function handle.
+ */
+int LBSGetPowerFieldFunction(lua_State* L);
+
+/**
  * Writes the angular fluxes of a LBS groupset to file.
  *
  * \param SolverIndex int Handle to the solver for which the group

--- a/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
+++ b/lua/modules/linear_bolzmann_solvers/lbs_solver/lbs_get_field_funcs.cc
@@ -15,6 +15,7 @@ namespace opensnlua
 {
 
 RegisterLuaFunctionInNamespace(LBSGetScalarFieldFunctionList, lbs, GetScalarFieldFunctionList);
+RegisterLuaFunctionInNamespace(LBSGetPowerFieldFunction, lbs, GetPowerFieldFunction);
 
 int
 LBSGetScalarFieldFunctionList(lua_State* L)
@@ -60,19 +61,24 @@ LBSGetScalarFieldFunctionList(lua_State* L)
     }
   }
 
-  //// Power generation
-  // if (lbs_solver.Options().power_field_function_on)
-  //{
-  //   const size_t ff = lbs_solver.GetHandleToPowerGenFieldFunc();
-  //   auto local_ff = lbs_solver.GetFieldFunctions()[ff];
-  //
-  //   lua_pushinteger(L, 1 + count++);
-  //   lua_pushinteger(L, static_cast<lua_Integer>(GetStackFFHandle(local_ff)));
-  //
-  //   lua_settable(L, -3);
-  // }
-
   return LuaReturn(L, ff_handles, ff_handles.size());
 }
 
+int
+LBSGetPowerFieldFunction(lua_State* L)
+{
+  const std::string fname = "lbs.GetPowerFieldFunction";
+  LuaCheckArgs<size_t>(L, fname);
+
+  // Get pointer to solver
+  const auto solver_handle = LuaArg<size_t>(L, 1);
+  const auto& lbs_solver =
+    opensn::GetStackItem<opensn::LBSSolver>(opensn::object_stack, solver_handle, fname);
+
+  if (lbs_solver.Options().power_field_function_on)
+    return LuaReturn(L, lbs_solver.GetHandleToPowerGenFieldFunc());
+  else
+    throw std::logic_error("The power field function is not enabled. Use \"power_field_function_on "
+                           "= true\" in the input options to enable it.");
+}
 } // namespace opensnlua


### PR DESCRIPTION
There was no simple way to access the power field function that can be turned on in LBS solver within Lua. This PR adds the Lua routine `lbs.GetPowerFieldFunction` which either returns the appropriate field function handle or throws an error if the option to create the power field function is turned off.