### PR TITLE
Python testing updates

### DIFF
--- a/python/lib/console.cc
+++ b/python/lib/console.cc
@@ -31,7 +31,7 @@ Console::BindBarrier(const mpi::Communicator& comm)
   py::module main = py::module::import("__main__");
   main.def(
     "MPIBarrier",
-    [&comm](void)
+    [comm](void)
     {
       comm.barrier();
     },

--- a/test/python/framework/post_processors/solver_info_01.py
+++ b/test/python/framework/post_processors/solver_info_01.py
@@ -42,10 +42,10 @@ if __name__ == "__main__":
     for t in range(1, 21):
         phys0.Step()
         time = phys0.GetTimeNew()
-        print(t, "{:.3f} {:.5f}".format(time, phys0.GetPopulationNew()), sep="\t")
+        print(t, "{:.3f} {:.5f}".format(time, phys0.GetPopulationNew()), sep="\t", flush=True)
         phys0.Advance()
         if time > 0.1:
             phys0.SetRho(0.8)
 
-    print("Manually printing Post-Processor:")
+    print("Manually printing Post-Processor:", flush=True)
     Print([pp0])

--- a/test/python/framework/post_processors/solver_info_02.py
+++ b/test/python/framework/post_processors/solver_info_02.py
@@ -51,10 +51,10 @@ if __name__ == "__main__":
     for t in range(1, 21):
         phys0.Step()
         time = phys0.GetTimeNew()
-        print(t, "{:.3f} {:.5f}".format(time, phys0.GetPopulationNew()), sep="\t")
+        print(t, "{:.3f} {:.5f}".format(time, phys0.GetPopulationNew()), sep="\t", flush=True)
         phys0.Advance()
         if time > 0.1:
             phys0.SetRho(0.8)
 
-    print("Manual neutron_population1=", f"{pp[1].GetValue():.5f}", sep="\t")
-    print("Manual neutron_population1=", f"{pp21.GetValue():.5f}", sep="\t")
+    print("Manual neutron_population1=", f"{pp[1].GetValue():.5f}", sep="\t", flush=True)
+    print("Manual neutron_population1=", f"{pp21.GetValue():.5f}", sep="\t", flush=True)

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     pquad = GLCProductQuadrature2DXY(4, 8)
 
     # Solver
-    if k_method == "scdsa" or k_method == "smm":
+    if "scdsa" in k_method or "smm" in k_method:
         inner_linear_method = "classic_richardson"
         l_max_its = 2
     else:

--- a/test/src/job_manager.py
+++ b/test/src/job_manager.py
@@ -381,7 +381,7 @@ def RunTests(tests: list, argv):
             if slot.Probe():
                 system_load += slot.test.num_procs
 
-        time.sleep(0.01)
+        time.sleep(1.0)
 
         if done:
             break

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -68,7 +68,7 @@ class TestSlot:
                                         cwd=test.file_dir,
                                         shell=True,
                                         stdout=self.stdout_file,
-                                        stderr=self.stdout_file,
+                                        stderr=self.stderr_file,
                                         universal_newlines=True)
 
     def Probe(self):

--- a/tools/developer/lsan.supp
+++ b/tools/developer/lsan.supp
@@ -7,3 +7,4 @@ leak:libmpi.so.*
 
 # Dependencies
 leak:libpetsc.so.*
+leak:_PyMem_RawMalloc


### PR DESCRIPTION
1. Updating Python post processor tests to ensure consistent output across platforms.
2. Resolving a stack-use-after-scope issue in the Python binding of MPIBarrier.
3. Updating LSAN suppressions for Python.
4. Increasing the job wait time in the regression testing script to improve reliability.
5. Updating large C5G7 inputs to correctly set number of sweeps for SCDSA and SMM methods.