### PR TITLE
Refactor `CheckPointInsideCell` and fix for polyhedra

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -433,14 +433,8 @@ MeshContinuum::CheckPointInsideCell(const Cell& cell, const Vector3& point) cons
 
       for (size_t side = 0; side < num_sides; ++side)
       {
-        // Form the four tri faces within the tetrahedron within this side
-        const size_t sp1 = (side < (num_sides - 1)) ? side + 1 : 0;
-        const auto& v0 = grid_ref.vertices[face.vertex_ids[side]];
-        const auto& v1 = vfc;
-        const auto& v2 = grid_ref.vertices[face.vertex_ids[sp1]];
-        const auto& v3 = vcc;
-        const std::array<std::array<Vector3, 3>, 4> tet_face_vertices = {
-          {{{v0, v1, v2}}, {{v0, v2, v3}}, {{v1, v3, v2}}, {{v0, v3, v1}}}};
+        // Vertices to each of the four tetrahedral faces on this side
+        const auto tet_face_vertices = GetTetrahedralFaceVertices(cell, face, side);
 
         // Considered within the tet if within all four tri face planes
         bool within_tet = true;
@@ -725,6 +719,22 @@ MeshContinuum::ComputeVolumePerMaterialID() const
                 << pair.second << std::endl;
     log.Log() << std::endl;
   }
+}
+
+std::array<std::array<Vector3, 3>, 4>
+MeshContinuum::GetTetrahedralFaceVertices(const Cell& cell,
+                                          const CellFace& face,
+                                          const size_t side) const
+{
+  assert(cell.Type() == CellType::POLYHEDRON);
+  const auto num_sides = face.vertex_ids.size();
+  assert(side < num_sides);
+  const size_t sp1 = (side < (num_sides - 1)) ? side + 1 : 0;
+  const auto& v0 = vertices[face.vertex_ids[side]];
+  const auto& v1 = face.centroid;
+  const auto& v2 = vertices[face.vertex_ids[sp1]];
+  const auto& v3 = cell.centroid;
+  return {{{{v0, v1, v2}}, {{v0, v2, v3}}, {{v1, v3, v2}}, {{v0, v3, v1}}}};
 }
 
 } // namespace opensn

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -163,6 +163,13 @@ public:
   /// Compute volume per material id's
   void ComputeVolumePerMaterialID() const;
 
+  /**
+   * Get the face vertices of a tetrahedron contained within the given face and
+   * side of a polyhedron.
+   */
+  std::array<std::array<Vector3, 3>, 4>
+  GetTetrahedralFaceVertices(const Cell& cell, const CellFace& face, const size_t side) const;
+
 private:
   /// Spatial dimension
   unsigned int dim_;

