### PR TITLE
Adding support for MPI-distributed meshes.

### DIFF
--- a/framework/mesh/mesh_generator/distributed_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/distributed_mesh_generator.cc
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/mesh/mesh_generator/distributed_mesh_generator.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/data_types/byte_array.h"
+#include "framework/logging/log.h"
+#include "framework/utils/timer.h"
+#include "framework/utils/utils.h"
+#include "framework/object_factory.h"
+#include "framework/runtime.h"
+
+namespace opensn
+{
+
+OpenSnRegisterObjectInNamespace(mesh, DistributedMeshGenerator);
+
+InputParameters
+DistributedMeshGenerator::GetInputParameters()
+{
+  InputParameters params = MeshGenerator::GetInputParameters();
+
+  params.SetGeneralDescription(
+    "Generates and partitions the mesh on location 0. The partitioned mesh is "
+    "broadcast to all other locations.");
+  params.SetDocGroup("doc_MeshGenerators");
+
+  return params;
+}
+
+DistributedMeshGenerator::DistributedMeshGenerator(const InputParameters& params)
+  : MeshGenerator(params), num_parts_(opensn::mpi_comm.size())
+{
+}
+
+void
+DistributedMeshGenerator::Execute()
+{
+  const int rank = opensn::mpi_comm.rank();
+  const int num_parts = opensn::mpi_comm.size();
+  DistributedMeshData mesh_info;
+
+  log.Log() << program_timer.GetTimeString() << " Distributing mesh with " << num_parts << " parts";
+
+  if (rank == 0)
+  {
+    std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
+    for (auto mesh_generator_ptr : inputs_)
+    {
+      auto new_umesh = mesh_generator_ptr->GenerateUnpartitionedMesh(current_umesh);
+      current_umesh = new_umesh;
+    }
+    current_umesh = GenerateUnpartitionedMesh(current_umesh);
+
+    const auto cell_pids = PartitionMesh(*current_umesh, num_parts);
+    auto serial_data = DistributeSerializedMeshData(cell_pids, *current_umesh, num_parts);
+    mesh_info = DeserializeMeshData(serial_data);
+  }
+  else
+  {
+    std::vector<std::byte> data;
+    opensn::mpi_comm.recv<std::byte>(0, rank, data);
+    ByteArray serial_data(data);
+    mesh_info = DeserializeMeshData(serial_data);
+  }
+
+  auto grid_ptr = SetupLocalMesh(mesh_info);
+  mesh_stack.push_back(grid_ptr);
+
+  opensn::mpi_comm.barrier();
+
+  log.Log() << program_timer.GetTimeString() << " Mesh successfully distributed";
+}
+
+ByteArray
+DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t>& cell_pids,
+                                                       const UnpartitionedMesh& umesh,
+                                                       int num_parts)
+{
+  const auto& vertex_subs = umesh.GetVertextCellSubscriptions();
+  const auto& raw_cells = umesh.RawCells();
+  const auto& raw_vertices = umesh.Vertices();
+  ByteArray loc0_data;
+
+  for (int pid = 0; pid < num_parts; ++pid)
+  {
+    ByteArray serial_data;
+
+    std::vector<uint64_t> local_cells_needed;
+    std::set<uint64_t> cells_needed;
+    std::set<uint64_t> vertices_needed;
+    local_cells_needed.reserve(cell_pids.size() / num_parts);
+
+    for (uint64_t cell_global_id = 0; cell_global_id < cell_pids.size(); ++cell_global_id)
+    {
+      if (cell_pids[cell_global_id] == pid)
+      {
+        const auto& raw_cell = *raw_cells[cell_global_id];
+        local_cells_needed.push_back(cell_global_id);
+        cells_needed.emplace(cell_global_id);
+
+        for (uint64_t vid : raw_cell.vertex_ids)
+        {
+          vertices_needed.emplace(vid);
+
+          // Process ghost cells
+          for (uint64_t ghost_gid : vertex_subs[vid])
+          {
+            if (ghost_gid != cell_global_id && cells_needed.find(ghost_gid) == cells_needed.end())
+            {
+              cells_needed.emplace(ghost_gid);
+              const auto& ghost_raw_cell = *raw_cells[ghost_gid];
+              // Insert ghost vertex IDs
+              for (uint64_t gvid : ghost_raw_cell.vertex_ids)
+                vertices_needed.emplace(gvid);
+            }
+          }
+        }
+      }
+    }
+
+    // Basic mesh data
+    serial_data.Write<unsigned int>(umesh.Dimension());
+    serial_data.Write(static_cast<int>(umesh.Type()));
+    serial_data.Write(umesh.Extruded());
+    auto& ortho_attrs = umesh.OrthoAttributes();
+    serial_data.Write(ortho_attrs.Nx);
+    serial_data.Write(ortho_attrs.Ny);
+    serial_data.Write(ortho_attrs.Nz);
+    serial_data.Write(raw_vertices.size());
+
+    // Boundaries
+    const auto& bndry_map = umesh.BoundaryIDMap();
+    serial_data.Write(bndry_map.size());
+    for (const auto& [bid, bname] : bndry_map)
+    {
+      serial_data.Write(bid);
+      const size_t num_chars = bname.size();
+      serial_data.Write(num_chars);
+      for (size_t i = 0; i < num_chars; ++i)
+        serial_data.Write(bname.data()[i]);
+    }
+
+    // Number of cells and vertices
+    serial_data.Write(cells_needed.size());
+    serial_data.Write(vertices_needed.size());
+
+    // Cell data
+    for (const auto& cell_global_id : cells_needed)
+    {
+      const auto& cell = *raw_cells[cell_global_id];
+      serial_data.Write(static_cast<int>(cell_pids[cell_global_id]));
+      serial_data.Write(cell_global_id);
+      serial_data.Write(cell.type);
+      serial_data.Write(cell.sub_type);
+      serial_data.Write(cell.centroid.x);
+      serial_data.Write(cell.centroid.y);
+      serial_data.Write(cell.centroid.z);
+      serial_data.Write(cell.material_id);
+      serial_data.Write(cell.vertex_ids.size());
+      for (uint64_t vid : cell.vertex_ids)
+        serial_data.Write(vid);
+
+      serial_data.Write(cell.faces.size());
+      for (const auto& face : cell.faces)
+      {
+        serial_data.Write(face.vertex_ids.size());
+        for (uint64_t vid : face.vertex_ids)
+          serial_data.Write(vid);
+        serial_data.Write(face.has_neighbor);
+        serial_data.Write(face.neighbor);
+      }
+    }
+
+    // Vertex data
+    for (uint64_t vid : vertices_needed)
+    {
+      serial_data.Write(vid);
+      serial_data.Write(raw_vertices[vid]);
+    }
+
+    if (pid == 0)
+      loc0_data = serial_data;
+    else
+      opensn::mpi_comm.send<std::byte>(pid, pid, serial_data.Data().data(), serial_data.Size());
+  }
+
+  return loc0_data;
+}
+
+DistributedMeshGenerator::DistributedMeshData
+DistributedMeshGenerator::DeserializeMeshData(ByteArray& serial_data)
+{
+  DistributedMeshData info_block;
+
+  // Basic mesh data
+  info_block.dimension = serial_data.Read<unsigned int>();
+  info_block.mesh_type = static_cast<MeshType>(serial_data.Read<int>());
+  info_block.extruded = serial_data.Read<bool>();
+  info_block.ortho_attributes.Nx = serial_data.Read<size_t>();
+  info_block.ortho_attributes.Ny = serial_data.Read<size_t>();
+  info_block.ortho_attributes.Nz = serial_data.Read<size_t>();
+  info_block.num_global_vertices = serial_data.Read<size_t>();
+
+  // Boundaries
+  auto num_bndries = serial_data.Read<size_t>();
+  for (auto b = 0; b < num_bndries; ++b)
+  {
+    auto bid = serial_data.Read<uint64_t>();
+    auto num_chars = serial_data.Read<size_t>();
+    std::string bname(num_chars, ' ');
+    for (auto i = 0; i < num_chars; ++i)
+      bname.data()[i] = serial_data.Read<char>();
+    info_block.boundary_id_map.insert(std::make_pair(bid, bname));
+  }
+
+  // Number of cells and vertices
+  size_t num_cells = serial_data.Read<size_t>();
+  size_t num_vertices = serial_data.Read<size_t>();
+
+  // Cell data
+  for (size_t i = 0; i < num_cells; ++i)
+  {
+    int cell_pid = serial_data.Read<int>();
+    uint64_t cell_gid = serial_data.Read<uint64_t>();
+    auto type = serial_data.Read<CellType>();
+    auto sub_type = serial_data.Read<CellType>();
+
+    UnpartitionedMesh::LightWeightCell cell(type, sub_type);
+
+    cell.centroid.x = serial_data.Read<double>();
+    cell.centroid.y = serial_data.Read<double>();
+    cell.centroid.z = serial_data.Read<double>();
+    cell.material_id = serial_data.Read<int>();
+
+    size_t num_vids = serial_data.Read<size_t>();
+    for (size_t v = 0; v < num_vids; ++v)
+      cell.vertex_ids.push_back(serial_data.Read<uint64_t>());
+
+    size_t num_faces = serial_data.Read<size_t>();
+    for (size_t f = 0; f < num_faces; ++f)
+    {
+      UnpartitionedMesh::LightWeightFace face;
+      size_t num_face_vids = serial_data.Read<size_t>();
+      for (size_t v = 0; v < num_face_vids; ++v)
+        face.vertex_ids.push_back(serial_data.Read<uint64_t>());
+
+      face.has_neighbor = serial_data.Read<bool>();
+      face.neighbor = serial_data.Read<uint64_t>();
+
+      cell.faces.push_back(std::move(face));
+    }
+    info_block.cells.insert(std::make_pair(std::make_pair(cell_pid, cell_gid), cell));
+  }
+
+  // Vertex data
+  for (size_t i = 0; i < num_vertices; ++i)
+  {
+    uint64_t vid = serial_data.Read<uint64_t>();
+    Vector3 vertex;
+    vertex.x = serial_data.Read<double>();
+    vertex.y = serial_data.Read<double>();
+    vertex.z = serial_data.Read<double>();
+    info_block.vertices.insert(std::make_pair(vid, vertex));
+  }
+
+  return info_block;
+}
+
+std::shared_ptr<MeshContinuum>
+DistributedMeshGenerator::SetupLocalMesh(DistributedMeshData& mesh_info)
+{
+  auto grid_ptr = MeshContinuum::New();
+  grid_ptr->GetBoundaryIDMap() = mesh_info.boundary_id_map;
+
+  auto& vertices = mesh_info.vertices;
+  for (const auto& [vid, vertex] : vertices)
+    grid_ptr->vertices.Insert(vid, vertex);
+
+  auto& cells = mesh_info.cells;
+  for (const auto& [pidgid, raw_cell] : cells)
+  {
+    const auto& [cell_pid, cell_global_id] = pidgid;
+    auto cell = SetupCell(raw_cell, cell_global_id, cell_pid, STLVertexListHelper(vertices));
+
+    grid_ptr->cells.push_back(std::move(cell));
+  }
+
+  grid_ptr->SetDimension(mesh_info.dimension);
+  grid_ptr->SetType(mesh_info.mesh_type);
+  grid_ptr->SetExtruded(mesh_info.extruded);
+  grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);
+  grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices);
+  ComputeAndPrintStats(*grid_ptr);
+
+  return grid_ptr;
+}
+
+} // namespace opensn

