### PR TITLE
Moved volumes and areas to cells and faces

### DIFF
--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -188,16 +188,16 @@ FieldFunctionGridBased::GetPointValue(const Vector3& point) const
   }         // if in bounding box
 
   // Communicate number of point hits
-  size_t globl_num_point_hits;
-  mpi_comm.all_reduce(local_num_point_hits, globl_num_point_hits, mpi::op::sum<size_t>());
+  size_t global_num_point_hits;
+  mpi_comm.all_reduce(local_num_point_hits, global_num_point_hits, mpi::op::sum<size_t>());
 
-  std::vector<double> globl_point_value(num_components, 0.0);
+  std::vector<double> global_point_value(num_components, 0.0);
   mpi_comm.all_reduce(
-    local_point_value.data(), 1, globl_point_value.data(), mpi::op::sum<double>());
+    local_point_value.data(), 1, global_point_value.data(), mpi::op::sum<double>());
 
-  Scale(globl_point_value, 1.0 / static_cast<double>(globl_num_point_hits));
+  Scale(global_point_value, 1.0 / static_cast<double>(global_num_point_hits));
 
-  return globl_point_value;
+  return global_point_value;
 }
 
 double

--- a/framework/math/spatial_discretization/cell_mappings/cell_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/cell_mapping.cc
@@ -14,57 +14,19 @@ CellMapping::CellMapping(const std::shared_ptr<MeshContinuum> grid,
                          const Cell& cell,
                          size_t num_nodes,
                          std::vector<Vector3> node_locations,
-                         std::vector<std::vector<int>> face_node_mappings,
-                         const VolumeAndAreaFunction& volume_area_function)
-  : ref_grid_(grid),
+                         std::vector<std::vector<int>> face_node_mappings)
+  : grid_(grid),
     cell_(cell),
     num_nodes_(num_nodes),
     node_locations_(std::move(node_locations)),
     face_node_mappings_(std::move(face_node_mappings))
 {
-  volume_area_function(ref_grid_, cell, volume_, areas_);
-}
-
-const Cell&
-CellMapping::ReferenceCell() const
-{
-  return cell_;
-}
-
-const std::shared_ptr<MeshContinuum>
-CellMapping::ReferenceGrid() const
-{
-  return ref_grid_;
-}
-
-size_t
-CellMapping::GetNumNodes() const
-{
-  return num_nodes_;
 }
 
 size_t
 CellMapping::GetNumFaceNodes(size_t face_index) const
 {
   return face_node_mappings_.at(face_index).size();
-}
-
-const std::vector<std::vector<int>>&
-CellMapping::GetFaceNodeMappings() const
-{
-  return face_node_mappings_;
-}
-
-double
-CellMapping::GetCellVolume() const
-{
-  return volume_;
-}
-
-double
-CellMapping::GetFaceArea(size_t face_index) const
-{
-  return areas_[face_index];
 }
 
 int
@@ -79,101 +41,6 @@ CellMapping::MapFaceNode(size_t face_index, size_t face_node_index) const
     throw std::out_of_range("CellMapping::MapFaceNode: "
                             "Either face_index or face_node_index is out of range");
   }
-}
-
-void
-CellMapping::ComputeCellVolumeAndAreas(const std::shared_ptr<MeshContinuum> grid,
-                                       const Cell& cell,
-                                       double& volume,
-                                       std::vector<double>& areas)
-{
-  switch (cell.GetType())
-  {
-    case CellType::SLAB:
-    {
-      const auto& v0 = grid->vertices[cell.vertex_ids[0]];
-      const auto& v1 = grid->vertices[cell.vertex_ids[1]];
-
-      volume = (v1 - v0).Norm();
-      areas = {1.0, 1.0};
-      break;
-    }
-    case CellType::POLYGON:
-    {
-      volume = 0.0;
-      const auto& v2 = cell.centroid;
-
-      size_t num_faces = cell.faces.size();
-      areas.reserve(num_faces);
-
-      for (size_t f = 0; f < num_faces; ++f)
-      {
-        const uint64_t v0i = cell.faces[f].vertex_ids[0];
-        const uint64_t v1i = cell.faces[f].vertex_ids[1];
-
-        const auto& v0 = grid->vertices[v0i];
-        const auto& v1 = grid->vertices[v1i];
-
-        areas.push_back((v1 - v0).Norm());
-
-        const Vector3 sidev01 = v1 - v0;
-        const Vector3 sidev02 = v2 - v0;
-
-        double sidedetJ = ((sidev01.x) * (sidev02.y) - (sidev02.x) * (sidev01.y));
-
-        volume += sidedetJ / 2.0;
-      } // for face
-
-      break;
-    }
-    case CellType::POLYHEDRON:
-    {
-      volume = 0.0;
-      const auto& vcc = cell.centroid;
-
-      size_t num_faces = cell.faces.size();
-      areas.assign(num_faces, 0.0);
-      for (size_t f = 0; f < num_faces; ++f)
-      {
-        const auto& face = cell.faces[f];
-        const size_t num_edges = face.vertex_ids.size();
-        for (size_t e = 0; e < num_edges; ++e)
-        {
-          size_t ep1 = (e < (num_edges - 1)) ? e + 1 : 0;
-          uint64_t v0i = face.vertex_ids[e];
-          uint64_t v1i = face.vertex_ids[ep1];
-
-          const auto& v0 = grid->vertices[v0i];
-          const auto& v1 = cell.faces[f].centroid;
-          const auto& v2 = grid->vertices[v1i];
-          const auto& v3 = vcc;
-
-          const auto sidev01 = v1 - v0;
-          const auto sidev02 = v2 - v0;
-          const auto sidev03 = v3 - v0;
-
-          Matrix3x3 J;
-
-          J.SetColJVec(0, sidev01);
-          J.SetColJVec(1, sidev02);
-          J.SetColJVec(2, sidev03);
-
-          areas[f] += (sidev01.Cross(sidev02)).Norm() / 2.0;
-          volume += J.Det() / 6.0;
-        } // for edge
-      }   // for face
-      break;
-    }
-    default:
-      throw std::logic_error("CellMapping::ComputeCellVolume: "
-                             "Unsupported cell type.");
-  }
-}
-
-const std::vector<Vector3>&
-CellMapping::GetNodeLocations() const
-{
-  return node_locations_;
 }
 
 } // namespace opensn

