### PR TITLE
Add external library wrapping CUDA API (on going)

### DIFF
--- a/external/gpu/.clang-format
+++ b/external/gpu/.clang-format
@@ -1,0 +1,73 @@
+Language:        Cpp
+BasedOnStyle:  LLVM
+
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments:
+  PadOperators:    false
+AlignOperands:   AlignAfterOperator
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: true
+AttributeMacros:
+  - __host__
+  - __device__
+  - __global__
+  - __shared__
+  - __managed__
+  - __cuhost__
+  - __cudevice__
+  - __cuhostdev__
+BraceWrapping:
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAfterAttributes: Always
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterComma
+ColumnLimit:     120
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IndentWidth:     4
+IndentCaseBlocks:    false
+IndentCaseLabels:    true
+InsertBraces:    true
+InsertNewlineAtEOF: true
+IndentPPDirectives: BeforeHash
+IndentRequiresClause: false
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 40
+PenaltyExcessCharacter: 100
+PointerAlignment: Middle
+ReferenceAlignment: Middle
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SpaceAfterCStyleCast: true
+SpaceBeforeCaseColon: true
+SpaceAroundPointerQualifiers: Both
+SpacesBeforeTrailingComments: 2
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         1
+Standard:        c++20

--- a/external/gpu/cuda/allocator.hpp
+++ b/external/gpu/cuda/allocator.hpp
@@ -1,0 +1,73 @@
+/*
+ * Created on Fri, April 04 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_ALLOCATOR_HPP_
+#define GPU_CUDA_ALLOCATOR_HPP_
+
+#include <cstddef>  // std::size_t
+
+#include "declaration.hpp"  // cuda::PinnedHostAllocator
+#include "exception.hpp"    // cuda::check_cuda_error
+
+namespace gpu {
+
+// Pinned memory allocator
+// -----------------------
+
+/** @brief Allocator for host pinned memory.
+ *  @details A memory allocator for host memory, designed to ensure compatibility with C++ containers (after C++20).
+ *  Memory pages of the allocated region are pinned to the physical memory, ensuring seamless asynchronous data
+ *  transfer.
+ */
+template <typename T>
+class cuda::PinnedHostAllocator {
+  public:
+    /** @brief Value type */
+    using value_type = T;
+
+    /// @name Contructors
+    /// @{
+    /** @brief Default constructor.*/
+    PinnedHostAllocator() noexcept = default;
+    /** @brief Constructor from another allocator.*/
+    template <class U>
+    PinnedHostAllocator(const cuda::PinnedHostAllocator<U> & src) noexcept {}
+    /// @}
+
+    /// @name Actions
+    /// @{
+    /** @brief Allocate memory.
+     *  @details Allocate ``n * sizeof(T)`` bytes on the current device and return the pointer to the allocated region.
+     */
+    T * allocate(std::size_t n) {
+        if (n == 0) {
+            return nullptr;
+        }
+        T * result = nullptr;
+        cuda::check_cuda_error(::cudaMallocHost(&result, n * sizeof(T)));
+        return result;
+    }
+    /** @brief Deallocate memory.*/
+    void deallocate(T * ptr, std::size_t n) noexcept {
+        if (ptr) {
+            ::cudaFreeHost(ptr);
+        }
+    }
+    /** @brief Construct an object at a given address in the allocated memory (remove after C++17).*/
+    template <class U, class... Args>
+    void construct(U * p, Args &&... args) {
+        ::new (reinterpret_cast<void *>(p)) U(std::forward<Args>(args)...);
+    }
+    /** @brief Destroy an object at a given address in the allocated memory (remove after C++17).*/
+    template <class U>
+    void destroy(U * p) {
+        p->~U();
+    }
+    /// @}
+};
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_ALLOCATOR_HPP_

--- a/external/gpu/cuda/declaration.hpp
+++ b/external/gpu/cuda/declaration.hpp
@@ -1,0 +1,27 @@
+/*
+ * Created on Fri, April 04 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_DECLARATION_HPP_
+#define GPU_CUDA_DECLARATION_HPP_
+
+namespace gpu::cuda {
+
+class CudaException;
+inline void check_cuda_error(::cudaError_t error);
+
+template <typename T>
+class PinnedHostAllocator;
+
+template <typename T>
+class SynchronousDeviceDeleter;
+
+template <typename T>
+T * device_malloc(std::size_t size);
+
+class Stream;
+
+}  // namespace gpu::cuda
+
+#endif  // GPU_CUDA_DECLARATION_HPP_

--- a/external/gpu/cuda/deleter.hpp
+++ b/external/gpu/cuda/deleter.hpp
@@ -1,0 +1,31 @@
+/*
+ * Created on Tue, April 08 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_DELETER_HPP_
+#define GPU_CUDA_DELETER_HPP_
+
+#include "declaration.hpp"  // cuda::SynchronousDeviceDeleter
+#include "exception.hpp"    // cuda::check_cuda_error
+
+namespace gpu {
+
+/** @brief Deleter for cudaFree.*/
+template <typename T>
+class cuda::SynchronousDeviceDeleter {
+  public:
+    /** @brief Default constructor.*/
+    constexpr SynchronousDeviceDeleter(void) = default;
+
+    /** @brief Copy constructor.*/
+    template <class U>
+    SynchronousDeviceDeleter(const SynchronousDeviceDeleter<U> & other) noexcept {}
+
+    /** @brief Call operator.*/
+    inline void operator()(T * ptr) const { cuda::check_cuda_error(::cudaFree(reinterpret_cast<void *>(ptr))); }
+};
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_DELETER_HPP_

