### PR TITLE
Refactoring API for computing norms

### DIFF
--- a/framework/math/math.cc
+++ b/framework/math/math.cc
@@ -100,7 +100,7 @@ Mult(const std::vector<double>& x, const double& val)
 }
 
 double
-Vec1Norm(const std::vector<double>& x)
+L1Norm(const std::vector<double>& x)
 {
   // Local Variables
   size_t n = x.size();
@@ -113,7 +113,7 @@ Vec1Norm(const std::vector<double>& x)
 }
 
 double
-Vec2Norm(const std::vector<double>& x)
+L2Norm(const std::vector<double>& x)
 {
   // Local Variables
   size_t n = x.size();
@@ -126,7 +126,7 @@ Vec2Norm(const std::vector<double>& x)
 }
 
 double
-VecInfinityNorm(const std::vector<double>& x)
+LInfNorm(const std::vector<double>& x)
 {
   // Local Variables
   size_t n = x.size();
@@ -139,7 +139,7 @@ VecInfinityNorm(const std::vector<double>& x)
 }
 
 double
-VecPNorm(const std::vector<double>& x, const double& p)
+LpNorm(const std::vector<double>& x, const double& p)
 {
   // Local Variables
   size_t n = x.size();

--- a/framework/math/math.h
+++ b/framework/math/math.h
@@ -113,7 +113,7 @@ std::vector<double> Mult(const std::vector<double>& x, const double& val);
  * \|\boldsymbol{x}\|_{1}=\sum_{i=1}^{n}\left|x_{i}\right|
  * \f]
  */
-double Vec1Norm(const std::vector<double>& x);
+double L1Norm(const std::vector<double>& x);
 
 /**
  * Returns the 2-norm. Also known as the Euclidian or Frobenius norm.
@@ -122,7 +122,7 @@ double Vec1Norm(const std::vector<double>& x);
  * \|\boldsymbol{x}\|_{2}=\sqrt{x_{1}^{2}+\cdots+x_{n}^{2}}
  * \f]
  */
-double Vec2Norm(const std::vector<double>& x);
+double L2Norm(const std::vector<double>& x);
 
 /**
  * Returns the infinity-norm.
@@ -131,7 +131,7 @@ double Vec2Norm(const std::vector<double>& x);
  * \|\mathbf{x}\|_{\infty}=\max \left(\left|x_{1}\right|,
  * \ldots,\left|x_{n}\right|\right) \f]
  */
-double VecInfinityNorm(const std::vector<double>& x);
+double LInfNorm(const std::vector<double>& x);
 
 /**
  * Returns the p-norm.
@@ -140,7 +140,7 @@ double VecInfinityNorm(const std::vector<double>& x);
  * \|\mathbf{x}\|_{p}=\left(\sum_{i=1}^{n}\left|x_{i}\right|^{p}\right)^{1 / p}
  * \f]
  */
-double VecPNorm(const std::vector<double>& x, const double& p);
+double LpNorm(const std::vector<double>& x, const double& p);
 
 /**
  * Computes the dot product of two vectors.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adjoint.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_adjoint_solver/lbs_adjoint.cc
@@ -54,7 +54,7 @@ MakeExpRepFromP1(const std::array<double, 4>& P1_moments, bool verbose)
       const double b = x(1);
       const double FOUR_PI = 4.0 * M_PI;
 
-      double size_J = Vec2Norm({J_x, J_y, J_z});
+      double size_J = L2Norm({J_x, J_y, J_z});
 
       return Vector<double>((FOUR_PI / b) * exp(a) * sinh(b) - 1.0,
                             (FOUR_PI / b / b) * exp(a) * (b * cosh(b) - sinh(b)) - size_J);
@@ -83,7 +83,7 @@ MakeExpRepFromP1(const std::array<double, 4>& P1_moments, bool verbose)
   double J_z = P1_moments[3];
 
   // Compute initial ratio size_J/phi
-  double size_J_i = Vec2Norm({J_x, J_y, J_z});
+  double size_J_i = L2Norm({J_x, J_y, J_z});
   double ratio_i = size_J_i / phi;
 
   if (phi < 1.0e-10 or ratio_i > 0.9)
@@ -99,7 +99,7 @@ MakeExpRepFromP1(const std::array<double, 4>& P1_moments, bool verbose)
     J_z /= phi;
   }
 
-  double size_J_f = Vec2Norm({J_x, J_y, J_z});
+  double size_J_f = L2Norm({J_x, J_y, J_z});
   double ratio_f = size_J_f;
 
   if (verbose)


### PR DESCRIPTION
Functions are renamed as:
- Vec1Norm -> L1Norm
- Vec2Norm -> L2Norm
- VecInfinityNorm -> LInfNorm
- VecPNorm -> LpNorm

Closes #351
