### PR TITLE
Simplifying SPLS implementation. Creating levelized SPLS.

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_solver/sweep_chunks/lbs_curvilinear_sweep_chunk_pwl.cc
@@ -94,7 +94,7 @@ SweepChunkPwlrz::Sweep(AngleSet& angle_set)
 
   // Loop over each cell
   const auto& spds = angle_set.GetSPDS();
-  const auto& spls = spds.LocalSubgrid().item_id;
+  const auto& spls = spds.LocalSubgrid();
   const size_t num_spls = spls.size();
   for (size_t spls_index = 0; spls_index < num_spls; ++spls_index)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/cbc.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/cbc.cc
@@ -51,10 +51,10 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega, const MeshContinuum& grid, bool allow_c
   }
 
   // Generate topological sorting
-  spls_.item_id.clear();
-  boost::topological_sort(local_DG, std::back_inserter(spls_.item_id));
-  std::reverse(spls_.item_id.begin(), spls_.item_id.end());
-  if (spls_.item_id.empty())
+  spls_.clear();
+  boost::topological_sort(local_DG, std::back_inserter(spls_));
+  std::reverse(spls_.begin(), spls_.end());
+  if (spls_.empty())
   {
     throw std::logic_error("CBC_SPDS: Cyclic dependencies found in the local cell graph.\n"
                            "Cycles need to be allowed by the calling application.");

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.h
@@ -40,8 +40,17 @@ public:
   /// Return a reference to the direction vector.
   const Vector3& Omega() const { return omega_; }
 
-  /// Return a reference to the associated sweep-plane local subset (SPLS).
-  const SPLS& LocalSubgrid() const { return spls_; }
+  /**
+   * Return a reference to the Sweep-Plane Local Subgrid (SPLS) associated with this SPDS. A SPLS
+   * (“spills”) is a contiguous collection of cells that is the lowest level in the SPDS hierarchy.
+   * The intent is that the locations responsible for executing sweeps on this collection of cells
+   * can readily read to and write from a common data structure. A SPLS contains one or more entire
+   * cellsets — it cannot split a cellset.
+   */
+  const std::vector<int>& LocalSubgrid() const { return spls_; }
+
+  /// Return a reference to the levelized SPLS.
+  const std::vector<std::vector<int>>& LevelizedLocalSubgrid() const { return levelized_spls_; }
 
   /// Returns the location dependencies for this SPDS.
   const std::vector<int>& LocationDependencies() const { return location_dependencies_; }
@@ -139,7 +148,9 @@ protected:
   /// Reference to the grid.
   const MeshContinuum& grid_;
   /// Sweep-plane local subgrid associated with this SPDS.
-  SPLS spls_;
+  std::vector<int> spls_;
+  /// Levelized sweep-plane local subgrid associated with this SPDS.
+  std::vector<std::vector<int>> levelized_spls_;
   /// Location dependencies.
   std::vector<int> location_dependencies_;
   /// Location successors.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/sweep.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/sweep.h
@@ -38,17 +38,6 @@ struct Task
   bool completed = false;
 };
 
-/**
- * Sweep Plane Local Subgrid (“spills”), a contiguous collection of cells that defines the lowest
- * level in the SPDS hierarchy. The intent is that the processing “locations” responsible for
- * executing sweeps on this collection of cells can readily read to and write from a common data
- * structure. A SPLS contains one or more entire cellsets — it cannot split a cellset.
- */
-struct SPLS
-{
-  std::vector<int> item_id;
-};
-
 /// Stage Task Dependency Graphs
 struct STDG
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/aah_sweep_chunk.cc
@@ -61,7 +61,7 @@ AahSweepChunk::Sweep(AngleSet& angle_set)
 
   // Loop over each cell
   const auto& spds = angle_set.GetSPDS();
-  const auto& spls = spds.LocalSubgrid().item_id;
+  const auto& spls = spds.LocalSubgrid();
   const size_t num_spls = spls.size();
   for (size_t spls_index = 0; spls_index < num_spls; ++spls_index)
   {


### PR DESCRIPTION
This PR simplifies the SPLS implementation and creates a levelized version of SPLS. The levelized version is necessary to enable parallelism along the sweep front. Although not included in this PR, I have implemented and tested a levelized version of the AAH sweepchunk and all regression tests pass.

**Note that this PR changes our sweep ordering.**
