### PR TITLE
Bring back `find_package(Boost)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ if (OPENSN_WITH_CUDA)
 endif()
 
 find_package(HDF5 REQUIRED COMPONENTS C HL)
+find_package(Boost REQUIRED)
 
 if(OPENSN_WITH_LUA)
     find_package(Lua 5.3 REQUIRED)


### PR DESCRIPTION
This was accidently removed by 8d4caf8a9ebf0a98706b4d4fd5404544d728ab62
This fixes the OpenSn build on systems where `boost` is located in non-standard location.