### PR TITLE
Adding L2-convergence check to the AGS iterative solver

### DIFF
--- a/framework/math/math.h
+++ b/framework/math/math.h
@@ -213,4 +213,8 @@ double PowerIteration(const MatDbl& A,
                       int max_it = 2000,
                       double tol = 1.0e-13);
 
+double ComputePointwiseChange(std::vector<double>& x, std::vector<double>& y);
+
+double ComputeL2Change(std::vector<double>& x, std::vector<double>& y);
+
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.cc
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "modules//linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 #include "framework/math/linear_solver/linear_matrix_action_Ax.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
@@ -41,7 +42,7 @@ AGSSolver::Solve()
 
     if (lbs_solver_.Options().ags_pointwise_convergence)
     {
-      double pw_change = ComputePointwisePhiChange();
+      double pw_change = ComputePointwisePhiChange(lbs_solver_, phi_old_);
       double rho = (iter == 0) ? 0.0 : sqrt(pw_change / pw_change_prev);
       pw_change_prev = pw_change;
 
@@ -57,7 +58,7 @@ AGSSolver::Solve()
     }
     else
     {
-      double norm = ComputeL2PhiChange();
+      double norm = ComputeL2PhiChange(lbs_solver_, phi_old_);
 
       iter_stats << std::left << std::setw(5) << iter << " Error Norm " << std::left
                  << std::setw(14) << norm;
@@ -92,64 +93,6 @@ AGSSolver::Solve()
   // iteration limit
   if (lbs_solver_.RestartsEnabled() && lbs_solver_.Options().enable_ags_restart_write)
     lbs_solver_.WriteRestartData();
-}
-
-double
-AGSSolver::ComputeL2PhiChange() const
-{
-  double norm = 0.0;
-  auto& phi_new = lbs_solver_.PhiNewLocal();
-  for (int i = 0; i < phi_new.size(); ++i)
-  {
-    double val = phi_new[i] - phi_old_[i];
-    norm += val * val;
-  }
-
-  double global_norm = 0.0;
-  mpi_comm.all_reduce<double>(norm, global_norm, mpi::op::sum<double>());
-  global_norm = std::sqrt(global_norm);
-
-  return global_norm;
-}
-
-double
-AGSSolver::ComputePointwisePhiChange() const
-{
-  auto grid_ptr = GetCurrentMesh();
-  auto& cell_transport_views = lbs_solver_.GetCellTransportViews();
-  auto& groupsets = lbs_solver_.Groupsets();
-  auto& phi_new = lbs_solver_.PhiNewLocal();
-  auto num_moments = lbs_solver_.NumMoments();
-
-  double pw_change = 0.0;
-  for (const auto& cell : grid_ptr->local_cells)
-  {
-    auto& transport_view = cell_transport_views[cell.local_id_];
-    for (int i = 0; i < cell.vertex_ids_.size(); ++i)
-    {
-      for (auto groupset : groupsets)
-      {
-        int gsi = groupset.groups_.front().id_;
-        for (int g = 0; g < groupset.groups_.size(); ++g)
-        {
-          size_t m0g_idx = transport_view.MapDOF(i, 0, gsi + g);
-          double max_phi = std::max(fabs(phi_new[m0g_idx]), fabs(phi_old_[m0g_idx]));
-          for (int m = 0; m < num_moments; ++m)
-          {
-            size_t mng_idx = transport_view.MapDOF(i, m, gsi + g);
-            double delta_phi = std::fabs(phi_new[mng_idx] - phi_old_[mng_idx]);
-            if (max_phi >= std::numeric_limits<double>::min())
-              pw_change = std::max(delta_phi / max_phi, pw_change);
-            else
-              pw_change = std::max(delta_phi, pw_change);
-          } // for g
-        }   // for m
-      }     // for groupset
-    }       // for i
-  }         // for c
-  double global_pw_change = 0.0;
-  mpi_comm.all_reduce<double>(pw_change, global_pw_change, mpi::op::max<double>());
-  return global_pw_change;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h
@@ -48,6 +48,8 @@ private:
   double tolerance_;
   bool verbose_;
 
+  double ComputeL2PhiChange() const;
+
   double ComputePointwisePhiChange() const;
 };
 

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/ags_solver.h
@@ -47,10 +47,6 @@ private:
   int max_iterations_;
   double tolerance_;
   bool verbose_;
-
-  double ComputeL2PhiChange() const;
-
-  double ComputePointwisePhiChange() const;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/classic_richardson.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/classic_richardson.h
@@ -56,8 +56,6 @@ protected:
 private:
   std::vector<double> saved_q_moments_local_;
   std::vector<double> psi_new_, psi_old_;
