### PR TITLE
Sweep chunk zeroing bug

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adj_solver.cc
@@ -101,7 +101,7 @@ DiscreteOrdinatesAdjointSolver::Execute()
         const auto dof_map = cell_view.MapDOF(i, m, 0);
 
         for (int g : set_group_numbers)
-          phi_old_local_[dof_map + g] *= pow(-1.0, ell);
+          phi_new_local_[dof_map + g] *= pow(-1.0, ell);
       } // for moment
     }   // node i
   }     // for cell
@@ -134,7 +134,7 @@ DiscreteOrdinatesAdjointSolver::ComputeInnerProduct()
         for (int i = 0; i < transport_view.NumNodes(); ++i)
         {
           const auto dof_map = transport_view.MapDOF(i, 0, g);
-          const auto& phi = phi_old_local_[dof_map];
+          const auto& phi = phi_new_local_[dof_map];
 
           local_integral += q * phi * fe_values.intV_shapeI(i);
         } // for node
@@ -163,7 +163,7 @@ DiscreteOrdinatesAdjointSolver::ComputeInnerProduct()
           for (int i = 0; i < num_nodes; ++i)
           {
             const auto dof_map = transport_view.MapDOF(i, 0, g);
-            const auto& phi = phi_old_local_[dof_map];
+            const auto& phi = phi_new_local_[dof_map];
 
             local_integral += S * phi * shape_values(i);
           } // for node
@@ -240,13 +240,13 @@ DiscreteOrdinatesAdjointSolver::ExportImportanceMap(const std::string& file_name
           for (int g : set_group_numbers)
           {
             if (ell == 0 and em == 0)
-              p1_moments[g](0) = std::fabs(phi_old_local_[dof_map + g]);
+              p1_moments[g](0) = std::fabs(phi_new_local_[dof_map + g]);
             if (ell == 1 and em == 1)
-              p1_moments[g](1) = phi_old_local_[dof_map + g];
+              p1_moments[g](1) = phi_new_local_[dof_map + g];
             if (ell == 1 and em == -1)
-              p1_moments[g](2) = phi_old_local_[dof_map + g];
+              p1_moments[g](2) = phi_new_local_[dof_map + g];
             if (ell == 1 and em == 0)
-              p1_moments[g](3) = phi_old_local_[dof_map + g];
+              p1_moments[g](3) = phi_new_local_[dof_map + g];
           } // for g
         }   // for m
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -623,14 +623,14 @@ DiscreteOrdinatesSolver::ComputeBalance()
 
   // Get material source
   // This is done using the SetSource routine because it allows a lot of flexibility.