--- a/framework/math/spatial_discretization/cell_mappings/cell_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/cell_mapping.h
@@ -27,24 +27,21 @@ class CellMapping
 {
 public:
   /// Returns the cell this mapping is based on.
-  const Cell& ReferenceCell() const;
+  const Cell& GetCell() const { return cell_; }
 
   /// Returns the grid on which the cell for this mapping lives.
-  const std::shared_ptr<MeshContinuum> ReferenceGrid() const;
+  const std::shared_ptr<MeshContinuum> GetGrid() const { return grid_; }
 
   /// Returns the number of nodes on this element.
-  size_t GetNumNodes() const;
+  size_t GetNumNodes() const { return num_nodes_; }
 
   /// Returns the number of nodes on the given face.
   size_t GetNumFaceNodes(size_t face_index) const;
 
-  const std::vector<std::vector<int>>& GetFaceNodeMappings() const;
+  const std::vector<std::vector<int>>& GetFaceNodeMappings() const { return face_node_mappings_; }
 
-  /// Returns the cell volume.
-  double GetCellVolume() const;
-
-  /// Returns the given face area.
-  double GetFaceArea(size_t face_index) const;
+  /// Returns the node locations associated with this element.
+  const std::vector<Vector3>& GetNodeLocations() const { return node_locations_; }
 
   /**
    * Given the face index and the face node index, returns the index of the cell node the face node
@@ -71,9 +68,6 @@ public:
   virtual void GradShapeValues(const Vector3& xyz,
                                std::vector<Vector3>& gradshape_values) const = 0;
 
-  /// Returns the node locations associated with this element.
-  const std::vector<Vector3>& GetNodeLocations() const;
-
   /// Makes the volumetric/internal finite element data for this element.
   virtual VolumetricFiniteElementData MakeVolumetricFiniteElementData() const = 0;
 
@@ -83,36 +77,17 @@ public:
   virtual ~CellMapping() = default;
 
 protected:
-  /**
-   * This function gets called to compute the cell-volume andface-areas. If simple linear cells are
-   * used then the default CellMapping::ComputeCellVolumeAndAreas can be used as this function.
-   * Otherwise (i.e. for higher order elements, the child-class should bind a different function to
-   * this.
-   */
-  using VolumeAndAreaFunction = std::function<void(
-    const std::shared_ptr<MeshContinuum>, const Cell&, double&, std::vector<double>&)>;
-
-  CellMapping(const std::shared_ptr<MeshContinuum> grid,
+  CellMapping(std::shared_ptr<MeshContinuum> grid,
               const Cell& cell,
               size_t num_nodes,
               std::vector<Vector3> node_locations,
-              std::vector<std::vector<int>> face_node_mappings,
-              const VolumeAndAreaFunction& volume_area_function);
+              std::vector<std::vector<int>> face_node_mappings);
 
-  /// Static method that all child elements can use as a default.
-  static void ComputeCellVolumeAndAreas(const std::shared_ptr<MeshContinuum> grid,
-                                        const Cell& cell,
-                                        double& volume,
-                                        std::vector<double>& areas);
-
-  const std::shared_ptr<MeshContinuum> ref_grid_;
+  const std::shared_ptr<MeshContinuum> grid_;
   const Cell& cell_;
 
   const size_t num_nodes_;
   const std::vector<Vector3> node_locations_;
-
-  double volume_ = 0.0;
-  std::vector<double> areas_;
 
   /**
    * For each cell face, map from the face node index to the corresponding cell node index. More

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.cc
@@ -14,12 +14,8 @@ PieceWiseLinearBaseMapping::PieceWiseLinearBaseMapping(
   const Cell& cell,
   size_t num_nodes,
   std::vector<std::vector<int>> face_node_mappings)
-  : CellMapping(grid,
-                cell,
-                num_nodes,
-                GetVertexLocations(grid, cell),
-                std::move(face_node_mappings),
-                &CellMapping::ComputeCellVolumeAndAreas)
+  : CellMapping(
+      grid, cell, num_nodes, GetVertexLocations(grid, cell), std::move(face_node_mappings))
 {
 }
 
@@ -45,11 +41,8 @@ PieceWiseLinearBaseMapping::MakeFaceNodeMapping(const Cell& cell)
         }
       } // for cell i
       if (mapping < 0)
-      {
-        log.LogAllError() << "Unknown face mapping encountered. "
-                             "pwl_polyhedron.h";
-        Exit(EXIT_FAILURE);
-      }
+        throw std::runtime_error("Unknown face mapping encountered.");
+
       face_dof_mapping.push_back(mapping);
     } // for face i
 
@@ -59,7 +52,7 @@ PieceWiseLinearBaseMapping::MakeFaceNodeMapping(const Cell& cell)
 }
 
 std::vector<Vector3>
-PieceWiseLinearBaseMapping::GetVertexLocations(const std::shared_ptr<MeshContinuum> grid,
+PieceWiseLinearBaseMapping::GetVertexLocations(const std::shared_ptr<MeshContinuum>& grid,
                                                const Cell& cell)
 {
   std::vector<Vector3> verts;

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_base_mapping.h
@@ -20,13 +20,13 @@ class PieceWiseLinearBaseMapping : public CellMapping
 protected:
 public:
   /// Constructor.
-  PieceWiseLinearBaseMapping(const std::shared_ptr<MeshContinuum> grid,
+  PieceWiseLinearBaseMapping(std::shared_ptr<MeshContinuum> grid,
                              const Cell& cell,
                              size_t num_nodes,
                              std::vector<std::vector<int>> face_node_mappings);
 
 protected:
-  static std::vector<Vector3> GetVertexLocations(const std::shared_ptr<MeshContinuum> grid,
+  static std::vector<Vector3> GetVertexLocations(const std::shared_ptr<MeshContinuum>& grid,
                                                  const Cell& cell);
 
   /**

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.cc
@@ -31,8 +31,8 @@ PieceWiseLinearPolygonMapping::PieceWiseLinearPolygonMapping(
   {
     const CellFace& face = poly_cell.faces[side];
 
-    const auto& v0 = ref_grid_->vertices[face.vertex_ids[0]];
-    const auto& v1 = ref_grid_->vertices[face.vertex_ids[1]];
+    const auto& v0 = grid_->vertices[face.vertex_ids[0]];
+    const auto& v1 = grid_->vertices[face.vertex_ids[1]];
     Vector3 v2 = vc_;
 
     Vector3 sidev01 = v1 - v0;
@@ -189,7 +189,7 @@ PieceWiseLinearPolygonMapping::ShapeValue(const int i, const Vector3& xyz) const
 {
   for (int s = 0; s < num_of_subtris_; ++s)
   {
-    const auto& p0 = ref_grid_->vertices[sides_[s].v_index[0]];
+    const auto& p0 = grid_->vertices[sides_[s].v_index[0]];
     Vector3 xyz_ref = xyz - p0;
 
     Vector3 xi_eta_zeta = sides_[s].Jinv * xyz_ref;
@@ -227,7 +227,7 @@ PieceWiseLinearPolygonMapping::ShapeValues(const Vector3& xyz, Vector<double>& s
   shape_values.Resize(num_nodes_, 0.0);
   for (int s = 0; s < num_of_subtris_; ++s)
   {
-    const auto& p0 = ref_grid_->vertices[sides_[s].v_index[0]];
+    const auto& p0 = grid_->vertices[sides_[s].v_index[0]];
     Vector3 xi_eta_zeta = sides_[s].Jinv * (xyz - p0);
 
     double xi = xi_eta_zeta.x;
@@ -267,7 +267,7 @@ PieceWiseLinearPolygonMapping::GradShapeValue(const int i, const Vector3& xyz) c
 
   for (int e = 0; e < num_of_subtris_; ++e)
   {
-    const auto& p0 = ref_grid_->vertices[sides_[e].v_index[0]];
+    const auto& p0 = grid_->vertices[sides_[e].v_index[0]];
     Vector3 xyz_ref = xyz - p0;
 
     Vector3 xi_eta_zeta = sides_[e].Jinv * xyz_ref;

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polygon_mapping.h
@@ -31,10 +31,10 @@ public:
 
   SurfaceFiniteElementData MakeSurfaceFiniteElementData(size_t face_index) const override;
 
-  /// Precomputation of the partial derivative along x of the shape function at a quadrature point.
+  /// Pre-computation of the partial derivative along x of the shape function at a quadrature point.
   double SideGradShape_x(uint32_t side, uint32_t i) const;
 
-  /// Precomputation of the partial derivative along y of the shape function at a quadrature point.
+  /// Pre-computation of the partial derivative along y of the shape function at a quadrature point.
   double SideGradShape_y(uint32_t side, uint32_t i) const;
 
   double ShapeValue(int i, const Vector3& xyz) const override;

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.cc
@@ -53,9 +53,9 @@ PieceWiseLinearPolyhedronMapping::PieceWiseLinearPolyhedronMapping(
       side_data.v_index[0] = v0index;
       side_data.v_index[1] = v1index;
 
-      const auto& v0 = ref_grid_->vertices[v0index];
+      const auto& v0 = grid_->vertices[v0index];
       const auto& v1 = vfc;
-      const auto& v2 = ref_grid_->vertices[v1index];
+      const auto& v2 = grid_->vertices[v1index];
       const auto& v3 = vcc;
 
       side_data.v0 = v0;
@@ -415,7 +415,7 @@ PieceWiseLinearPolyhedronMapping::ShapeValue(const int i, const Vector3& xyz) co
     for (size_t s = 0; s < face_data_[f].sides.size(); ++s)
     {
       // Map xyz to xi_eta_zeta
-      const auto& p0 = ref_grid_->vertices[face_data_[f].sides[s].v_index[0]];
+      const auto& p0 = grid_->vertices[face_data_[f].sides[s].v_index[0]];
       Vector3 xyz_ref = xyz - p0;
 
       Vector3 xi_eta_zeta = face_data_[f].sides[s].Jinv * xyz_ref;
@@ -464,7 +464,7 @@ PieceWiseLinearPolyhedronMapping::ShapeValues(const Vector3& xyz,
     {
       auto& side_fe_info = face_data_[f].sides[s];
       // Map xyz to xi_eta_zeta
-      const auto& p0 = ref_grid_->vertices[side_fe_info.v_index[0]];
+      const auto& p0 = grid_->vertices[side_fe_info.v_index[0]];
       Vector3 xi_eta_zeta = side_fe_info.Jinv * (xyz - p0);
 
       double xi = xi_eta_zeta.x;
@@ -510,7 +510,7 @@ PieceWiseLinearPolyhedronMapping::GradShapeValue(const int i, const Vector3& xyz
     for (size_t s = 0; s < face_data_[f].sides.size(); ++s)
     {
       // Map xyz to xi_eta_zeta
-      const auto& p0 = ref_grid_->vertices[face_data_[f].sides[s].v_index[0]];
+      const auto& p0 = grid_->vertices[face_data_[f].sides[s].v_index[0]];
       Vector3 xyz_ref = xyz - p0;
 
       Vector3 xi_eta_zeta = face_data_[f].sides[s].Jinv * xyz_ref;

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_polyhedron_mapping.h
@@ -23,7 +23,7 @@ class PieceWiseLinearPolyhedronMapping : public PieceWiseLinearBaseMapping
 public:
   /// Constructor for the Piecewise Linear Polyhedron cell finite element view.
   PieceWiseLinearPolyhedronMapping(const Cell& polyh_cell,
-                                   const std::shared_ptr<MeshContinuum> ref_grid,
+                                   std::shared_ptr<MeshContinuum> ref_grid,
                                    const TetrahedraQuadrature& volume_quadrature,
                                    const TriangleQuadrature& surface_quadrature);
 

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
@@ -17,8 +17,8 @@ PieceWiseLinearSlabMapping::PieceWiseLinearSlabMapping(
 {
   v0i_ = slab_cell.vertex_ids[0];
   v1i_ = slab_cell.vertex_ids[1];
-  v0_ = ref_grid_->vertices[v0i_];
-  const auto& v1 = ref_grid_->vertices[v1i_];
+  v0_ = grid_->vertices[v0i_];
+  const auto& v1 = grid_->vertices[v1i_];
 
   Vector3 v01 = v1 - v0_;
   h_ = v01.Norm();
@@ -64,8 +64,8 @@ PieceWiseLinearSlabMapping::SlabGradShape(uint32_t index) const
 double
 PieceWiseLinearSlabMapping::ShapeValue(const int i, const Vector3& xyz) const
 {
-  const auto& p0 = ref_grid_->vertices[v0i_];
-  const auto& p1 = ref_grid_->vertices[v1i_];
+  const auto& p0 = grid_->vertices[v0i_];
+  const auto& p1 = grid_->vertices[v1i_];
   Vector3 xyz_ref = xyz - p0;
 
   Vector3 v01 = p1 - p0;
@@ -87,8 +87,8 @@ void
 PieceWiseLinearSlabMapping::ShapeValues(const Vector3& xyz, Vector<double>& shape_values) const
 {
   shape_values.Resize(num_nodes_, 0.0);
-  const auto& p0 = ref_grid_->vertices[v0i_];
-  const auto& p1 = ref_grid_->vertices[v1i_];
+  const auto& p0 = grid_->vertices[v0i_];
+  const auto& p1 = grid_->vertices[v1i_];
   Vector3 xyz_ref = xyz - p0;
 
   Vector3 v01 = p1 - p0;

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.h
@@ -21,7 +21,7 @@ class PieceWiseLinearSlabMapping : public PieceWiseLinearBaseMapping
 public:
   /// Constructor for a slab view.
   PieceWiseLinearSlabMapping(const Cell& slab_cell,
-                             const std::shared_ptr<MeshContinuum> ref_grid,
+                             std::shared_ptr<MeshContinuum> ref_grid,
                              const LineQuadrature& volume_quadrature);
 
   VolumetricFiniteElementData MakeVolumetricFiniteElementData() const override;

--- a/framework/math/spatial_discretization/cell_mappings/finite_volume/finite_volume_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_volume/finite_volume_mapping.cc
@@ -14,7 +14,7 @@ FiniteVolumeMapping::MakeVolumetricFiniteElementData() const
                                      {{cell_.centroid}},
                                      {{1.0}},
                                      {{Vector3(0, 0, 0)}},
-                                     {volume_},
+                                     {cell_.volume},
                                      face_node_mappings_,
                                      num_nodes_);
 }
@@ -26,7 +26,7 @@ FiniteVolumeMapping::MakeSurfaceFiniteElementData(size_t face_index) const
                                   {{Vector3(0, 0, 0)}},
                                   {{1.0}},
                                   {{Vector3(0, 0, 0)}},
-                                  {areas_[face_index]},
+                                  {cell_.faces[face_index].area},
                                   {{Vector3(0, 0, 0)}},
                                   face_node_mappings_,
                                   1);

--- a/framework/math/spatial_discretization/cell_mappings/finite_volume/finite_volume_mapping.h
+++ b/framework/math/spatial_discretization/cell_mappings/finite_volume/finite_volume_mapping.h
@@ -23,33 +23,28 @@ public:
                                const Cell& cell,
                                const Vector3& cc,
                                std::vector<std::vector<int>> face_node_mappings)
-    : CellMapping(grid,
-                  cell,
-                  1,
-                  {cell.centroid},
-                  std::move(face_node_mappings),
-                  &CellMapping::ComputeCellVolumeAndAreas)
+    : CellMapping(grid, cell, 1, {cell.centroid}, std::move(face_node_mappings))
   {
   }
 
   double ShapeValue(int i, const Vector3& xyz) const override
   {
-    if (ref_grid_->CheckPointInsideCell(cell_, xyz))
-      return 1.0;
-    else
-      return 0.0;
+    return grid_->CheckPointInsideCell(cell_, xyz) ? 1.0 : 0.0;
   }
+
   void ShapeValues(const Vector3& xyz, Vector<double>& shape_values) const override
   {
-    if (ref_grid_->CheckPointInsideCell(cell_, xyz))
+    if (grid_->CheckPointInsideCell(cell_, xyz))
       shape_values = Vector<double>(num_nodes_, 1.0);
     else
       shape_values = Vector<double>(num_nodes_, 0.0);
   }
+
   Vector3 GradShapeValue(int i, const Vector3& xyz) const override
   {
     return Vector3(0.0, 0.0, 0.0);
   }
+
   void GradShapeValues(const Vector3& xyz, std::vector<Vector3>& gradshape_values) const override
   {
     gradshape_values.assign(num_nodes_, Vector3(0, 0, 0));

--- a/framework/mesh/cell/cell.cc
+++ b/framework/mesh/cell/cell.cc
@@ -319,10 +319,12 @@ Cell::ComputeGeometricInfo(const MeshContinuum* grid)
       {
         const auto& v0 = grid->vertices[face.vertex_ids[0]];
         const auto& v1 = grid->vertices[face.vertex_ids[1]];
-        const auto subnormal = (v0 - centroid).Cross(v1 - centroid);
-        volume += 0.5 * subnormal.Norm();
-        break;
+
+        const auto e0 = v1 - v0;
+        const auto e1 = centroid - v0;
+        volume += 0.5 * std::fabs(e0.x * e1.y - e0.y * e1.x);
       }
+      break;
     }
 
     // The volume of a polyhedron is the sum of the sub-tetrahedrons

--- a/framework/mesh/cell/cell.cc
+++ b/framework/mesh/cell/cell.cc
@@ -295,8 +295,9 @@ Cell::ComputeGeometricInfo(const MeshContinuum* grid)
   centroid /= static_cast<double>(vertex_ids.size());
 
   // Compute face geometric data
+  unsigned int f = 0;
   for (auto& face : faces)
-    face.ComputeGeometricInfo(grid);
+    face.ComputeGeometricInfo(grid, f++);
 
   // Compute cell volumes
   volume = 0.0;

--- a/framework/mesh/mesh_generator/distributed_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/distributed_mesh_generator.cc
@@ -13,6 +13,49 @@
 namespace opensn
 {
 
+DistributedMeshGenerator::DistributedMeshGenerator(const InputParameters& params)
+  : MeshGenerator(params), num_partitions_(mpi_comm.size())
+{
+}
+
+std::shared_ptr<MeshContinuum>
+DistributedMeshGenerator::Execute()
+{
+  const auto rank = mpi_comm.rank();
+  const auto num_partitions = mpi_comm.size();
+  DistributedMeshData mesh_info;
+
+  log.Log() << program_timer.GetTimeString() << " Distributing mesh with " << num_partitions
+            << " parts";
+
+  if (rank == 0)
+  {
+    std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
+    for (const auto& mesh_generator_ptr : inputs_)
+      current_umesh = mesh_generator_ptr->GenerateUnpartitionedMesh(current_umesh);
+    current_umesh = GenerateUnpartitionedMesh(current_umesh);
+
+    const auto cell_pids = PartitionMesh(*current_umesh, num_partitions);
+    auto serial_data = DistributeSerializedMeshData(cell_pids, *current_umesh, num_partitions);
+    mesh_info = DeserializeMeshData(serial_data);
+  }
+  else
+  {
+    std::vector<std::byte> data;
+    mpi_comm.recv<std::byte>(0, rank, data);
+    ByteArray serial_data(data);
+    mesh_info = DeserializeMeshData(serial_data);
+  }
+
+  auto grid_ptr = SetupLocalMesh(mesh_info);
+
+  mpi_comm.barrier();
+
+  log.Log() << program_timer.GetTimeString() << " Mesh successfully distributed";
+
+  return grid_ptr;
+}
+
 OpenSnRegisterObjectInNamespace(mesh, DistributedMeshGenerator);
 
 InputParameters
@@ -31,73 +74,28 @@ DistributedMeshGenerator::GetInputParameters()
 std::shared_ptr<DistributedMeshGenerator>
 DistributedMeshGenerator::Create(const ParameterBlock& params)
 {
-  auto& factory = opensn::ObjectFactory::GetInstance();
+  const auto& factory = ObjectFactory::GetInstance();
   return factory.Create<DistributedMeshGenerator>("mesh::DistributedMeshGenerator", params);
-}
-
-DistributedMeshGenerator::DistributedMeshGenerator(const InputParameters& params)
-  : MeshGenerator(params), num_parts_(opensn::mpi_comm.size())
-{
-}
-
-std::shared_ptr<MeshContinuum>
-DistributedMeshGenerator::Execute()
-{
-  const int rank = opensn::mpi_comm.rank();
-  const int num_parts = opensn::mpi_comm.size();
-  DistributedMeshData mesh_info;
-
-  log.Log() << program_timer.GetTimeString() << " Distributing mesh with " << num_parts << " parts";
-
-  if (rank == 0)
-  {
-    std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
-    for (auto mesh_generator_ptr : inputs_)
-    {
-      auto new_umesh = mesh_generator_ptr->GenerateUnpartitionedMesh(current_umesh);
-      current_umesh = new_umesh;
-    }
-    current_umesh = GenerateUnpartitionedMesh(current_umesh);
-
-    const auto cell_pids = PartitionMesh(*current_umesh, num_parts);
-    auto serial_data = DistributeSerializedMeshData(cell_pids, *current_umesh, num_parts);
-    mesh_info = DeserializeMeshData(serial_data);
-  }
-  else
-  {
-    std::vector<std::byte> data;
-    opensn::mpi_comm.recv<std::byte>(0, rank, data);
-    ByteArray serial_data(data);
-    mesh_info = DeserializeMeshData(serial_data);
-  }
-
-  auto grid_ptr = SetupLocalMesh(mesh_info);
-
-  opensn::mpi_comm.barrier();
-
-  log.Log() << program_timer.GetTimeString() << " Mesh successfully distributed";
-
-  return grid_ptr;
 }
 
 ByteArray
 DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t>& cell_pids,
                                                        const UnpartitionedMesh& umesh,
-                                                       int num_parts)
+                                                       const int num_partitions)
 {
   const auto& vertex_subs = umesh.GetVertextCellSubscriptions();
   const auto& raw_cells = umesh.GetRawCells();
   const auto& raw_vertices = umesh.GetVertices();
   ByteArray loc0_data;
 
-  for (int pid = 0; pid < num_parts; ++pid)
+  for (int pid = 0; pid < num_partitions; ++pid)
   {
     ByteArray serial_data;
 
     std::vector<uint64_t> local_cells_needed;
     std::set<uint64_t> cells_needed;
     std::set<uint64_t> vertices_needed;
-    local_cells_needed.reserve(cell_pids.size() / num_parts);
+    local_cells_needed.reserve(cell_pids.size() / num_partitions);
 
     for (uint64_t cell_global_id = 0; cell_global_id < cell_pids.size(); ++cell_global_id)
     {
@@ -107,19 +105,20 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
         local_cells_needed.push_back(cell_global_id);
         cells_needed.emplace(cell_global_id);
 
-        for (uint64_t vid : raw_cell.vertex_ids)
+        for (const auto vid : raw_cell.vertex_ids)
         {
           vertices_needed.emplace(vid);
 
           // Process ghost cells
-          for (uint64_t ghost_gid : vertex_subs[vid])
+          for (const auto ghost_gid : vertex_subs[vid])
           {
             if (ghost_gid != cell_global_id && cells_needed.find(ghost_gid) == cells_needed.end())
             {
               cells_needed.emplace(ghost_gid);
               const auto& ghost_raw_cell = *raw_cells[ghost_gid];
+
               // Insert ghost vertex IDs
-              for (uint64_t gvid : ghost_raw_cell.vertex_ids)
+              for (const auto gvid : ghost_raw_cell.vertex_ids)
                 vertices_needed.emplace(gvid);
             }
           }
@@ -131,10 +130,10 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
     serial_data.Write<unsigned int>(umesh.GetDimension());
     serial_data.Write(static_cast<int>(umesh.GetType()));
     serial_data.Write(umesh.IsExtruded());
-    auto& ortho_attrs = umesh.GetOrthoAttributes();
-    serial_data.Write(ortho_attrs.Nx);
-    serial_data.Write(ortho_attrs.Ny);
-    serial_data.Write(ortho_attrs.Nz);
+    const auto& [Nx, Ny, Nz] = umesh.GetOrthoAttributes();
+    serial_data.Write(Nx);
+    serial_data.Write(Ny);
+    serial_data.Write(Nz);
     serial_data.Write(raw_vertices.size());
 
     // Boundaries
@@ -146,7 +145,7 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
       const size_t num_chars = bname.size();
       serial_data.Write(num_chars);
       for (size_t i = 0; i < num_chars; ++i)
-        serial_data.Write(bname.data()[i]);
+        serial_data.Write(bname[i]);
     }
 
     // Number of cells and vertices
@@ -166,14 +165,14 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
       serial_data.Write(cell.centroid.z);
       serial_data.Write(cell.material_id);
       serial_data.Write(cell.vertex_ids.size());
-      for (uint64_t vid : cell.vertex_ids)
+      for (const auto vid : cell.vertex_ids)
         serial_data.Write(vid);
 
       serial_data.Write(cell.faces.size());
       for (const auto& face : cell.faces)
       {
         serial_data.Write(face.vertex_ids.size());
-        for (uint64_t vid : face.vertex_ids)
+        for (const auto vid : face.vertex_ids)
           serial_data.Write(vid);
         serial_data.Write(face.has_neighbor);
         serial_data.Write(face.neighbor);
@@ -181,7 +180,7 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
     }
 
     // Vertex data
-    for (uint64_t vid : vertices_needed)
+    for (const auto vid : vertices_needed)
     {
       serial_data.Write(vid);
       serial_data.Write(raw_vertices[vid].x);
@@ -192,9 +191,9 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
     if (pid == 0)
       loc0_data = serial_data;
     else
-      opensn::mpi_comm.send<std::byte>(pid, pid, serial_data.Data().data(), serial_data.Size());
+      mpi_comm.send<std::byte>(
+        pid, pid, serial_data.Data().data(), static_cast<int>(serial_data.Size()));
   }
-
   return loc0_data;
 }
 
@@ -213,28 +212,28 @@ DistributedMeshGenerator::DeserializeMeshData(ByteArray& serial_data)
   info_block.num_global_vertices = serial_data.Read<size_t>();
 
   // Boundaries
-  auto num_bndries = serial_data.Read<size_t>();
-  for (auto b = 0; b < num_bndries; ++b)
+  auto num_boundaries = serial_data.Read<size_t>();
+  for (auto b = 0; b < num_boundaries; ++b)
   {
-    auto bid = serial_data.Read<uint64_t>();
-    auto num_chars = serial_data.Read<size_t>();
+    const auto bid = serial_data.Read<uint64_t>();
+    const auto num_chars = serial_data.Read<size_t>();
     std::string bname(num_chars, ' ');
     for (auto i = 0; i < num_chars; ++i)
-      bname.data()[i] = serial_data.Read<char>();
+      bname[i] = serial_data.Read<char>();
     info_block.boundary_id_map.insert(std::make_pair(bid, bname));
   }
 
   // Number of cells and vertices
-  auto num_cells = serial_data.Read<size_t>();
-  auto num_vertices = serial_data.Read<size_t>();
+  const auto num_cells = serial_data.Read<size_t>();
+  const auto num_vertices = serial_data.Read<size_t>();
 
   // Cell data
   for (size_t i = 0; i < num_cells; ++i)
   {
-    int cell_pid = serial_data.Read<int>();
-    auto cell_gid = serial_data.Read<uint64_t>();
-    auto type = serial_data.Read<CellType>();
-    auto sub_type = serial_data.Read<CellType>();
+    const auto cell_pid = serial_data.Read<int>();
+    const auto cell_gid = serial_data.Read<uint64_t>();
+    const auto type = serial_data.Read<CellType>();
+    const auto sub_type = serial_data.Read<CellType>();
 
     UnpartitionedMesh::LightWeightCell cell(type, sub_type);
 
@@ -243,11 +242,11 @@ DistributedMeshGenerator::DeserializeMeshData(ByteArray& serial_data)
     cell.centroid.z = serial_data.Read<double>();
     cell.material_id = serial_data.Read<int>();
 
-    auto num_vids = serial_data.Read<size_t>();
+    const auto num_vids = serial_data.Read<size_t>();
     for (size_t v = 0; v < num_vids; ++v)
       cell.vertex_ids.push_back(serial_data.Read<uint64_t>());
 
-    auto num_faces = serial_data.Read<size_t>();
+    const auto num_faces = serial_data.Read<size_t>();
     for (size_t f = 0; f < num_faces; ++f)
     {
       UnpartitionedMesh::LightWeightFace face;
@@ -273,7 +272,6 @@ DistributedMeshGenerator::DeserializeMeshData(ByteArray& serial_data)
     vertex.z = serial_data.Read<double>();
     info_block.vertices.insert(std::make_pair(vid, vertex));
   }
-
   return info_block;
 }
 
@@ -291,9 +289,7 @@ DistributedMeshGenerator::SetupLocalMesh(DistributedMeshData& mesh_info)
   for (const auto& [pidgid, raw_cell] : cells)
   {
     const auto& [cell_pid, cell_global_id] = pidgid;
-    auto cell = SetupCell(raw_cell, cell_global_id, cell_pid, STLVertexListHelper(vertices));
-
-    grid_ptr->cells.PushBack(std::move(cell));
+    grid_ptr->cells.PushBack(SetupCell(raw_cell, cell_global_id, cell_pid));
   }
 
   grid_ptr->SetDimension(mesh_info.dimension);
@@ -301,6 +297,8 @@ DistributedMeshGenerator::SetupLocalMesh(DistributedMeshData& mesh_info)
   grid_ptr->SetExtruded(mesh_info.extruded);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);
   grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices);
+  grid_ptr->ComputeGeometricInfo();
+
   ComputeAndPrintStats(grid_ptr);
 
   return grid_ptr;

--- a/framework/mesh/mesh_generator/extruder_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/extruder_mesh_generator.cc
@@ -8,62 +8,6 @@
 namespace opensn
 {
 
-OpenSnRegisterObjectInNamespace(mesh, ExtruderMeshGenerator);
-
-OpenSnRegisterObjectParametersOnlyInNamespace(mesh, ExtrusionLayer);
-
-InputParameters
-ExtrusionLayer::GetInputParameters()
-{
-  InputParameters params;
-
-  params.SetGeneralDescription("A collection of parameters defining an extrusion layer.");
-  params.SetDocGroup("doc_MeshGenerators");
-
-  params.AddOptionalParameter("h", 1.0, "Layer height. Cannot be specified if \"z\" is specified.");
-  params.AddOptionalParameter("n", 1, "Number of sub-layers");
-  params.AddOptionalParameter("z",
-                              0.0,
-                              "The z-coordinate at the top of the layer. "
-                              "Cannot be specified if \"n\" is specified.");
-
-  params.ConstrainParameterRange("n", AllowableRangeLowLimit::New(0, false));
-
-  return params;
-}
-
-InputParameters
-ExtruderMeshGenerator::GetInputParameters()
-{
-  InputParameters params = MeshGenerator::GetInputParameters();
-
-  params.SetGeneralDescription(
-    "Extrudes 2D geometry. Extrusion layers are specified using an \\ref mesh__ExtrusionLayer "
-    "specification which takes either pairs of parameters: Pair A = \"n\" and \"z\", or Pair B = "
-    "\"n\" and \"h\". When pair A is used then the z-levels will be computed automatically. Vice "
-    "versa, when pair B is used then the h-levels will be computed automatically. Layers can be "
-    "specified with a mixture of Pair A and Pair B. For example: Two main layers, one specified "
-    "using a height, and the other specified using a z-level.");
-  params.SetDocGroup("MeshGenerator");
-
-  params.AddRequiredParameterArray("layers", "A list of layers");
-  params.LinkParameterToBlock("layers", "mesh::ExtrusionLayer");
-
-  params.AddOptionalParameter(
-    "top_boundary_name", "ZMAX", "The name to associate with the top boundary.");
-  params.AddOptionalParameter(
-    "bottom_boundary_name", "ZMIN", "The name to associate with the bottom boundary.");
-
-  return params;
-}
-
-std::shared_ptr<ExtruderMeshGenerator>
-ExtruderMeshGenerator::Create(const ParameterBlock& params)
-{
-  auto& factory = opensn::ObjectFactory::GetInstance();
-  return factory.Create<ExtruderMeshGenerator>("mesh::ExtruderMeshGenerator", params);
-}
-
 ExtruderMeshGenerator::ExtruderMeshGenerator(const InputParameters& params)
   : MeshGenerator(params),
     top_boundary_name_(params.GetParamValue<std::string>("top_boundary_name")),
@@ -78,25 +22,25 @@ ExtruderMeshGenerator::ExtruderMeshGenerator(const InputParameters& params)
     valid_params.SetErrorOriginScope("ExtruderMeshGenerator:\"layers\"");
     valid_params.AssignParameters(layer_block);
 
-    const int h_and_z_config = int(layer_block.Has("h")) + int(layer_block.Has("z"));
+    const auto h_and_z_config =
+      static_cast<int>(layer_block.Has("h")) + static_cast<int>(layer_block.Has("z"));
 
     if (h_and_z_config != 1)
-      OpenSnInvalidArgument("For an ExtrusionLayer either \"h\" or \"z\" must"
-                            "be specified and also not both.");
+      throw std::invalid_argument("For an ExtrusionLayer either \"h\" or \"z\" must "
+                                  "be specified and also not both.");
 
-    auto n = valid_params.GetParamValue<uint32_t>("n");
     double h;
+    const auto n = valid_params.GetParamValue<uint32_t>("n");
     if (layer_block.Has("h"))
       h = valid_params.GetParamValue<double>("h");
     else
     {
-      auto z = valid_params.GetParamValue<double>("z");
-      OpenSnInvalidArgumentIf(z <= current_z_level,
-                              "For extrusion layers, the \"z\" coordinates must "
-                              "be monotonically increasing.");
+      const auto z = valid_params.GetParamValue<double>("z");
+      if (z <= current_z_level)
+        throw std::invalid_argument("For extrusion layers, the \"z\" coordinates must "
+                                    "be monotonically increasing.");
       h = z - current_z_level;
     }
-
     current_z_level += h;
 
     layers_.push_back(ExtrusionLayer{h, n});
@@ -112,17 +56,19 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
   log.Log0Verbose1() << "ExtruderMeshGenerator::GenerateUnpartitionedMesh";
   const Vector3 khat(0.0, 0.0, 1.0);
 
-  OpenSnInvalidArgumentIf(input_umesh->GetDimension() != 2,
-                          "Input mesh is not 2D. A 2D mesh is required for extrusion");
+  if (input_umesh->GetDimension() != 2)
+    throw std::invalid_argument("Input mesh is not 2D. A 2D mesh is required for extrusion");
 
   const auto& template_vertices = input_umesh->GetVertices();
   const auto& template_cells = input_umesh->GetRawCells();
 
-  const size_t num_template_vertices = template_vertices.size();
-  const size_t num_template_cells = template_cells.size();
+  const auto num_template_vertices = template_vertices.size();
+  const auto num_template_cells = template_cells.size();
 
-  OpenSnLogicalErrorIf(template_vertices.empty(), "Input mesh has no vertices.");
-  OpenSnLogicalErrorIf(template_cells.empty(), "Input mesh has no cells.");
+  if (template_vertices.empty())
+    throw std::logic_error("Input mesh has no vertices.");
+  if (template_cells.empty())
+    throw std::logic_error("Input mesh has no cells.");
 
   // Check cells
   for (const auto& template_cell_ptr : template_cells)
@@ -137,14 +83,10 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
     const auto& v1 = template_vertices[template_cell.vertex_ids[0]];
     const auto& v2 = template_vertices[template_cell.vertex_ids[1]];
 
-    auto v01 = v1 - v0;
-    auto v02 = v2 - v0;
-
-    if (v01.Cross(v02).Dot(khat) < 0.0)
-      throw std::logic_error("Extruder attempting to extrude a template"
-                             " cell with a normal pointing downward. This"
-                             " causes erratic behavior and needs to be"
-                             " corrected.");
+    if ((v1 - v0).Cross(v2 - v0).Dot(khat) < 0.0)
+      throw std::logic_error("Extruder attempting to extrude a template cell with a normal "
+                             "pointing downward. This causes erratic behavior and needs to be "
+                             "corrected.");
   }
 
   auto umesh = std::make_shared<UnpartitionedMesh>();
@@ -153,37 +95,37 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
   auto& umesh_bndry_map = umesh->GetBoundaryIDMap();
   umesh_bndry_map = input_umesh->GetBoundaryIDMap();
 
-  const uint64_t zmax_bndry_id = umesh->MakeBoundaryID(top_boundary_name_);
+  const auto zmax_bndry_id = umesh->MakeBoundaryID(top_boundary_name_);
   umesh_bndry_map[zmax_bndry_id] = top_boundary_name_;
-  const uint64_t zmin_bndry_id = umesh->MakeBoundaryID(bottom_boundary_name_);
+  const auto zmin_bndry_id = umesh->MakeBoundaryID(bottom_boundary_name_);
   umesh_bndry_map[zmin_bndry_id] = bottom_boundary_name_;
 
   // Setup z-levels
   double current_z = 0.0;
   std::vector<double> z_levels = {current_z};
-  for (const auto& layer : layers_)
+  for (const auto& [height, num_sub_layers] : layers_)
   {
-    const double dz = layer.height / layer.num_sub_layers;
-    for (uint32_t i = 0; i < layer.num_sub_layers; ++i)
+    const double dz = height / num_sub_layers;
+    for (uint32_t i = 0; i < num_sub_layers; ++i)
       z_levels.push_back(current_z += dz);
   }
 
   // Build vertices
   auto& extruded_vertices = umesh->GetVertices();
-  for (const double z_level : z_levels)
+  for (const auto z_level : z_levels)
     for (const auto& template_vertex : template_vertices)
-      extruded_vertices.push_back(Vector3(template_vertex.x, template_vertex.y, z_level));
+      extruded_vertices.emplace_back(template_vertex.x, template_vertex.y, z_level);
 
   // Build cells
   size_t k = 0;
-  for (const auto& layer : layers_)
+  for (const auto& [height, num_sub_layers] : layers_)
   {
-    for (uint32_t n = 0; n < layer.num_sub_layers; ++n)
+    for (uint32_t n = 0; n < num_sub_layers; ++n)
     {
       size_t tc_counter = 0;
       for (const auto& template_cell : template_cells)
       {
-        // Determine cell sub-type
+        // Determine cell subtype
         CellType extruded_subtype;
         switch (template_cell->sub_type)
         {
@@ -205,7 +147,7 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
         new_cell.material_id = template_cell->material_id;
 
         // Build vertices
-        const size_t tc_num_verts = template_cell->vertex_ids.size();
+        const auto tc_num_verts = template_cell->vertex_ids.size();
         new_cell.vertex_ids.reserve(2 * tc_num_verts);
         for (const auto tc_vid : template_cell->vertex_ids)
           new_cell.vertex_ids.push_back(tc_vid + k * num_template_vertices);
@@ -299,6 +241,62 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
 
   log.Log0Verbose1() << "ExtruderMeshGenerator::GenerateUnpartitionedMesh Done";
   return umesh;
+}
+
+OpenSnRegisterObjectParametersOnlyInNamespace(mesh, ExtrusionLayer);
+
+InputParameters
+ExtrusionLayer::GetInputParameters()
+{
+  InputParameters params;
+
+  params.SetGeneralDescription("A collection of parameters defining an extrusion layer.");
+  params.SetDocGroup("doc_MeshGenerators");
+
+  params.AddOptionalParameter("h", 1.0, "Layer height. Cannot be specified if \"z\" is specified.");
+  params.AddOptionalParameter("n", 1, "Number of sub-layers");
+  params.AddOptionalParameter("z",
+                              0.0,
+                              "The z-coordinate at the top of the layer. "
+                              "Cannot be specified if \"n\" is specified.");
+
+  params.ConstrainParameterRange("n", AllowableRangeLowLimit::New(0, false));
+
+  return params;
+}
+
+OpenSnRegisterObjectInNamespace(mesh, ExtruderMeshGenerator);
+
+InputParameters
+ExtruderMeshGenerator::GetInputParameters()
+{
+  InputParameters params = MeshGenerator::GetInputParameters();
+
+  params.SetGeneralDescription(
+    "Extrudes 2D geometry. Extrusion layers are specified using an \\ref mesh__ExtrusionLayer "
+    "specification which takes either pairs of parameters: Pair A = \"n\" and \"z\", or Pair B = "
+    "\"n\" and \"h\". When pair A is used then the z-levels will be computed automatically. Vice "
+    "versa, when pair B is used then the h-levels will be computed automatically. Layers can be "
+    "specified with a mixture of Pair A and Pair B. For example: Two main layers, one specified "
+    "using a height, and the other specified using a z-level.");
+  params.SetDocGroup("MeshGenerator");
+
+  params.AddRequiredParameterArray("layers", "A list of layers");
+  params.LinkParameterToBlock("layers", "mesh::ExtrusionLayer");
+
+  params.AddOptionalParameter(
+    "top_boundary_name", "ZMAX", "The name to associate with the top boundary.");
+  params.AddOptionalParameter(
+    "bottom_boundary_name", "ZMIN", "The name to associate with the bottom boundary.");
+
+  return params;
+}
+
+std::shared_ptr<ExtruderMeshGenerator>
+ExtruderMeshGenerator::Create(const ParameterBlock& params)
+{
+  const auto& factory = ObjectFactory::GetInstance();
+  return factory.Create<ExtruderMeshGenerator>("mesh::ExtruderMeshGenerator", params);
 }
 
 } // namespace opensn

--- a/framework/mesh/mesh_generator/from_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/from_file_mesh_generator.h
@@ -16,6 +16,7 @@ public:
 protected:
   std::shared_ptr<UnpartitionedMesh>
   GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh) override;
+
   const std::string filename_;
   const std::string material_id_fieldname_;
   const std::string boundary_id_fieldname_;

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -13,6 +13,210 @@
 
 namespace opensn
 {
+MeshGenerator::MeshGenerator(const InputParameters& params)
+  : Object(params),
+    scale_(params.GetParamValue<double>("scale")),
+    replicated_(params.GetParamValue<bool>("replicated_mesh"))
+{
+  // Convert input handles
+  const auto inputs = params.GetParamVectorValue<std::shared_ptr<MeshGenerator>>("inputs");
+  for (auto& mesh_generator : inputs)
+    inputs_.push_back(mesh_generator);
+
+  // Set partitioner
+  if (params.IsParameterValid("partitioner"))
+    partitioner_ = params.GetParamValue<std::shared_ptr<GraphPartitioner>>("partitioner");
+  else
+  {
+    const auto& factory = ObjectFactory::GetInstance();
+    auto valid_params = PETScGraphPartitioner::GetInputParameters();
+    partitioner_ =
+      factory.Create<PETScGraphPartitioner>("mesh::PETScGraphPartitioner", ParameterBlock());
+  }
+}
+
+std::shared_ptr<UnpartitionedMesh>
+MeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh)
+{
+  return input_umesh;
+}
+
+std::shared_ptr<MeshContinuum>
+MeshGenerator::Execute()
+{
+  // Execute all input generators
+  // Note these could be empty
+  std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
+  for (const auto& mesh_generator_ptr : inputs_)
+    current_umesh = mesh_generator_ptr->GenerateUnpartitionedMesh(current_umesh);
+
+  // Generate final umesh and convert it
+  current_umesh = GenerateUnpartitionedMesh(current_umesh);
+
+  std::vector<int64_t> cell_pids;
+  const auto num_partitions = mpi_comm.size();
+
+  if (mpi_comm.rank() == 0)
+    cell_pids = PartitionMesh(*current_umesh, num_partitions);
+  BroadcastPIDs(cell_pids, 0, mpi_comm);
+
+  std::vector<size_t> partI_num_cells(num_partitions, 0);
+  for (const auto pid : cell_pids)
+    partI_num_cells[pid] += 1;
+
+  size_t avg_num_cells = 0;
+  auto max_num_cells = partI_num_cells.front();
+  auto min_num_cells = partI_num_cells.front();
+  for (size_t count : partI_num_cells)
+  {
+    max_num_cells = std::max(max_num_cells, count);
+    min_num_cells = std::min(min_num_cells, count);
+    avg_num_cells += count;
+  }
+  avg_num_cells /= num_partitions;
+
+  if (mpi_comm.rank() == 0)
+    log.Log() << "Number of cells per partition (max,min,avg) = " << max_num_cells << ","
+              << min_num_cells << "," << avg_num_cells;
+  if (min_num_cells == 0)
+    throw std::runtime_error("Partitioning failed. At least one partition contains no cells.");
+
+  auto grid_ptr = SetupMesh(current_umesh, cell_pids);
+
+  mpi_comm.barrier();
+
+  return grid_ptr;
+}
+
+std::vector<int64_t>
+MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh, const int num_partitions) const
+{
+  const auto& raw_cells = input_umesh.GetRawCells();
+  const auto num_raw_cells = raw_cells.size();
+
+  if (num_raw_cells == 0)
+    throw std::logic_error("No cells in final input mesh");
+
+  // Build cell graph and centroids
+  std::vector<std::vector<uint64_t>> cell_graph;
+  std::vector<Vector3> cell_centroids;
+
+  cell_graph.reserve(num_raw_cells);
+  cell_centroids.reserve(num_raw_cells);
+  {
+    for (const auto& raw_cell_ptr : raw_cells)
+    {
+      std::vector<uint64_t> cell_graph_node; // <-- Note A
+      for (auto& face : raw_cell_ptr->faces)
+        if (face.has_neighbor)
+          cell_graph_node.push_back(face.neighbor);
+
+      cell_graph.push_back(cell_graph_node);
+      cell_centroids.push_back(raw_cell_ptr->centroid);
+    }
+  }
+
+  // Note A: We do not add the diagonal here. If we do, ParMETIS seems
+  // to produce suboptimal partitions
+
+  // Execute partitioner
+  std::vector<int64_t> cell_pids =
+    partitioner_->Partition(cell_graph, cell_centroids, num_partitions);
+
+  RebalancePartitions(cell_pids, num_partitions);
+
+  return cell_pids;
+}
+
+std::shared_ptr<MeshContinuum>
+MeshGenerator::SetupMesh(const std::shared_ptr<UnpartitionedMesh>& input_umesh,
+                         const std::vector<int64_t>& cell_pids) const
+{
+  // Convert mesh
+  auto grid_ptr = MeshContinuum::New();
+
+  grid_ptr->GetBoundaryIDMap() = input_umesh->GetBoundaryIDMap();
+
+  size_t cell_global_id = 0;
+  auto& vertex_subs = input_umesh->GetVertextCellSubscriptions();
+
+  for (auto& raw_cell : input_umesh->GetRawCells())
+  {
+    if (CellHasLocalScope(mpi_comm.rank(), *raw_cell, cell_global_id, vertex_subs, cell_pids))
+    {
+      auto cell = SetupCell(*raw_cell, cell_global_id, cell_pids[cell_global_id]);
+
+      for (const auto vid : cell->vertex_ids)
+        grid_ptr->vertices.Insert(vid, input_umesh->GetVertices()[vid]);
+
+      grid_ptr->cells.PushBack(std::move(cell));
+    }
+    ++cell_global_id;
+  } // for raw_cell
+
+  grid_ptr->SetDimension(input_umesh->GetDimension());
+  grid_ptr->SetType(input_umesh->GetType());
+  grid_ptr->SetExtruded(input_umesh->IsExtruded());
+  grid_ptr->SetOrthoAttributes(input_umesh->GetOrthoAttributes());
+  grid_ptr->SetGlobalVertexCount(input_umesh->GetVertices().size());
+  grid_ptr->ComputeGeometricInfo();
+
+  ComputeAndPrintStats(grid_ptr);
+
+  return grid_ptr;
+}
+
+bool
+MeshGenerator::CellHasLocalScope(const int location_id,
+                                 const UnpartitionedMesh::LightWeightCell& lwcell,
+                                 const uint64_t cell_global_id,
+                                 const std::vector<std::set<uint64_t>>& vertex_subscriptions,
+                                 const std::vector<int64_t>& cell_partition_ids) const
+{
+  if (replicated_)
+    return true;
+
+  // First determine if the cell is a local cell
+  if (static_cast<int>(cell_partition_ids[cell_global_id]) == location_id)
+    return true;
+
+  // Now determine if the cell is a ghost cell
+  for (const auto vid : lwcell.vertex_ids)
+    for (const auto cid : vertex_subscriptions[vid])
+    {
+      if (cid == cell_global_id)
+        continue;
+
+      if (static_cast<int>(cell_partition_ids[cid]) == location_id)
+        return true;
+    }
+  return false;
+}
+
+std::unique_ptr<Cell>
+MeshGenerator::SetupCell(const UnpartitionedMesh::LightWeightCell& raw_cell,
+                         const uint64_t global_id,
+                         const uint64_t partition_id)
+{
+  auto cell = std::make_unique<Cell>(raw_cell.type, raw_cell.sub_type);
+  cell->centroid = raw_cell.centroid;
+  cell->global_id = global_id;
+  cell->partition_id = partition_id;
+  cell->material_id = raw_cell.material_id;
+
+  cell->vertex_ids = raw_cell.vertex_ids;
+
+  size_t face_counter = 0;
+  for (auto& raw_face : raw_cell.faces)
+  {
+    CellFace newFace;
+    newFace.has_neighbor = raw_face.has_neighbor;
+    newFace.neighbor_id = raw_face.neighbor;
+    newFace.vertex_ids = raw_face.vertex_ids;
+    cell->faces.push_back(newFace);
+  }
+  return cell;
+}
 
 OpenSnRegisterObjectInNamespace(mesh, MeshGenerator);
 
@@ -47,89 +251,12 @@ MeshGenerator::GetInputParameters()
 std::shared_ptr<MeshGenerator>
 MeshGenerator::Create(const ParameterBlock& params)
 {
-  auto& factory = opensn::ObjectFactory::GetInstance();
+  const auto& factory = ObjectFactory::GetInstance();
   return factory.Create<MeshGenerator>("mesh::MeshGenerator", params);
 }
 
-MeshGenerator::MeshGenerator(const InputParameters& params)
-  : Object(params),
-    scale_(params.GetParamValue<double>("scale")),
-    replicated_(params.GetParamValue<bool>("replicated_mesh"))
-{
-  // Convert input handles
-  auto inputs = params.GetParamVectorValue<std::shared_ptr<MeshGenerator>>("inputs");
-  for (auto& mesh_generator : inputs)
-    inputs_.push_back(mesh_generator);
-
-  // Set partitioner
-  if (params.IsParameterValid("partitioner"))
-    partitioner_ = params.GetParamValue<std::shared_ptr<GraphPartitioner>>("partitioner");
-  else
-  {
-    auto& factory = ObjectFactory::GetInstance();
-    auto valid_params = PETScGraphPartitioner::GetInputParameters();
-    partitioner_ =
-      factory.Create<PETScGraphPartitioner>("mesh::PETScGraphPartitioner", ParameterBlock());
-  }
-}
-
-std::shared_ptr<UnpartitionedMesh>
-MeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh)
-{
-  return input_umesh;
-}
-
-std::shared_ptr<MeshContinuum>
-MeshGenerator::Execute()
-{
-  // Execute all input generators
-  // Note these could be empty
-  std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
-  for (auto mesh_generator_ptr : inputs_)
-  {
-    auto new_umesh = mesh_generator_ptr->GenerateUnpartitionedMesh(current_umesh);
-    current_umesh = new_umesh;
-  }
-
-  // Generate final umesh and convert it
-  current_umesh = GenerateUnpartitionedMesh(current_umesh);
-
-  auto num_partitions = opensn::mpi_comm.size();
-  std::vector<int64_t> cell_pids;
-  if (opensn::mpi_comm.rank() == 0)
-    cell_pids = PartitionMesh(*current_umesh, num_partitions);
-  BroadcastPIDs(cell_pids, 0, mpi_comm);
-
-  std::vector<size_t> partI_num_cells(num_partitions, 0);
-  for (int64_t pid : cell_pids)
-    partI_num_cells[pid] += 1;
-
-  size_t max_num_cells = partI_num_cells.front();
-  size_t min_num_cells = partI_num_cells.front();
-  size_t avg_num_cells = 0;
-  for (size_t count : partI_num_cells)
-  {
-    max_num_cells = std::max(max_num_cells, count);
-    min_num_cells = std::min(min_num_cells, count);
-    avg_num_cells += count;
-  }
-  avg_num_cells /= num_partitions;
-
-  if (opensn::mpi_comm.rank() == 0)
-    log.Log() << "Number of cells per partition (max,min,avg) = " << max_num_cells << ","
-              << min_num_cells << "," << avg_num_cells;
-  if (min_num_cells == 0)
-    throw std::runtime_error("Partitioning failed. At least one partition contains no cells.");
-
-  auto grid_ptr = SetupMesh(std::move(current_umesh), cell_pids);
-
-  opensn::mpi_comm.barrier();
-
-  return grid_ptr;
-}
-
 void
-MeshGenerator::ComputeAndPrintStats(const std::shared_ptr<MeshContinuum> grid)
+MeshGenerator::ComputeAndPrintStats(const std::shared_ptr<MeshContinuum>& grid)
 {
   const size_t num_local_cells = grid->local_cells.size();
   size_t num_global_cells = 0;
@@ -142,14 +269,14 @@ MeshGenerator::ComputeAndPrintStats(const std::shared_ptr<MeshContinuum> grid)
   size_t min_num_local_cells;
   mpi_comm.all_reduce(num_local_cells, min_num_local_cells, mpi::op::min<size_t>());
 
-  const size_t avg_num_local_cells = num_global_cells / opensn::mpi_comm.size();
+  const size_t avg_num_local_cells = num_global_cells / mpi_comm.size();
   const size_t num_local_ghosts = grid->cells.GhostCellCount();
   const double local_ghost_to_local_cell_ratio = double(num_local_ghosts) / double(num_local_cells);
 
   double average_ghost_ratio;
   mpi_comm.all_reduce(local_ghost_to_local_cell_ratio, average_ghost_ratio, mpi::op::sum<double>());
 
-  average_ghost_ratio /= opensn::mpi_comm.size();
+  average_ghost_ratio /= mpi_comm.size();
 
   std::stringstream outstr;
   outstr << "Mesh statistics:\n";
@@ -162,77 +289,47 @@ MeshGenerator::ComputeAndPrintStats(const std::shared_ptr<MeshContinuum> grid)
 
   log.Log() << "\n" << outstr.str() << "\n\n";
 
-  log.LogAllVerbose2() << opensn::mpi_comm.rank() << "Local cells=" << num_local_cells;
+  log.LogAllVerbose2() << mpi_comm.rank() << "Local cells=" << num_local_cells;
 
   if (min_num_local_cells == 0)
     throw std::runtime_error("Partitioning failed. At least one partition contains no cells.");
 }
 
-std::vector<int64_t>
-MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh, int num_partitions)
+void
+MeshGenerator::BroadcastPIDs(std::vector<int64_t>& cell_pids,
+                             const int root,
+                             const mpi::Communicator& communicator)
 {
-  const auto& raw_cells = input_umesh.GetRawCells();
-  const size_t num_raw_cells = raw_cells.size();
-
-  OpenSnLogicalErrorIf(num_raw_cells == 0, "No cells in final input mesh");
-
-  // Build cell graph and centroids
-  std::vector<std::vector<uint64_t>> cell_graph;
-  std::vector<Vector3> cell_centroids;
-
-  cell_graph.reserve(num_raw_cells);
-  cell_centroids.reserve(num_raw_cells);
-  {
-    for (const auto& raw_cell_ptr : raw_cells)
-    {
-      std::vector<uint64_t> cell_graph_node; // <-- Note A
-      for (auto& face : raw_cell_ptr->faces)
-        if (face.has_neighbor)
-          cell_graph_node.push_back(face.neighbor);
-
-      cell_graph.push_back(cell_graph_node);
-      cell_centroids.push_back(raw_cell_ptr->centroid);
-    }
-  }
-
-  // Note A: We do not add the diagonal here. If we do, ParMETIS seems
-  // to produce sub-optimal partitions
-
-  // Execute partitioner
-  std::vector<int64_t> cell_pids =
-    partitioner_->Partition(cell_graph, cell_centroids, num_partitions);
-
-  RebalancePartitions(cell_pids, num_partitions);
-
-  return cell_pids;
+  // Broadcast partitioning to all locations
+  communicator.broadcast(cell_pids, root);
 }
 
 void
-MeshGenerator::RebalancePartitions(std::vector<int64_t>& cell_pids, int num_partitions)
+MeshGenerator::RebalancePartitions(std::vector<int64_t>& cell_pids, const int num_partitions)
 {
   // Count the number of cells in each partition
   std::vector<int> cells_per_partition(num_partitions, 0);
-  for (int partition : cell_pids)
-    cells_per_partition[partition]++;
+  for (const auto partition : cell_pids)
+    ++cells_per_partition[partition];
 
   // Check if any partition has zero cells
   if (std::none_of(cells_per_partition.begin(),
                    cells_per_partition.end(),
-                   [](int count) { return count == 0; }))
+                   [](const int count) { return count == 0; }))
   {
     return;
   }
 
   // Redistributed cells from heavy partitions
-  int total_cells = cell_pids.size();
-  int target = total_cells / num_partitions;
+  const auto total_cells = cell_pids.size();
+  const auto target = total_cells / num_partitions;
 
   for (int partition = 0; partition < num_partitions; ++partition)
   {
     while (cells_per_partition[partition] > target)
     {
-      auto it = std::min_element(cells_per_partition.begin(), cells_per_partition.end());
-      int min_partition = std::distance(cells_per_partition.begin(), it);
+      const auto it = std::min_element(cells_per_partition.begin(), cells_per_partition.end());
+      const auto min_partition = std::distance(cells_per_partition.begin(), it);
       if (min_partition == partition or cells_per_partition[min_partition] >= target)
         break;
 
@@ -241,178 +338,13 @@ MeshGenerator::RebalancePartitions(std::vector<int64_t>& cell_pids, int num_part
         if (cell_pid == partition)
         {
           cell_pid = min_partition;
-          cells_per_partition[partition]--;
-          cells_per_partition[min_partition]++;
+          --cells_per_partition[partition];
+          ++cells_per_partition[min_partition];
           break;
         }
       }
     }
   }
-}
-
-std::shared_ptr<MeshContinuum>
-MeshGenerator::SetupMesh(std::shared_ptr<UnpartitionedMesh> input_umesh,
-                         const std::vector<int64_t>& cell_pids)
-{
-  // Convert mesh
-  auto grid_ptr = MeshContinuum::New();
-
-  grid_ptr->GetBoundaryIDMap() = input_umesh->GetBoundaryIDMap();
-
-  auto& vertex_subs = input_umesh->GetVertextCellSubscriptions();
-  size_t cell_globl_id = 0;
-  for (auto& raw_cell : input_umesh->GetRawCells())
-  {
-    if (CellHasLocalScope(
-          opensn::mpi_comm.rank(), *raw_cell, cell_globl_id, vertex_subs, cell_pids))
-    {
-      auto cell = SetupCell(*raw_cell,
-                            cell_globl_id,
-                            cell_pids[cell_globl_id],
-                            STLVertexListHelper(input_umesh->GetVertices()));
-
-      for (uint64_t vid : cell->vertex_ids)
-        grid_ptr->vertices.Insert(vid, input_umesh->GetVertices()[vid]);
-
-      grid_ptr->cells.PushBack(std::move(cell));
-    }
-
-    ++cell_globl_id;
-  } // for raw_cell
-
-  grid_ptr->SetDimension(input_umesh->GetDimension());
-  grid_ptr->SetType(input_umesh->GetType());
-  grid_ptr->SetExtruded(input_umesh->IsExtruded());
-  grid_ptr->SetOrthoAttributes(input_umesh->GetOrthoAttributes());
-
-  grid_ptr->SetGlobalVertexCount(input_umesh->GetVertices().size());
-
-  ComputeAndPrintStats(grid_ptr);
-
-  return grid_ptr;
-}
-
-void
-MeshGenerator::BroadcastPIDs(std::vector<int64_t>& cell_pids,
-                             int root,
-                             const mpi::Communicator& communicator)
-{
-  // Broadcast partitioning to all locations
-  communicator.broadcast(cell_pids, root);
-}
-
-bool
-MeshGenerator::CellHasLocalScope(int location_id,
-                                 const UnpartitionedMesh::LightWeightCell& lwcell,
-                                 uint64_t cell_global_id,
-                                 const std::vector<std::set<uint64_t>>& vertex_subscriptions,
-                                 const std::vector<int64_t>& cell_partition_ids) const
-{
-  if (replicated_)
-    return true;
-  // First determine if the cell is a local cell
-  int cell_pid = static_cast<int>(cell_partition_ids[cell_global_id]);
-  if (cell_pid == location_id)
-    return true;
-
-  // Now determine if the cell is a ghost cell
-  for (uint64_t vid : lwcell.vertex_ids)
-    for (uint64_t cid : vertex_subscriptions[vid])
-    {
-      if (cid == cell_global_id)
-        continue;
-      int adj_pid = static_cast<int>(cell_partition_ids[cid]);
-      if (adj_pid == location_id)
-        return true;
-    }
-
-  return false;
-}
-
-std::unique_ptr<Cell>
-MeshGenerator::SetupCell(const UnpartitionedMesh::LightWeightCell& raw_cell,
-                         uint64_t global_id,
-                         uint64_t partition_id,
-                         const VertexListHelper& vertices)
-{
-  auto cell = std::make_unique<Cell>(raw_cell.type, raw_cell.sub_type);
-  cell->centroid = raw_cell.centroid;
-  cell->global_id = global_id;
-  cell->partition_id = partition_id;
-  cell->material_id = raw_cell.material_id;
-
-  cell->vertex_ids = raw_cell.vertex_ids;
-
-  size_t face_counter = 0;
-  for (auto& raw_face : raw_cell.faces)
-  {
-    CellFace newFace;
-
-    newFace.has_neighbor = raw_face.has_neighbor;
-    newFace.neighbor_id = raw_face.neighbor;
-
-    newFace.vertex_ids = raw_face.vertex_ids;
-    auto vfc = Vector3(0.0, 0.0, 0.0);
-    for (auto fvid : newFace.vertex_ids)
-      vfc = vfc + vertices.at(fvid);
-    newFace.centroid = vfc / static_cast<double>(newFace.vertex_ids.size());
-
-    if (cell->GetType() == CellType::SLAB)
-    {
-      // A slab face is very easy. If it is the first face
-      // the normal is -khat. If it is the second face then
-      // it is +khat.
-      if (face_counter == 0)
-        newFace.normal = Vector3(0.0, 0.0, -1.0);
-      else
-        newFace.normal = Vector3(0.0, 0.0, 1.0);
-    }
-    else if (cell->GetType() == CellType::POLYGON)
-    {
-      // A polygon face is just a line so we can just grab
-      // the first vertex and form a vector with the face
-      // centroid. The normal is then just khat
-      // cross-product with this vector.
-      uint64_t fvid = newFace.vertex_ids[0];
-      auto vec_vvc = vertices.at(fvid) - newFace.centroid;
-
-      newFace.normal = Vector3(0.0, 0.0, 1.0).Cross(vec_vvc);
-      newFace.normal.Normalize();
-    }
-    else if (cell->GetType() == CellType::POLYHEDRON)
-    {
-      // A face of a polyhedron can itself be a polygon
-      // which can be multifaceted. Here we need the
-      // average normal over all the facets computed
-      // using an area-weighted average.
-      const size_t num_face_verts = newFace.vertex_ids.size();
-      double total_area = 0.0;
-      for (size_t fv = 0; fv < num_face_verts; ++fv)
-      {
-        size_t fvp1 = (fv < (num_face_verts - 1)) ? fv + 1 : 0;
-
-        uint64_t fvid_m = newFace.vertex_ids[fv];
-        uint64_t fvid_p = newFace.vertex_ids[fvp1];
-
-        auto leg_m = vertices.at(fvid_m) - newFace.centroid;
-        auto leg_p = vertices.at(fvid_p) - newFace.centroid;
-
-        auto vn = leg_m.Cross(leg_p);
-
-        double area = 0.5 * vn.Norm();
-        total_area += area;
-
-        newFace.normal = newFace.normal + area * vn.Normalized();
-      }
-      newFace.normal = newFace.normal / total_area;
-      newFace.normal.Normalize();
-    }
-    ++face_counter;
-
-    cell->faces.push_back(newFace);
-  }
-
-  return cell;
 }
 
 } // namespace opensn

--- a/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/orthogonal_mesh_generator.cc
@@ -7,6 +7,91 @@
 
 namespace opensn
 {
+OrthogonalMeshGenerator::OrthogonalMeshGenerator(const InputParameters& params)
+  : MeshGenerator(params)
+{
+  // Parse the node_sets param
+  if (params.IsParameterValid("node_sets"))
+  {
+    auto& node_sets_param = params.GetParam("node_sets");
+    node_sets_param.RequireBlockTypeIs(ParameterBlockType::ARRAY);
+    for (const auto& node_list_block : node_sets_param)
+    {
+      OpenSnInvalidArgumentIf(node_list_block.GetType() != ParameterBlockType::ARRAY,
+                              "The entries of \"node_sets\" are required to be of type \"Array\".");
+
+      node_sets_.push_back(node_list_block.GetVectorValue<double>());
+    }
+  }
+
+  // Check they were not empty and <=3
+  if (node_sets_.empty())
+    throw std::invalid_argument(
+      "No nodes have been provided. At least one node set must be provided");
+  if (node_sets_.size() > 3)
+    throw std::invalid_argument(
+      "More than 3 node sets have been provided. The maximum allowed is 3.");
+
+  size_t ns = 0;
+  for (const auto& node_set : node_sets_)
+  {
+    if (node_set.size() < 2)
+      throw std::invalid_argument("Node set " + std::to_string(ns) + " only has " +
+                                  std::to_string(node_set.size()) + " nodes. " +
+                                  "A minimum of 2 is required to define a cell.");
+    ++ns;
+  }
+
+  // Check each node_set
+  size_t set_number = 0;
+  for (const auto& node_set : node_sets_)
+  {
+    if (node_set.empty())
+      throw std::invalid_argument("Node set " + std::to_string(set_number) + " " +
+                                  "in parameter \"node_sets\" may not be empty");
+
+    bool monotonic = true;
+    auto prev_value = node_set[0];
+    for (size_t k = 1; k < node_set.size(); ++k)
+    {
+      if (node_set[k] <= prev_value)
+      {
+        monotonic = false;
+        break;
+      }
+      prev_value = node_set[k];
+    }
+    if (not monotonic)
+    {
+      std::stringstream outstr;
+      for (const auto value : node_set)
+        outstr << value << " ";
+      throw std::invalid_argument("Node sets in parameter \"node_sets\" requires all "
+                                  "values to be monotonically increasing. Node set: " +
+                                  outstr.str());
+    }
+    ++set_number;
+  }
+}
+
+std::shared_ptr<UnpartitionedMesh>
+OrthogonalMeshGenerator::GenerateUnpartitionedMesh(
+  const std::shared_ptr<UnpartitionedMesh> input_umesh)
+{
+  if (input_umesh != nullptr)
+    throw std::invalid_argument("OrthogonalMeshGenerator can not be preceded by another"
+                                " mesh generator because it cannot process an input mesh");
+
+  if (node_sets_.size() == 1)
+    return CreateUnpartitioned1DOrthoMesh(node_sets_[0]);
+  if (node_sets_.size() == 2)
+    return CreateUnpartitioned2DOrthoMesh(node_sets_[0], node_sets_[1]);
+  if (node_sets_.size() == 3)
+    return CreateUnpartitioned3DOrthoMesh(node_sets_[0], node_sets_[1], node_sets_[2]);
+
+  // This will never get triggered because of the checks in constructor
+  throw std::logic_error("");
+}
 
 OpenSnRegisterObjectInNamespace(mesh, OrthogonalMeshGenerator);
 
@@ -28,93 +113,8 @@ OrthogonalMeshGenerator::GetInputParameters()
 std::shared_ptr<OrthogonalMeshGenerator>
 OrthogonalMeshGenerator::Create(const ParameterBlock& params)
 {
-  auto& factory = opensn::ObjectFactory::GetInstance();
+  const auto& factory = ObjectFactory::GetInstance();
   return factory.Create<OrthogonalMeshGenerator>("mesh::OrthogonalMeshGenerator", params);
-}
-
-OrthogonalMeshGenerator::OrthogonalMeshGenerator(const InputParameters& params)
-  : MeshGenerator(params)
-{
-  // Parse the node_sets param
-  if (params.IsParameterValid("node_sets"))
-  {
-    auto& node_sets_param = params.GetParam("node_sets");
-    node_sets_param.RequireBlockTypeIs(ParameterBlockType::ARRAY);
-    for (const auto& node_list_block : node_sets_param)
-    {
-      OpenSnInvalidArgumentIf(node_list_block.GetType() != ParameterBlockType::ARRAY,
-                              "The entries of \"node_sets\" are required to be of type \"Array\".");
-
-      node_sets_.push_back(node_list_block.GetVectorValue<double>());
-    }
-  }
-
-  // Check they were not empty and <=3
-  OpenSnInvalidArgumentIf(node_sets_.empty(),
-                          "No nodes have been provided. At least one node set must be provided");
-
-  OpenSnInvalidArgumentIf(node_sets_.size() > 3,
-                          "More than 3 node sets have been provided. The "
-                          "maximum allowed is 3.");
-
-  size_t ns = 0;
-  for (const auto& node_set : node_sets_)
-  {
-    OpenSnInvalidArgumentIf(node_set.size() < 2,
-                            "Node set " + std::to_string(ns) + " only has " +
-                              std::to_string(node_set.size()) +
-                              " nodes. A minimum of 2 is required to define a cell.");
-    ++ns;
-  }
-
-  // Check each node_set
-  size_t set_number = 0;
-  for (const auto& node_set : node_sets_)
-  {
-    OpenSnInvalidArgumentIf(node_set.empty(),
-                            "Node set " + std::to_string(set_number) +
-                              " in parameter \"node_sets\" may not be empty");
-
-    bool monotonic = true;
-    double prev_value = node_set[0];
-    for (size_t k = 1; k < node_set.size(); ++k)
-    {
-      if (node_set[k] <= prev_value)
-      {
-        monotonic = false;
-        break;
-      }
-
-      prev_value = node_set[k];
-    }
-    if (not monotonic)
-    {
-      std::stringstream outstr;
-      for (double value : node_set)
-        outstr << value << " ";
-      OpenSnInvalidArgument("Node sets in parameter \"node_sets\" requires all "
-                            "values to be monotonically increasing. Node set: " +
-                            outstr.str());
-    }
-  }
-}
-
-std::shared_ptr<UnpartitionedMesh>
-OrthogonalMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh)
-{
-  OpenSnInvalidArgumentIf(input_umesh != nullptr,
-                          "OrthogonalMeshGenerator can not be preceded by another"
-                          " mesh generator because it cannot process an input mesh");
-
-  if (node_sets_.size() == 1)
-    return CreateUnpartitioned1DOrthoMesh(node_sets_[0]);
-  else if (node_sets_.size() == 2)
-    return CreateUnpartitioned2DOrthoMesh(node_sets_[0], node_sets_[1]);
-  else if (node_sets_.size() == 3)
-    return CreateUnpartitioned3DOrthoMesh(node_sets_[0], node_sets_[1], node_sets_[2]);
-  else
-    // This will never get triggered because of the checks in constructor
-    throw std::logic_error("");
 }
 
 std::shared_ptr<UnpartitionedMesh>
@@ -131,19 +131,19 @@ OrthogonalMeshGenerator::CreateUnpartitioned1DOrthoMesh(const std::vector<double
   umesh->SetDimension(1);
 
   // Create vertices
-  size_t Nz = vertices.size();
+  const auto Nz = vertices.size();
 
   umesh->SetOrthoAttributes(1, 1, Nz - 1);
   umesh->AddBoundary(ZMIN, "ZMIN");
   umesh->AddBoundary(ZMAX, "ZMAX");
 
   umesh->GetVertices().reserve(Nz);
-  for (auto& vertex : zverts)
+  for (const auto& vertex : zverts)
     umesh->GetVertices().push_back(vertex);
 
   // Create cells
-  const size_t max_cz = zverts.size() - 2;
-  for (size_t c = 0; c < (zverts.size() - 1); ++c)
+  const auto max_cz = zverts.size() - 2;
+  for (size_t c = 0; c < zverts.size() - 1; ++c)
   {
     auto cell =
       std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::SLAB, CellType::SLAB);
@@ -195,8 +195,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned2DOrthoMesh(const std::vector<double
   umesh->SetDimension(2);
 
   // Create vertices
-  const size_t Nx = vertices_1d_x.size();
-  const size_t Ny = vertices_1d_y.size();
+  const auto Nx = vertices_1d_x.size();
+  const auto Ny = vertices_1d_y.size();
 
   umesh->SetOrthoAttributes(Nx - 1, Ny - 1, 1);
   umesh->AddBoundary(XMIN, "XMIN");
@@ -227,13 +227,13 @@ OrthogonalMeshGenerator::CreateUnpartitioned2DOrthoMesh(const std::vector<double
   }
 
   // Create cells
-  auto& vmap = vertex_ij_to_i_map;
-  auto& cmap = cells_ij_to_i_map;
-  const size_t max_j = Nx - 2;
-  const size_t max_i = Ny - 2;
-  for (size_t i = 0; i < (Ny - 1); ++i)
+  const auto& vmap = vertex_ij_to_i_map;
+  const auto& cmap = cells_ij_to_i_map;
+  const auto max_j = Nx - 2;
+  const auto max_i = Ny - 2;
+  for (size_t i = 0; i < Ny - 1; ++i)
   {
-    for (size_t j = 0; j < (Nx - 1); ++j)
+    for (size_t j = 0; j < Nx - 1; ++j)
     {
       auto cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYGON,
                                                                        CellType::QUADRILATERAL);
@@ -312,9 +312,9 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
   umesh->SetDimension(3);
 
   // Create vertices
-  size_t Nx = vertices_1d_x.size();
-  size_t Ny = vertices_1d_y.size();
-  size_t Nz = vertices_1d_z.size();
+  const auto Nx = vertices_1d_x.size();
+  const auto Ny = vertices_1d_y.size();
+  const auto Nz = vertices_1d_z.size();
 
   umesh->SetOrthoAttributes(Nx - 1, Ny - 1, Nz - 1);
   umesh->AddBoundary(XMIN, "XMIN");
@@ -355,23 +355,23 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
 
   {
     uint64_t c = 0;
-    for (size_t i = 0; i < (Ny - 1); ++i)
-      for (size_t j = 0; j < (Nx - 1); ++j)
-        for (size_t k = 0; k < (Nz - 1); ++k)
+    for (size_t i = 0; i < Ny - 1; ++i)
+      for (size_t j = 0; j < Nx - 1; ++j)
+        for (size_t k = 0; k < Nz - 1; ++k)
           cells_ijk_to_i_map[i][j][k] = c++;
   }
 
   // Create cells
-  auto& vmap = vertex_ijk_to_i_map;
-  auto& cmap = cells_ijk_to_i_map;
-  const size_t max_j = Nx - 2;
-  const size_t max_i = Ny - 2;
-  const size_t max_k = Nz - 2;
-  for (size_t i = 0; i < (Ny - 1); ++i)
+  const auto& vmap = vertex_ijk_to_i_map;
+  const auto& cmap = cells_ijk_to_i_map;
+  const auto max_j = Nx - 2;
+  const auto max_i = Ny - 2;
+  const auto max_k = Nz - 2;
+  for (size_t i = 0; i < Ny - 1; ++i)
   {
-    for (size_t j = 0; j < (Nx - 1); ++j)
+    for (size_t j = 0; j < Nx - 1; ++j)
     {
-      for (size_t k = 0; k < (Nz - 1); ++k)
+      for (size_t k = 0; k < Nz - 1; ++k)
       {
         auto cell = std::make_shared<UnpartitionedMesh::LightWeightCell>(CellType::POLYHEDRON,
                                                                          CellType::HEXAHEDRON);
@@ -394,8 +394,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
                                                   vmap[i + 1][j + 1][k],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i][j + 1][k + 1]};
-          face.neighbor = (j == max_j) ? XMAX : cmap[i][j + 1][k];
-          face.has_neighbor = (j != max_j);
+          face.neighbor = j == max_j ? XMAX : cmap[i][j + 1][k];
+          face.has_neighbor = j != max_j;
           cell->faces.push_back(face);
         }
         // West face
@@ -404,8 +404,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
 
           face.vertex_ids = std::vector<uint64_t>{
             vmap[i][j][k], vmap[i][j][k + 1], vmap[i + 1][j][k + 1], vmap[i + 1][j][k]};
-          face.neighbor = (j == 0) ? XMIN : cmap[i][j - 1][k];
-          face.has_neighbor = (j != 0);
+          face.neighbor = j == 0 ? XMIN : cmap[i][j - 1][k];
+          face.has_neighbor = j != 0;
           cell->faces.push_back(face);
         }
         // North face
@@ -416,8 +416,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
                                                   vmap[i + 1][j][k + 1],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i + 1][j + 1][k]};
-          face.neighbor = (i == max_i) ? YMAX : cmap[i + 1][j][k];
-          face.has_neighbor = (i != max_i);
+          face.neighbor = i == max_i ? YMAX : cmap[i + 1][j][k];
+          face.has_neighbor = i != max_i;
           cell->faces.push_back(face);
         }
         // South face
@@ -426,8 +426,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
 
           face.vertex_ids = std::vector<uint64_t>{
             vmap[i][j][k], vmap[i][j + 1][k], vmap[i][j + 1][k + 1], vmap[i][j][k + 1]};
-          face.neighbor = (i == 0) ? YMIN : cmap[i - 1][j][k];
-          face.has_neighbor = (i != 0);
+          face.neighbor = i == 0 ? YMIN : cmap[i - 1][j][k];
+          face.has_neighbor = i != 0;
           cell->faces.push_back(face);
         }
         // Top face
@@ -438,8 +438,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
                                                   vmap[i][j + 1][k + 1],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i + 1][j][k + 1]};
-          face.neighbor = (k == max_k) ? ZMAX : cmap[i][j][k + 1];
-          face.has_neighbor = (k != max_k);
+          face.neighbor = k == max_k ? ZMAX : cmap[i][j][k + 1];
+          face.has_neighbor = k != max_k;
           cell->faces.push_back(face);
         }
         // Bottom face
@@ -448,8 +448,8 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(const std::vector<double
 
           face.vertex_ids = std::vector<uint64_t>{
             vmap[i][j][k], vmap[i + 1][j][k], vmap[i + 1][j + 1][k], vmap[i][j + 1][k]};
-          face.neighbor = (k == 0) ? ZMIN : cmap[i][j][k - 1];
-          face.has_neighbor = (k != 0);
+          face.neighbor = k == 0 ? ZMIN : cmap[i][j][k - 1];
+          face.has_neighbor = k != 0;
           cell->faces.push_back(face);
         }
 

--- a/framework/mesh/mesh_generator/orthogonal_mesh_generator.h
+++ b/framework/mesh/mesh_generator/orthogonal_mesh_generator.h
@@ -17,6 +17,13 @@ protected:
   std::shared_ptr<UnpartitionedMesh>
   GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh) override;
 
+  std::vector<std::vector<double>> node_sets_;
+
+public:
+  static InputParameters GetInputParameters();
+  static std::shared_ptr<OrthogonalMeshGenerator> Create(const ParameterBlock& params);
+
+protected:
   static std::shared_ptr<UnpartitionedMesh>
   CreateUnpartitioned1DOrthoMesh(const std::vector<double>& vertices);
 
@@ -28,12 +35,6 @@ protected:
   CreateUnpartitioned3DOrthoMesh(const std::vector<double>& vertices_1d_x,
                                  const std::vector<double>& vertices_1d_y,
                                  const std::vector<double>& vertices_1d_z);
-
-  std::vector<std::vector<double>> node_sets_;
-
-public:
-  static InputParameters GetInputParameters();
-  static std::shared_ptr<OrthogonalMeshGenerator> Create(const ParameterBlock& params);
 };
 
 } // namespace opensn

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -15,6 +15,20 @@ class ByteArray;
  */
 class SplitFileMeshGenerator : public MeshGenerator
 {
+protected:
+  struct SplitMeshInfo
+  {
+    unsigned int dimension;
+    MeshType mesh_type;
+    bool extruded;
+    OrthoMeshAttributes ortho_attributes;
+
+    std::map<std::pair<int, uint64_t>, UnpartitionedMesh::LightWeightCell> cells;
+    std::map<uint64_t, Vector3> vertices;
+    std::map<uint64_t, std::string> boundary_id_map;
+    size_t num_global_vertices;
+  };
+
 public:
   explicit SplitFileMeshGenerator(const InputParameters& params);
 
@@ -23,26 +37,11 @@ public:
 protected:
   void WriteSplitMesh(const std::vector<int64_t>& cell_pids,
                       const UnpartitionedMesh& umesh,
-                      int num_parts);
-  static void SerializeCell(const UnpartitionedMesh::LightWeightCell& cell,
-                            ByteArray& serial_buffer);
-  struct SplitMeshInfo
-  {
-    unsigned int dimension;
-    std::map<std::pair<int, uint64_t>, UnpartitionedMesh::LightWeightCell> cells;
-    std::map<uint64_t, Vector3> vertices;
-    std::map<uint64_t, std::string> boundary_id_map;
-    MeshType mesh_type;
-    bool extruded;
-    OrthoMeshAttributes ortho_attributes;
-    size_t num_global_vertices;
-  };
-  SplitMeshInfo ReadSplitMesh();
+                      int num_partitions) const;
 
-  static std::shared_ptr<MeshContinuum> SetupLocalMesh(SplitMeshInfo& mesh_info);
+  SplitMeshInfo ReadSplitMesh() const;
 
-  // void
-  const int num_parts_;
+  const int num_partitions_;
   const std::string split_mesh_dir_path_;
   const std::string file_prefix_;
   const bool read_only_;
@@ -51,6 +50,12 @@ protected:
 public:
   static InputParameters GetInputParameters();
   static std::shared_ptr<SplitFileMeshGenerator> Create(const ParameterBlock& params);
+
+protected:
+  static std::shared_ptr<MeshContinuum> SetupLocalMesh(SplitMeshInfo& mesh_info);
+
+  static void SerializeCell(const UnpartitionedMesh::LightWeightCell& cell,
+                            ByteArray& serial_buffer);
 };
 
 } // namespace opensn

