### PR TITLE
Use compiler major version number for module names on self-hosted runners

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -13,33 +13,33 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - gcc/9.5.0
-          - gcc/10.5.0
-          - gcc/12.3.0
-          - gcc/13.2.0
-          - clang/12.0.1
-          - clang/14.0.6
-          - clang/16.0.6
-          - clang/17.0.6
-          - intel/oneapi-2024.1
+          - gcc/9
+          - gcc/10
+          - gcc/12
+          - gcc/13
+          - clang/12
+          - clang/14
+          - clang/16
+          - clang/17
+          - intel/oneapi
     steps:
       - uses: actions/checkout@v3
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           test/run_tests -d test/ -j 32 -v 1 -w 3
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           test/run_tests -d tutorials -j 32 -v 1 -w 3
 
@@ -50,21 +50,21 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/clang/17.0.6
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/clang/17
           cmake --preset clang+debug+sanitizer
           cmake --build --preset clang+debug+sanitizer -j64
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/clang/17.0.6
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/clang/17
           export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
           test/run_tests -d test/ -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/opensn-test
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/clang/17.0.6
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/clang/17
           export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
           test/run_tests -d tutorials/ -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/opensn-test

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -18,18 +18,18 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/gcc/12.3.0
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/gcc/12
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/gcc/12.3.0
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/gcc/12
           test/run_tests -d test/ -j 32 -v 1 -w 3
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/gcc/12.3.0
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/gcc/12
           test/run_tests -d tutorials -j 32 -v 1 -w 3

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -13,12 +13,12 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/gcc/12.3.0
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/gcc/12
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles
-          module load opensn/gcc/12.3.0
+          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
+          module load opensn/gcc/12
           test/run_tests -d test/ -j 32 -v 1 -w 4


### PR DESCRIPTION
Allows us to easily update compiler minor versions without needing to modify our workflows for the self-hosted runners.