### PR TITLE
Suppressing colorized log output when using the Python module

### DIFF
--- a/pyopensn/py_env.cc
+++ b/pyopensn/py_env.cc
@@ -32,6 +32,7 @@ PyEnv::PyEnv()
   ::PetscOptionsSetValue(NULL, "-options_left", "0");
   ::PetscOptionsInsertString(nullptr, "-no_signal_handler");
   ::PetscInitialize(nullptr, nullptr, nullptr, nullptr);
+  opensn::suppress_color = true;
   Initialize();
 }
 


### PR DESCRIPTION
Removes extraneous ANSI escape codes from output when running with the Python module. This fixes the issue with failing regression tests when testing with the Python module (all tests in `transport_steady`, `transport_adjoint`, `transport_keigen`, `transport_steady_cyl`, and `transport_steady_cbc` pass with the module).