### PR TITLE
Cleaning up use of PETSc iterative method names

### DIFF
--- a/framework/math/linear_solver/linear_solver.cc
+++ b/framework/math/linear_solver/linear_solver.cc
@@ -7,16 +7,9 @@
 namespace opensn
 {
 
-LinearSolver::LinearSolver(const std::string& iterative_method,
+LinearSolver::LinearSolver(const std::string& petsc_iterative_method,
                            std::shared_ptr<LinearSolverContext> context_ptr)
-  : solver_name_(iterative_method), iterative_method_(iterative_method), context_ptr_(context_ptr)
-{
-}
-
-LinearSolver::LinearSolver(const std::string& solver_name,
-                           const std::string& iterative_method,
-                           std::shared_ptr<LinearSolverContext> context_ptr)
-  : solver_name_(solver_name), iterative_method_(iterative_method), context_ptr_(context_ptr)
+  : context_ptr_(context_ptr), petsc_iterative_method_(petsc_iterative_method)
 {
 }
 
@@ -83,17 +76,11 @@ LinearSolver::Setup()
 
   KSPCreate(opensn::mpi_comm, &ksp_);
 
-  // In OpenSn the PETSc version of Richardson iteration is referred to as krylov_richardson to
-  // distinguish it from classic Richardson. At this point, we need to convert from
-  // krylov_richardson to the correct PETSc algorithm name.
-  if (iterative_method_ == "krylov_richardson")
-    KSPSetType(ksp_, "richardson");
-  else
-    KSPSetType(ksp_, iterative_method_.c_str());
+  KSPSetType(ksp_, petsc_iterative_method_.c_str());
 
   ApplyToleranceOptions();
 
-  if (iterative_method_ == "gmres")
+  if (petsc_iterative_method_ == "gmres")
   {
     KSPGMRESSetRestart(ksp_, tolerance_options.gmres_restart_interval);
     KSPGMRESSetBreakdownTolerance(ksp_, tolerance_options.gmres_breakdown_tolerance);

--- a/framework/math/linear_solver/linear_solver.h
+++ b/framework/math/linear_solver/linear_solver.h
@@ -32,11 +32,7 @@ public:
     double gmres_breakdown_tolerance = 1.0e6;
   } tolerance_options;
 
-  LinearSolver(const std::string& iterative_method,
-               std::shared_ptr<LinearSolverContext> context_ptr);
-
-  LinearSolver(const std::string& solver_name,
-               const std::string& iterative_method,
+  LinearSolver(const std::string& petsc_iterative_method,
                std::shared_ptr<LinearSolverContext> context_ptr);
 
   virtual ~LinearSolver();
@@ -72,8 +68,6 @@ protected:
   virtual void SetRHS() = 0;
   virtual void PostSolveCallback();
 
-  const std::string solver_name_;
-  const std::string iterative_method_;
   std::shared_ptr<LinearSolverContext> context_ptr_ = nullptr;
   Mat A_ = nullptr;
   Vec b_ = nullptr;
@@ -83,6 +77,7 @@ protected:
   int64_t num_global_dofs_ = 0;
 
 private:
+  const std::string petsc_iterative_method_;
   bool system_set_ = false;
   bool suppress_kspsolve_ = false;
 };

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_linear_solver.cc
@@ -167,8 +167,8 @@ WGSLinearSolver::SetRHS()
   // SetSource for RHS
   saved_q_moments_local_ = lbs_solver.QMomentsLocal();
 
-  const bool single_richardson =
-    iterative_method_ == "krylov_richardson" and tolerance_options.maximum_iterations == 1;
+  const bool single_richardson = groupset.iterative_method == IterativeMethod::KRYLOV_RICHARDSON and
+                                 tolerance_options.maximum_iterations == 1;
 
   if (not single_richardson)
   {


### PR DESCRIPTION
This PR cleans up the use of PETSc iterative method names and fixes an issue in `WGSLinearSolver` where we were checking for the wrong name. This PR also restricts the use of the PETSc name to the `LinearSolver `class.