-
-  double ComputePointwisePsiChange();
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.cc
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include <numeric>
+
+namespace opensn
+{
+
+double
+ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  int groupset_id,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old)
+{
+  return ComputePointwisePhiChange(lbs_solver, std::vector<int>{groupset_id}, opt_phi_old);
+}
+
+double
+ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old)
+{
+  return ComputePointwisePhiChange(lbs_solver, std::vector<int>{}, opt_phi_old);
+}
+
+double
+ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  std::vector<int> groupset_ids,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old)
+{
+  if (groupset_ids.empty())
+  {
+    groupset_ids.resize(lbs_solver.Groupsets().size());
+    std::iota(groupset_ids.begin(), groupset_ids.end(), 0);
+  }
+
+  auto& phi_new = lbs_solver.PhiNewLocal();
+  std::vector<double>& phi_old =
+    opt_phi_old.has_value() ? opt_phi_old.value().get() : lbs_solver.PhiOldLocal();
+
+  auto grid_ptr = GetCurrentMesh();
+  auto& cell_transport_views = lbs_solver.GetCellTransportViews();
+  auto num_moments = lbs_solver.NumMoments();
+
+  double pw_change = 0.0;
+  for (const auto& cell : grid_ptr->local_cells)
+  {
+    auto& transport_view = cell_transport_views[cell.local_id_];
+    for (auto i = 0; i < cell.vertex_ids_.size(); ++i)
+    {
+      for (auto id : groupset_ids)
+      {
+        auto& groupset = lbs_solver.Groupsets()[id];
+        auto gsi = groupset.groups_.front().id_;
+        for (auto g = 0; g < groupset.groups_.size(); ++g)
+        {
+          auto m0g_idx = transport_view.MapDOF(i, 0, gsi + g);
+          double max_phi = std::max(fabs(phi_new[m0g_idx]), fabs(phi_old[m0g_idx]));
+          for (auto m = 0; m < num_moments; ++m)
+          {
+            auto mng_idx = transport_view.MapDOF(i, m, gsi + g);
+            double delta_phi = std::fabs(phi_new[mng_idx] - phi_old[mng_idx]);
+            if (max_phi >= std::numeric_limits<double>::min())
+              pw_change = std::max(delta_phi / max_phi, pw_change);
+            else
+              pw_change = std::max(delta_phi, pw_change);
+          } // for m
+        }   // for g
+      }     // for id
+    }       // for i
+  }         // for cell
+
+  double global_pw_change = 0.0;
+  mpi_comm.all_reduce<double>(pw_change, global_pw_change, mpi::op::max<double>());
+
+  return global_pw_change;
+}
+
+double
+ComputeL2PhiChange(LBSSolver& lbs_solver,
+                   std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old)
+{
+  double norm = 0.0;
+  auto& phi_new = lbs_solver.PhiNewLocal();
+  std::vector<double>& phi_old =
+    opt_phi_old.has_value() ? opt_phi_old.value().get() : lbs_solver.PhiOldLocal();
+
+  for (auto i = 0; i < phi_new.size(); ++i)
+  {
+    double val = phi_new[i] - phi_old[i];
+    norm += val * val;
+  }
+
+  double global_norm = 0.0;
+  mpi_comm.all_reduce<double>(norm, global_norm, mpi::op::sum<double>());
+
+  return std::sqrt(global_norm);
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/convergence.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/lbs_solver/groupset/lbs_groupset.h"
+#include <vector>
+#include <optional>
+
+namespace opensn
+{
+
+class LBSSolver;
+
+double ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  int groupset_id,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old = std::nullopt);
+
+double ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old = std::nullopt);
+
+double ComputePointwisePhiChange(
+  LBSSolver& lbs_solver,
+  std::vector<int> groupset_ids,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old = std::nullopt);
+
+double ComputeL2PhiChange(
+  LBSSolver& lbs_solver,
+  std::optional<const std::reference_wrapper<std::vector<double>>> opt_phi_old = std::nullopt);
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -1604,47 +1604,6 @@ LBSSolver::InitializeBoundaries()
   }   // for bndry id
 }
 
