### PR TITLE
Temporarily removing tutorials from sanitizer workflow

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -62,13 +62,6 @@ jobs:
           module load python3/3.12.3 opensn/clang/17
           export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
           test/run_tests -d test/python -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/python/opensn-test
-      - name: test tutorials
-        shell: bash
-        run: |
-          module load python3/3.12.3 opensn/clang/17
-          export LSAN_OPTIONS=suppressions=$PWD/tools/developer/lsan.supp
-          export PYTHONPATH=$PWD/build-debug-sanitizer
-          test/run_tests -d tutorials/python -j 32 -v 1 -w 3 --exe build-debug-sanitizer/test/python/opensn-test
 
   coverage:
     runs-on: [self-hosted]

--- a/test/src/test_slot.py
+++ b/test/src/test_slot.py
@@ -147,7 +147,7 @@ class TestSlot:
         test_file_name = os.path.relpath(test_path, self.argv.directory)
 
         if not os.path.isfile(test_path):
-            test.annotations.append("Lua file missing")
+            test.annotations.append("Input file missing")
 
         args_str = ', '.join(map(str, test.args))
         if len(args_str) != 0:


### PR DESCRIPTION
This PR temporarily removes tutorials from our sanitizer workflow until our CI Python install supports sanitizers.