### PR TITLE
Moving coordinate system info

### DIFF
--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -30,7 +30,7 @@ FieldFunctionGridBased::GetInputParameters()
 
   params.AddOptionalParameter("discretization", "FV", "The spatial discretization type to be used");
   params.AddOptionalParameter(
-    "coordinate_system", "cartesian", "Coordinate system to apply to element mappings");
+    "coord_sys", "cartesian", "Coordinate system to apply to element mappings");
   params.AddOptionalParameter("quadrature_order",
                               0,
                               "If supplied, will overwrite the default for the "
@@ -41,7 +41,7 @@ FieldFunctionGridBased::GetInputParameters()
 
   params.ConstrainParameterRange("discretization", AllowableRangeList::New({"FV", "PWLC", "PWLD"}));
   params.ConstrainParameterRange(
-    "coordinate_system", AllowableRangeList::New({"cartesian", "cylindrical", "spherical"}));
+    "coord_sys", AllowableRangeList::New({"cartesian", "cylindrical", "spherical"}));
 
   return params;
 }
@@ -333,8 +333,8 @@ FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
     return FiniteVolume::New(grid);
 
   std::string cs = "cartesian";
-  if (params.IsParameterValid("coordinate_system"))
-    cs = params.GetParamValue<std::string>("coordinate_system");
+  if (params.IsParameterValid("coord_sys"))
+    cs = params.GetParamValue<std::string>("coord_sys");
 
   QuadratureOrder q_order = QuadratureOrder::SECOND;
 

--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -326,25 +326,15 @@ FieldFunctionGridBased::ExportMultipleToVTK(
 std::shared_ptr<SpatialDiscretization>
 FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
 {
-  const auto grid_ptr = params.GetParamValue<std::shared_ptr<MeshContinuum>>("mesh");
+  const auto grid = params.GetParamValue<std::shared_ptr<MeshContinuum>>("mesh");
   const auto sdm_type = params.GetParamValue<std::string>("discretization");
 
   if (sdm_type == "FV")
-    return FiniteVolume::New(grid_ptr);
+    return FiniteVolume::New(grid);
 
-  CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN;
   std::string cs = "cartesian";
   if (params.IsParameterValid("coordinate_system"))
-  {
     cs = params.GetParamValue<std::string>("coordinate_system");
-
-    if (cs == "cartesian")
-      cs_type = CoordinateSystemType::CARTESIAN;
-    if (cs == "cylindrical")
-      cs_type = CoordinateSystemType::CYLINDRICAL;
-    if (cs == "spherical")
-      cs_type = CoordinateSystemType::SPHERICAL;
-  }
 
   QuadratureOrder q_order = QuadratureOrder::SECOND;
 
@@ -360,16 +350,18 @@ FieldFunctionGridBased::MakeSpatialDiscretization(const InputParameters& params)
   {
     if (cs == "cartesian")
       q_order = QuadratureOrder::SECOND;
-    if (cs == "cylindrical")
+    else if (cs == "cylindrical")
       q_order = QuadratureOrder::THIRD;
-    if (cs == "spherical")
+    else if (cs == "spherical")
       q_order = QuadratureOrder::FOURTH;
+    else
+      throw std::logic_error("Unrecognized coordinate system.");
   }
 
   if (sdm_type == "PWLC")
-    return PieceWiseLinearContinuous::New(grid_ptr, q_order, cs_type);
+    return PieceWiseLinearContinuous::New(grid, q_order);
   else if (sdm_type == "PWLD")
-    return PieceWiseLinearDiscontinuous::New(grid_ptr, q_order, cs_type);
+    return PieceWiseLinearDiscontinuous::New(grid, q_order);
 
   // If not returned by now
   OpenSnInvalidArgument("Unsupported discretization \"" + sdm_type + "\"");

--- a/framework/math/math.h
+++ b/framework/math/math.h
@@ -27,15 +27,6 @@ class SpatialDiscretization_PWLC;
 
 using MatVec3 = std::vector<std::vector<Vector3>>;
 
-/// Coordinate system type.
-enum class CoordinateSystemType
-{
-  UNDEFINED = 0,
-  CARTESIAN = 1,
-  CYLINDRICAL = 2,
-  SPHERICAL = 3,
-};
-
 /// Spatial discretization type.
 enum class SpatialDiscretizationType
 {

--- a/framework/math/spatial_discretization/finite_element/finite_element_base.h
+++ b/framework/math/spatial_discretization/finite_element/finite_element_base.h
@@ -22,10 +22,9 @@ public:
 
 protected:
   explicit FiniteElementBase(const std::shared_ptr<MeshContinuum> grid,
-                             CoordinateSystemType cs_type,
                              SpatialDiscretizationType sdm_type,
                              QuadratureOrder q_order)
-    : SpatialDiscretization(grid, cs_type, sdm_type), q_order_(q_order)
+    : SpatialDiscretization(grid, sdm_type), q_order_(q_order)
   {
   }
 

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.cc
@@ -12,9 +12,8 @@ namespace opensn
 
 PieceWiseLinearBase::PieceWiseLinearBase(const std::shared_ptr<MeshContinuum> grid,
                                          QuadratureOrder q_order,
-                                         SpatialDiscretizationType sdm_type,
-                                         CoordinateSystemType cs_type)
-  : FiniteElementBase(grid, cs_type, sdm_type, q_order),
+                                         SpatialDiscretizationType sdm_type)
+  : FiniteElementBase(grid, sdm_type, q_order),
     line_quad_order_arbitrary_(q_order),
     tri_quad_order_arbitrary_(q_order),
     tet_quad_order_arbitrary_(q_order)
@@ -38,7 +37,7 @@ PieceWiseLinearBase::CreateCellMappings()
       {
         const auto& vol_quad = line_quad_order_arbitrary_;
 
-        mapping = make_unique<PieceWiseLinearSlabMapping>(cell, ref_grid_, vol_quad);
+        mapping = make_unique<PieceWiseLinearSlabMapping>(cell, grid_, vol_quad);
         break;
       }
       case CellType::POLYGON:
@@ -46,7 +45,7 @@ PieceWiseLinearBase::CreateCellMappings()
         const auto& vol_quad = tri_quad_order_arbitrary_;
         const auto& area_quad = line_quad_order_arbitrary_;
 
-        mapping = make_unique<PieceWiseLinearPolygonMapping>(cell, ref_grid_, vol_quad, area_quad);
+        mapping = make_unique<PieceWiseLinearPolygonMapping>(cell, grid_, vol_quad, area_quad);
         break;
       }
       case CellType::POLYHEDRON:
@@ -54,8 +53,7 @@ PieceWiseLinearBase::CreateCellMappings()
         const auto& vol_quad = tet_quad_order_arbitrary_;
         const auto& area_quad = tri_quad_order_arbitrary_;
 
-        mapping =
-          make_unique<PieceWiseLinearPolyhedronMapping>(cell, ref_grid_, vol_quad, area_quad);
+        mapping = make_unique<PieceWiseLinearPolyhedronMapping>(cell, grid_, vol_quad, area_quad);
         break;
       }
       default:
