### PR TITLE
Bringing back `GetPowerFieldFunction`

### DIFF
--- a/lua/lib/opensn.cc
+++ b/lua/lib/opensn.cc
@@ -563,6 +563,7 @@ static bool reg = opensnlua::Console::Bind(
       .beginNamespace("lbs")
       .deriveClass<LBSSolver, Solver>("LBSSolver")
       .addFunction("SetOptions", &LBSSolver::SetOptions)
+      .addFunction("GetPowerFieldFunction", &LBSSolver::GetPowerFieldFunction)
       .endClass()
       //
       .deriveClass<DiscreteOrdinatesSolver, LBSSolver>("DiscreteOrdinatesSolver")

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.cc
@@ -421,13 +421,13 @@ LBSSolver::MapPhiFieldFunction(size_t g, size_t m) const
   return phi_field_functions_local_map_.at({g, m});
 }
 
-size_t
-LBSSolver::GetHandleToPowerGenFieldFunc() const
+std::shared_ptr<FieldFunctionGridBased>
+LBSSolver::GetPowerFieldFunction() const
 {
   OpenSnLogicalErrorIf(not options_.power_field_function_on,
                        "Called when options_.power_field_function_on == false");
 
-  return power_gen_fieldfunc_local_handle_;
+  return field_functions_[power_gen_fieldfunc_local_handle_];
 }
 
 InputParameters

--- a/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
+++ b/modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h
@@ -205,8 +205,8 @@ public:
   /// Gets the local handle of a flux-moment based field function.
   size_t MapPhiFieldFunction(size_t g, size_t m) const;
 
-  /// Returns the local handle to the power generation field function, if enabled.
-  size_t GetHandleToPowerGenFieldFunc() const;
+  /// Returns the power generation field function, if enabled.
+  std::shared_ptr<FieldFunctionGridBased> GetPowerFieldFunction() const;
 
   void Initialize() override;
 


### PR DESCRIPTION
Originally, this API was returning a Lua handle. Now, it returns a pointer to the `FieldFunctionGridBased` class.

refs #506 