### PR TITLE
Add `MeshMapping` for future separate mesh acceleration

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -126,6 +126,10 @@ public:
   /// Checks whether a point is within a cell.
   bool CheckPointInsideCell(const Cell& cell, const Vector3& point) const;
 
+  /// Checks whether a point is within a cell face.
+  bool
+  CheckPointInsideCellFace(const Cell& cell, const std::size_t face_i, const Vector3& point) const;
+
   MeshType GetType() const { return mesh_type_; }
 
   void SetType(MeshType type) { mesh_type_ = type; }

--- a/framework/mesh/mesh_mapping/mesh_mapping.cc
+++ b/framework/mesh/mesh_mapping/mesh_mapping.cc
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/mesh/mesh_mapping/mesh_mapping.h"
+#include "framework/logging/log.h"
+#include "framework/mesh/cell/cell.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
+
+#include <sstream>
+
+namespace opensn
+{
+
+const std::size_t MeshMapping::invalid_face_index = std::numeric_limits<std::size_t>::max();
+
+MeshMapping::CoarseMapping::CoarseMapping(const Cell& coarse_cell)
+  : fine_faces{coarse_cell.faces.size()}
+{
+}
+
+MeshMapping::FineMapping::FineMapping(const Cell& fine_cell)
+  : coarse_cell(nullptr), coarse_faces(fine_cell.faces.size(), MeshMapping::invalid_face_index)
+{
+}
+
+void
+MeshMapping::Build(const MeshContinuum& fine_grid, const MeshContinuum& coarse_grid)
+
+{
+  if (opensn::mpi_comm.size() > 1)
+    OpenSnLogicalError("MeshMapping is not currently supported in parallel.");
+  if (fine_grid.GetDimension() != coarse_grid.GetDimension())
+    OpenSnLogicalError("Grid dimensions are not equal for mapping. Fine dimension = " +
+                       std::to_string(fine_grid.GetDimension()) +
+                       ", coarse dimension = " + std::to_string(coarse_grid.GetDimension()) + ".");
+
+  coarse_to_fine_.clear();
+  fine_to_coarse_.clear();
+
+  // Instantiate the maps; constructors take the cell to size the face maps.
+  for (const auto& coarse_cell : coarse_grid.local_cells)
+    coarse_to_fine_.emplace(&coarse_cell, coarse_cell);
+  for (const auto& fine_cell : fine_grid.local_cells)
+    fine_to_coarse_.emplace(&fine_cell, fine_cell);
+
+  // Volumetric mapping; find the coarse cell that contains a fine cell centroid
+  for (auto& [fine_cell_ptr, fine_mapping] : fine_to_coarse_)
+  {
+    const auto& fine_cell = *fine_cell_ptr;
+    for (const auto& coarse_cell : coarse_grid.local_cells)
+      if (coarse_grid.CheckPointInsideCell(coarse_cell, fine_cell.centroid))
+      {
+        fine_mapping.coarse_cell = &coarse_cell;
+        break;
+      }
+
+    if (!fine_mapping.coarse_cell)
+    {
+      std::ostringstream oss;
+      oss << "Failed to find a corresponding coarse cell for fine cell " << fine_cell.global_id
+          << " with centroid " << fine_cell.centroid.PrintStr() << ".";
+      OpenSnLogicalError(oss.str());
+    }
+
+    coarse_to_fine_.at(fine_mapping.coarse_cell).fine_cells.push_back(fine_cell_ptr);
+  }
+
+  // Ensure that coarse cell volume is equal to the sum of the fine cell volumes contained within it
+  auto fine_sdm_ptr = PieceWiseLinearContinuous::New(fine_grid);
+  auto& fine_sdm = *fine_sdm_ptr;
+  auto coarse_sdm_ptr = PieceWiseLinearContinuous::New(coarse_grid);
+  auto& coarse_sdm = *coarse_sdm_ptr;
+  for (const auto& [coarse_cell_ptr, coarse_mapping] : coarse_to_fine_)
+  {
+    const auto& coarse_cell = *coarse_cell_ptr;
+    const auto& coarse_cell_mapping = coarse_sdm.GetCellMapping(coarse_cell);
+    const auto coarse_cell_volume = coarse_cell_mapping.GetCellVolume();
+    double total_fine_volume = 0;
+    for (const auto fine_cell_ptr : coarse_mapping.fine_cells)
+    {
+      const auto& fine_cell = *fine_cell_ptr;
+      const auto& fine_cell_mapping = fine_sdm.GetCellMapping(fine_cell);
+      total_fine_volume += fine_cell_mapping.GetCellVolume();
+    }
+    if (std::abs(total_fine_volume - coarse_cell_volume) > 1.e-6)
+    {
+      std::ostringstream oss;
+      oss << "Coarse cell " << coarse_cell.global_id << " with centroid "
+          << coarse_cell.centroid.PrintStr() << " volumetric mapping failed.";
+      OpenSnLogicalError(oss.str());
+    }
+  }
+
+  // Surface mapping; find the coarse cell face that contains a fine cell face centroid
+  for (auto& [fine_cell_ptr, fine_mapping] : fine_to_coarse_)
+  {
+    const auto& fine_cell = *fine_cell_ptr;
+    const auto& coarse_cell = *fine_mapping.coarse_cell;
+    auto& coarse_mapping = coarse_to_fine_.at(&coarse_cell);
+    for (size_t fine_face_i = 0; fine_face_i < fine_cell.faces.size(); ++fine_face_i)
+    {
+      const auto& fine_face = fine_cell.faces[fine_face_i];
+      for (size_t coarse_face_i = 0; coarse_face_i < coarse_cell.faces.size(); ++coarse_face_i)
+      {
+        if (coarse_grid.CheckPointInsideCellFace(coarse_cell, coarse_face_i, fine_face.centroid))
+        {
+          coarse_mapping.fine_faces[coarse_face_i].emplace_back(fine_cell_ptr, fine_face_i);
+          fine_mapping.coarse_faces[fine_face_i] = coarse_face_i;
+          break;
+        }
+      }
+    }
+  }
+
+  // Ensure that coarse cell area is equal to the sum of the fine cell areas contained within it
+  for (const auto& [coarse_cell_ptr, coarse_mapping] : coarse_to_fine_)
+  {
+    const auto& coarse_cell = *coarse_cell_ptr;
+    for (size_t coarse_face_i = 0; coarse_face_i < coarse_cell.faces.size(); ++coarse_face_i)
+    {
+      double total_fine_face_area = 0;
+      const auto& fine_faces = coarse_mapping.fine_faces[coarse_face_i];
+      for (const auto& [fine_cell_ptr, fine_face_i] : fine_faces)
+      {
+        const auto& fine_face = fine_cell_ptr->faces[fine_face_i];
+        total_fine_face_area += fine_face.ComputeFaceArea(fine_grid);
+      }
+      const auto& coarse_face = coarse_cell.faces[coarse_face_i];
+      const auto coarse_face_area = coarse_face.ComputeFaceArea(coarse_grid);
+      if (std::abs(total_fine_face_area - coarse_face_area) > 1.e-6)
+      {
+        std::ostringstream oss;
+        oss << "Coarse cell " << coarse_cell.global_id << " face " << coarse_face_i
+            << " with centroid " << coarse_face.centroid.PrintStr() << " surface mapping failed.";
+        OpenSnLogicalError(oss.str());
+      }
+    }
+  }
+}
+
+const MeshMapping::CoarseMapping&
+MeshMapping::GetCoarseMapping(const Cell& coarse_cell) const
+{
+  const auto it = coarse_to_fine_.find(&coarse_cell);
+  if (it == coarse_to_fine_.end())
+    OpenSnLogicalError("MeshMapping::GetCoarseMapping(): Coarse cell not found in mapping.");
+  return it->second;
+}
+
+const MeshMapping::FineMapping&
+MeshMapping::GetFineMapping(const Cell& fine_cell) const
+{
+  const auto it = fine_to_coarse_.find(&fine_cell);
+  if (it == fine_to_coarse_.end())
+    OpenSnLogicalError("MeshMapping::GetFineMapping(): Fine cell not found in mapping.");
+  return it->second;
+}
+
+} // namespace opensn