@@ -66,13 +64,13 @@ PieceWiseLinearBase::CreateCellMappings()
     return mapping;
   };
 
-  for (const auto& cell : ref_grid_->local_cells)
+  for (const auto& cell : grid_->local_cells)
     cell_mappings_.push_back(MakeCellMapping(cell));
 
-  const auto ghost_ids = ref_grid_->cells.GetGhostGlobalIDs();
+  const auto ghost_ids = grid_->cells.GetGhostGlobalIDs();
   for (uint64_t ghost_id : ghost_ids)
   {
-    auto ghost_mapping = MakeCellMapping(ref_grid_->cells[ghost_id]);
+    auto ghost_mapping = MakeCellMapping(grid_->cells[ghost_id]);
     nb_cell_mappings_.insert(std::make_pair(ghost_id, std::move(ghost_mapping)));
   }
 }

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.h
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_base.h
@@ -22,8 +22,7 @@ protected:
   /// Constructor
   explicit PieceWiseLinearBase(const std::shared_ptr<MeshContinuum> grid,
                                QuadratureOrder q_order,
-                               SpatialDiscretizationType sdm_type,
-                               CoordinateSystemType cs_type);
+                               SpatialDiscretizationType sdm_type);
 
   LineQuadrature line_quad_order_arbitrary_;
   TriangleQuadrature tri_quad_order_arbitrary_;

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h
@@ -20,9 +20,7 @@ class PieceWiseLinearContinuous : public PieceWiseLinearBase
 public:
   /// Construct a shared object using the protected constructor.
   static std::shared_ptr<PieceWiseLinearContinuous>
-  New(const std::shared_ptr<MeshContinuum> grid,
-      QuadratureOrder q_order = QuadratureOrder::SECOND,
-      CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN);
+  New(const std::shared_ptr<MeshContinuum> grid, QuadratureOrder q_order = QuadratureOrder::SECOND);
 
   void BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
                             std::vector<int64_t>& nodal_nnz_off_diag,
@@ -63,8 +61,7 @@ protected:
 
 private:
   explicit PieceWiseLinearContinuous(const std::shared_ptr<MeshContinuum> grid,
-                                     QuadratureOrder q_order,
-                                     CoordinateSystemType cs_type);
+                                     QuadratureOrder q_order);
 };
 
 } // namespace opensn

--- a/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h
+++ b/framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h
@@ -20,9 +20,7 @@ class PieceWiseLinearDiscontinuous : public PieceWiseLinearBase
 public:
   /// Construct a shared object using the protected constructor.
   static std::shared_ptr<PieceWiseLinearDiscontinuous>
-  New(const std::shared_ptr<MeshContinuum> grid,
-      QuadratureOrder q_order = QuadratureOrder::SECOND,
-      CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN);
+  New(const std::shared_ptr<MeshContinuum> grid, QuadratureOrder q_order = QuadratureOrder::SECOND);
 
   void BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
                             std::vector<int64_t>& nodal_nnz_off_diag,