--- a/framework/mesh/mesh_mapping/mesh_mapping.h
+++ b/framework/mesh/mesh_mapping/mesh_mapping.h
@@ -23,33 +23,33 @@ public:
   MeshMapping() = default;
 
   /// Builds the mapping.
-  void Build(const std::shared_ptr<MeshContinuum> fine_grid,
-             const std::shared_ptr<MeshContinuum> coarse_grif);
-
-  /// Identifier for an invalid face index that means a face maps to nothing.
-  static const std::size_t invalid_face_index;
+  void Build(const std::shared_ptr<MeshContinuum>& fine_grid,
+             const std::shared_ptr<MeshContinuum>& coarse_grid);
 
   /// Helper struct for storing the mapping to a coarse cell from a fine cell.
   struct CoarseMapping
   {
     /// Constructor. Sizes fine_faces based on the number of faces within the coarse cell.
-    CoarseMapping(const Cell& coarse_cell);
+    explicit CoarseMapping(const Cell& coarse_cell);
+
     /// The fine cells contained within a coarse cell.
     std::vector<const Cell*> fine_cells;
     /// The fine cell faces contained within each coarse cell face.
     /// Outer index coarse cell face index (size == # of faces in coarse cell)
     /// Inner index is arbitrary and entries are fine Cell -> fine CellFace index
-    std::vector<std::vector<std::pair<const Cell*, std::size_t>>> fine_faces;
+    std::vector<std::vector<std::pair<const Cell*, size_t>>> fine_faces;
   };
