### PR TITLE
Fix GCC compiler warnings for MeshContinuum and NDArray classes

### DIFF
--- a/framework/data_types/ndarray.h
+++ b/framework/data_types/ndarray.h
@@ -41,7 +41,7 @@ public:
    * This constructor creates an empty array and initializes the reference
    * count to one.
    */
-  NDArray() noexcept : size_(0), storage_(nullptr), dimensions_{}, strides_{} {}
+  NDArray() noexcept : rank_(D), size_(0), storage_(nullptr), dimensions_{}, strides_{} {}
 
   /**
    * Creates an array with the specified number of elements in each dimension,

--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -18,15 +18,15 @@ namespace opensn
 {
 
 MeshContinuum::MeshContinuum()
-  : local_cells(local_cells_),
+  : dim_(0),
+    mesh_type_(UNSTRUCTURED),
+    extruded_(false),
+    global_vertex_count_(0),
+    local_cells(local_cells_),
     cells(local_cells_,
           ghost_cells_,
           global_cell_id_to_local_id_map_,
-          global_cell_id_to_nonlocal_id_map_),
-    dim_(0),
-    mesh_type_(UNSTRUCTURED),
-    extruded_(false),
-    global_vertex_count_(0)
+          global_cell_id_to_nonlocal_id_map_)
 {
 }
 

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -22,7 +22,27 @@ class MeshGenerator;
  */
 class MeshContinuum
 {
+private:
+  /// Spatial dimension
+  unsigned int dim_;
+  MeshType mesh_type_;
+  bool extruded_;
+  OrthoMeshAttributes ortho_attributes_;
+  std::map<uint64_t, std::string> boundary_id_map_;
+
+  uint64_t global_vertex_count_;
+
+  std::vector<std::unique_ptr<Cell>> local_cells_; ///< Actual local cells
+  std::vector<std::unique_ptr<Cell>> ghost_cells_; ///< Locally stored ghosts
+
+  std::map<uint64_t, uint64_t> global_cell_id_to_local_id_map_;
+  std::map<uint64_t, uint64_t> global_cell_id_to_nonlocal_id_map_;
+
 public:
+  VertexHandler vertices;
+  LocalCellHandler local_cells;
+  GlobalCellHandler cells;
+
   MeshContinuum();
 
   unsigned int Dimension() const { return dim_; }
@@ -185,27 +205,6 @@ public:
                                 const std::string& boundary_name);
 
   void SetOrthoAttributes(const OrthoMeshAttributes& attrs) { ortho_attributes_ = attrs; }
-
-public:
-  VertexHandler vertices;
-  LocalCellHandler local_cells;
-  GlobalCellHandler cells;
-
-private:
-  /// Spatial dimension
-  unsigned int dim_;
-  MeshType mesh_type_;
-  bool extruded_;
-  OrthoMeshAttributes ortho_attributes_;
-  std::map<uint64_t, std::string> boundary_id_map_;
-
-  uint64_t global_vertex_count_;
-
-  std::vector<std::unique_ptr<Cell>> local_cells_; ///< Actual local cells
-  std::vector<std::unique_ptr<Cell>> ghost_cells_; ///< Locally stored ghosts
-
-  std::map<uint64_t, uint64_t> global_cell_id_to_local_id_map_;
-  std::map<uint64_t, uint64_t> global_cell_id_to_nonlocal_id_map_;
 };
 
 } // namespace opensn

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -22,27 +22,7 @@ class MeshGenerator;
  */
 class MeshContinuum
 {
-private:
-  /// Spatial dimension
-  unsigned int dim_;
-  MeshType mesh_type_;
-  bool extruded_;
-  OrthoMeshAttributes ortho_attributes_;
-  std::map<uint64_t, std::string> boundary_id_map_;
-
-  uint64_t global_vertex_count_;
-
-  std::vector<std::unique_ptr<Cell>> local_cells_; ///< Actual local cells
-  std::vector<std::unique_ptr<Cell>> ghost_cells_; ///< Locally stored ghosts
-
-  std::map<uint64_t, uint64_t> global_cell_id_to_local_id_map_;
-  std::map<uint64_t, uint64_t> global_cell_id_to_nonlocal_id_map_;
-
 public:
-  VertexHandler vertices;
-  LocalCellHandler local_cells;
-  GlobalCellHandler cells;
-
   MeshContinuum();
 
   unsigned int Dimension() const { return dim_; }
@@ -205,6 +185,27 @@ public:
                                 const std::string& boundary_name);
 
   void SetOrthoAttributes(const OrthoMeshAttributes& attrs) { ortho_attributes_ = attrs; }
+
+private:
+  /// Spatial dimension
+  unsigned int dim_;
+  MeshType mesh_type_;
+  bool extruded_;
+  OrthoMeshAttributes ortho_attributes_;
+  std::map<uint64_t, std::string> boundary_id_map_;
+
+  uint64_t global_vertex_count_;
+
+  std::vector<std::unique_ptr<Cell>> local_cells_; ///< Actual local cells
+  std::vector<std::unique_ptr<Cell>> ghost_cells_; ///< Locally stored ghosts
+
+  std::map<uint64_t, uint64_t> global_cell_id_to_local_id_map_;
+  std::map<uint64_t, uint64_t> global_cell_id_to_nonlocal_id_map_;
+
+public:
+  VertexHandler vertices;
+  LocalCellHandler local_cells;
+  GlobalCellHandler cells;
 };
 
 } // namespace opensn


### PR DESCRIPTION
With these fixes, I think we'll have clean builds across all of our supported compilers.