@@ -63,8 +61,7 @@ protected:
 
 private:
   explicit PieceWiseLinearDiscontinuous(const std::shared_ptr<MeshContinuum> grid,
-                                        QuadratureOrder q_order,
-                                        CoordinateSystemType cs_type);
+                                        QuadratureOrder q_order);
 };
 
 } // namespace opensn

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.cc
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.cc
@@ -13,22 +13,21 @@
 namespace opensn
 {
 
-FiniteVolume::FiniteVolume(const std::shared_ptr<MeshContinuum> grid, CoordinateSystemType cs_type)
-  : SpatialDiscretization(grid, cs_type, SpatialDiscretizationType::FINITE_VOLUME)
+FiniteVolume::FiniteVolume(const std::shared_ptr<MeshContinuum> grid)
+  : SpatialDiscretization(grid, SpatialDiscretizationType::FINITE_VOLUME)
 {
   CreateCellMappings();
-
   OrderNodes();
 }
 
 std::shared_ptr<FiniteVolume>
-FiniteVolume::New(const std::shared_ptr<MeshContinuum> grid, CoordinateSystemType cs_type)
+FiniteVolume::New(const std::shared_ptr<MeshContinuum> grid)
 {
   // First try to find an existing spatial discretization that matches the
   // one requested.
   for (auto& sdm : sdm_stack)
     if (sdm->GetType() == SpatialDiscretizationType::FINITE_VOLUME and sdm->GetGrid() == grid and
-        sdm->GetCoordinateSystemType() == cs_type)
+        sdm->GetGrid()->GetCoordinateSystem() == grid->GetCoordinateSystem())
     {
       auto sdm_ptr = std::dynamic_pointer_cast<FiniteVolume>(sdm);
 
@@ -39,7 +38,7 @@ FiniteVolume::New(const std::shared_ptr<MeshContinuum> grid, CoordinateSystemTyp
 
   // If no existing discretization was found then go ahead and make a
   // new one
-  auto new_sdm = std::shared_ptr<FiniteVolume>(new FiniteVolume(grid, cs_type));
+  auto new_sdm = std::shared_ptr<FiniteVolume>(new FiniteVolume(grid));
 
   sdm_stack.push_back(new_sdm);
 
@@ -65,7 +64,7 @@ FiniteVolume::CreateCellMappings()
       case CellType::POLYHEDRON:
       {
         mapping = make_unique<FiniteVolumeMapping>(
-          ref_grid_, cell, cell.centroid, std::vector<std::vector<int>>(cell.faces.size(), {-1}));
+          grid_, cell, cell.centroid, std::vector<std::vector<int>>(cell.faces.size(), {-1}));
         break;
       }
       default:
@@ -75,13 +74,13 @@ FiniteVolume::CreateCellMappings()
     return mapping;
   };
 
-  for (const auto& cell : ref_grid_->local_cells)
+  for (const auto& cell : grid_->local_cells)
     cell_mappings_.push_back(MakeCellMapping(cell));
 
-  const auto ghost_ids = ref_grid_->cells.GetGhostGlobalIDs();
+  const auto ghost_ids = grid_->cells.GetGhostGlobalIDs();
   for (uint64_t ghost_id : ghost_ids)
   {
-    auto ghost_mapping = MakeCellMapping(ref_grid_->cells[ghost_id]);
+    auto ghost_mapping = MakeCellMapping(grid_->cells[ghost_id]);
     nb_cell_mappings_.insert(std::make_pair(ghost_id, std::move(ghost_mapping)));
   }
 }
@@ -92,7 +91,7 @@ FiniteVolume::OrderNodes()
   static std::string mapping_error = "FiniteVolume::OrderNodes: Error mapping neighbor cells";
 
   // Communicate node counts
-  const uint64_t local_num_nodes = ref_grid_->local_cells.size();
+  const uint64_t local_num_nodes = grid_->local_cells.size();
   mpi_comm.all_gather(local_num_nodes, locJ_block_size_);
 
   // Build block addresses
@@ -110,11 +109,11 @@ FiniteVolume::OrderNodes()
   global_base_block_size_ = global_num_nodes;
 
   // Sort neigbor ids
-  const auto neighbor_gids = ref_grid_->cells.GetGhostGlobalIDs();
+  const auto neighbor_gids = grid_->cells.GetGhostGlobalIDs();
   std::map<uint64_t, std::vector<uint64_t>> sorted_nb_gids;
   for (uint64_t gid : neighbor_gids)
   {
-    const auto& cell = ref_grid_->cells[gid];
+    const auto& cell = grid_->cells[gid];
     sorted_nb_gids[cell.partition_id].push_back(gid);
   }
 
@@ -132,10 +131,10 @@ FiniteVolume::OrderNodes()
     local_ids.reserve(gids.size());
     for (uint64_t gid : gids)
     {
-      if (not ref_grid_->IsCellLocal(gid))
+      if (not grid_->IsCellLocal(gid))
         throw std::logic_error(mapping_error);
 
-      const auto& local_cell = ref_grid_->cells[gid];
+      const auto& local_cell = grid_->cells[gid];
       local_ids.push_back(local_cell.local_id);
     } // for gid
   }   // for pid_list_pair
@@ -165,8 +164,8 @@ FiniteVolume::OrderNodes()
     }
   } // for pid_list_pair
 
-  local_base_block_size_ = ref_grid_->local_cells.size();
-  global_base_block_size_ = ref_grid_->GetGlobalNumberOfCells();
+  local_base_block_size_ = grid_->local_cells.size();
+  global_base_block_size_ = grid_->GetGlobalNumberOfCells();
 }
 
 void
@@ -180,7 +179,7 @@ FiniteVolume::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
   nodal_nnz_in_diag.clear();
   nodal_nnz_off_diag.clear();
 
-  const size_t num_local_cells = ref_grid_->local_cells.size();
+  const size_t num_local_cells = grid_->local_cells.size();
 
   nodal_nnz_in_diag.resize(num_local_cells * N, 0.0);
   nodal_nnz_off_diag.resize(num_local_cells * N, 0.0);
