### PR TITLE
Fixing circular dependencies in header files

### DIFF
--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -3,13 +3,16 @@
 
 #pragma once
 
-#include "framework/mesh/mesh.h"
 #include "framework/data_types/data_types.h"
+#include "framework/mesh/mesh_vector.h"
 #include <tuple>
+#include <vector>
 
 // Appending cell types to namespace
 namespace opensn
 {
+
+class MeshContinuum;
 
 enum class CellType
 {

--- a/framework/mesh/logical_volume/logical_volume.h
+++ b/framework/mesh/logical_volume/logical_volume.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "framework/object.h"
-#include "framework/mesh/mesh.h"
+#include "framework/mesh/mesh_vector.h"
 #include "framework/logging/log.h"
+#include "framework/object.h"
 #include <array>
 
 namespace opensn


### PR DESCRIPTION
This PR corrects a small number of circular header dependencies in the code base as identified by `clang-tidy`. Partially address #462 as I don't believe this will find re-inclusions.

`clang-tidy` can be used to analyze headers and identify true circular dependencies. An example invocation is below:
```
run-clang-tidy -checks='-*,misc-header-include-cycle' -p build -extra-arg=-I/opt/local/opensn/clang/19.1.5/mpich-4.3.0b1/include
```