### PR TITLE
Adding coverage workflow and Coveralls integration to nightly builds

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -27,25 +27,21 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           test/run_tests -d test/ -j 32 -v 1 -w 3
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           test/run_tests -d tutorials -j 32 -v 1 -w 3
       - name: test unit
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/${{ matrix.compiler }}
           build/test/opensn-unit
 
@@ -56,21 +52,49 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/clang/17
           cmake --preset clang+debug+sanitizer
           cmake --build --preset clang+debug+sanitizer -j64
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/clang/17
           export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
           test/run_tests -d test/ -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/opensn-test
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/clang/17
           export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
           test/run_tests -d tutorials/ -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/opensn-test
+
+  coverage:
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        shell: bash
+        run: |
+          module load opensn/gcc/14
+          cmake --preset coverage
+          cmake --build --preset coverage -j64
+      - name: test
+        shell: bash
+        run: |
+          module load opensn/gcc/14
+          test/run_tests -d test/ -j 32 -v 1 -w 3 --exe build-coverage/test/opensn-test
+      - name: unit tests
+        shell: bash
+        run: |
+          module load opensn/gcc/14
+          ./build-coverage/test/opensn-unit
+      - name: test tutorials
+        shell: bash
+        run: |
+          module load opensn/gcc/14
+          test/run_tests -d tutorials/ -j 32 -v 1 -w 3 --exe build-coverage/test/opensn-test
+      - name: coveralls
+        shell: bash
+        run: |
+          gcovr --gcov-suspicious-hits-threshold=2000000000000 -r . --filter '^(framework|lua|modules)/' --coveralls coverage.json
+          /opt/local/opensn/coveralls/bin/coveralls -c /opt/local/opensn/coveralls/.coveralls.yml -f coverage.json

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -18,24 +18,20 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           test/run_tests -d test/ -j 32 -v 1 -w 3
       - name: test tutorials
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           test/run_tests -d tutorials -j 32 -v 1 -w 3
       - name: test unit
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           build/test/opensn-unit

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -13,18 +13,15 @@ jobs:
       - name: build
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           test/run_tests -d test/ -j 32 -v 1 -w 4
       - name: test unit
         shell: bash
         run: |
-          export MODULEPATH=/scratch-local/software/modulefiles:$MODULEPATH
           module load opensn/gcc/12
           build/test/opensn-unit

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,16 +14,16 @@
       }
     },
     {
-      "name": "clang+coverage",
-      "displayName": "Clang coverage",
-      "description": "Configure with Clang for coverage",
+      "name": "coverage",
+      "displayName": "Coverage",
+      "description": "Configure for code coverage",
       "generator": "Unix Makefiles",
       "binaryDir": "build-coverage",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS": "-g -O1 -fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_C_FLAGS": "-g -O1 -fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate -fcoverage-mapping"
+        "CMAKE_CXX_FLAGS": "-g -O1 -fprofile-arcs -ftest-coverage",
+        "CMAKE_C_FLAGS": "-g -O1 -fprofile-arcs -ftest-coverage",
+        "CMAKE_EXE_LINKER_FLAGS": "-g -fprofile-arcs -ftest-coverage"
       }
     }
   ],
@@ -35,9 +35,9 @@
       "configuration": "Debug with sanitizer"
     },
     {
-      "name": "clang+coverage",
-      "displayName": "Clang coverage",
-      "configurePreset": "clang+coverage",
+      "name": "coverage",
+      "displayName": "Coverage",
+      "configurePreset": "coverage",
       "configuration": "Coverage"
     }
   ]


### PR DESCRIPTION
Clang's source-based coverage seems to have an issue with shared object libraries, so I've modified the CMake coverage preset to use gcov and switched to GCC to prevent any version discrepancies. I've added the coverage workflow and Coveralls integration to the nightly build tests for the time being. If everything goes smoothly, we can move them to the regression workflow or wherever we would like.

If the coverage workflow runs smoothly for a couple of nights, I'll add the badge to the main page.

Here's a link to the first coverage report: https://coveralls.io/builds/72376782