@@ -190,7 +189,7 @@ FiniteVolume::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
     const unsigned int num_comps = unknown_manager.unknowns[uk].num_components;
     for (int comp = 0; comp < num_comps; ++comp)
     {
-      for (auto& cell : ref_grid_->local_cells)
+      for (auto& cell : grid_->local_cells)
       {
         const int64_t i = MapDOFLocal(cell, 0, unknown_manager, uk, comp);
 
@@ -201,7 +200,7 @@ FiniteVolume::BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
           if (not face.has_neighbor)
             continue;
 
-          if (face.IsNeighborLocal(ref_grid_.get()))
+          if (face.IsNeighborLocal(grid_.get()))
             nodal_nnz_in_diag[i] += 1;
           else
             nodal_nnz_off_diag[i] += 1;
@@ -222,7 +221,7 @@ FiniteVolume::MapDOF(const Cell& cell,
 
   const size_t num_unknowns = unknown_manager.GetTotalUnknownStructureSize();
   const size_t block_id = unknown_manager.MapUnknown(unknown_id, component);
-  const size_t num_local_cells = ref_grid_->local_cells.size();
+  const size_t num_local_cells = grid_->local_cells.size();
 
   if (component >= num_unknowns)
     return -1;
@@ -263,7 +262,7 @@ FiniteVolume::MapDOFLocal(const Cell& cell,
 
   const size_t num_unknowns = unknown_manager.GetTotalUnknownStructureSize();
   const size_t block_id = unknown_manager.MapUnknown(unknown_id, component);
-  const size_t num_local_cells = ref_grid_->local_cells.size();
+  const size_t num_local_cells = grid_->local_cells.size();
 
   if (component >= num_unknowns)
     return -1;
@@ -280,7 +279,7 @@ FiniteVolume::MapDOFLocal(const Cell& cell,
   {
     const size_t num_local_dofs = GetNumLocalDOFs(unknown_manager);
     const size_t num_ghost_nodes = GetNumGhostDOFs(UNITARY_UNKNOWN_MANAGER);
-    const uint64_t ghost_local_id = ref_grid_->cells.GetGhostLocalID(cell.global_id);
+    const uint64_t ghost_local_id = grid_->cells.GetGhostLocalID(cell.global_id);
 
     if (storage == UnknownStorageType::BLOCK)
       address = static_cast<int64_t>(num_local_dofs) +
@@ -298,7 +297,7 @@ FiniteVolume::GetNumGhostDOFs(const UnknownManager& unknown_manager) const
 {
   unsigned int N = unknown_manager.GetTotalUnknownStructureSize();
 
-  return ref_grid_->cells.GhostCellCount() * N;
+  return grid_->cells.GhostCellCount() * N;
 }
 
 std::vector<int64_t>
@@ -307,13 +306,13 @@ FiniteVolume::GetGhostDOFIndices(const UnknownManager& unknown_manager) const
   std::vector<int64_t> dof_ids;
   dof_ids.reserve(GetNumGhostDOFs(unknown_manager));
 
-  std::vector<uint64_t> ghost_cell_ids = ref_grid_->cells.GetGhostGlobalIDs();
+  std::vector<uint64_t> ghost_cell_ids = grid_->cells.GetGhostGlobalIDs();
 
   const size_t num_uks = unknown_manager.unknowns.size();
 
   for (const auto cell_id : ghost_cell_ids)
   {
-    const auto& cell = ref_grid_->cells[cell_id];
+    const auto& cell = grid_->cells[cell_id];
     for (size_t u = 0; u < num_uks; ++u)
     {
       const auto& unkn = unknown_manager.unknowns[u];

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.h
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.h
@@ -21,15 +21,13 @@ private:
   std::map<uint64_t, uint64_t> neighbor_cell_local_ids_;
 
 private:
-  explicit FiniteVolume(const std::shared_ptr<MeshContinuum> grid, CoordinateSystemType cs_type);
+  explicit FiniteVolume(const std::shared_ptr<MeshContinuum> grid);
 
 public:
   virtual ~FiniteVolume() = default;
 
   /// Publicly accessible construction handler.
-  static std::shared_ptr<FiniteVolume>
-  New(const std::shared_ptr<MeshContinuum> grid,
-      CoordinateSystemType cs_type = CoordinateSystemType::CARTESIAN);
+  static std::shared_ptr<FiniteVolume> New(const std::shared_ptr<MeshContinuum> grid);
 
   void CreateCellMappings();
 

--- a/framework/math/spatial_discretization/spatial_discretization.cc
+++ b/framework/math/spatial_discretization/spatial_discretization.cc
@@ -10,12 +10,8 @@ namespace opensn
 {
 
 SpatialDiscretization::SpatialDiscretization(const std::shared_ptr<MeshContinuum> grid,
-                                             CoordinateSystemType cs_type,
                                              SpatialDiscretizationType sdm_type)
-  : UNITARY_UNKNOWN_MANAGER({std::make_pair(UnknownType::SCALAR, 0)}),
-    ref_grid_(grid),
-    coord_sys_type_(cs_type),
-    type_(sdm_type)
+  : UNITARY_UNKNOWN_MANAGER({std::make_pair(UnknownType::SCALAR, 0)}), grid_(grid), type_(sdm_type)
 {
 }
 
@@ -46,13 +42,7 @@ SpatialDiscretization::GetType() const
 const std::shared_ptr<MeshContinuum>
 SpatialDiscretization::GetGrid() const
 {
-  return ref_grid_;
-}
-
-CoordinateSystemType
-SpatialDiscretization::GetCoordinateSystemType() const
-{
-  return coord_sys_type_;
+  return grid_;
 }
 
 size_t
@@ -133,7 +123,7 @@ std::vector<std::vector<std::vector<int>>>
 SpatialDiscretization::MakeInternalFaceNodeMappings(const double tolerance) const
 {
   std::vector<std::vector<std::vector<int>>> cell_adj_mapping;
-  for (const auto& cell : ref_grid_->local_cells)
+  for (const auto& cell : grid_->local_cells)
   {
     const auto& cell_mapping = this->GetCellMapping(cell);
     const auto& node_locations = cell_mapping.GetNodeLocations();
@@ -148,7 +138,7 @@ SpatialDiscretization::MakeInternalFaceNodeMappings(const double tolerance) cons
       std::vector<int> face_adj_mapping(num_face_nodes, -1);
       if (face.has_neighbor)
       {
-        const auto& adj_cell = ref_grid_->cells[face.neighbor_id];
+        const auto& adj_cell = grid_->cells[face.neighbor_id];
         const auto& adj_cell_mapping = this->GetCellMapping(adj_cell);
         const auto& adj_node_locations = adj_cell_mapping.GetNodeLocations();
         const size_t adj_num_nodes = adj_cell_mapping.GetNumNodes();
@@ -206,7 +196,7 @@ SpatialDiscretization::CopyVectorWithUnknownScope(const std::vector<double>& fro
 
     const size_t num_comps = ukA.num_components;
 
-    for (const auto& cell : ref_grid_->local_cells)
+    for (const auto& cell : grid_->local_cells)
     {
       const auto& cell_mapping = this->GetCellMapping(cell);
       const size_t num_nodes = cell_mapping.GetNumNodes();
@@ -273,7 +263,7 @@ SpatialDiscretization::Spherical1DSpatialWeightFunction(const Vector3& point)
 SpatialDiscretization::SpatialWeightFunction
 SpatialDiscretization::GetSpatialWeightingFunction() const
 {
-  switch (coord_sys_type_)
+  switch (grid_->GetCoordinateSystem())
   {
     case CoordinateSystemType::CARTESIAN:
       return CartesianSpatialWeightFunction;

--- a/framework/math/spatial_discretization/spatial_discretization.h
+++ b/framework/math/spatial_discretization/spatial_discretization.h
@@ -34,8 +34,6 @@ public:
   /// Returns the reference grid on which this discretization is based.
   const std::shared_ptr<MeshContinuum> GetGrid() const;
 
-  CoordinateSystemType GetCoordinateSystemType() const;
-
   /**
    * Builds the sparsity pattern for a local block matrix compatible withthe given unknown manager.
    * The modified vectors are: `nodal_nnz_in_diag` which specifies for each row the number of
@@ -213,10 +211,9 @@ public:
 
 protected:
   SpatialDiscretization(const std::shared_ptr<MeshContinuum> grid,
-                        CoordinateSystemType cs_type,
                         SpatialDiscretizationType sdm_type);
 
-  const std::shared_ptr<MeshContinuum> ref_grid_;
+  const std::shared_ptr<MeshContinuum> grid_;
   std::vector<std::unique_ptr<CellMapping>> cell_mappings_;
   std::map<uint64_t, std::shared_ptr<CellMapping>> nb_cell_mappings_;
 
@@ -226,8 +223,6 @@ protected:
 
   uint64_t local_base_block_size_ = 0;
   uint64_t global_base_block_size_ = 0;
-
-  const CoordinateSystemType coord_sys_type_;
 
 private:
   const SpatialDiscretizationType type_;

--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -13,6 +13,7 @@
 namespace opensn
 {
 
+class Cell;
 class MeshContinuum;
 
 enum class CellType
@@ -56,7 +57,7 @@ public:
   int GetNeighborAdjacentFaceIndex(const MeshContinuum* grid) const;
 
   /// Computes the geometric info on the face.
-  void ComputeGeometricInfo(const MeshContinuum* grid, unsigned int f);
+  void ComputeGeometricInfo(const MeshContinuum* grid, const Cell& cell);
 
   /// Serializes a face into a vector of bytes.
   ByteArray Serialize() const;
@@ -81,6 +82,7 @@ public:
 
   /// A list of the vertices
   std::vector<uint64_t> vertex_ids;
+  void ComputeGeometricInfo(const MeshContinuum* grid, const Cell& cell, const unsigned int f);
 };
 
 /// Generic mesh cell object

--- a/framework/mesh/mesh.h
+++ b/framework/mesh/mesh.h
@@ -8,6 +8,14 @@
 namespace opensn
 {
 
+enum CoordinateSystemType : int
+{
+  UNDEFINED = 0,
+  CARTESIAN = 1,
+  CYLINDRICAL = 2,
+  SPHERICAL = 3,
+};
+
 enum MeshType : int
 {
   ORTHOGONAL,

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -30,6 +30,9 @@ public:
   MeshType GetType() const { return mesh_type_; }
   void SetType(const MeshType type) { mesh_type_ = type; }
 
+  CoordinateSystemType GetCoordinateSystem() const { return coord_sys_; }
+  void SetCoordinateSystem(const CoordinateSystemType coord_sys) { coord_sys_ = coord_sys; }
+
   bool Extruded() const { return extruded_; }
   void SetExtruded(const bool extruded) { extruded_ = extruded; }
 
@@ -151,6 +154,7 @@ private:
   /// Spatial dimension
   unsigned int dim_;
   MeshType mesh_type_;
+  CoordinateSystemType coord_sys_;
   bool extruded_;
   OrthoMeshAttributes ortho_attributes_;
   std::map<uint64_t, std::string> boundary_id_map_;

--- a/framework/mesh/mesh_generator/distributed_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/distributed_mesh_generator.cc
@@ -128,6 +128,7 @@ DistributedMeshGenerator::DistributeSerializedMeshData(const std::vector<int64_t
 
     // Basic mesh data
     serial_data.Write<unsigned int>(umesh.GetDimension());
+    serial_data.Write(static_cast<int>(umesh.GetCoordinateSystem()));
     serial_data.Write(static_cast<int>(umesh.GetType()));
     serial_data.Write(umesh.IsExtruded());
     const auto& [Nx, Ny, Nz] = umesh.GetOrthoAttributes();
@@ -204,6 +205,7 @@ DistributedMeshGenerator::DeserializeMeshData(ByteArray& serial_data)
 
   // Basic mesh data
   info_block.dimension = serial_data.Read<unsigned int>();
+  info_block.coord_sys = static_cast<CoordinateSystemType>(serial_data.Read<int>());
   info_block.mesh_type = static_cast<MeshType>(serial_data.Read<int>());
   info_block.extruded = serial_data.Read<bool>();
   info_block.ortho_attributes.Nx = serial_data.Read<size_t>();
@@ -293,6 +295,7 @@ DistributedMeshGenerator::SetupLocalMesh(DistributedMeshData& mesh_info)
   }
 
   grid_ptr->SetDimension(mesh_info.dimension);
+  grid_ptr->SetCoordinateSystem(mesh_info.coord_sys);
   grid_ptr->SetType(mesh_info.mesh_type);
   grid_ptr->SetExtruded(mesh_info.extruded);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);

--- a/framework/mesh/mesh_generator/distributed_mesh_generator.h
+++ b/framework/mesh/mesh_generator/distributed_mesh_generator.h
@@ -46,6 +46,8 @@ private:
   {
     /// Dimension of the mesh (2D, 3D).
     unsigned int dimension;
+    /// The coordinate system of the mesh.
+    CoordinateSystemType coord_sys;
     /// Type of mesh.
     MeshType mesh_type;
     /// Whether the mesh is extruded or not.

--- a/framework/mesh/mesh_generator/extruder_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/extruder_mesh_generator.cc
@@ -233,6 +233,7 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMe
   }   // for layer
 
   umesh->SetDimension(3);
+  umesh->SetCoordinateSystem(input_umesh->GetCoordinateSystem());
   umesh->SetExtruded(true);
 
   umesh->ComputeCentroids();

--- a/framework/mesh/mesh_generator/from_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/from_file_mesh_generator.h
@@ -20,6 +20,7 @@ protected:
   const std::string filename_;
   const std::string block_id_fieldname_;
   const std::string boundary_id_fieldname_;
+  const CoordinateSystemType coord_sys_;
 
 public:
   static InputParameters GetInputParameters();

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -155,6 +155,7 @@ MeshGenerator::SetupMesh(const std::shared_ptr<UnpartitionedMesh>& input_umesh,
   } // for raw_cell
 
   grid_ptr->SetDimension(input_umesh->GetDimension());
+  grid_ptr->SetCoordinateSystem(input_umesh->GetCoordinateSystem());
   grid_ptr->SetType(input_umesh->GetType());
   grid_ptr->SetExtruded(input_umesh->IsExtruded());
   grid_ptr->SetOrthoAttributes(input_umesh->GetOrthoAttributes());

--- a/framework/mesh/mesh_generator/orthogonal_mesh_generator.h
+++ b/framework/mesh/mesh_generator/orthogonal_mesh_generator.h
@@ -17,6 +17,7 @@ protected:
   std::shared_ptr<UnpartitionedMesh>
   GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> input_umesh) override;
 
+  const CoordinateSystemType coord_sys_;
   std::vector<std::vector<double>> node_sets_;
 
 public:
@@ -25,16 +26,19 @@ public:
 
 protected:
   static std::shared_ptr<UnpartitionedMesh>
-  CreateUnpartitioned1DOrthoMesh(const std::vector<double>& vertices);
+  CreateUnpartitioned1DOrthoMesh(const std::vector<double>& vertices,
+                                 CoordinateSystemType coord_sys = CARTESIAN);
 
   static std::shared_ptr<UnpartitionedMesh>
   CreateUnpartitioned2DOrthoMesh(const std::vector<double>& vertices_1d_x,
-                                 const std::vector<double>& vertices_1d_y);
+                                 const std::vector<double>& vertices_1d_y,
+                                 CoordinateSystemType coord_sys = CARTESIAN);
 
   static std::shared_ptr<UnpartitionedMesh>
   CreateUnpartitioned3DOrthoMesh(const std::vector<double>& vertices_1d_x,
                                  const std::vector<double>& vertices_1d_y,
-                                 const std::vector<double>& vertices_1d_z);
+                                 const std::vector<double>& vertices_1d_z,
+                                 CoordinateSystemType coord_sys = CARTESIAN);
 };
 
 } // namespace opensn

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.cc
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.cc
@@ -146,7 +146,7 @@ SplitFileMeshGenerator::WriteSplitMesh(const std::vector<int64_t>& cell_pids,
     // Write mesh attributes and general info
     WriteBinaryValue(ofile, num_partitions); // int
     WriteBinaryValue<unsigned int>(ofile, umesh.GetDimension());
-
+    WriteBinaryValue(ofile, static_cast<int>(umesh.GetCoordinateSystem()));
     WriteBinaryValue(ofile, static_cast<int>(umesh.GetType()));
     WriteBinaryValue(ofile, umesh.IsExtruded());
     const auto& [Nx, Ny, Nz] = umesh.GetOrthoAttributes();
@@ -254,6 +254,7 @@ SplitFileMeshGenerator::ReadSplitMesh() const
                            " processes.");
 
   info_block.dimension = ReadBinaryValue<unsigned int>(ifile);
+  info_block.coord_sys = static_cast<CoordinateSystemType>(ReadBinaryValue<int>(ifile));
   info_block.mesh_type = static_cast<MeshType>(ReadBinaryValue<int>(ifile));
   info_block.extruded = ReadBinaryValue<bool>(ifile);
   info_block.ortho_attributes.Nx = ReadBinaryValue<size_t>(ifile);
@@ -388,6 +389,7 @@ SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
   }
 
   grid_ptr->SetDimension(mesh_info.dimension);
+  grid_ptr->SetCoordinateSystem(mesh_info.coord_sys);
   grid_ptr->SetType(mesh_info.mesh_type);
   grid_ptr->SetExtruded(mesh_info.extruded);
   grid_ptr->SetOrthoAttributes(mesh_info.ortho_attributes);

--- a/framework/mesh/mesh_generator/split_file_mesh_generator.h
+++ b/framework/mesh/mesh_generator/split_file_mesh_generator.h
@@ -19,6 +19,7 @@ protected:
   struct SplitMeshInfo
   {
     unsigned int dimension;
+    CoordinateSystemType coord_sys;
     MeshType mesh_type;
     bool extruded;
     OrthoMeshAttributes ortho_attributes;

--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -59,14 +59,23 @@ public:
   unsigned int GetDimension() const { return dim_; }
   void SetDimension(unsigned int dim) { dim_ = dim; }
 
-  const BoundBox& GetBoundingBox() const { return bound_box_; }
-  void ComputeBoundingBox();
+  CoordinateSystemType GetCoordinateSystem() const { return coord_sys_; }
+  void SetCoordinateSystem(const CoordinateSystemType coord_sys) { coord_sys_ = coord_sys; }
 
   void SetType(MeshType type) { mesh_type_ = type; }
   const MeshType& GetType() const { return mesh_type_; }
 
   void SetExtruded(bool extruded) { extruded_ = extruded; }
   bool IsExtruded() const { return extruded_; }
+
+  void SetOrthoAttributes(size_t nx, size_t ny, size_t nz);
+  const OrthoMeshAttributes& GetOrthoAttributes() const { return ortho_attrs_; }
+
+  const BoundBox& GetBoundingBox() const { return bound_box_; }
+  void ComputeBoundingBox();
+
+  const std::map<uint64_t, std::string>& GetBoundaryIDMap() const { return boundary_id_map_; }
+  std::map<uint64_t, std::string>& GetBoundaryIDMap() { return boundary_id_map_; }
 
   const std::vector<std::set<uint64_t>>& GetVertextCellSubscriptions() const
   {
@@ -105,15 +114,10 @@ public:
 
   void AddBoundary(uint64_t id, const std::string& name);
 
-  const std::map<uint64_t, std::string>& GetBoundaryIDMap() const { return boundary_id_map_; }
-  std::map<uint64_t, std::string>& GetBoundaryIDMap() { return boundary_id_map_; }
-
-  void SetOrthoAttributes(size_t nx, size_t ny, size_t nz);
-  const OrthoMeshAttributes& GetOrthoAttributes() const { return ortho_attrs_; }
-
 protected:
   /// Spatial mesh dimension
   unsigned int dim_;
+  CoordinateSystemType coord_sys_;
   MeshType mesh_type_;
   bool extruded_;
   OrthoMeshAttributes ortho_attrs_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.h
@@ -17,8 +17,6 @@ namespace opensn
 class DiscreteOrdinatesCurvilinearProblem : public DiscreteOrdinatesProblem
 {
 private:
-  /// Coordinate system type.
-  CoordinateSystemType coord_system_type_;
   /** Discretisation pointer to matrices of the secondary cell view  (matrices of the primary cell
    * view forwarded to the base class).
    */

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -30,7 +30,7 @@ struct WGSContext;
 class LBSProblem : public Problem
 {
 public:
-  explicit LBSProblem(const std::string& name, std::shared_ptr<MeshContinuum> grid_ptr);
+  explicit LBSProblem(const std::string& name, std::shared_ptr<MeshContinuum> grid);
 
   /// Input parameters based construction.
   explicit LBSProblem(const InputParameters& params);
@@ -338,7 +338,7 @@ protected:
   std::vector<std::shared_ptr<PointSource>> point_sources_;
   std::vector<std::shared_ptr<VolumetricSource>> volumetric_sources_;
 
-  std::shared_ptr<MeshContinuum> grid_ptr_;
+  std::shared_ptr<MeshContinuum> grid_;
   std::shared_ptr<opensn::SpatialDiscretization> discretization_ = nullptr;
 
   std::vector<CellFaceNodalMapping> grid_nodal_mappings_;

--- a/python/lib/mesh.cc
+++ b/python/lib/mesh.cc
@@ -444,6 +444,8 @@ WrapMeshGenerator(py::module& mesh)
         Flag, when set, makes the mesh appear in full fidelity on each process.
     node_sets: List[List[float]]
         Sets of nodes per dimension. Node values must be monotonically increasing.
+    coord_sys: {'cartesian', 'cylindrical', 'spherical'}
+        The coordinate system of the mesh.
     )"
   );
 
@@ -486,6 +488,8 @@ WrapMeshGenerator(py::module& mesh)
         .e files.
     boundary_id_fieldname: str, default=''
         The name of the field storing boundary-ids.
+    coord_sys: {'cartesian', 'cylindrical', 'spherical'}
+        The coordinate system of the mesh.
     )"
   );
 
@@ -578,6 +582,8 @@ WrapMeshGenerator(py::module& mesh)
         PETScGraphPartitioner with a "parmetis" setting.
     replicated_mesh: bool, default=False
         Flag, when set, makes the mesh appear in full fidelity on each process.
+    coord_sys: {'cartesian', 'cylindrical', 'spherical'}
+        The coordinate system of the mesh.
     )"
   );
   // clang-format on

--- a/test/lua/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
+++ b/test/lua/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.lua
@@ -30,7 +30,10 @@ for d = 1, dim do
   end
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2] } })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes[1], nodes[2] },
+  coord_sys = "cylindrical",
+})
 grid = meshgen1:Execute()
 
 -- Set block IDs
@@ -57,7 +60,6 @@ pquad0 = aquad.CreateGLCProductQuadrature2DRZ(4, 8)
 
 lbs_block = {
   mesh = grid,
-  coord_system = 2,
   num_groups = ngrp,
   groupsets = {
     {

--- a/test/lua/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
+++ b/test/lua/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.lua
@@ -30,7 +30,10 @@ for d = 1, dim do
   end
 end
 
-meshgen1 = mesh.OrthogonalMeshGenerator.Create({ node_sets = { nodes[1], nodes[2] } })
+meshgen1 = mesh.OrthogonalMeshGenerator.Create({
+  node_sets = { nodes[1], nodes[2] },
+  coord_sys = "cylindrical",
+})
 grid = meshgen1:Execute()
 
 -- Set block IDs
@@ -61,7 +64,6 @@ pquad0 = aquad.CreateGLCProductQuadrature2DRZ(4, 8)
 
 lbs_block = {
   mesh = grid,
-  coord_system = 2,
   num_groups = ngrp,
   groupsets = {
     {

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.py
@@ -14,6 +14,7 @@ import math
 
 if "opensn_console" not in globals():
     from mpi4py import MPI
+
     size = MPI.COMM_WORLD.size
     rank = MPI.COMM_WORLD.rank
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
@@ -40,7 +41,7 @@ if __name__ == "__main__":
         delta = length[d] / ncells[d]
         node_set = [i * delta for i in range(ncells[d] + 1)]
         nodes.append(node_set)
-    meshgen = OrthogonalMeshGenerator(node_sets=[nodes[0], nodes[1]])
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes[0], nodes[1]], coord_sys="cylindrical")
     grid = meshgen.Execute()
 
     # Set block IDs
@@ -69,7 +70,6 @@ if __name__ == "__main__":
     # Create the curvilinear solver (for cylindrical geometry)
     phys = DiscreteOrdinatesCurvilinearProblem(
         mesh=grid,
-        coord_system=2,
         num_groups=ngrp,
         groupsets=[
             {

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.py
@@ -13,6 +13,7 @@ import sys
 
 if "opensn_console" not in globals():
     from mpi4py import MPI
+
     size = MPI.COMM_WORLD.size
     rank = MPI.COMM_WORLD.rank
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
@@ -39,7 +40,7 @@ if __name__ == "__main__":
         delta = length[d] / ncells[d]
         node_set = [i * delta for i in range(ncells[d] + 1)]
         nodes.append(node_set)
-    meshgen = OrthogonalMeshGenerator(node_sets=[nodes[0], nodes[1]])
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes[0], nodes[1]], coord_sys="cylindrical")
     grid = meshgen.Execute()
 
     # Define a logical volume covering the entire domain and set block IDs
@@ -66,7 +67,6 @@ if __name__ == "__main__":
     # Create and configure the curvilinear solver for cylindrical geometry
     phys = DiscreteOrdinatesCurvilinearProblem(
         mesh=grid,
-        coord_system=2,
         num_groups=ngrp,
         groupsets=[
             {


### PR DESCRIPTION
This PR moves coordinate system information to the mesh from discretizations. Coordinate systems can now be set within `OrthogonalMeshGenerator` and `FromFileMeshGenerator` using the `coord_sys` argument in input parameters. Coordinate system inputs were also standardized to `coord_sys` across the input language and the curvilinear solver was cleaned up.