### PR TITLE
returning the volume per blockID in python

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -767,8 +767,8 @@ MeshContinuum::MapCellFace(const Cell& cur_cell, const Cell& adj_cell, const uns
   throw std::logic_error("MeshContinuum::MapCellFace: Mapping failure.");
 }
 
-void
-MeshContinuum::ComputeVolumePerBlockID()
+std::map<int, double>
+MeshContinuum::ComputeVolumePerBlockID() const
 {
   // Create a map to hold local volume with local block as key
   std::map<int, double> block_volumes;
@@ -823,13 +823,7 @@ MeshContinuum::ComputeVolumePerBlockID()
     global_block_volumes[global_block_ids[i]] = global_volumes[i];
   }
 
-  // Output the volumes per material_id on the root process
-  if (mpi_comm.rank() == 0)
-  {
-    for (const auto& [id, vol] : global_block_volumes)
-      log.Log() << "Block ID: " << id << " Volume: " << std::setprecision(12) << vol << std::endl;
-    log.Log() << std::endl;
-  }
+  return global_block_volumes;
 }
 
 } // namespace opensn

--- a/framework/mesh/mesh_continuum/mesh_continuum.h
+++ b/framework/mesh/mesh_continuum/mesh_continuum.h
@@ -145,7 +145,7 @@ public:
   GlobalCellHandler cells;
 
   /// Compute volume per block IDs
-  void ComputeVolumePerBlockID();
+  std::map<int, double> ComputeVolumePerBlockID() const;
 
 private:
   /// Spatial dimension

--- a/python/lib/mesh.cc
+++ b/python/lib/mesh.cc
@@ -18,6 +18,7 @@
 #include "framework/mesh/surface_mesh/surface_mesh.h"
 #include "framework/utils/timer.h"
 #include <pybind11/functional.h>
+#include <pybind11/stl.h>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -120,7 +121,14 @@ WrapMesh(py::module& mesh)
   mesh_continuum.def(
     "ComputeVolumePerBlockID",
     &MeshContinuum::ComputeVolumePerBlockID,
-    "Compute volume per block ID."
+    R"(
+    Compute volume per block ID
+
+    Returns
+    -------
+    Dict[int, float]
+        Key is the block ID and the value is the computed volume
+    )"
   );
   mesh_continuum.def(
     "SetBlockIDFromFunction",

--- a/test/python/framework/mesh/tests.json
+++ b/test/python/framework/mesh/tests.json
@@ -25,13 +25,13 @@
     "checks": [
       {
         "type": "KeyValuePair",
-        "key": "[0]  Block ID: 0 Volume:",
+        "key": "Block 0: volume =",
         "goldvalue": 11.25,
         "abs_tol": 1.0e-6
       },
       {
         "type": "KeyValuePair",
-        "key": "[0]  Block ID: 1 Volume:",
+        "key": "Block 1: volume =",
         "goldvalue": 13.75,
         "abs_tol": 1.0e-6
       }

--- a/test/python/framework/mesh/volume_per_material.py
+++ b/test/python/framework/mesh/volume_per_material.py
@@ -45,4 +45,9 @@ if __name__ == "__main__":
     vol1 = RPPLogicalVolume(xmin=-1000.0, xmax=L / N, infy=True, infz=True)
     grid.SetBlockIDFromLogicalVolume(vol1, 1, True)
 
-    grid.ComputeVolumePerBlockID()
+    volumes_per_block = grid.ComputeVolumePerBlockID()
+
+    if rank == 0:
+        # iterate through block → volume
+        for block_id, volume in volumes_per_block.items():
+            print(f"Block {block_id}: volume = {volume:.4f}")


### PR DESCRIPTION
returning the volume per blockID in python

usage is:
```
volumes_per_block = grid.ComputeVolumePerBlockID()

# iterate through block → volume
for block_id, volume in volumes_per_block.items():
    print(f"Block {block_id}: volume = {volume:.6e}")
```