### PR TITLE
Falling back to module mode if find_package(Boost CONFIG) fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,11 @@ if (OPENSN_WITH_CUDA)
 endif()
 
 find_package(HDF5 REQUIRED COMPONENTS C HL)
-find_package(Boost REQUIRED CONFIG)
+find_package(Boost CONFIG)
+if (NOT Boost_FOUND)
+    message(STATUS "Boost CONFIG not found, falling back to module mode")
+    find_package(Boost REQUIRED)
+endif()
 
 if(OPENSN_WITH_LUA)
     find_package(Lua 5.3 REQUIRED)


### PR DESCRIPTION
Header only installs of Boost don't include `BoostConfig.cmake`. Since many installs are header-only, fall back to using the `FindBoost` module if `find_package(Boost CONFIG)` fails.