### PR TITLE
Public destructor for CurvilinearQuadrature and default constructor for Function

### DIFF
--- a/framework/math/functions/function.h
+++ b/framework/math/functions/function.h
@@ -12,6 +12,7 @@ namespace opensn
 class Function : public Object
 {
 public:
+  Function() = default;
   static InputParameters GetInputParameters() { return Object::GetInputParameters(); }
 
 protected:

--- a/framework/math/functions/scalar_material_function.h
+++ b/framework/math/functions/scalar_material_function.h
@@ -13,6 +13,7 @@ namespace opensn
 class ScalarMaterialFunction : public Function
 {
 public:
+  ScalarMaterialFunction() = default;
   static InputParameters GetInputParameters() { return Function::GetInputParameters(); }
   explicit ScalarMaterialFunction(const InputParameters& params) : Function(params) {}
 

--- a/framework/math/functions/scalar_spatial_function.h
+++ b/framework/math/functions/scalar_spatial_function.h
@@ -13,6 +13,7 @@ namespace opensn
 class ScalarSpatialFunction : public Function
 {
 public:
+  ScalarSpatialFunction() = default;
   static InputParameters GetInputParameters() { return Function::GetInputParameters(); }
   explicit ScalarSpatialFunction(const InputParameters& params) : Function(params) {}
 

--- a/framework/math/functions/scalar_spatial_material_function.h
+++ b/framework/math/functions/scalar_spatial_material_function.h
@@ -13,6 +13,7 @@ namespace opensn
 class ScalarSpatialMaterialFunction : public Function
 {
 public:
+  ScalarSpatialMaterialFunction() = default;
   static InputParameters GetInputParameters() { return Function::GetInputParameters(); }
   explicit ScalarSpatialMaterialFunction(const InputParameters& params) : Function(params) {}
 

--- a/framework/math/functions/vector_spatial_function.h
+++ b/framework/math/functions/vector_spatial_function.h
@@ -13,6 +13,7 @@ namespace opensn
 class VectorSpatialFunction : public Function
 {
 public:
+  VectorSpatialFunction() = default;
   static InputParameters GetInputParameters() { return Function::GetInputParameters(); }
   explicit VectorSpatialFunction(const InputParameters& params) : Function(params) {}
 

--- a/framework/math/functions/vector_spatial_material_function.h
+++ b/framework/math/functions/vector_spatial_material_function.h
@@ -13,6 +13,7 @@ namespace opensn
 class VectorSpatialMaterialFunction : public Function
 {
 public:
+  VectorSpatialMaterialFunction() = default;
   static InputParameters GetInputParameters() { return Function::GetInputParameters(); }
   explicit VectorSpatialMaterialFunction(const InputParameters& params) : Function(params) {}
 

--- a/framework/math/quadratures/angular/curvilinear_product_quadrature.h
+++ b/framework/math/quadratures/angular/curvilinear_product_quadrature.h
@@ -27,12 +27,12 @@ protected:
 
   CurvilinearQuadrature(int dimension) : ProductQuadrature(dimension) {}
 
-  virtual ~CurvilinearQuadrature() = default;
-
 public:
   const std::vector<double>& GetDiamondDifferenceFactor() const { return fac_diamond_difference_; }
 
   const std::vector<double>& GetStreamingOperatorFactor() const { return fac_streaming_operator_; }
+
+  virtual ~CurvilinearQuadrature() = default;
 };
 
 class GLCProductQuadrature2DRZ : public CurvilinearQuadrature


### PR DESCRIPTION
In this PR:

- Destructor of [`CurvilinearQuadrature`](https://github.com/Open-Sn/opensn/issues/509) is made public.
- Default constructor to `Function` classes (`ScalarMaterialFunction`, `ScalarSpatialFunction`, `ScalarSpatialMaterialFunction`, `VectorSpatialFunction`, `VectorSpatialMaterialFunction`), paving the way for binding these classes with Python.

Closes #509