### PR TITLE
Workflow updates

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -23,7 +23,7 @@ jobs:
           - clang/17
           - intel/oneapi
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |
@@ -48,7 +48,7 @@ jobs:
   sanitize:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |
@@ -71,7 +71,7 @@ jobs:
   coverage:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |
@@ -99,3 +99,35 @@ jobs:
           module load opensn/gcc/14 python3/3.12.3
           gcovr --gcov-suspicious-hits-threshold=2000000000000 -r . --filter '^(framework|lua|modules)/' --coveralls coverage.json
           /opt/local/opensn/coveralls/bin/coveralls -c /opt/local/opensn/coveralls/.coveralls.yml -f coverage.json
+
+  python:
+    name: "${{ matrix.compiler }}"
+    runs-on: [self-hosted]
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - gcc/14
+          - clang/17
+          - intel/oneapi
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        shell: bash
+        run: |
+          module load opensn/${{ matrix.compiler }}
+          mkdir build && cd build && cmake -DOPENSN_WITH_PYTHON=True .. && make -j && cd ..
+      - name: test
+        shell: bash
+        run: |
+          module load opensn/${{ matrix.compiler }}
+          test/run_tests -d test/python -j 32 -v 1 -w 3
+      - name: test tutorials
+        shell: bash
+        run: |
+          module load opensn/${{ matrix.compiler }}
+          test/run_tests -d tutorials/python -j 32 -v 1 -w 3
+      - name: test unit
+        shell: bash
+        run: |
+          module load opensn/${{ matrix.compiler }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build documentation
         shell: bash
         run: |
-          module load opensn/gcc/13.3.0 python3/3.12.3 doxygen/1.13.2
+          module load opensn/gcc/14 python3/3.12.3 doxygen/1.13.2
           mkdir build && cd build
           cmake -DOPENSN_WITH_DOCS=ON -DOPENSN_WITH_PYTHON_MODULE=ON ..
           make -j __init__ doc

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -14,24 +14,24 @@ jobs:
   test:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           test/run_tests -d test/lua -j 32 -v 1 -w 3
       - name: test tutorials
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           test/run_tests -d tutorials/lua -j 32 -v 1 -w 3
       - name: test unit
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           build/test/opensn-unit

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -9,19 +9,19 @@ jobs:
   test:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           mkdir build && cd build && cmake .. && make -j && cd ..
       - name: test
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           test/run_tests -d test/lua -j 32 -v 1 -w 4
       - name: test unit
         shell: bash
         run: |
-          module load opensn/gcc/12
+          module load opensn/gcc/14
           build/test/opensn-unit


### PR DESCRIPTION
1. Bump actions version to v4 across the board.
2.  Standardize on GCC 14 for all tests that use GCC.
3.  Add Python testing.
4. Fixes test directory argument to test script to account for splitting tests into Lua and Python directories.