-double
-LBSSolver::ComputePointwisePhiChange(LBSGroupset& groupset)
-{
-  double pw_change = 0.0;
-  int gsi = groupset.groups_[0].id_;
-
-  for (const auto& cell : grid_ptr_->local_cells)
-  {
-    auto& transport_view = cell_transport_views_[cell.local_id_];
-
-    for (int i = 0; i < cell.vertex_ids_.size(); ++i)
-    {
-      for (int m = 0; m < num_moments_; ++m)
-      {
-        size_t mapping = transport_view.MapDOF(i, m, gsi);
-        double* phi_new_m = &phi_new_local_[mapping];
-        double* phi_old_m = &phi_old_local_[mapping];
-
-        for (int g = 0; g < groupset.groups_.size(); ++g)
-        {
-          size_t map0 = transport_view.MapDOF(i, 0, gsi + g);
-          double abs_phi_m0 = fabs(phi_new_local_[map0]);
-          double abs_phi_old_m0 = fabs(phi_old_local_[map0]);
-          double max_phi = std::max(abs_phi_m0, abs_phi_old_m0);
-          double delta_phi = std::fabs(phi_new_m[g] - phi_old_m[g]);
-
-          if (max_phi >= std::numeric_limits<double>::min())
-            pw_change = std::max(delta_phi / max_phi, pw_change);
-          else
-            pw_change = std::max(delta_phi, pw_change);
-        }
-      }
-    }
-  }
-
-  double global_pw_change = 0.0;
-  mpi_comm.all_reduce<double>(pw_change, global_pw_change, mpi::op::max<double>());
-
-  return global_pw_change;
-}
-
 void
 LBSSolver::InitializeSolverSchemes()
 {

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -463,6 +463,10 @@ LBSSolver::OptionsBlock()
   params.AddOptionalParameter(
     "max_ags_iterations", 100, "Maximum number of across-groupset iterations.");
   params.AddOptionalParameter("ags_tolerance", 1.0e-6, "Across-groupset iterations tolerance.");
+  params.AddOptionalParameter("ags_convergence_check",
+                              "l2",
+                              "Type of convergence check for AGS iterations. Valid values are "
+                              "`\"l2\"` and '\"pointwise\"'");
   params.AddOptionalParameter(
     "verbose_ags_iterations", true, "Flag to control verbosity of across-groupset iterations.");
   params.AddOptionalParameter("power_field_function_on",
@@ -508,6 +512,8 @@ LBSSolver::OptionsBlock()
     "volumetric_sources", {}, "An array of handles to volumetric sources.");
   params.AddOptionalParameter("clear_volumetric_sources", false, "Clears all volumetric sources.");
   params.ConstrainParameterRange("spatial_discretization", AllowableRangeList::New({"pwld"}));
+  params.ConstrainParameterRange("ags_convergence_check",
+                                 AllowableRangeList::New({"l2", "pointwise"}));
   params.ConstrainParameterRange("field_function_prefix_option",
                                  AllowableRangeList::New({"prefix", "solver_name"}));
 
@@ -641,6 +647,13 @@ LBSSolver::SetOptions(const InputParameters& params)
 
     else if (spec.Name() == "ags_tolerance")
       options_.ags_tolerance = spec.GetValue<double>();
+
+    else if (spec.Name() == "ags_convergence_check")
+    {
+      auto check = spec.GetValue<std::string>();
+      if (check == "pointwise")
+        options_.ags_pointwise_convergence = true;
+    }
 
     else if (spec.Name() == "verbose_ags_iterations")
       options_.verbose_ags_iterations = spec.GetValue<bool>();

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
@@ -297,9 +297,6 @@ public:
                                 const std::vector<size_t>& m_indices,
                                 const std::vector<size_t>& g_indices);
 
-  /// Computes the pointwise difference between new and old phi.
-  double ComputePointwisePhiChange(LBSGroupset& groupset);
-
   /**
    * Compute the total fission production in the problem.
    * \author Zachary Hardy.

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_structs.h
@@ -220,6 +220,7 @@ struct LBSOptions
   bool verbose_inner_iterations = true;
   bool verbose_ags_iterations = true;
   bool verbose_outer_iterations = true;
+  bool ags_pointwise_convergence = false;
   int max_ags_iterations = 100;
   double ags_tolerance = 1.0e-6;
 

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -726,7 +726,7 @@
       {
         "type": "KeyValuePair",
         "key": "[0]   Out-flow rate               =",
-        "goldvalue": 1.343586e+01,
+        "goldvalue": 1.343510e+01,
         "abs_tol": 1.0e-6
       }
     ]


### PR DESCRIPTION
This PR changes the default convergence check for the AGS solver from a pointwise check on phi to a check on the L2 norm of the error in phi. This mirrors the behavior of the old PETSc AGS solver and brings some consistency to convergence checking across the WGS and AGS solvers. Using a pointwise convergence check for AGS is optional, and will be used by the Classic Richardson WGS solver since it also uses a pointwise convergence check.