### PR TITLE
Restoring function stack for the Lua interface and update Lua inputs

### DIFF
--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -33,6 +33,7 @@ std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 std::vector<std::shared_ptr<Object>> object_stack;
 std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
 std::vector<std::shared_ptr<PostProcessor>> postprocessor_stack;
+std::vector<std::shared_ptr<Function>> function_stack;
 
 int
 Initialize()
@@ -66,6 +67,7 @@ Finalize()
   object_stack.clear();
   sdm_stack.clear();
   postprocessor_stack.clear();
+  function_stack.clear();
 
   CALI_MARK_END(opensn::program.c_str());
 }

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -28,6 +28,7 @@ class Timer;
 class Logger;
 class PostProcessor;
 class Object;
+class Function;
 
 extern mpi::Communicator mpi_comm;
 extern Logger& log;
@@ -45,6 +46,7 @@ extern std::vector<std::shared_ptr<FieldFunction>> field_function_stack;
 extern std::vector<std::shared_ptr<Object>> object_stack;
 extern std::vector<std::shared_ptr<SpatialDiscretization>> sdm_stack;
 extern std::vector<std::shared_ptr<PostProcessor>> postprocessor_stack;
+extern std::vector<std::shared_ptr<Function>> function_stack;
 
 /// Customized exceptions.
 class RecoverableException : public std::runtime_error

--- a/test/lua/framework/tutorials/tutorial_93_raytracing.lua
+++ b/test/lua/framework/tutorials/tutorial_93_raytracing.lua
@@ -19,7 +19,7 @@ grid = meshgen1:Execute()
 -- Set block IDs
 grid:SetUniformBlockID(0)
 
-grid:SetupOrthogonalBoundaries()
+grid:SetOrthogonalBoundaries()
 
 unit_sim_tests.SimTest93_RayTracing({ mesh = grid })
 

--- a/test/lua/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.lua
+++ b/test/lua/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.lua
@@ -20,7 +20,7 @@ grid = meshgen1:Execute()
 -- Set block IDs
 grid:SetUniformBlockID(0)
 
-grid:SetupOrthogonalBoundaries()
+grid:SetOrthogonalBoundaries()
 
 function MMS_phi(pt)
   return math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y)

--- a/test/lua/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.lua
+++ b/test/lua/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.lua
@@ -20,7 +20,7 @@ grid = meshgen1:Execute()
 -- Set block IDs
 grid:SetUniformBlockID(0)
 
-grid:SetupOrthogonalBoundaries()
+grid:SetOrthogonalBoundaries()
 
 function MMS_phi(pt)
   return math.cos(math.pi * pt.x) + math.cos(math.pi * pt.y)


### PR DESCRIPTION
This PR restore the function stack that was accidentally removed in PR 574. It also modifies Lua tests to use SetOrthogonalBoundaries instead of SetupOrthogonalBoundaries.