-  auto mat_src = phi_old_local_;
+  auto mat_src = phi_new_local_;
   mat_src.assign(mat_src.size(), 0.0);
   for (auto& groupset : groupsets_)
   {
     q_moments_local_.assign(q_moments_local_.size(), 0.0);
     active_set_source_function_(groupset,
                                 q_moments_local_,
-                                phi_old_local_,
+                                phi_new_local_,
                                 APPLY_FIXED_SOURCES | APPLY_AGS_FISSION_SOURCES |
                                   APPLY_WGS_FISSION_SOURCES);
     LBSSolver::GSScopedCopyPrimarySTLvectors(groupset, q_moments_local_, mat_src);
@@ -700,11 +700,8 @@ DiscreteOrdinatesSolver::ComputeBalance()
 
     // Outflow: The group-wise outflow was determined during a solve so we just accumulate it here.
     for (int f = 0; f < cell.faces.size(); ++f)
-    {
-      const auto& face = cell.faces[f];
       for (int g = 0; g < num_groups_; ++g)
         local_out_flow += transport_view.GetOutflow(f, g);
-    }
 
     // Absorption and sources
     const auto& xs = transport_view.XS();
@@ -714,7 +711,7 @@ DiscreteOrdinatesSolver::ComputeBalance()
       for (int g = 0; g < num_groups_; ++g)
       {
         size_t imap = transport_view.MapDOF(i, 0, g);
-        double phi_0g = phi_old_local_[imap];
+        double phi_0g = phi_new_local_[imap];
         double q_0g = mat_src[imap];
 
         local_absorption += sigma_a[g] * phi_0g * IntV_shapeI(i);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+
+namespace opensn
+{
+void
+SweepChunk::ZeroDestinationPhi()
+{
+  const auto gsi = groupset_.groups.front().id;
+  const auto gss = groupset_.groups.size();
+
+  for (const auto& cell : grid_.local_cells)
+  {
+    const auto& transport_view = cell_transport_views_[cell.local_id];
+
+    for (int i = 0; i < cell.vertex_ids.size(); ++i)
+    {
+      for (int m = 0; m < num_moments_; ++m)
+      {
+        const auto mapping = transport_view.MapDOF(i, m, gsi);
+        for (int g = 0; g < gss; ++g)
+        {
+          (*destination_phi_)[mapping + g] = 0.0;
+        } // for g
+      }   // for moment
+    }     // for dof
+  }       // for cell
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -74,8 +74,11 @@ protected:
   /// Sets the location where flux moments are to be written.
   void SetDestinationPhi(std::vector<double>& phi) { destination_phi_ = (&phi); }
 
-  /// Sets all elements of the output vector to zero.
-  void ZeroDestinationPhi() { (*destination_phi_).assign((*destination_phi_).size(), 0.0); }
+  /**
+   * Sets the portion of the output flux moments vector corresponding to the groupset this
+   * sweep chunk operates on to zero.
+   */
+  void ZeroDestinationPhi();
 
   /// Returns a reference to the output flux moments vector.
   std::vector<double>& GetDestinationPhi() { return *destination_phi_; }

--- a/modules/linear_boltzmann_solvers/lbs_solver/io/flux_moments_io.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/io/flux_moments_io.cc
@@ -19,7 +19,7 @@ LBSSolverIO::WriteFluxMoments(
   std::ofstream file(file_name, std::ofstream::binary | std::ofstream::out | std::ofstream::trunc);
   OpenSnLogicalErrorIf(not file.is_open(), "Failed to open " + file_name + ".");
 
-  std::vector<double>& src = opt_src.has_value() ? opt_src.value().get() : lbs_solver.PhiOldLocal();
+  std::vector<double>& src = opt_src.has_value() ? opt_src.value().get() : lbs_solver.PhiNewLocal();
 
   log.Log() << "Writing flux moments to " << file_base;
 

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/nl_keigen_ags_solver.cc
@@ -117,10 +117,10 @@ NLKEigenvalueAGSSolver::PostSolveCallback()
   // Unpack solution
   const auto& groups = lbs_solver.Groups();
   lbs_solver.SetPrimarySTLvectorFromGroupScopedPETScVec(
-    groups.front().id, groups.back().id, x_, lbs_solver.PhiOldLocal());
+    groups.front().id, groups.back().id, x_, lbs_solver.PhiNewLocal());
 
   // Compute final k_eff
-  double k_eff = lbs_solver.ComputeFissionProduction(lbs_solver.PhiOldLocal());
+  double k_eff = lbs_solver.ComputeFissionProduction(lbs_solver.PhiNewLocal());
 
   PetscInt number_of_func_evals;
   SNESGetNumberFunctionEvals(nl_solver_, &number_of_func_evals);

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.cc
@@ -33,10 +33,6 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
   WGSContext* gs_context_ptr;
   MatShellGetContext(matrix, &gs_context_ptr);
 
-  // Shorten some names
-  LBSSolver& lbs_solver = gs_context_ptr->lbs_solver;
-  LBSGroupset& groupset = gs_context_ptr->groupset;
-
   // Copy krylov action_vector into local
   lbs_solver.SetPrimarySTLvectorFromGSPETScVec(groupset, action_vector, PhiSTLOption::PHI_OLD);
 

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -2063,7 +2063,7 @@ LBSSolver::MakeSourceMomentsFromPhi()
   {
     active_set_source_function_(groupset,
                                 source_moments,
-                                phi_old_local_,
+                                phi_new_local_,
                                 APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES |
                                   APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
   }
@@ -2097,7 +2097,7 @@ LBSSolver::UpdateFieldFunctions()
         const int64_t imapA = sdm.MapDOFLocal(cell, i, phi_uk_man, m, g);
         const int64_t imapB = sdm.MapDOFLocal(cell, i);
 
-        data_vector_local[imapB] = phi_old_local_[imapA];
+        data_vector_local[imapB] = phi_new_local_[imapA];
       } // for node
     }   // for cell
 
@@ -2135,7 +2135,7 @@ LBSSolver::UpdateFieldFunctions()
           // const double kappa_g = xs->Kappa()[g];
           const double kappa_g = options_.power_default_kappa;
 
-          nodal_power += kappa_g * sigma_fg * phi_old_local_[imapB + g];
+          nodal_power += kappa_g * sigma_fg * phi_new_local_[imapB + g];
         } // for g
 
         data_vector_local[imapA] = nodal_power;

--- a/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -755,8 +755,7 @@
   },
   {
     "file": "transport_1d_4_dsa_ortho_inf.lua",
-    "comment":
-      "1D LinearBSolver test of a block of graphite mimicking an infinite medium. DSA and TG",
+    "comment": "1D LinearBSolver test of a block of graphite mimicking an infinite medium. DSA and TG",
     "num_procs": 1,
     "checks": [
       {
@@ -822,7 +821,7 @@
       {
         "type": "KeyValuePair",
         "key": "[0]   Out-flow rate               =",
-        "goldvalue": 1.343510e+01,
+        "goldvalue": 1.343586e+01,
         "abs_tol": 1.0e-6
       }
     ]


### PR DESCRIPTION
The routine `SweepChunk::ZeroDestinationPhi` which gets called within `SweepScheduler::ZeroFluxDataStructures` which gets called within `SweepWGSContext::ApplyInverseTransportOperator` zeros the entire `destination_phi` vector (set to `LBSSolver::phi_new_local_`). This is a problem because sweep chunks operate on groupsets and flux moments vector  is defined over all groups. For single groupset problems, this does not pose an issue, but for multiple groupset problems, it means that with the standard machinery of groupset scoped copying `phi_new_local_` at the end of a solve will be zero for all groupsets other than the last groupset. As a result, the AGS solver actually converges only on the last groupset instead of the full flux moments vector. This PR rewrites the `SweepChunk::ZeroDestinationPhi` routine to zero only the portions of `destination_phi` that correspond to the groupset the sweep chunk is operating on. This results in small diffs on existing tests.