--- a/framework/mesh/mesh_mapping/mesh_mapping.h
+++ b/framework/mesh/mesh_mapping/mesh_mapping.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+namespace opensn
+{
+class MeshContinuum;
+class Cell;
+
+/**
+ * Produces a mapping between a fine mesh and a coarse mesh.
+ * Each fine mesh cell face must be fully contained within a
+ * coarse mesh face. The meshes can be the same.
+ */
+class MeshMapping
+{
+public:
+  MeshMapping() = default;
+
+  /// Builds the mapping.
+  void Build(const MeshContinuum& fine_grid, const MeshContinuum& coarse_grif);
+
+  /// Identifier for an invalid face index that means a face maps to nothing.
+  static const std::size_t invalid_face_index;
+
+  /// Helper struct for storing the mapping to a coarse cell from a fine cell.
+  struct CoarseMapping
+  {
+    /// Constructor. Sizes fine_faces based on the number of faces within the coarse cell.
+    CoarseMapping(const Cell& coarse_cell);
+    /// The fine cells contained within a coarse cell.
+    std::vector<const Cell*> fine_cells;
+    /// The fine cell faces contained within each coarse cell face.
+    /// Outer index coarse cell face index (size == # of faces in coarse cell)
+    /// Inner index is arbitrary and entries are fine Cell -> fine CellFace index
+    std::vector<std::vector<std::pair<const Cell*, std::size_t>>> fine_faces;
+  };
+  /// Helper struct for storing the mapping from a coarse cell to fine cells.
+  struct FineMapping
+  {
+    /// Constructor. Sizes coarse_faces based on the number of faces within the fine cell.
+    FineMapping(const Cell& fine_cell);
+    /// The coarse cell that the fine cell is contained within.
+    const Cell* coarse_cell;
+    /// The coarse CellFace index each fine CellFace is contained within (if any)
+    std::vector<std::size_t> coarse_faces;
+  };
+
+  /// Get the mapping from the given coarse mesh cell.
+  const CoarseMapping& GetCoarseMapping(const Cell& coarse_cell) const;
+  /// Get the mapping for the given fine mesh cell.
+  const FineMapping& GetFineMapping(const Cell& fine_cell) const;
+
+private:
+  /// Mapping for coarse cells to fine cells.
+  std::unordered_map<const Cell*, CoarseMapping> coarse_to_fine_;
+  /// Mapping for fine cells to a coarse cell.
+  std::unordered_map<const Cell*, FineMapping> fine_to_coarse_;
+};
+} // namespace opensn

