### PR TITLE
Modified the CMakeLists.txt file in the main dir and the test dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,12 +125,16 @@ if(caliper_FOUND)
 endif()
 
 # google test
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.15.2
-)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest QUIET)
+if(NOT TARGET GTest::gtest_main)
+    message(STATUS "System GoogleTest not found. Fetching GoogleTest via FetchContent.")
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.15.2
+    )
+    FetchContent_MakeAvailable(googletest)
+endif()
 
 # compile options
 set(OPENSN_CXX_FLAGS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries(opensn-unit
     ${HDF5_LIBRARIES}
     caliper
     MPI::MPI_CXX
-    gmock_main
-    gtest_main
+    GTest::gmock_main
+    GTest::gtest_main
 )
 if(OPENSN_WITH_LUA)
     add_subdirectory(lua)


### PR DESCRIPTION
We now look for a system gtest and link against that instead of building gtest locally and then linking against that. If a system gtest is not found, gtest is built locally and then linked against. This is in response to Issue #554.