+
   /// Helper struct for storing the mapping from a coarse cell to fine cells.
   struct FineMapping
   {
     /// Constructor. Sizes coarse_faces based on the number of faces within the fine cell.
-    FineMapping(const Cell& fine_cell);
+    explicit FineMapping(const Cell& fine_cell);
+
     /// The coarse cell that the fine cell is contained within.
     const Cell* coarse_cell;
     /// The coarse CellFace index each fine CellFace is contained within (if any)
-    std::vector<std::size_t> coarse_faces;
+    std::vector<size_t> coarse_faces;
   };
 
   /// Get the mapping from the given coarse mesh cell.
@@ -62,5 +62,9 @@ private:
   std::unordered_map<const Cell*, CoarseMapping> coarse_to_fine_;
   /// Mapping for fine cells to a coarse cell.
   std::unordered_map<const Cell*, FineMapping> fine_to_coarse_;
+
+public:
+  /// Identifier for an invalid face index that means a face maps to nothing.
+  static const size_t invalid_face_index;
 };
 } // namespace opensn

--- a/framework/post_processors/aggregate_nodal_value_post_processor.cc
+++ b/framework/post_processors/aggregate_nodal_value_post_processor.cc
@@ -132,26 +132,26 @@ AggregateNodalValuePostProcessor::Execute(const Event& event_context)
 
   if (operation_ == "max")
   {
-    double globl_max_value;
-    mpi_comm.all_reduce(local_max_value, globl_max_value, mpi::op::sum<double>());
+    double global_max_value;
+    mpi_comm.all_reduce(local_max_value, global_max_value, mpi::op::sum<double>());
 
-    value_ = ParameterBlock("", globl_max_value);
+    value_ = ParameterBlock("", global_max_value);
   }
   else if (operation_ == "min")
   {
-    double globl_min_value;
-    mpi_comm.all_reduce(local_min_value, globl_min_value, mpi::op::min<double>());
+    double global_min_value;
+    mpi_comm.all_reduce(local_min_value, global_min_value, mpi::op::min<double>());
 
-    value_ = ParameterBlock("", globl_min_value);
+    value_ = ParameterBlock("", global_min_value);
   }
   else if (operation_ == "avg")
   {
-    double globl_accumulation;
-    mpi_comm.all_reduce(local_accumulation, globl_accumulation, mpi::op::sum<double>());
+    double global_accumulation;
+    mpi_comm.all_reduce(local_accumulation, global_accumulation, mpi::op::sum<double>());
 
-    const size_t num_globl_dofs =
+    const size_t num_global_dofs =
       ref_ff.GetSpatialDiscretization().GetNumGlobalDOFs(ref_ff.GetUnknownManager());
-    value_ = ParameterBlock("", globl_accumulation / double(num_globl_dofs));
+    value_ = ParameterBlock("", global_accumulation / double(num_global_dofs));
   }
   else
     OpenSnLogicalError("Unsupported operation type \"" + operation_ + "\".");

