### PR TITLE
Fixing install target for lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,12 @@ if(OPENSN_WITH_LUA)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/opensn
         FILES_MATCHING PATTERN "*.h"
     )
+
+    install(
+        DIRECTORY ${CMAKE_SOURCE_DIR}/external/LuaBridge
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/opensn
+        FILES_MATCHING PATTERN "*.h"
+    )
 endif()
 
 if(OPENSN_WITH_PYTHON)

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -9,16 +9,18 @@ target_include_directories(libopensnlua
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/external
+    PUBLIC
     ${LUA_INCLUDE_DIR}
 )
 
 target_link_libraries(libopensnlua
     PRIVATE
     libopensn
-    ${LUA_LIBRARIES}
     ${PETSC_LIBRARY}
     MPI::MPI_CXX
     caliper
+    PUBLIC
+    ${LUA_LIBRARIES}
 )
 
 target_compile_definitions(libopensnlua PRIVATE OPENSN_WITH_LUA)


### PR DESCRIPTION
- Lua is a dependency, so needs to be included and linked publicly, so the depending apps do not have to bother with discovering, including, and linking the libs. We really want to use the header location and libs we built OpenSn against
- Also, install LuaBridge so that OpenSn-based apps can register/bind their new classes