--- a/framework/mesh/mesh_vector.h
+++ b/framework/mesh/mesh_vector.h
@@ -253,6 +253,16 @@ struct Vector3 : public std::enable_shared_from_this<Vector3>
     return out.str();
   }
 
+  /// Absolute equality check with another point.
+  bool AbsoluteEquals(const Vector3& other, const double tol = 1.e-6) const
+  {
+    if (std::abs(other.x - x) > tol)
+      return false;
+    if (std::abs(other.y - y) > tol)
+      return false;
+    return std::abs(other.z - z) < tol;
+  }
+
   static constexpr size_t Size() { return 3; }
 };
 

--- a/test/unit/framework/mesh/mesh_continuum_test.cc
+++ b/test/unit/framework/mesh/mesh_continuum_test.cc
@@ -1,31 +1,11 @@
 #include "test/unit/opensn_unit_test.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "framework/mesh/mesh_generator/orthogonal_mesh_generator.h"
 
 using namespace opensn;
 
 class MeshContinuumTest : public OpenSnUnitTest
 {
 };
-
-/// Helper for building a MeshContinuum for an orthogonal mesh
-/// given an array of nodes (one for each dimension)
-std::shared_ptr<MeshContinuum>
-BuildOrthogonalMesh(const std::vector<std::vector<double>>& node_sets)
-{
-  ParameterBlock array("node_sets");
-  for (std::size_t i = 0; i < node_sets.size(); ++i)
-    array.AddParameter(ParameterBlock(std::to_string(i + 1), node_sets[i]));
-  array.ChangeToArray();
-
-  ParameterBlock block("");
-  block.AddParameter(array);
-
-  auto params = OrthogonalMeshGenerator::GetInputParameters();
-  params.AssignParameters(block);
-  auto grid_ptr = OrthogonalMeshGenerator(params).Execute();
-  return grid_ptr;
-}
 
 /// Helper for the PointInsideCellXD tests
 void