--- a/framework/post_processors/cell_volume_integral_post_processor.cc
+++ b/framework/post_processors/cell_volume_integral_post_processor.cc
@@ -130,16 +130,16 @@ CellVolumeIntegralPostProcessor::Execute(const Event& event_context)
     } // for qp
   }   // for cell-id
 
-  double globl_integral;
-  mpi_comm.all_reduce(local_integral, globl_integral, mpi::op::sum<double>());
+  double global_integral;
+  mpi_comm.all_reduce(local_integral, global_integral, mpi::op::sum<double>());
   if (not compute_volume_average_)
-    value_ = ParameterBlock("", globl_integral);
+    value_ = ParameterBlock("", global_integral);
   else
   {
-    double globl_volume;
-    mpi_comm.all_reduce(local_volume, globl_volume, mpi::op::sum<double>());
+    double global_volume;
+    mpi_comm.all_reduce(local_volume, global_volume, mpi::op::sum<double>());
 
-    value_ = ParameterBlock("", globl_integral / globl_volume);
+    value_ = ParameterBlock("", global_integral / global_volume);
   }
 
   const int event_code = event_context.GetCode();

--- a/lua/lib/lbs.cc
+++ b/lua/lib/lbs.cc
@@ -49,7 +49,7 @@ LBSComputeLeakage(std::shared_ptr<opensn::DiscreteOrdinatesSolver> solver,
       bndry_ids.push_back(supported_boundary_names.at(name));
   }
   else
