### PR TITLE
Simple partition rebalancing

### DIFF
--- a/framework/mesh/mesh_generator/mesh_generator.h
+++ b/framework/mesh/mesh_generator/mesh_generator.h
@@ -95,6 +95,17 @@ protected:
   const bool replicated_;
   std::vector<MeshGenerator*> inputs_;
   GraphPartitioner* partitioner_ = nullptr;
+
+private:
+  /**
+   * Rebalance partitions so that all partitions contain cells. If we find a partition
+   * that has zero cells, move cells from heavier partitions to the partition with zero
+   * cells. This procedure can easily destroy the spatial locality of the partitioning,
+   * so it is used as a last resort to keep the code from throwing an exception when it
+   * finds a partition with zero cells.
+   * \todo Explore more robust partitioners that can better distribute cells across available PEs.
+   */
+  void RebalancePartitions(std::vector<int64_t>& cell_pids, int num_partitions);
 };
 
 } // namespace opensn


### PR DESCRIPTION
This PR adds a simple partition rebalancing algorithm that allows the code to continue execution if the partitioner creates partitions with zero cells. The algorithm computes the average number of cells per partition and moves cell from heavier partitions to the partition with zero cells. This algorithm is a last resort as it will likely destroy the spatial locality of the partitioning.

See issue #409.