--- a/test/unit/framework/mesh/mesh_mapping_test.cc
+++ b/test/unit/framework/mesh/mesh_mapping_test.cc
@@ -1,0 +1,146 @@
+#include "test/unit/opensn_unit_test.h"
+#include "framework/mesh/mesh_mapping/mesh_mapping.h"
+
+using namespace opensn;
+
+class MeshMappingTest : public OpenSnUnitTest
+{
+};
+
+void
+TestMapping(const MeshContinuum& fine_grid, const MeshContinuum& coarse_grid)
+{
+  MeshMapping mesh_mapping;
+  mesh_mapping.Build(fine_grid, coarse_grid);
+
+  // Volumetric mapping; check all coarse cells against all fine cells
+  for (const auto& coarse_cell : coarse_grid.local_cells)
+  {
+    const auto& coarse_mapping = mesh_mapping.GetCoarseMapping(coarse_cell);
+    for (const auto& fine_cell : fine_grid.local_cells)
+    {
+      const auto in_coarse_mapping =
+        std::find(coarse_mapping.fine_cells.begin(), coarse_mapping.fine_cells.end(), &fine_cell) !=
+        coarse_mapping.fine_cells.end();
+      const auto& fine_mapping = mesh_mapping.GetFineMapping(fine_cell);
+      const auto in_fine_mapping = fine_mapping.coarse_cell == &coarse_cell;
+      EXPECT_EQ(in_coarse_mapping, in_fine_mapping);
+
+      const auto fine_within_coarse =
+        coarse_grid.CheckPointInsideCell(coarse_cell, fine_cell.centroid);
+      EXPECT_EQ(in_coarse_mapping, fine_within_coarse);
+    }
+  }
+
+  // Surface mapping. Check all fine cell faces against all coarse cell faces
+  for (const auto& fine_cell : fine_grid.local_cells)
+  {
+    const auto& fine_mapping = mesh_mapping.GetFineMapping(fine_cell);
+    for (std::size_t fine_face_i = 0; fine_face_i < fine_cell.faces.size(); ++fine_face_i)
+    {
+      const auto& fine_face = fine_cell.faces[fine_face_i];
+      bool found_mapping = false;
+      for (const auto& coarse_cell : coarse_grid.local_cells)
+      {
+        const auto& coarse_mapping = mesh_mapping.GetCoarseMapping(coarse_cell);
+        for (std::size_t coarse_face_i = 0; coarse_face_i < coarse_cell.faces.size();
+             ++coarse_face_i)
+        {
+          const auto in_fine_mapping = (fine_mapping.coarse_cell == &coarse_cell) &&
+                                       (fine_mapping.coarse_faces[fine_face_i] == coarse_face_i);
+          const auto& coarse_face_mapping = coarse_mapping.fine_faces[coarse_face_i];
+          const auto in_coarse_mapping =
+            std::find(coarse_face_mapping.begin(),
+                      coarse_face_mapping.end(),
+                      std::make_pair(&fine_cell, fine_face_i)) != coarse_face_mapping.end();
+          EXPECT_EQ(in_fine_mapping, in_coarse_mapping);
+
+          if (in_fine_mapping)
+          {
+            EXPECT_FALSE(found_mapping);
+            found_mapping = true;
+          }
+          const auto fine_face_within_coarse =
+            coarse_grid.CheckPointInsideCellFace(coarse_cell, coarse_face_i, fine_face.centroid);
+          const auto fine_within_coarse =
+            coarse_grid.CheckPointInsideCell(coarse_cell, fine_cell.centroid);
+          EXPECT_EQ(in_fine_mapping, fine_face_within_coarse && fine_within_coarse);
+        }
+      }
+      if (!found_mapping)
+        EXPECT_EQ(MeshMapping::invalid_face_index, fine_mapping.coarse_faces[fine_face_i]);
+    }
+  }
+}
+
+TEST_F(MeshMappingTest, Test1D)
+{
+  const auto fine_grid_ptr = BuildOrthogonalMesh({{-1.0, -0.8, -0.75, -0.5, -0.25, 0.0, 0.5, 1.0}});
+  const auto coarse_grid_ptr = BuildOrthogonalMesh({{-1.0, -0.5, 0.0, 0.5, 1.0}});
+  TestMapping(*fine_grid_ptr, *coarse_grid_ptr);
+}
+
+TEST_F(MeshMappingTest, Test2D)
+{
+  const auto fine_grid_ptr =
+    BuildOrthogonalMesh({{-1.0, -0.8, -0.75, -0.5, -0.25, 0.0, 0.5, 1.0},
+                         {-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0}});
+  const auto coarse_grid_ptr =
+    BuildOrthogonalMesh({{-1.0, -0.5, 0.0, 0.5, 1.0}, {-1.0, -0.5, 0.0, 0.5, 1.0}});
+  TestMapping(*fine_grid_ptr, *coarse_grid_ptr);
+}
+
+TEST_F(MeshMappingTest, Test3D)
+{
+  const auto fine_grid_ptr =
+    BuildOrthogonalMesh({{-1.0, -0.75, -0.5, -0.25, 0.0, 0.5, 1.0},
+                         {-1.0, -0.9, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0},
+                         {-1.0, -0.75, -0.5, -0.25, 0.0, 0.5, 1.0}});
+  const auto coarse_grid_ptr =
+    BuildOrthogonalMesh({{-1.0, 0.0, 1.0}, {-1.0, 0.0, 1.0}, {-1.0, -0.5, 0.0, 0.5, 1.0}});
+  TestMapping(*fine_grid_ptr, *coarse_grid_ptr);
+}
+
+TEST_F(MeshMappingTest, GetCoarseMappingMissing)
+{
+  const auto grid_ptr = BuildOrthogonalMesh({{-1.0, 1.0}});
+
+  MeshMapping mesh_mapping;
+  EXPECT_THROW(
+    {
+      try
+      {
+        for (const auto& cell : grid_ptr->local_cells)
+          mesh_mapping.GetCoarseMapping(cell);
+      }
+      catch (const std::logic_error& e)
+      {
+        EXPECT_TRUE(std::string(e.what()).find("Coarse cell not found in mapping") !=
+                    std::string::npos);
+        throw;
+      }
+    },
+    std::logic_error);
+}
+
+TEST_F(MeshMappingTest, GetFineMappingMissing)
+{
+  const auto grid_ptr = BuildOrthogonalMesh({{-1.0, 1.0}});
+
+  MeshMapping mesh_mapping;
+  EXPECT_THROW(
+    {
+      try
+      {
+        for (const auto& cell : grid_ptr->local_cells)
+          mesh_mapping.GetFineMapping(cell);
+      }
+      catch (const std::logic_error& e)
+      {
+        EXPECT_TRUE(std::string(e.what()).find("Fine cell not found in mapping") !=
+                    std::string::npos);
+        throw;
+      }
+    },
+    std::logic_error);
+}

