### PR TITLE
typo in filename broke the doco build

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -76,8 +76,8 @@ if(DOXYGEN_FOUND AND NOT ${SPHINX_BUILD} STREQUAL SPHINX_BUILD-NOTFOUND)
             src/tutorials/mesh/mesh_read_gmsh_3D.ipynb COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/tutorials/python/mesh/mesh_read_obj_2D.ipynb
             src/tutorials/mesh/mesh_read_obj_2D.ipynb COPYONLY)
-    configure_file(${CMAKE_SOURCE_DIR}/tutorials/python/mesh/mesh_read_VTU_3D.ipynb
-            src/tutorials/mesh/mesh_read_VTU_3D.ipynb COPYONLY)
+    configure_file(${CMAKE_SOURCE_DIR}/tutorials/python/mesh/mesh_read_vtu_3D.ipynb
+            src/tutorials/mesh/mesh_read_vtu_3D.ipynb COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/tutorials/python/mesh/mesh_extrude.ipynb
             src/tutorials/mesh/mesh_extrude.ipynb COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/tutorials/python/mesh/mesh_ortho_3D_blockIDs.ipynb

--- a/tutorials/python/mesh/index.rst
+++ b/tutorials/python/mesh/index.rst
@@ -10,6 +10,6 @@ Meshing and Partitioning
    mesh_read_gmsh_2D
    mesh_read_gmsh_3D
    mesh_read_obj_2D
-   mesh_read_VTU_3D
+   mesh_read_vtu_3D
    mesh_extrude
    mesh_ortho_3D_blockIDs


### PR DESCRIPTION
this should fix the doc not building. I changed the notebook file name to be lowercase vtu and the cmakelist was not changed appropriately. sorry, it was not caught during the review process and i suppose that trying to build the doc is not part of testing