### PR TITLE
Add Python binding for ScalarSpatialFunction

### DIFF
--- a/doc/pyapi/index.rst
+++ b/doc/pyapi/index.rst
@@ -43,6 +43,7 @@ Function wrappers
 
    math.Function
    math.ScalarMaterialFunction
+   math.ScalarSpatialFunction
    math.ScalarSpatialMaterialFunction
    math.VectorSpatialFunction
 

--- a/pyopensn/py_env.cc
+++ b/pyopensn/py_env.cc
@@ -12,7 +12,7 @@ namespace opensn
 
 PyEnv::PyEnv()
 {
-  // Check if environment is already initialized
+  // check if environment is already initialized
   if (PyEnv::p_default_env != nullptr)
   {
     return;
@@ -37,7 +37,7 @@ PyEnv::PyEnv()
 
 PyEnv::~PyEnv()
 {
-  // Finalize the run
+  // finalize the run
   Finalize();
   ::PetscFinalize();
   // Print execution time
@@ -47,7 +47,7 @@ PyEnv::~PyEnv()
     std::cout << "Elapsed execution time: " << program_timer.GetTimeString() << "\n";
     std::cout << Timer::GetLocalDateTimeString() << " " << program << " finished execution.\n";
   }
-  // Flush caliper
+  // flush caliper
   cali_mgr.flush();
 }
 

--- a/python/lib/functor.h
+++ b/python/lib/functor.h
@@ -9,6 +9,7 @@
 
 #include "framework/math/functions/function.h"
 #include "framework/math/functions/scalar_material_function.h"
+#include "framework/math/functions/scalar_spatial_function.h"
 #include "framework/math/functions/scalar_spatial_material_function.h"
 #include "framework/math/functions/vector_spatial_function.h"
 #include <functional>
@@ -29,6 +30,21 @@ public:
 
 protected:
   std::function<double(double, int)> func_;
+};
+
+/// Bind class for scalar spatial function
+class PySSFunction : public ScalarSpatialFunction
+{
+public:
+  PySSFunction(const std::function<double(const Vector3&)>& func)
+    : ScalarSpatialFunction(), func_(func)
+  {
+  }
+
+  inline double Evaluate(const Vector3& xyz) const override { return this->func_(xyz); }
+
+protected:
+  std::function<double(const Vector3&)> func_;
 };
 
 /// Bind class for scalar spatial material function

--- a/python/lib/math.cc
+++ b/python/lib/math.cc
@@ -232,6 +232,7 @@ WrapFunctors(py::module& math)
     Empty constructor.
     )"
   );
+
   // scalar material function
   auto scalar_material_function = py::class_<PySMFunction, std::shared_ptr<PySMFunction>, Function>(
     math,
@@ -292,6 +293,66 @@ WrapFunctors(py::module& math)
     )",
     py::arg("val"),
     py::arg("mat_id")
+  );
+
+  // scalar spatial function
+  auto scalar_spatial_function = py::class_<PySSFunction, std::shared_ptr<PySSFunction>, Function>(
+    math,
+    "ScalarSpatialFunction",
+    R"(
+    Scalar spatial function.
+
+    Functions that accept a 3D vector as input and return a scalar.
+
+    Wrapper of :cpp:class:`opensn::ScalarSpatialFunction`.
+
+    Examples
+    --------
+    >>> # Create from a Python function
+    >>> def foo(point):
+    ...     return point.Norm()
+    >>> f = ScalarSpatialFunction(foo)
+    >>> 
+    >>> # Create from lambda
+    >>> a = Vector3(0., 0., 1.)
+    >>> g = ScalarSpatialFunction(lambda p : p @ a)
+    >>> 
+    >>> # Evaluate
+    >>> f(Vector3(4., 4., 7.))
+    9.0
+    >>> g(Vector3(1., 2., 3.))
+    3.0
+    )"
+  );
+  scalar_spatial_function.def(
+    py::init(
+      [](const std::function<double(const Vector3&)>& func)
+      {
+        return std::make_shared<PySSFunction>(func);
+      }
+    ),
+    R"(
+    Construct a scalar spatial function from associated Python function or lambda.
+
+    Parameters
+    ----------
+    func: Callable[[pyopensn.math.Vector3], float]
+        Referenced scalar spatial function.
+    )",
+    py::arg("func")
+  );
+  scalar_spatial_function.def(
+    "__call__",
+    &PySSFunction::Evaluate,
+    R"(
+    Evaluate the associated function.
+
+    Parameters
+    ----------
+    xyz: pyopensn.math.Vector3
+        The xyz coordinates of the point where the function is called.
+    )",
+    py::arg("xyz")
   );
 
   // scalar spatial material function


### PR DESCRIPTION
In this PR, Python binding for `ScalarSpatialFunction` is added.