--- a/framework/mesh/mesh_generator/distributed_mesh_generator.h
+++ b/framework/mesh/mesh_generator/distributed_mesh_generator.h
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/mesh/mesh_generator/mesh_generator.h"
+
+namespace opensn
+{
+
+/**
+ * This class is responsible for generating a mesh, partitioning it, and distributing the
+ * individual partitions to different MPI locations. The mesh is generated on location 0,
+ * partitioned into multiple parts, serialized, and distributed to all other MPI ranks.
+ *
+ * The mesh data is serialized into a `ByteArray` for efficient MPI communication and
+ * deserialized at the receiving locations to reconstruct the mesh locally.
+ */
+class DistributedMeshGenerator : public MeshGenerator
+{
+public:
+  /**
+   * Get the input parameters for this class.
+   *
+   * \return Input parameters for configuring the DistributedMeshGenerator.
+   */
+  static InputParameters GetInputParameters();
+
+public:
+  /**
+   * Constructor for the DistributedMeshGenerator.
+   *
+   * \param params Input parameters for mesh generation and distribution.
+   */
+  explicit DistributedMeshGenerator(const InputParameters& params);
+
+  /**
+   * Executes the mesh generation and distribution process.
+   *
+   * On location 0, the mesh is generated, partitioned, serialized, and distributed to
+   * other MPI ranks. Other ranks receive the serialized mesh data, deserialize it,
+   * and set up the local mesh.
+   */
+  void Execute() override;
+
+private:
+  /**
+   * Structure holding distributed mesh data.
+   *
+   * This structure holds the essential information about the mesh that will be distributed
+   * among MPI ranks, including cells, vertices, boundary ID mappings, and mesh attributes.
+   */
+  struct DistributedMeshData
+  {
+    /// Dimension of the mesh (2D, 3D).
+    unsigned int dimension;
+    /// Map of cells (partition ID, cell global ID).
+    std::map<std::pair<int, uint64_t>, UnpartitionedMesh::LightWeightCell> cells;
+    /// Map of vertices by global vertex ID.
+    std::map<uint64_t, Vector3> vertices;
+    /// Map of boundary IDs to boundary names.
+    std::map<uint64_t, std::string> boundary_id_map;
+    /// Type of mesh.
+    MeshType mesh_type;
+    /// Whether the mesh is extruded or not.
+    bool extruded;
+    /// Attributes for orthogonal mesh, if applicable.
+    OrthoMeshAttributes ortho_attributes;
+    /// Number of global vertices in the mesh.
+    size_t num_global_vertices;
+  };
+
+  /**
+   * Serializes and distributes the mesh data to other MPI ranks.
+   *
+   * The mesh data is serialized into a `ByteArray` and distributed via MPI. The partitioned
+   * mesh is sent to different ranks based on the partitioning.
+   *
+   * \param cell_pids A vector of cell partition IDs.
+   * \param umesh The unpartitioned mesh object containing mesh information.
+   * \param num_parts The number of partitions to distribute.
+   * \return The serialized mesh data for location 0.
+   */
+  ByteArray DistributeSerializedMeshData(const std::vector<int64_t>& cell_pids,
+                                         const UnpartitionedMesh& umesh,
+                                         int num_parts);
+
+  /**
+   * Deserializes the mesh data from a `ByteArray`.
+   *
+   * This function reconstructs the mesh from the serialized data received from location 0.
+   *
+   * \param serial_data The serialized mesh data in a `ByteArray`.
+   * \return The deserialized mesh data.
+   */
+  DistributedMeshData DeserializeMeshData(ByteArray& serial_data);
+
+  /**
+   * Sets up the local mesh on each MPI rank from the deserialized mesh data.
+   *
+   * The mesh is reconstructed from the deserialized mesh data on each rank. The local mesh
+   * is then prepared and added to the mesh stack.
+   *
+   * \param mesh_info The deserialized mesh data containing information about cells, vertices, and
+   * boundaries.
+   * \return A shared pointer to the local mesh.
+   */
+  std::shared_ptr<MeshContinuum> SetupLocalMesh(DistributedMeshData& mesh_info);
+
+private:
+  /// The number of partitions for distributing the mesh.
+  const int num_parts_;
+};
+
+} // namespace opensn

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -536,6 +536,50 @@
     ]
   },
   {
+    "file": "transport_3d_6a_dist_mesh.lua",
+    "comment": "3D LinearBSolver test distributed mesh configuration A",
+    "num_procs": 4,
+    "weight_class": "intermediate",
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "max-grp0(latest)",
+        "wordnum": 4,
+        "gold": 1.131566e-01,
+        "abs_tol": 1.0e-6
+      },
+      {
+        "type": "FloatCompare",
+        "key": "max-grp19(latest)",
+        "wordnum": 4,
+        "gold": 7.340585e-04,
+        "abs_tol": 1.0e-9
+      }
+    ]
+  },
+  {
+    "file": "transport_3d_6b_dist_mesh.lua",
+    "comment": "3D LinearBSolver test distributed mesh configuration B",
+    "num_procs": 4,
+    "weight_class": "intermediate",
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "max-grp0(latest)",
+        "wordnum": 4,
+        "gold": 1.131566e-01,
+        "abs_tol": 1.0e-6
+      },
+      {
+        "type": "FloatCompare",
+        "key": "max-grp19(latest)",
+        "wordnum": 4,
+        "gold": 7.340585e-04,
+        "abs_tol": 1.0e-9
+      }
+    ]
+  },
+  {
     "file": "reed_balance.lua",
     "comment": "1D LinearBSolver Reed problem with balance printout",
     "num_procs": 1,

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_dist_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_dist_mesh.lua
@@ -1,0 +1,141 @@
+-- 3D Transport test with distributed-mesh + ortho mesh.
+-- SDM: PWLD
+-- Test: max-grp0(latest) =  1.131566e-01
+--       max-grp19(latest) = 7.340585e-04
+
+num_procs = 4
+
+-- Check num_procs
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
+end
+
+-- Cells
+div = 8
+Nx = math.floor(128 / div)
+Ny = math.floor(128 / div)
+Nz = math.floor(256 / div)
+
+-- Dimensions
+Lx = 10.0
+Ly = 10.0
+Lz = 10.0
+
+xmesh = {}
+xmin = 0.0
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
+end
+
+ymesh = {}
+ymin = 0.0
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
+end
+
+zmesh = {}
+zmin = 0.0
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
+end
+
+meshgen1 = mesh.DistributedMeshGenerator.Create({
+  inputs = {
+    mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh, zmesh } }),
+  },
+})
+
+mesh.MeshGenerator.Execute(meshgen1)
+
+mesh.SetUniformMaterialID(0)
+
+-- Add materials
+materials = {}
+materials[1] = mat.AddMaterial("Test Material")
+
+num_groups = 21
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
+
+src = {}
+for g = 1, num_groups do
+  src[g] = 0.0
+end
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+
+-- Setup Physics
+pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 4)
+
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, 20 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+  sweep_type = "CBC",
+}
+bsrc = {}
+for g = 1, num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "isotropic", group_strength = bsrc },
+  },
+  scattering_order = 1,
+  save_angular_flux = true,
+}
+
+phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys1, lbs_options)
+
+-- Initialize and Execute Solver
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
+
+solver.Initialize(ss_solver)
+solver.Execute(ss_solver)
+
+-- Get field functions
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+
+pp1 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp0",
+  field_function = fflist[1],
+  compute_volume_average = true,
+  print_numeric_format = "scientific",
+})
+pp2 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp19",
+  field_function = fflist[20],
+  compute_volume_average = true,
+  print_numeric_format = "scientific",
+})
+post.Execute({ pp1, pp2 })
+
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
+end
+
+log.PrintTimingGraph()

