### PR TITLE
Removing block id remapping for Gmsh meshes

### DIFF
--- a/framework/mesh/io/gmsh_io_v22.cc
+++ b/framework/mesh/io/gmsh_io_v22.cc
@@ -302,35 +302,6 @@ MeshIO::FromGmshV22(const UnpartitionedMesh::Options& options)
 
   file.close();
 
-  // Remap block-ids
-  std::set<int> block_ids_set_as_read;
-  std::map<int, int> block_mapping;
-
-  for (auto& cell : mesh->GetRawCells())
-    block_ids_set_as_read.insert(cell->block_id);
-
-  std::set<int> boundary_ids_set_as_read;
-  std::map<int, int> boundary_mapping;
-
-  for (auto& cell : mesh->GetRawBoundaryCells())
-    boundary_ids_set_as_read.insert(cell->block_id);
-
-  {
-    int m = 0;
-    for (const auto& mat_id : block_ids_set_as_read)
-      block_mapping.insert(std::make_pair(mat_id, m++));
-
-    int b = 0;
-    for (const auto& bndry_id : boundary_ids_set_as_read)
-      boundary_mapping.insert(std::make_pair(bndry_id, b++));
-  }
-
-  for (auto& cell : mesh->GetRawCells())
-    cell->block_id = block_mapping[cell->block_id];
-
-  for (auto& cell : mesh->GetRawBoundaryCells())
-    cell->block_id = boundary_mapping[cell->block_id];
-
   unsigned int dimension = (mesh_is_2D) ? 2 : 3;
   mesh->SetDimension(dimension);
   mesh->SetType(UNSTRUCTURED);

--- a/framework/mesh/io/gmsh_io_v41.cc
+++ b/framework/mesh/io/gmsh_io_v41.cc
@@ -279,9 +279,6 @@ MeshIO::FromGmshV41(const UnpartitionedMesh::Options& options)
     }
   }
 
-  if (element_data.size() != num_elements)
-    throw std::logic_error(fname + ": Missing element data.");
-
   for (const auto& [element_tag, element_type, physical_reg, node_tags] : element_data)
   {
     auto& raw_boundary_cells = mesh->GetRawBoundaryCells();
@@ -391,35 +388,6 @@ MeshIO::FromGmshV41(const UnpartitionedMesh::Options& options)
   } // for elements
 
   file.close();
-
-  // Remap block-ids
-  std::set<int> block_ids_set_as_read;
-  std::map<int, int> block_mapping;
-
-  for (auto& cell : mesh->GetRawCells())
-    block_ids_set_as_read.insert(cell->block_id);
-
-  std::set<int> boundary_ids_set_as_read;
-  std::map<int, int> boundary_mapping;
-
-  for (auto& cell : mesh->GetRawBoundaryCells())
-    boundary_ids_set_as_read.insert(cell->block_id);
-
-  {
-    int m = 0;
-    for (const auto& blk_id : block_ids_set_as_read)
-      block_mapping.insert(std::make_pair(blk_id, m++));
-
-    int b = 0;
-    for (const auto& bndry_id : boundary_ids_set_as_read)
-      boundary_mapping.insert(std::make_pair(bndry_id, b++));
-  }
-
-  for (auto& cell : mesh->GetRawCells())
-    cell->block_id = block_mapping[cell->block_id];
-
-  for (auto& cell : mesh->GetRawBoundaryCells())
-    cell->block_id = boundary_mapping[cell->block_id];
 
   unsigned int dimension = (mesh_is_2D) ? 2 : 3;
   mesh->SetDimension(dimension);

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -1017,7 +1017,6 @@ LBSProblem::InitializeMaterials()
     {
       const auto& xs_ptr = block_id_to_xs_map_[cell.block_id];
       auto& transport_view = cell_transport_views_[cell.local_id];
-
       transport_view.ReassignXS(*xs_ptr);
     }
 
@@ -1291,7 +1290,6 @@ LBSProblem::InitializeParrays()
   for (auto& cell : grid_ptr_->local_cells)
   {
     size_t num_nodes = discretization_->GetCellNumNodes(cell);
-    int mat_id = cell.block_id;
 
     // compute cell volumes
     double cell_volume = 0.0;
@@ -1347,13 +1345,12 @@ LBSProblem::InitializeParrays()
 
     if (num_nodes > max_cell_dof_count_)
       max_cell_dof_count_ = num_nodes;
-
     cell_transport_views_.emplace_back(cell_phi_address,
                                        num_nodes,
                                        num_grps,
                                        num_moments_,
                                        num_faces,
-                                       *block_id_to_xs_map_[mat_id],
+                                       *block_id_to_xs_map_[cell.block_id],
                                        cell_volume,
                                        face_local_flags,
                                        face_locality,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v2.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     # Source
     strength = [0.0 for _ in range(num_groups)]
     strength[0] = 100.0
-    mg_src = VolumetricSource(block_ids=[1], group_strength=strength)
+    mg_src = VolumetricSource(block_ids=[2], group_strength=strength)
 
     # Quadrature
     Npolar = 4
@@ -59,7 +59,7 @@ if __name__ == "__main__":
             },
         ],
         xs_map=[
-            {"block_ids": [0, 1], "xs": xs_diag},
+            {"block_ids": [1, 2], "xs": xs_diag},
         ],
         options={
             "boundary_conditions": [

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v4.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v4.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     # Source
     strength = [0.0 for _ in range(num_groups)]
     strength[0] = 100.0
-    mg_src = VolumetricSource(block_ids=[1], group_strength=strength)
+    mg_src = VolumetricSource(block_ids=[2], group_strength=strength)
 
     # Quadrature
     Npolar = 4
@@ -59,7 +59,7 @@ if __name__ == "__main__":
             },
         ],
         xs_map=[
-            {"block_ids": [0, 1], "xs": xs_diag},
+            {"block_ids": [1, 2], "xs": xs_diag},
         ],
         options={
             "boundary_conditions": [

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v2.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # Source
     strength = [0.0 for _ in range(num_groups)]
     strength[0] = 100.0
-    mg_src = VolumetricSource(block_ids=[1], group_strength=strength)
+    mg_src = VolumetricSource(block_ids=[2], group_strength=strength)
 
     # Quadrature
     Npolar = 4
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             },
         ],
         xs_map=[
-            {"block_ids": [0, 1], "xs": xs_diag},
+            {"block_ids": [1, 2, 3], "xs": xs_diag},
         ],
         options={
             "boundary_conditions": [

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v4.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v4.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # Source
     strength = [0.0 for _ in range(num_groups)]
     strength[0] = 100.0
-    mg_src = VolumetricSource(block_ids=[1], group_strength=strength)
+    mg_src = VolumetricSource(block_ids=[2], group_strength=strength)
 
     # Quadrature
     Npolar = 4
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             },
         ],
         xs_map=[
-            {"block_ids": [0, 1], "xs": xs_diag},
+            {"block_ids": [1, 2, 3], "xs": xs_diag},
         ],
         options={
             "boundary_conditions": [


### PR DESCRIPTION
The current behavior for OpenSn is to remap Gmsh physical region ids so that block ids always starts at 0. For example, a Gmsh mesh with physical regions 1 and 2 will have those regions remapped to block ids 0 and 1. This PR removes this remapping so that block ids correspond to the original Gmsh physical region tags.