-    bndry_ids = solver->GetGrid()->GetDomainUniqueBoundaryIDs();
+    bndry_ids = solver->GetGrid()->GetUniqueBoundaryIDs();
 
   // Compute the leakage
   const auto leakage = solver->ComputeLeakage(bndry_ids);

--- a/modules/diffusion/cfem_diffusion_solver.cc
+++ b/modules/diffusion/cfem_diffusion_solver.cc
@@ -188,10 +188,10 @@ CFEMDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid_ptr_->GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
+  auto global_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
-  for (uint64_t bndry_id : globl_unique_bndry_ids)
+  for (uint64_t bndry_id : global_unique_bndry_ids)
   {
     if (grid_boundary_id_map.count(bndry_id) == 0)
       throw std::logic_error(fname + ": Boundary id " + std::to_string(bndry_id) +

--- a/modules/diffusion/cfem_diffusion_solver.cc
+++ b/modules/diffusion/cfem_diffusion_solver.cc
@@ -188,7 +188,7 @@ CFEMDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid_ptr_->GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid_ptr_->GetDomainUniqueBoundaryIDs();
+  auto globl_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
   for (uint64_t bndry_id : globl_unique_bndry_ids)

--- a/modules/diffusion/dfem_diffusion_solver.cc
+++ b/modules/diffusion/dfem_diffusion_solver.cc
@@ -180,7 +180,7 @@ DFEMDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid_ptr_->GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid_ptr_->GetDomainUniqueBoundaryIDs();
+  auto globl_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
   for (uint64_t bndry_id : globl_unique_bndry_ids)

--- a/modules/diffusion/dfem_diffusion_solver.cc
+++ b/modules/diffusion/dfem_diffusion_solver.cc
@@ -618,26 +618,26 @@ DFEMDiffusionSolver::HPerpendicular(const Cell& cell, unsigned int f)
   const auto& cell_mapping = sdm.GetCellMapping(cell);
   double hp;
 
-  const size_t num_faces = cell.faces.size();
-  const size_t num_vertices = cell.vertex_ids.size();
+  const auto num_faces = cell.faces.size();
+  const auto num_vertices = cell.vertex_ids.size();
 
-  const double volume = cell_mapping.GetCellVolume();
-  const double face_area = cell_mapping.GetFaceArea(f);
+  const auto volume = cell.volume;
+  const auto face_area = cell.faces.at(f).area;
 
   /**Lambda to compute surface area.*/
-  auto ComputeSurfaceArea = [&cell_mapping, &num_faces]()
+  auto ComputeSurfaceArea = [&cell, &num_faces]()
   {
     double surface_area = 0.0;
     for (size_t fr = 0; fr < num_faces; ++fr)
-      surface_area += cell_mapping.GetFaceArea(fr);
+      surface_area += cell.faces[fr].area;
 
     return surface_area;
   };
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
   if (cell.GetType() == CellType::SLAB)
+  {
     hp = volume / 2.0;
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
+  }
   else if (cell.GetType() == CellType::POLYGON)
   {
     if (num_faces == 3)
@@ -646,10 +646,12 @@ DFEMDiffusionSolver::HPerpendicular(const Cell& cell, unsigned int f)
       hp = volume / face_area;
     else // Nv > 4
     {
-      const double surface_area = ComputeSurfaceArea();
+      const auto surface_area = ComputeSurfaceArea();
 
       if (num_faces % 2 == 0)
+      {
         hp = 4.0 * volume / surface_area;
+      }
       else
       {
         hp = 2.0 * volume / surface_area;
@@ -659,10 +661,9 @@ DFEMDiffusionSolver::HPerpendicular(const Cell& cell, unsigned int f)
       }
     }
   }
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
   else if (cell.GetType() == CellType::POLYHEDRON)
   {
-    const double surface_area = ComputeSurfaceArea();
+    const auto surface_area = ComputeSurfaceArea();
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;

--- a/modules/diffusion/dfem_diffusion_solver.cc
+++ b/modules/diffusion/dfem_diffusion_solver.cc
@@ -180,10 +180,10 @@ DFEMDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid_ptr_->GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
+  auto global_unique_bndry_ids = grid_ptr_->GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
-  for (uint64_t bndry_id : globl_unique_bndry_ids)
+  for (uint64_t bndry_id : global_unique_bndry_ids)
   {
     if (grid_boundary_id_map.count(bndry_id) == 0)
       throw std::logic_error(fname + ": Boundary id " + std::to_string(bndry_id) +

--- a/modules/diffusion/fv_diffusion_solver.cc
+++ b/modules/diffusion/fv_diffusion_solver.cc
@@ -287,7 +287,7 @@ FVDiffusionSolver::Execute()
   for (const auto& cell_P : grid.local_cells)
   {
     const auto& cell_mapping = sdm.GetCellMapping(cell_P);
-    const double volume_P = cell_mapping.GetCellVolume(); // Volume of present cell
+    const auto volume_P = cell_P.volume;
     const auto& x_cc_P = cell_P.centroid;
 
     const auto imat = cell_P.material_id;
@@ -300,12 +300,11 @@ FVDiffusionSolver::Execute()
     MatSetValue(A_, imap, imap, sigma_a * volume_P, ADD_VALUES);
     VecSetValue(b_, imap, q_ext * volume_P, ADD_VALUES);
 
-    for (size_t f = 0; f < cell_P.faces.size(); ++f)
+    for (const auto& face : cell_P.faces)
     {
-      const auto& face = cell_P.faces[f];
       const auto& x_fc = face.centroid;
       const auto x_PF = x_fc - x_cc_P;
-      const auto A_f = cell_mapping.GetFaceArea(f);
+      const auto A_f = face.area;
       const auto A_f_n = A_f * face.normal;
 
       if (face.has_neighbor)

--- a/modules/diffusion/fv_diffusion_solver.cc
+++ b/modules/diffusion/fv_diffusion_solver.cc
@@ -172,7 +172,7 @@ FVDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid.GetDomainUniqueBoundaryIDs();
+  auto globl_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
   for (uint64_t bndry_id : globl_unique_bndry_ids)

--- a/modules/diffusion/fv_diffusion_solver.cc
+++ b/modules/diffusion/fv_diffusion_solver.cc
@@ -172,10 +172,10 @@ FVDiffusionSolver::Initialize()
   log.Log() << "Global num cells: " << grid.GetGlobalNumberOfCells();
 
   // BIDs
-  auto globl_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
+  auto global_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
-  for (uint64_t bndry_id : globl_unique_bndry_ids)
+  for (uint64_t bndry_id : global_unique_bndry_ids)
   {
     if (grid_boundary_id_map.count(bndry_id) == 0)
       throw std::logic_error(fname + ": Boundary id " + std::to_string(bndry_id) +

--- a/modules/diffusion/mg_diffusion_solver.cc
+++ b/modules/diffusion/mg_diffusion_solver.cc
@@ -327,8 +327,8 @@ MGDiffusionSolver::Initialize()
   InitializeMaterials(unique_material_ids);
 
   // BIDs
-  auto globl_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
-  SetBCs(globl_unique_bndry_ids);
+  auto global_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
+  SetBCs(global_unique_bndry_ids);
 
   // Make SDM
   sdm_ptr_ = PieceWiseLinearContinuous::New(grid_ptr_);
@@ -617,19 +617,19 @@ MGDiffusionSolver::ComputeTwoGridVolumeFractions()
 }
 
 void
-MGDiffusionSolver::SetBCs(const std::vector<uint64_t>& globl_unique_bndry_ids)
+MGDiffusionSolver::SetBCs(const std::vector<uint64_t>& global_unique_bndry_ids)
 {
   const std::string fname = "MGSolver::SetBCs";
   log.Log0Verbose1() << "Setting Boundary Conditions";
 
   uint64_t max_boundary_id = 0;
-  for (const auto& id : globl_unique_bndry_ids)
+  for (const auto& id : global_unique_bndry_ids)
     max_boundary_id = std::max(id, max_boundary_id);
 
   log.Log() << "Max boundary id identified: " << max_boundary_id;
 
   const auto& grid_boundary_id_map = grid_ptr_->GetBoundaryIDMap();
-  for (uint64_t bndry_id : globl_unique_bndry_ids)
+  for (uint64_t bndry_id : global_unique_bndry_ids)
   {
     if (grid_boundary_id_map.count(bndry_id) == 0)
       throw std::logic_error(fname + ": Boundary id " + std::to_string(bndry_id) +
@@ -1113,9 +1113,9 @@ MGDiffusionSolver::UpdateFluxWithTwoGrid(int64_t iverbose)
       for (size_t i = 0; i < num_nodes; ++i)
       {
         const int64_t imap = sdm.MapDOFLocal(cell, i);
-        const int64_t imap_globl = sdm.MapDOF(cell, i);
+        const int64_t imap_global = sdm.MapDOF(cell, i);
         const double aux = xlocal_tg[imap] * VF_[counter][i] * xstg.spectrum[g];
-        VecSetValue(x_[g], imap_globl, aux, ADD_VALUES);
+        VecSetValue(x_[g], imap_global, aux, ADD_VALUES);
       } // i
     }   // g
     counter++;

--- a/modules/diffusion/mg_diffusion_solver.cc
+++ b/modules/diffusion/mg_diffusion_solver.cc
@@ -327,7 +327,7 @@ MGDiffusionSolver::Initialize()
   InitializeMaterials(unique_material_ids);
 
   // BIDs
-  auto globl_unique_bndry_ids = grid.GetDomainUniqueBoundaryIDs();
+  auto globl_unique_bndry_ids = grid.GetUniqueBoundaryIDs();
   SetBCs(globl_unique_bndry_ids);
 
   // Make SDM

--- a/modules/diffusion/mg_diffusion_solver.cc
+++ b/modules/diffusion/mg_diffusion_solver.cc
@@ -608,7 +608,7 @@ MGDiffusionSolver::ComputeTwoGridVolumeFractions()
       double vol_frac_shape_i = 0.0;
       for (size_t qp : fe_vol_data.GetQuadraturePointIndices())
         vol_frac_shape_i += fe_vol_data.ShapeValue(i, qp) * fe_vol_data.JxW(qp);
-      vol_frac_shape_i /= cell_mapping.GetCellVolume();
+      vol_frac_shape_i /= cell.volume;
       VF_[counter][i] = vol_frac_shape_i;
     } // for i
 

--- a/modules/diffusion/mg_diffusion_solver.h
+++ b/modules/diffusion/mg_diffusion_solver.h
@@ -66,7 +66,7 @@ public:
 
 private:
   void InitializeMaterials(std::set<int>& material_ids);
-  void SetBCs(const std::vector<uint64_t>& globl_unique_bndry_ids);
+  void SetBCs(const std::vector<uint64_t>& global_unique_bndry_ids);
   void AssembleAbext();
   void ComputeTwoGridParams();
   void ComputeTwoGridVolumeFractions();

--- a/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/diffusion_dfem_solver/iterative_methods/mip_wgs_context.cc
@@ -58,13 +58,13 @@ std::pair<int64_t, int64_t>
 MIPWGSContext::GetSystemSize()
 {
   const size_t local_node_count = lbs_solver.GetLocalNodeCount();
-  const size_t globl_node_count = lbs_solver.GetGlobalNodeCount();
+  const size_t global_node_count = lbs_solver.GetGlobalNodeCount();
 
   const size_t groupset_numgrps = groupset.groups.size();
   const size_t local_size = local_node_count * groupset_numgrps;
-  const size_t globl_size = globl_node_count * groupset_numgrps;
+  const size_t global_size = global_node_count * groupset_numgrps;
 
-  return {static_cast<int64_t>(local_size), static_cast<int64_t>(globl_size)};
+  return {static_cast<int64_t>(local_size), static_cast<int64_t>(global_size)};
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/iterative_methods/sweep_wgs_context.cc
@@ -73,30 +73,30 @@ SweepWGSContext::GetSystemSize()
   CALI_CXX_MARK_SCOPE("SweepWGSContext::SystemSize");
 
   const size_t local_node_count = lbs_solver.GetLocalNodeCount();
-  const size_t globl_node_count = lbs_solver.GetGlobalNodeCount();
+  const size_t global_node_count = lbs_solver.GetGlobalNodeCount();
   const size_t num_moments = lbs_solver.GetNumMoments();
 
   const size_t groupset_numgrps = groupset.groups.size();
   const auto num_delayed_psi_info = groupset.angle_agg->GetNumDelayedAngularDOFs();
   const size_t local_size =
     local_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.first;
-  const size_t globl_size =
-    globl_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.second;
+  const size_t global_size =
+    global_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.second;
   const size_t num_angles = groupset.quadrature->abscissae.size();
-  const size_t num_psi_global = globl_node_count * num_angles * groupset.groups.size();
-  const size_t num_delayed_psi_globl = num_delayed_psi_info.second;
+  const size_t num_psi_global = global_node_count * num_angles * groupset.groups.size();
+  const size_t num_delayed_psi_global = num_delayed_psi_info.second;
 
   if (log_info)
   {
     log.Log() << "Total number of angular unknowns: " << num_psi_global << "\n"
-              << "Number of lagged angular unknowns: " << num_delayed_psi_globl << "("
+              << "Number of lagged angular unknowns: " << num_delayed_psi_global << "("
               << std::setprecision(2)
-              << static_cast<double>(num_delayed_psi_globl) * 100 /
+              << static_cast<double>(num_delayed_psi_global) * 100 /
                    static_cast<double>(num_psi_global)
               << "%)";
   }
 
-  return {static_cast<int64_t>(local_size), static_cast<int64_t>(globl_size)};
+  return {static_cast<int64_t>(local_size), static_cast<int64_t>(global_size)};
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -97,21 +97,21 @@ DiscreteOrdinatesSolver::GetNumPhiIterativeUnknowns()
   CALI_CXX_MARK_SCOPE("DiscreteOrdinatesSolver::GetNumPhiIterativeUnknowns");
   const auto& sdm = *discretization_;
   const size_t num_local_phi_dofs = sdm.GetNumLocalDOFs(flux_moments_uk_man_);
-  const size_t num_globl_phi_dofs = sdm.GetNumGlobalDOFs(flux_moments_uk_man_);
+  const size_t num_global_phi_dofs = sdm.GetNumGlobalDOFs(flux_moments_uk_man_);
 
   size_t num_local_psi_dofs = 0;
-  size_t num_globl_psi_dofs = 0;
+  size_t num_global_psi_dofs = 0;
   for (auto& groupset : groupsets_)
   {
     const auto num_delayed_psi_info = groupset.angle_agg->GetNumDelayedAngularDOFs();
     num_local_psi_dofs += num_delayed_psi_info.first;
-    num_globl_psi_dofs += num_delayed_psi_info.second;
+    num_global_psi_dofs += num_delayed_psi_info.second;
   }
 
   const size_t num_local_dofs = num_local_phi_dofs + num_local_psi_dofs;
-  const size_t num_globl_dofs = num_globl_phi_dofs + num_globl_psi_dofs;
+  const size_t num_global_dofs = num_global_phi_dofs + num_global_psi_dofs;
 
-  return {num_local_dofs, num_globl_dofs};
+  return {num_local_dofs, num_global_dofs};
 }
 
 void
@@ -406,25 +406,25 @@ DiscreteOrdinatesSolver::ComputeBalance()
   size_t table_size = local_balance_table.size();
 
   // Compute global balance
-  std::vector<double> globl_balance_table(table_size, 0.0);
+  std::vector<double> global_balance_table(table_size, 0.0);
   mpi_comm.all_reduce(
-    local_balance_table.data(), table_size, globl_balance_table.data(), mpi::op::sum<double>());
-  double globl_absorption = globl_balance_table.at(0);
-  double globl_production = globl_balance_table.at(1);
-  double globl_in_flow = globl_balance_table.at(2);
-  double globl_out_flow = globl_balance_table.at(3);
-  double globl_balance = globl_balance_table.at(4);
-  double globl_gain = globl_balance_table.at(5);
+    local_balance_table.data(), table_size, global_balance_table.data(), mpi::op::sum<double>());
+  double global_absorption = global_balance_table.at(0);
+  double global_production = global_balance_table.at(1);
+  double global_in_flow = global_balance_table.at(2);
+  double global_out_flow = global_balance_table.at(3);
+  double global_balance = global_balance_table.at(4);
+  double global_gain = global_balance_table.at(5);
 
   log.Log() << "Balance table:\n"
             << std::setprecision(6) << std::scientific
-            << " Absorption rate             = " << globl_absorption << "\n"
-            << " Production rate             = " << globl_production << "\n"
-            << " In-flow rate                = " << globl_in_flow << "\n"
-            << " Out-flow rate               = " << globl_out_flow << "\n"
-            << " Gain (In-flow + Production) = " << globl_gain << "\n"
-            << " Balance (Gain - Loss)       = " << globl_balance << "\n"
-            << " Balance/Gain, in %          = " << globl_balance / globl_gain * 100. << "\n";
+            << " Absorption rate             = " << global_absorption << "\n"
+            << " Production rate             = " << global_production << "\n"
+            << " In-flow rate                = " << global_in_flow << "\n"
+            << " Out-flow rate               = " << global_out_flow << "\n"
+            << " Gain (In-flow + Production) = " << global_gain << "\n"
+            << " Balance (Gain - Loss)       = " << global_balance << "\n"
+            << " Balance/Gain, in %          = " << global_balance / global_gain * 100. << "\n";
 
   opensn::mpi_comm.barrier();
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -510,7 +510,7 @@ DiscreteOrdinatesSolver::ComputeLeakage(const std::vector<uint64_t>& boundary_id
                        "The option `save_angular_flux` must be set to `true` in order "
                        "to compute outgoing currents.");
 
-  const auto unique_bids = grid_ptr_->GetDomainUniqueBoundaryIDs();
+  const auto unique_bids = grid_ptr_->GetUniqueBoundaryIDs();
   for (const auto& bid : boundary_ids)
   {
     const auto it = std::find(unique_bids.begin(), unique_bids.end(), bid);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.cc
@@ -432,7 +432,7 @@ SPDS::PopulateCellRelationships(const Vector3& omega,
           // If it is in the current location
           if (face.IsNeighborLocal(grid_.get()))
           {
-            double weight = mu * face.ComputeFaceArea(grid_.get());
+            const auto weight = mu * face.area;
             cell_successors[c].insert(std::make_pair(face.GetNeighborLocalID(grid_.get()), weight));
           }
           else

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_scdsa.cc
@@ -424,9 +424,9 @@ PowerIterationKEigenSCDSA::MakePWLDVecGhostCommInfo(const SpatialDiscretization&
   log.Log() << "Making PWLD ghost communicator";
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(uk_man);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(uk_man);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(uk_man);
 
-  log.Log() << "Number of global dofs" << num_globl_dofs;
+  log.Log() << "Number of global dofs" << num_global_dofs;
 
   const size_t num_unknowns = uk_man.unknowns.size();
 
@@ -460,7 +460,7 @@ PowerIterationKEigenSCDSA::MakePWLDVecGhostCommInfo(const SpatialDiscretization&
 
   // Create the vector ghost communicator
   auto vgc = std::make_shared<VectorGhostCommunicator>(
-    num_local_dofs, num_globl_dofs, global_indices, mpi_comm);
+    num_local_dofs, num_global_dofs, global_indices, mpi_comm);
 
   // Create the map
   std::map<int64_t, int64_t> ghost_global_id_2_local_map;
@@ -515,9 +515,9 @@ PowerIterationKEigenSCDSA::NodallyAveragedPWLDVector(
         {
           const int64_t dof_dfem_map = pwld_sdm.MapDOFLocal(cell, i, uk_man, u, c);
           const int64_t dof_cfem_map = pwlc_sdm.MapDOFLocal(cell, i, uk_man, u, c);
-          const int64_t dof_cfem_map_globl = pwlc_sdm.MapDOF(cell, i, uk_man, u, c);
+          const int64_t dof_cfem_map_global = pwlc_sdm.MapDOF(cell, i, uk_man, u, c);
 
-          cfem_dof_global2local_map[dof_cfem_map_globl] = dof_cfem_map;
+          cfem_dof_global2local_map[dof_cfem_map_global] = dof_cfem_map;
 
           const double phi_value = input[dof_dfem_map];
 
@@ -553,12 +553,12 @@ PowerIterationKEigenSCDSA::NodallyAveragedPWLDVector(
         const size_t num_components = uk_man.unknowns[u].num_components;
         for (size_t c = 0; c < num_components; ++c)
         {
-          const int64_t dof_dfem_map_globl = pwld_sdm.MapDOF(cell, i, uk_man, u, c);
-          const int64_t dof_cfem_map_globl = pwlc_sdm.MapDOF(cell, i, uk_man, u, c);
-          if (cfem_dof_global2local_map.count(dof_cfem_map_globl) > 0)
+          const int64_t dof_dfem_map_global = pwld_sdm.MapDOF(cell, i, uk_man, u, c);
+          const int64_t dof_cfem_map_global = pwlc_sdm.MapDOF(cell, i, uk_man, u, c);
+          if (cfem_dof_global2local_map.count(dof_cfem_map_global) > 0)
           {
-            const int64_t dof_dfem_map = dfem_dof_global2local_map.at(dof_dfem_map_globl);
-            const int64_t dof_cfem_map = cfem_dof_global2local_map[dof_cfem_map_globl];
+            const int64_t dof_dfem_map = dfem_dof_global2local_map.at(dof_dfem_map_global);
+            const int64_t dof_cfem_map = cfem_dof_global2local_map[dof_cfem_map_global];
 
             const double phi_value = input_with_ghosts[dof_dfem_map];
 

--- a/modules/linear_boltzmann_solvers/executors/pi_keigen_smm.cc
+++ b/modules/linear_boltzmann_solvers/executors/pi_keigen_smm.cc
@@ -1102,7 +1102,7 @@ PowerIterationKEigenSMM::ComputeNodallyAveragedPWLDVector(const std::vector<doub
     // added into a PWLC DoF, a counter for that DoF is incremented so
     // that the PWLC DoFs can later be averaged.
     const auto& cell_mapping = pwld.GetCellMapping(cell);
-    const auto& vol = cell_mapping.GetCellVolume();
+    const auto& vol = cell.volume;
     for (int i = 0; i < cell_mapping.GetNumNodes(); ++i)
       for (int u = 0; u < uk_man.unknowns.size(); ++u)
         for (int c = 0; c < uk_man.unknowns[u].num_components; ++c)
@@ -1133,7 +1133,7 @@ PowerIterationKEigenSMM::ComputeNodallyAveragedPWLDVector(const std::vector<doub
   {
     const auto& cell = grid->cells[global_id];
     const auto& cell_mapping = pwld.GetCellMapping(cell);
-    const auto& vol = cell_mapping.GetCellVolume();
+    const auto& vol = cell.volume;
 
     for (int i = 0; i < cell_mapping.GetNumNodes(); ++i)
       if (pvids.find(cell.vertex_ids[i]) != pvids.end())

--- a/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/acceleration/diffusion_mip_solver.cc
@@ -1212,26 +1212,26 @@ DiffusionMIPSolver::HPerpendicular(const Cell& cell, unsigned int f)
   const auto& cell_mapping = sdm_.GetCellMapping(cell);
   double hp;
 
-  const size_t num_faces = cell.faces.size();
-  const size_t num_vertices = cell.vertex_ids.size();
+  const auto num_faces = cell.faces.size();
+  const auto num_vertices = cell.vertex_ids.size();
 
-  const double volume = cell_mapping.GetCellVolume();
-  const double face_area = cell_mapping.GetFaceArea(f);
+  const auto volume = cell.volume;
+  const auto face_area = cell.faces.at(f).area;
 
   /**Lambda to compute surface area.*/
-  auto ComputeSurfaceArea = [&cell_mapping, &num_faces]()
+  auto ComputeSurfaceArea = [&cell, &num_faces]()
   {
     double surface_area = 0.0;
     for (size_t fr = 0; fr < num_faces; ++fr)
-      surface_area += cell_mapping.GetFaceArea(fr);
+      surface_area += cell.faces[fr].area;
 
     return surface_area;
   };
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
   if (cell.GetType() == CellType::SLAB)
+  {
     hp = volume / 2.0;
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
+  }
   else if (cell.GetType() == CellType::POLYGON)
   {
     if (num_faces == 3)
@@ -1240,7 +1240,7 @@ DiffusionMIPSolver::HPerpendicular(const Cell& cell, unsigned int f)
       hp = volume / face_area;
     else // Nv > 4
     {
-      const double surface_area = ComputeSurfaceArea();
+      const auto surface_area = ComputeSurfaceArea();
 
       if (num_faces % 2 == 0)
         hp = 4.0 * volume / surface_area;
@@ -1253,10 +1253,9 @@ DiffusionMIPSolver::HPerpendicular(const Cell& cell, unsigned int f)
       }
     }
   }
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
   else if (cell.GetType() == CellType::POLYHEDRON)
   {
-    const double surface_area = ComputeSurfaceArea();
+    const auto surface_area = ComputeSurfaceArea();
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;

--- a/modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/point_source/point_source.cc
@@ -77,11 +77,10 @@ PointSource::Initialize(const LBSSolver& lbs_solver)
       const auto node_wgts = Mult(M_inv, shape_vals);
 
       // Increment the total volume
-      total_volume += cell_mapping.GetCellVolume();
+      total_volume += cell.volume;
 
       // Add to subscribers
-      subscribers.push_back(
-        Subscriber{cell_mapping.GetCellVolume(), cell.local_id, shape_vals, node_wgts});
+      subscribers.push_back(Subscriber{cell.volume, cell.local_id, shape_vals, node_wgts});
     }
   }
 

--- a/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
+++ b/test/framework/math/spatial_discretization/cg/sdm_test_01_continuous.cc
@@ -41,14 +41,14 @@ math_SDM_Test01_Continuous(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -418,29 +418,29 @@ MapFaceNodeDisc(const CellMapping& cur_cell_mapping,
 double
 HPerpendicular(const CellMapping& cell_mapping, unsigned int f)
 {
-  const auto& cell = cell_mapping.ReferenceCell();
+  const auto& cell = cell_mapping.GetCell();
   double hp;
 
-  const size_t num_faces = cell.faces.size();
-  const size_t num_vertices = cell.vertex_ids.size();
+  const auto num_faces = cell.faces.size();
+  const auto num_vertices = cell.vertex_ids.size();
 
-  const double volume = cell_mapping.GetCellVolume();
-  const double face_area = cell_mapping.GetFaceArea(f);
+  const auto volume = cell.volume;
+  const auto face_area = cell.faces.at(f).area;
 
   /**Lambda to compute surface area.*/
-  auto ComputeSurfaceArea = [&cell_mapping, &num_faces]()
+  auto ComputeSurfaceArea = [&cell, &num_faces]()
   {
     double surface_area = 0.0;
     for (size_t fr = 0; fr < num_faces; ++fr)
-      surface_area += cell_mapping.GetFaceArea(fr);
+      surface_area += cell.faces[fr].area;
 
     return surface_area;
   };
 
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
   if (cell.GetType() == CellType::SLAB)
+  {
     hp = volume / 2.0;
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
+  }
   else if (cell.GetType() == CellType::POLYGON)
   {
     if (num_faces == 3)
@@ -449,7 +449,7 @@ HPerpendicular(const CellMapping& cell_mapping, unsigned int f)
       hp = volume / face_area;
     else // Nv > 4
     {
-      const double surface_area = ComputeSurfaceArea();
+      const auto surface_area = ComputeSurfaceArea();
 
       if (num_faces % 2 == 0)
         hp = 4.0 * volume / surface_area;
@@ -462,10 +462,9 @@ HPerpendicular(const CellMapping& cell_mapping, unsigned int f)
       }
     }
   }
-  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
   else if (cell.GetType() == CellType::POLYHEDRON)
   {
-    const double surface_area = ComputeSurfaceArea();
+    const auto surface_area = ComputeSurfaceArea();
 
     if (num_faces == 4) // Tet
       hp = 3 * volume / surface_area;

--- a/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
+++ b/test/framework/math/spatial_discretization/dg/sdm_test_01_discontinuous.cc
@@ -55,14 +55,14 @@ math_SDM_Test02_DisContinuous(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 

--- a/test/framework/tutorials/fv_test1.cc
+++ b/test/framework/tutorials/fv_test1.cc
@@ -62,12 +62,12 @@ SimTest01_FV(const ParameterBlock& params)
     const int64_t imap = sdm.MapDOF(cell, 0);
 
     const auto& xp = cell.centroid;
-    const double V = cell_mapping.GetCellVolume();
+    const auto V = cell.volume;
 
     size_t f = 0;
     for (const auto& face : cell.faces)
     {
-      const auto Af = face.normal * cell_mapping.GetFaceArea(f);
+      const auto Af = face.normal * cell.faces.at(f).area;
 
       if (face.has_neighbor)
       {

--- a/test/framework/tutorials/fv_test1.cc
+++ b/test/framework/tutorials/fv_test1.cc
@@ -33,14 +33,14 @@ SimTest01_FV(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 

--- a/test/framework/tutorials/fv_test2.cc
+++ b/test/framework/tutorials/fv_test2.cc
@@ -63,12 +63,12 @@ SimTest02_FV(const ParameterBlock& params)
     const int64_t imap = sdm.MapDOF(cell, 0);
 
     const auto& xp = cell.centroid;
-    const double V = cell_mapping.GetCellVolume();
+    const auto V = cell.volume;
 
     size_t f = 0;
     for (const auto& face : cell.faces)
     {
-      const auto Af = face.normal * cell_mapping.GetFaceArea(f);
+      const auto Af = face.normal * face.area;
 
       if (face.has_neighbor)
       {
@@ -171,7 +171,7 @@ SimTest02_FV(const ParameterBlock& params)
     for (const auto& face : cell.faces)
     {
       const auto& xf = face.centroid;
-      const auto Af = cell_mapping.GetFaceArea(f) * face.normal;
+      const auto Af = face.normal * face.area;
 
       double phi_N = 0.0;
       auto xn = xp + 2 * (xf - xp);
@@ -188,7 +188,7 @@ SimTest02_FV(const ParameterBlock& params)
       grad_phi_P += Af * ((xn - xf).Norm() * phi_P + (xf - xp).Norm() * phi_N) / (xn - xp).Norm();
       ++f;
     } // for face
-    grad_phi_P /= cell_mapping.GetCellVolume();
+    grad_phi_P /= cell.volume;
 
     const int64_t xmap = sdm.MapDOFLocal(cell, 0, grad_uk_man, 0, 0);
     const int64_t ymap = sdm.MapDOFLocal(cell, 0, grad_uk_man, 0, 1);

--- a/test/framework/tutorials/fv_test2.cc
+++ b/test/framework/tutorials/fv_test2.cc
@@ -34,14 +34,14 @@ SimTest02_FV(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 
@@ -143,7 +143,7 @@ SimTest02_FV(const ParameterBlock& params)
   // Make ghosted vectors
   std::vector<int64_t> ghost_ids = sdm.GetGhostDOFIndices(OneDofPerNode);
 
-  VectorGhostCommunicator vgc(num_local_dofs, num_globl_dofs, ghost_ids, opensn::mpi_comm);
+  VectorGhostCommunicator vgc(num_local_dofs, num_global_dofs, ghost_ids, opensn::mpi_comm);
   std::vector<double> field_wg = vgc.MakeGhostedVector(field);
 
   vgc.CommunicateGhostEntries(field_wg);

--- a/test/framework/tutorials/pwlc_test1.cc
+++ b/test/framework/tutorials/pwlc_test1.cc
@@ -33,14 +33,14 @@ SimTest03_PWLC(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 

--- a/test/framework/tutorials/pwlc_test2.cc
+++ b/test/framework/tutorials/pwlc_test2.cc
@@ -35,14 +35,14 @@ SimTest04_PWLC(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Initializes Mats and Vecs
   const auto n = static_cast<int64_t>(num_local_dofs);
-  const auto N = static_cast<int64_t>(num_globl_dofs);
+  const auto N = static_cast<int64_t>(num_global_dofs);
   Mat A;
   Vec x, b;
 

--- a/test/framework/tutorials/tutorial_06_wdd.cc
+++ b/test/framework/tutorials/tutorial_06_wdd.cc
@@ -63,10 +63,10 @@ SimTest06_WDD(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_nodes = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_nodes = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_nodes = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local nodes: " << num_local_nodes;
-  opensn::log.Log() << "Num globl nodes: " << num_globl_nodes;
+  opensn::log.Log() << "Num globl nodes: " << num_global_nodes;
 
   // Make an angular quadrature
   std::shared_ptr<AngularQuadrature> quadrature;

--- a/test/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/framework/tutorials/tutorial_91a_pwld.cc
@@ -49,10 +49,10 @@ SimTest91_PWLD(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_nodes = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_nodes = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_nodes = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local nodes: " << num_local_nodes;
-  opensn::log.Log() << "Num globl nodes: " << num_globl_nodes;
+  opensn::log.Log() << "Num globl nodes: " << num_global_nodes;
 
   // Make an angular quadrature
   std::shared_ptr<AngularQuadrature> quadrature;

--- a/test/framework/tutorials/tutorial_93_raytracing.cc
+++ b/test/framework/tutorials/tutorial_93_raytracing.cc
@@ -59,10 +59,10 @@ SimTest93_RayTracing(const ParameterBlock& params)
     phi_uk_man.AddUnknown(UnknownType::VECTOR_N, num_groups);
 
   const size_t num_fem_local_dofs = sdm.GetNumLocalDOFs(phi_uk_man);
-  const size_t num_fem_globl_dofs = sdm.GetNumGlobalDOFs(phi_uk_man);
+  const size_t num_fem_global_dofs = sdm.GetNumGlobalDOFs(phi_uk_man);
 
   opensn::log.Log() << "Num local FEM DOFs: " << num_fem_local_dofs;
-  opensn::log.Log() << "Num globl FEM DOFs: " << num_fem_globl_dofs;
+  opensn::log.Log() << "Num globl FEM DOFs: " << num_fem_global_dofs;
 
   // Define tallies
   std::vector<double> phi_tally(num_fem_local_dofs, 0.0);

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
@@ -31,10 +31,10 @@ acceleration_Diffusion_CFEM(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalAndGhostDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Make Boundary conditions
   std::map<uint64_t, BoundaryCondition> bcs;

--- a/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
+++ b/test/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
@@ -49,10 +49,10 @@ acceleration_Diffusion_DFEM(const ParameterBlock& params)
   const auto& OneDofPerNode = sdm.UNITARY_UNKNOWN_MANAGER;
 
   const size_t num_local_dofs = sdm.GetNumLocalDOFs(OneDofPerNode);
-  const size_t num_globl_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
+  const size_t num_global_dofs = sdm.GetNumGlobalDOFs(OneDofPerNode);
 
   opensn::log.Log() << "Num local DOFs: " << num_local_dofs;
-  opensn::log.Log() << "Num globl DOFs: " << num_globl_dofs;
+  opensn::log.Log() << "Num globl DOFs: " << num_global_dofs;
 
   // Make Boundary conditions
   std::map<uint64_t, BoundaryCondition> bcs;


### PR DESCRIPTION
Moved cell volumes and face areas to the respective `Cell` and `CellFace` objects from `CellMapping`. Prior to this PR, face normals lived in `CellFace` and were computed in the `MeshGenerator::SetupCell` and cell volumes and areas lived in `CellMapping` were computed in `CellMapping::ComputeCellVolumeAndAreas`. Because the routines used to compute these geometric quantities only used mesh-level vertex data, it was not necessary to house these separately. All routines to compute this data has been moved under `ComputeGeometricInfo` within `MeshContinuum`, `Cell`, and `CellFace`. All data gets initialized in the `MeshGenerator` objects after cell and face definitions are completed.

Refs #471 