--- a/external/gpu/cuda/exception.hpp
+++ b/external/gpu/cuda/exception.hpp
@@ -1,0 +1,41 @@
+/*
+ * Created on Tue, April 01 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_EXCEPTION_HPP_
+#define GPU_CUDA_EXCEPTION_HPP_
+
+#include <stdexcept>  // std::runtime_error
+#include <string>     // std::string
+#include <sstream>    // std::ostringstream
+
+#include "declaration.hpp"  // cuda::CudaException, cuda::check_cuda_error
+
+namespace gpu {
+
+/** @brief Exception to be thrwon when encountering a CUDA error.*/
+class cuda::CudaException : public std::runtime_error {
+    public:
+      /** @brief Constructor.*/
+      explicit CudaException(::cudaError_t error) : std::runtime_error(cuda::CudaException::build_message(error)) {}
+
+  private:
+      /** @brief Helper function to build an informative error message.*/
+      static std::string build_message(::cudaError_t error) {
+          std::ostringstream message;
+          message << "CUDA Error(" << static_cast<int>(error) << "): " << ::cudaGetErrorString(error);
+          return message.str();
+      }
+  };
+
+/** @brief Check for CUDA error and throw.*/
+inline void cuda::check_cuda_error(::cudaError_t error) {
+    if (error != 0) {
+        throw cuda::CudaException(error);
+    }
+}
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_EXCEPTION_HPP_

--- a/external/gpu/cuda/main.hpp
+++ b/external/gpu/cuda/main.hpp
@@ -1,0 +1,36 @@
+/*
+ * Created on Tue, April 01 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_MAIN_HPP_
+#define GPU_CUDA_MAIN_HPP_
+
+#include <vector>  // std::vector
+#include <memory>  // std::unique_ptr
+
+#include "allocator.hpp"  // cuda::PinnedHostAllocator
+#include "deleter.hpp"    // cuda::SynchronousDeviceDeleter
+#include "malloc.hpp"     // cuda::device_malloc
+
+namespace gpu {
+
+/** @brief Pinned memory host vector.
+ *  @details Vector with memory allocated on pinned pages.
+ */
+template <typename T>
+using HostVector = std::vector<T, cuda::PinnedHostAllocator<T>>;
+
+/** @brief Device memory.*/
+template <typename T>
+using DeviceMemory = std::unique_ptr<T, cuda::SynchronousDeviceDeleter<T>>;
+
+/** @brief Allocate device memory.*/
+template <typename T>
+DeviceMemory<T> malloc(std::size_t n) {
+    return DeviceMemory<T>(cuda::device_malloc<T>(n));
+}
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_MAIN_HPP_

--- a/external/gpu/cuda/malloc.hpp
+++ b/external/gpu/cuda/malloc.hpp
@@ -1,0 +1,24 @@
+/*
+ * Created on Fri, April 11 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_MALLOC_HPP_
+#define GPU_CUDA_MALLOC_HPP_
+
+#include "declaration.hpp"  // cuda::device_malloc
+#include "exception.hpp"    // cuda::check_cuda_error
+
+namespace gpu {
+
+/** @brief Allocate device memory.*/
+template <typename T>
+T * cuda::device_malloc(std::size_t size) {
+    T * result;
+    cuda::check_cuda_error(::cudaMalloc(&result, sizeof(T) * size));
+    return result;
+}
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_MALLOC_HPP_

--- a/external/gpu/cuda/stream.hpp
+++ b/external/gpu/cuda/stream.hpp
@@ -1,0 +1,37 @@
+/*
+ * Created on Fri, April 11 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_CUDA_STREAM_HPP_
+#define GPU_CUDA_STREAM_HPP_
+
+#include <memory>       // std::shared_ptr
+#include <type_traits>  // std::remove_pointer_t
+
+#include "exception.hpp"  // cuda::check_cuda_error
+
+namespace gpu {
+
+using CudaStreamWrapper = std::shared_ptr<std::remove_pointer<::cudaStream_t>::type>;
+
+/** @brief CUDA stream.*/
+class cuda::Stream {
+  public:
+    /** @brief Default constructor.*/
+    inline Stream(void) {
+        ::cudaStream_t stream_ptr;
+        cuda::check_cuda_error(::cudaStreamCreate(&stream_ptr));
+        this->stream_ptr_ = CudaStreamWrapper(stream_ptr, ::cudaStreamDestroy);
+    }
+    /** @brief Take ownership from another pre-created CUDA stream.*/
+    inline Stream(::cudaStream_t stream_ptr) : stream_ptr_(stream_ptr, ::cudaStreamDestroy) {}
+
+  private:
+    /** @brief Underlying shared pointer.*/
+    CudaStreamWrapper stream_ptr_;
+};
+
+}  // namespace gpu
+
+#endif  // GPU_CUDA_STREAM_HPP_

--- a/external/gpu/gpu.h
+++ b/external/gpu/gpu.h
@@ -1,0 +1,13 @@
+/*
+ * Created on Tue, April 01 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#ifndef GPU_GPU_H
+#define GPU_GPU_H
+
+#ifdef __NVCC__
+    #include "cuda/main.hpp"
+#endif  // __NVCC__
+
+#endif  // GPU_GPU_H


### PR DESCRIPTION
In this PR:

 - Wrapper for GPU memory is added under the namespace `gpu`.
 - `Stream`, GPU memory allocator and pinned host `std::vector` was added.

In the future, a similar wrapper for hip ROCm (targeting AMD GPUs) will be added.