--- a/test/unit/framework/mesh/vector3_test.cc
+++ b/test/unit/framework/mesh/vector3_test.cc
@@ -226,6 +226,21 @@ TEST_F(Vector3Test, Inverse)
     std::runtime_error);
 }
 
+TEST_F(Vector3Test, AbsoluteEquals)
+{
+  const Vector3 a(1, 2, 3);
+
+  const Vector3 same = a;
+  EXPECT_TRUE(a.AbsoluteEquals(same));
+
+  for (std::size_t i = 0; i < 3; ++i)
+  {
+    Vector3 diff;
+    diff(i) += i + 1;
+    EXPECT_FALSE(a.AbsoluteEquals(diff));
+  }
+}
+
 TEST_F(Vector3Test, Size)
 {
   EXPECT_EQ(Vector3::Size(), std::size_t(3));

--- a/test/unit/opensn_unit_test.cc
+++ b/test/unit/opensn_unit_test.cc
@@ -1,5 +1,6 @@
 #include "test/unit/opensn_unit_test.h"
 #include "framework/runtime.h"
+#include "framework/mesh/mesh_generator/orthogonal_mesh_generator.h"
 
 void
 OpenSnUnitTest::SetUp()
@@ -11,4 +12,20 @@ void
 OpenSnUnitTest::TearDown()
 {
   opensn::Finalize();
+}
+
+std::shared_ptr<MeshContinuum>
+OpenSnUnitTest::BuildOrthogonalMesh(const std::vector<std::vector<double>>& node_sets) const
+{
+  ParameterBlock array("node_sets");
+  for (std::size_t i = 0; i < node_sets.size(); ++i)
+    array.AddParameter(ParameterBlock(std::to_string(i + 1), node_sets[i]));
+  array.ChangeToArray();
+
+  ParameterBlock block("");
+  block.AddParameter(array);
+
+  auto params = OrthogonalMeshGenerator::GetInputParameters();
+  params.AssignParameters(block);
+  return OrthogonalMeshGenerator(params).Execute();
 }

--- a/test/unit/opensn_unit_test.h
+++ b/test/unit/opensn_unit_test.h
@@ -1,10 +1,19 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+
+using namespace opensn;
 
 class OpenSnUnitTest : public ::testing::Test
 {
 public:
   void SetUp() override;
   void TearDown() override;
+
+protected:
+  /// Helper for building a MeshContinuum for an orthogonal mesh
+  /// given an array of nodes (one for each dimension)
+  std::shared_ptr<MeshContinuum>
+  BuildOrthogonalMesh(const std::vector<std::vector<double>>& node_sets) const;
 };


### PR DESCRIPTION
Adds the start for mapping between a fine and a coarse mesh for acceleration. I'm attempting to do this in pieces instead of one big PR, testing pieces at a time.

- Still serial only. Eventually, the fine mesh will be allowed to be parallel. The coarse mesh will remain serial (still need a way to do this).
- The execution of this isn't what it will be when actually used in production. Waiting on https://github.com/Open-Sn/opensn/pull/435 to be able to input multiple mesh generators. Another object will instantiate and execute this in the future. 
- The naming might be awful. `MeshMapping` might be confusing when compared with the discretization and `GetCellMapping`.

Adding comments for parts I have questions on / want specific feedback on.