### PR TITLE
WGS Context Cleanup

### DIFF
--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context.h
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context.h
@@ -10,16 +10,14 @@ namespace opensn
 
 class DiffusionDFEMSolver;
 
-struct MIPWGSContext2 : public WGSContext
+struct MIPWGSContext : public WGSContext
 {
-  DiffusionDFEMSolver& lbs_mip_ss_solver;
-
-  MIPWGSContext2(DiffusionDFEMSolver& lbs_mip_ss_solver,
-                 LBSGroupset& groupset,
-                 const SetSourceFunction& set_source_function,
-                 SourceFlags lhs_scope,
-                 SourceFlags rhs_scope,
-                 bool log_info);
+  MIPWGSContext(DiffusionDFEMSolver& solver,
+                LBSGroupset& groupset,
+                const SetSourceFunction& set_source_function,
+                SourceFlags lhs_scope,
+                SourceFlags rhs_scope,
+                bool log_info);
 
   void PreSetupCallback() override;
 

--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/lbs_mip_solver.cc
@@ -5,7 +5,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_solver/source_functions/source_function.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.h"
 #include "modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_linear_solver.h"
-#include "modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context2.h"
+#include "modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context.h"
 #include "framework/object_factory.h"
 
 namespace opensn
@@ -148,7 +148,7 @@ DiffusionDFEMSolver::InitializeWGSSolvers()
   for (auto& groupset : groupsets_)
   {
 
-    auto mip_wgs_context_ptr = std::make_shared<MIPWGSContext2>(
+    auto mip_wgs_context_ptr = std::make_shared<MIPWGSContext>(
       *this,
       groupset,
       active_set_source_function_,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -27,8 +27,7 @@ SweepWGSContext::SweepWGSContext(DiscreteOrdinatesSolver& lbs_solver,
     sweep_scheduler(lbs_solver.SweepType() == "AAH" ? SchedulingAlgorithm::DEPTH_OF_GRAPH
                                                     : SchedulingAlgorithm::FIRST_IN_FIRST_OUT,
                     *groupset.angle_agg,
-                    *sweep_chunk),
-    lbs_ss_solver(lbs_solver)
+                    *sweep_chunk)
 {
 }
 
@@ -136,7 +135,7 @@ SweepWGSContext::PostSolveCallback()
   // currently used in OpenSn). This step also zeros out balance variables and computes the correct
   // in-flow and out-flow. Classic Richardson calls this solely to compute balance quantities (note
   // that it does cost us an extra sweep that is technically not necessary).
-  lbs_ss_solver.ZeroOutflowBalanceVars(groupset);
+  dynamic_cast<DiscreteOrdinatesSolver&>(lbs_solver).ZeroOutflowBalanceVars(groupset);
   const auto scope = lhs_src_scope | rhs_src_scope;
   set_source_function(groupset, lbs_solver.QMomentsLocal(), lbs_solver.PhiOldLocal(), scope);
   sweep_scheduler.SetDestinationPhi(lbs_solver.PhiNewLocal());

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.h
@@ -13,12 +13,6 @@ namespace opensn
 
 struct SweepWGSContext : public WGSContext
 {
-  std::shared_ptr<SweepChunk> sweep_chunk;
-  SweepScheduler sweep_scheduler;
-  std::vector<double> sweep_times;
-
-  DiscreteOrdinatesSolver& lbs_ss_solver;
-
   SweepWGSContext(DiscreteOrdinatesSolver& lbs_solver,
                   LBSGroupset& groupset,
                   const SetSourceFunction& set_source_function,
@@ -36,6 +30,10 @@ struct SweepWGSContext : public WGSContext
   void ApplyInverseTransportOperator(SourceFlags scope) override;
 
   void PostSolveCallback() override;
+
+  std::shared_ptr<SweepChunk> sweep_chunk;
+  SweepScheduler sweep_scheduler;
+  std::vector<double> sweep_times;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/iterative_methods/wgs_context.h
@@ -18,14 +18,6 @@ class LBSSolver;
 
 struct WGSContext : public LinearSolverContext
 {
-  LBSSolver& lbs_solver;
-  LBSGroupset& groupset;
-  const SetSourceFunction& set_source_function;
-  SourceFlags lhs_src_scope;
-  SourceFlags rhs_src_scope;
-  bool log_info = true;
-  size_t counter_applications_of_inv_op = 0;
-
   WGSContext(LBSSolver& lbs_solver,
              LBSGroupset& groupset,
              const SetSourceFunction& set_source_function,
@@ -52,6 +44,14 @@ struct WGSContext : public LinearSolverContext
   virtual void ApplyInverseTransportOperator(SourceFlags scope) = 0;
 
   virtual void PostSolveCallback(){};
+
+  LBSSolver& lbs_solver;
+  LBSGroupset& groupset;
+  const SetSourceFunction& set_source_function;
+  SourceFlags lhs_src_scope;
+  SourceFlags rhs_src_scope;
+  bool log_info = true;
+  size_t counter_applications_of_inv_op = 0;
 };
 
 } // namespace opensn


### PR DESCRIPTION
The existing `WGSContext` stores a reference to an `LBSSolver`. The derived classes store this and a reference to the derived class (`DiffusionDFEMSolver` or `DiscreteOrdinatesSolver`). This seems redundant and unnecessary. Instead, storing an `std::shared_ptr<LBSSolver>` and casting where necessary seems more reasonable. This PR implements this.

One test fails: `test/framework/tutorials/tutorial_93_raytracing.lua`. The test segfaults during the call to `Finalize` and I cannot figure out why. Any advice on what the issue is would be much appreciated!