--- a/test/unit/framework/mesh/mesh_continuum_test.cc
+++ b/test/unit/framework/mesh/mesh_continuum_test.cc
@@ -1,0 +1,145 @@
+#include "test/unit/opensn_unit_test.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/mesh/mesh_generator/orthogonal_mesh_generator.h"
+
+using namespace opensn;
+
+class MeshContinuumTest : public OpenSnUnitTest
+{
+};
+
+/// Helper for building a MeshContinuum for an orthogonal mesh
+/// given an array of nodes (one for each dimension)
+std::shared_ptr<MeshContinuum>
+BuildOrthogonalMesh(const std::vector<std::vector<double>>& node_sets)
+{
+  EXPECT_EQ(mesh_stack.size(), 0);
+
+  ParameterBlock array("node_sets");
+  for (std::size_t i = 0; i < node_sets.size(); ++i)
+    array.AddParameter(ParameterBlock(std::to_string(i + 1), node_sets[i]));
+  array.ChangeToArray();
+
+  ParameterBlock block("");
+  block.AddParameter(array);
+
+  auto params = OrthogonalMeshGenerator::GetInputParameters();
+  params.AssignParameters(block);
+  OrthogonalMeshGenerator(params).Execute();
+  auto grid_ptr = mesh_stack.back();
+  mesh_stack.clear();
+  return grid_ptr;
+}
+
+/// Helper for the PointInsideCellXD tests
+void
+TestPointInsideCell(const MeshContinuum& grid)
+{
+  // Centroid is contained within cell whose centroid it is
+  for (const auto& cell : grid.local_cells)
+    for (const auto& other_cell : grid.local_cells)
+    {
+      const auto same_cell = cell.global_id == other_cell.global_id;
+      const auto within = grid.CheckPointInsideCell(other_cell, cell.centroid);
+      EXPECT_EQ(same_cell, within);
+    }
+
+  // Vertices are contained within cells
+  for (const auto& cell : grid.local_cells)
+    for (const auto vi : cell.vertex_ids)
+      for (const auto& other_cell : grid.local_cells)
+      {
+        const auto has_vertex =
+          std::find(other_cell.vertex_ids.begin(), other_cell.vertex_ids.end(), vi) !=
+          other_cell.vertex_ids.end();
+        const auto within = grid.CheckPointInsideCell(other_cell, grid.vertices[vi]);
+        EXPECT_EQ(has_vertex, within);
+      }
+
+  // Face centroids are contained within cells (including neighbors)
+  for (const auto& cell : grid.local_cells)
+    for (const auto& face : cell.faces)
+      for (const auto& other_cell : grid.local_cells)
+      {
+        const auto same_cell_or_neighbor =
+          (cell.global_id == other_cell.global_id ||
+           (face.has_neighbor && face.neighbor_id == other_cell.global_id));
+        const auto within = grid.CheckPointInsideCell(other_cell, face.centroid);
+        EXPECT_EQ(same_cell_or_neighbor, within);
+      }
+
+  if (grid.GetDimension() > 1)
+  {
+    // Face edge centroids contained
+    for (const auto& cell : grid.local_cells)
+      for (const auto& face : cell.faces)
+        for (size_t side = 0; side < face.vertex_ids.size(); ++side)
+        {
+          const size_t sp1 = (side < (face.vertex_ids.size() - 1)) ? side + 1 : 0;
+          const auto& v0 = grid.vertices[face.vertex_ids[side]];
+          const auto& v1 = grid.vertices[face.vertex_ids[sp1]];
+          const auto c = (v0 + v1) / 2.0;
+          EXPECT_TRUE(grid.CheckPointInsideCell(cell, c));
+        }
+  }
+
+  if (grid.GetDimension() == 3)
+  {
+    // Tetrahedral centroids contained
+    for (const auto& cell : grid.local_cells)
+      for (const auto& face : cell.faces)
+        for (size_t side = 0; side < face.vertex_ids.size(); ++side)
+        {
+          const size_t sp1 = (side < (face.vertex_ids.size() - 1)) ? side + 1 : 0;
+          const auto& v0 = grid.vertices[face.vertex_ids[side]];
+          const auto& v1 = face.centroid;
+          const auto& v2 = grid.vertices[face.vertex_ids[sp1]];
+          const auto& v3 = cell.centroid;
+          const auto c = (v0 + v1 + v2 + v3) / 4.0;
+          for (const auto& other_cell : grid.local_cells)
+          {
+            const auto same_cell = cell.global_id == other_cell.global_id;
+            const auto within = grid.CheckPointInsideCell(other_cell, c);
+            EXPECT_EQ(same_cell, within);
+          }
+        }
+
+    // Tetrahedral face centroids contained
+    for (const auto& cell : grid.local_cells)
+      for (const auto& face : cell.faces)
+        for (size_t side = 0; side < face.vertex_ids.size(); ++side)
+        {
+          const auto tet_face_vertices = grid.GetTetrahedralFaceVertices(cell, face, side);
+          for (const auto& v : tet_face_vertices)
+          {
+            const auto c = (v[0] + v[1] + v[2]) / 3.0;
+            for (const auto& other_cell : grid.local_cells)
+            {
+              const auto same_cell_or_neighbor =
+                (cell.global_id == other_cell.global_id ||
+                 (face.has_neighbor && face.neighbor_id == other_cell.global_id));
+              const auto within = grid.CheckPointInsideCell(other_cell, face.centroid);
+              EXPECT_EQ(same_cell_or_neighbor, within);
+            }
+          }
+        }
+  }
+}
+
+TEST_F(MeshContinuumTest, PointInsideCell1D)
+{
+  const auto grid_ptr = BuildOrthogonalMesh({{-1.0, -0.75, 0.0, 1.0, 2.0}});
+  TestPointInsideCell(*grid_ptr);
+}
+
+TEST_F(MeshContinuumTest, PointInsideCell2D)
+{
+  const auto grid_ptr = BuildOrthogonalMesh({{-1.0, -0.75, 0.0, 1.0}, {0.0, 0.5, 1.0}});
+  TestPointInsideCell(*grid_ptr);
+}
+
+TEST_F(MeshContinuumTest, PointInsideCell3D)
+{
+  const auto grid_ptr = BuildOrthogonalMesh({{-1.0, 1.0}, {0.0, 0.5, 1.0}, {-1.0, 0.0, 1.0}});
+  TestPointInsideCell(*grid_ptr);
+}


### PR DESCRIPTION
https://github.com/Open-Sn/opensn/pull/261 broke `CheckPointInsideCell` for polyhedra. Before the refactoring, if a single tetrahedron was found that contains the point, it was considered contained (see [here](https://github.com/wdhawkins/openSn/blob/fb1e7b055d910577acc437c0c71acb34704b186b/framework/mesh/mesh_continuum/mesh_continuum.cc#L975) for old version). After the refactoring, the point needed to be contained within _all_ tetrahedra. This corrects that issue.

Impressively, this bug didn't break anything. This probably needs unit tests.