--- a/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_dist_mesh.lua
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_dist_mesh.lua
@@ -1,0 +1,142 @@
+-- 3D Transport test with distributedt-mesh + 2D ortho mesh + extruded mesh.
+-- SDM: PWLD
+-- Test: Max-value1=6.55387e+00
+--       Max-value2=1.02940e+00
+
+num_procs = 4
+
+-- Check num_procs
+if check_num_procs == nil and number_of_processes ~= num_procs then
+  log.Log(
+    LOG_0ERROR,
+    "Incorrect amount of processors. "
+      .. "Expected "
+      .. tostring(num_procs)
+      .. ". Pass check_num_procs=false to override if possible."
+  )
+  os.exit(false)
+end
+
+-- Cells
+div = 8
+Nx = math.floor(128 / div)
+Ny = math.floor(128 / div)
+Nz = math.floor(256 / div)
+
+-- Dimensions
+Lx = 10.0
+Ly = 10.0
+Lz = 10.0
+
+xmesh = {}
+xmin = 0.0
+dx = Lx / Nx
+for i = 1, (Nx + 1) do
+  k = i - 1
+  xmesh[i] = xmin + k * dx
+end
+
+ymesh = {}
+ymin = 0.0
+dy = Ly / Ny
+for i = 1, (Ny + 1) do
+  k = i - 1
+  ymesh[i] = ymin + k * dy
+end
+
+zmesh = {}
+zmin = 0.0
+dz = Lz / Nz
+for i = 1, (Nz + 1) do
+  k = i - 1
+  zmesh[i] = zmin + k * dz
+end
+
+meshgen1 = mesh.DistributedMeshGenerator.Create({
+  inputs = {
+    mesh.OrthogonalMeshGenerator.Create({ node_sets = { xmesh, ymesh } }),
+    mesh.ExtruderMeshGenerator.Create({
+      layers = { { z = Lz, n = Nz } },
+    }),
+  },
+})
+
+mesh.MeshGenerator.Execute(meshgen1)
+
+mesh.SetUniformMaterialID(0)
+
+-- Add materials
+materials = {}
+materials[1] = mat.AddMaterial("Test Material")
+
+num_groups = 21
+mat.SetProperty(materials[1], TRANSPORT_XSECTIONS, OPENSN_XSFILE, "xs_graphite_pure.xs")
+
+src = {}
+for g = 1, num_groups do
+  src[g] = 0.0
+end
+mat.SetProperty(materials[1], ISOTROPIC_MG_SOURCE, FROM_ARRAY, src)
+
+-- Setup Physics
+pquad0 = aquad.CreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV, 2, 4)
+
+lbs_block = {
+  num_groups = num_groups,
+  groupsets = {
+    {
+      groups_from_to = { 0, 20 },
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+  sweep_type = "CBC",
+}
+bsrc = {}
+for g = 1, num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0 / 4.0 / math.pi
+lbs_options = {
+  boundary_conditions = {
+    { name = "xmin", type = "isotropic", group_strength = bsrc },
+  },
+  scattering_order = 1,
+  save_angular_flux = true,
+}
+
+phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys1, lbs_options)
+
+-- Initialize and Execute Solver
+ss_solver = lbs.SteadyStateSolver.Create({ lbs_solver_handle = phys1 })
+
+solver.Initialize(ss_solver)
+solver.Execute(ss_solver)
+
+-- Get field functions
+fflist, count = lbs.GetScalarFieldFunctionList(phys1)
+
+pp1 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp0",
+  field_function = fflist[1],
+  compute_volume_average = true,
+  print_numeric_format = "scientific",
+})
+pp2 = post.CellVolumeIntegralPostProcessor.Create({
+  name = "max-grp19",
+  field_function = fflist[20],
+  compute_volume_average = true,
+  print_numeric_format = "scientific",
+})
+post.Execute({ pp1, pp2 })
+
+if master_export == nil then
+  fieldfunc.ExportToVTKMulti(fflist, "ZPhi")
+end


### PR DESCRIPTION
This PR adds support for MPI-distributed meshes. Rank 0 builds and partitions the mesh and sends each piece of the mesh to the appropriate rank via MPI.  Tested out to ~27,000 ranks with various mesh types. 2.5X to 4X faster than our split mesh capability at that scale.

This probably needs to be our standard mesh generator, but I'm leaving it as an option until we have gained some experience using it.

I believe this resolves #20.