### PR TITLE
Modified CBC FLUDS to have its own vector that stores local cell angular fluxes

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/lbs_discrete_ordinates_solver.cc
@@ -231,7 +231,7 @@ DiscreteOrdinatesSolver::ReorientAdjointSolution()
                                std::to_string(gs) + " not found.");
 
       } // for angle m
-    }   // if saving angular flux
+    } // if saving angular flux
 
     const auto num_gs_groups = groupset.groups.size();
     const auto gsg_i = groupset.groups.front().id;
@@ -260,7 +260,7 @@ DiscreteOrdinatesSolver::ReorientAdjointSolution()
             phi_new_local_[dof_map + g] *= std::pow(-1.0, ell);
             phi_old_local_[dof_map + g] *= std::pow(-1.0, ell);
           } // for group g
-        }   // for moment m
+        } // for moment m
 
         // Reorient angular flux
         if (options_.save_angular_flux)
@@ -276,7 +276,7 @@ DiscreteOrdinatesSolver::ReorientAdjointSolution()
           }
         }
       } // for node i
-    }   // for cell
+    } // for cell
 
   } // for groupset
 }
@@ -368,13 +368,13 @@ DiscreteOrdinatesSolver::ComputeBalance()
                     const double psi = *bndry->PsiIncoming(cell.local_id, f, fi, n, g);
                     local_in_flow -= mu * wt * psi * IntFi_shapeI;
                   } // for group
-                }   // for fi
-              }     // if mu < 0
-            }       // for n
-          }         // for groupset
-        }           // if reflecting boundary
-      }             // if boundary
-    }               // for f
+                } // for fi
+              } // if mu < 0
+            } // for n
+          } // for groupset
+        } // if reflecting boundary
+      } // if boundary
+    } // for f
 
     // Outflow: The group-wise outflow was determined during a solve so we just accumulate it here.
     for (int f = 0; f < cell.faces.size(); ++f)
@@ -395,8 +395,8 @@ DiscreteOrdinatesSolver::ComputeBalance()
         local_absorption += sigma_a[g] * phi_0g * IntV_shapeI(i);
         local_production += q_0g * IntV_shapeI(i);
       } // for g
-    }   // for i
-  }     // for cell
+    } // for i
+  } // for cell
 
   // Compute local balance
   double local_balance = local_production + local_in_flow - local_absorption - local_out_flow;
@@ -484,13 +484,13 @@ DiscreteOrdinatesSolver::ComputeLeakage(const unsigned int groupset_id,
                 const auto psi = psi_new_local_[groupset_id][imap];
                 local_leakage[gsg] += weight * mu * psi * int_f_shape_i(i);
               } // for g
-            }   // outgoing
-          }     // for n
-        }       // for face node
-      }         // if right bndry
+            } // outgoing
+          } // for n
+        } // for face node
+      } // if right bndry
       ++f;
     } // for face
-  }   // for cell
+  } // for cell
 
   // Communicate to obtain global leakage
   std::vector<double> global_leakage(num_gs_groups, 0.0);
@@ -570,13 +570,13 @@ DiscreteOrdinatesSolver::ComputeLeakage(const std::vector<uint64_t>& boundary_id
                 const auto imap = discretization_->MapDOFLocal(cell, i, psi_uk_man, n, gsg);
                 bndry_leakage[g] += coeff * psi_gs[imap];
               } // for groupset group gsg
-            }   // for angle n
-          }     // for face index fi
-        }       // if face on desired boundary
+            } // for angle n
+          } // for face index fi
+        } // if face on desired boundary
         ++f;
       } // for face
-    }   // for cell
-  }     // for groupset gs
+    } // for cell
+  } // for groupset gs
 
   // Serialize the data
   std::vector<double> local_data;
@@ -963,7 +963,7 @@ DiscreteOrdinatesSolver::AssociateSOsAndDirections(const std::shared_ptr<MeshCon
 
       ++so_grouping_id;
     } // for so_grouping
-  }   // map scope
+  } // map scope
 
   return {unq_so_grps, dir_id_to_so_map};
 }
@@ -1030,14 +1030,10 @@ DiscreteOrdinatesSolver::InitFluxDataStructures(LBSGroupset& groupset)
       }
       else if (sweep_type_ == "CBC")
       {
-        OpenSnLogicalErrorIf(not options_.save_angular_flux,
-                             "When using sweep_type \"CBC\" then "
-                             "\"save_angular_flux\" must be true.");
         std::shared_ptr<FLUDS> fluds =
           std::make_shared<CBC_FLUDS>(gs_num_grps,
                                       angle_indices.size(),
                                       dynamic_cast<const CBC_FLUDSCommonData&>(fluds_common_data),
-                                      psi_new_local_[groupset.id],
                                       groupset.psi_uk_man_,
                                       *discretization_);
 
@@ -1054,7 +1050,7 @@ DiscreteOrdinatesSolver::InitFluxDataStructures(LBSGroupset& groupset)
       else
         OpenSnInvalidArgument("Unsupported sweeptype \"" + sweep_type_ + "\"");
     } // for an_ss
-  }   // for so_grouping
+  } // for so_grouping
 
   groupset.angle_agg->angle_set_groups.push_back(std::move(angle_set_group));
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_aggregation/angle_aggregation.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_aggregation/angle_aggregation.cc
@@ -65,7 +65,7 @@ AngleAggregation::ZeroIncomingDelayedPsi()
                   val = 0.0;
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -202,7 +202,7 @@ AngleAggregation::InitializeReflectingBCs()
             ++f;
           }
         } // for cells
-      }   // for angles
+      } // for angles
 
       // Determine if boundary is opposing reflecting
       // The boundary with the smallest bid will
@@ -228,7 +228,7 @@ AngleAggregation::InitializeReflectingBCs()
 
       reflecting_bcs_initialized = true;
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   if (reflecting_bcs_initialized)
     log.Log0Verbose1() << "Reflecting boundary conditions initialized.";
@@ -261,7 +261,7 @@ AngleAggregation::GetNumDelayedAngularDOFs()
                 local_ang_unknowns += dofvec.size();
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -307,7 +307,7 @@ AngleAggregation::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* x_r
                 }
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -353,7 +353,7 @@ AngleAggregation::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* x_r
                 }
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -399,7 +399,7 @@ AngleAggregation::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double
                 }
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -445,7 +445,7 @@ AngleAggregation::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double
                 }
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -493,7 +493,7 @@ AngleAggregation::GetNewDelayedAngularDOFsAsSTLVector()
                   psi_vector.push_back(val);
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -541,7 +541,7 @@ AngleAggregation::SetNewDelayedAngularDOFsFromSTLVector(const std::vector<double
                   val = stl_vector[index++];
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -583,7 +583,7 @@ AngleAggregation::GetOldDelayedAngularDOFsAsSTLVector()
                   psi_vector.push_back(val);
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -631,7 +631,7 @@ AngleAggregation::SetOldDelayedAngularDOFsFromSTLVector(const std::vector<double
                   val = stl_vector[index++];
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -663,7 +663,7 @@ AngleAggregation::SetDelayedPsiOld2New()
         rbndry.GetBoundaryFluxNew() = rbndry.GetBoundaryFluxOld();
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
@@ -693,7 +693,7 @@ AngleAggregation::SetDelayedPsiNew2Old()
         rbndry.GetBoundaryFluxOld() = rbndry.GetBoundaryFluxNew();
 
     } // if reflecting
-  }   // for bndry
+  } // for bndry
 
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.cc
@@ -69,8 +69,7 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
         all_tasks_completed = false;
       if (cell_task.num_dependencies == 0 and not cell_task.completed)
       {
-        sweep_chunk.SetCell(cell_task.cell_ptr, *this);
-        sweep_chunk.Sweep(*this);
+        const Cell* cell_ptr = cell_task.cell_ptr;
 
         for (uint64_t local_task_num : cell_task.successors)
           --current_task_list_[local_task_num].num_dependencies;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/cbc_angle_set.h
@@ -5,6 +5,7 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/angle_set/angle_set.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/cbc_async_comm.h"
+#include "modules/linear_boltzmann_solvers/lbs_solver/lbs_solver.h"
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/cbc_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/communicators/cbc_async_comm.cc
@@ -125,7 +125,7 @@ CBC_ASynchronousCommunicator::ReceiveData()
         cells_who_received_data.push_back(
           fluds_.GetSPDS().GetGrid()->MapCellGlobalID2LocalID(cell_global_id));
       } // while not at end of buffer
-    }   // Process each message embedded in buffer
+    } // Process each message embedded in buffer
   }
 
   cbc_fluds_.GetDeplocsOutgoingMessages().merge(received_messages);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.cc
@@ -12,15 +12,18 @@ namespace opensn
 CBC_FLUDS::CBC_FLUDS(size_t num_groups,
                      size_t num_angles,
                      const CBC_FLUDSCommonData& common_data,
-                     std::vector<double>& local_psi_data,
                      const UnknownManager& psi_uk_man,
                      const SpatialDiscretization& sdm)
   : FLUDS(num_groups, num_angles, common_data.GetSPDS()),
     common_data_(common_data),
-    local_psi_data_(local_psi_data),
     psi_uk_man_(psi_uk_man),
     sdm_(sdm)
 {
+  // Need to be sized to hold angles in an angleset for a groupset, instead of all angles in the
+  // groupset i.e., num angles in angle set * num groups in groupset for that angle set For the time
+  // being, use the full vector Each groupset is associated with a quadrature set
+  size_t num_ang_unknowns = sdm.GetNumLocalDOFs(psi_uk_man);
+  local_psi_data_.assign(num_ang_unknowns, 0.0);
 }
 
 const FLUDSCommonData&
@@ -29,17 +32,24 @@ CBC_FLUDS::GetCommonData() const
   return common_data_;
 }
 
-const std::vector<double>&
-CBC_FLUDS::GetLocalUpwindDataBlock() const
+// NEW METHOD to avoid having to access psi_new_local_[groupset.id]
+const double*
+CBC_FLUDS::GetLocalUpwindPsi(const Cell& face_neighbor,
+                             const unsigned int adj_cell_node_offset) const
 {
-  return local_psi_data_;
+  // Starting index for upwind cell's angular flux data
+  const auto dof_map = sdm_.MapDOFLocal(face_neighbor, 0, psi_uk_man_, 0, 0);
+
+  const auto local_face_upwind_psi = &local_psi_data_[dof_map];
+  return &local_face_upwind_psi[adj_cell_node_offset];
 }
 
-const double*
-CBC_FLUDS::GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell)
+// NEW METHOD to set angular value data for a downwind face of the cell
+double*
+CBC_FLUDS::GetLocalDownwindPsi(const Cell& cell)
 {
   const auto dof_map = sdm_.MapDOFLocal(cell, 0, psi_uk_man_, 0, 0);
-  return &psi_data_block[dof_map];
+  return &local_psi_data_[dof_map];
 }
 
 const std::vector<double>&

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/cbc_fluds.h
@@ -21,15 +21,21 @@ public:
   CBC_FLUDS(size_t num_groups,
             size_t num_angles,
             const CBC_FLUDSCommonData& common_data,
-            std::vector<double>& local_psi_data,
             const UnknownManager& psi_uk_man,
             const SpatialDiscretization& sdm);
 
   const FLUDSCommonData& GetCommonData() const;
 
+  // OLD METHOD: deprecate at some point
   const std::vector<double>& GetLocalUpwindDataBlock() const;
 
+  // OLD METHOD: deprecate at some point
   const double* GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell);
+
+  const double* GetLocalUpwindPsi(const Cell& face_neighbor,
+                                  const unsigned int adj_cell_node_offset) const;
+
+  double* GetLocalDownwindPsi(const Cell& cell);
 
   const std::vector<double>& GetNonLocalUpwindData(uint64_t cell_global_id,
                                                    unsigned int face_id) const;
@@ -77,9 +83,15 @@ public:
     return deplocs_outgoing_messages_;
   }
 
+  // Const getter (for reading from the subset)
+  const std::vector<double>& GetLocalPsiData() const { return local_psi_data_; }
+
+  // Non-const getter (for writing into the subset)
+  std::vector<double>& GetLocalPsiData() { return local_psi_data_; }
+
 private:
   const CBC_FLUDSCommonData& common_data_;
-  std::reference_wrapper<std::vector<double>> local_psi_data_;
+  std::vector<double> local_psi_data_;
   const UnknownManager& psi_uk_man_;
   const SpatialDiscretization& sdm_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/fluds/fluds.h
@@ -22,7 +22,7 @@ public:
     : num_groups_(num_groups),
       num_angles_(num_angles),
       num_groups_and_angles_(num_groups_ * num_angles_),
-      spds_(spds){};
+      spds_(spds) {};
 
   const SPDS& GetSPDS() const { return spds_; }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/scheduler/sweep_scheduler.cc
@@ -84,7 +84,7 @@ SweepScheduler::InitializeAlgoDOG()
             break;
           }
         } // for locations in plane
-      }   // for sweep planes
+      } // for sweep planes
 
       // Set up rule values
       if (loc_depth >= 0)
@@ -107,7 +107,7 @@ SweepScheduler::InitializeAlgoDOG()
       }
 
     } // for anglesets
-  }   // for quadrants/anglesetgroups
+  } // for quadrants/anglesetgroups
 
   std::stable_sort(rule_values_.begin(),
                    rule_values_.end(),
@@ -150,7 +150,7 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
       if (status != AngleSetStatus::FINISHED)
         finished = false;
     } // for each angleset rule
-  }   // while not finished
+  } // while not finished
 
   // Receive delayed data
   opensn::mpi_comm.barrier();
@@ -204,7 +204,7 @@ SweepScheduler::ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
         if (angle_set_status == AngleSetStatus::NOT_FINISHED)
           completion_status = AngleSetStatus::NOT_FINISHED;
       } // for angleset
-  }     // while not finished
+  } // while not finished
 
   // Receive delayed data
   opensn::mpi_comm.barrier();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep/spds/spds.cc
@@ -448,7 +448,7 @@ SPDS::PopulateCellRelationships(const Vector3& omega,
       }
       ++f;
     } // for face
-  }   // for cell
+  } // for cell
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/cbc_sweep_chunk.cc
@@ -63,6 +63,7 @@ CbcSweepChunk::SetAngleSet(AngleSet& angle_set)
 
   surface_source_active_ = IsSurfaceSourceActive();
   group_stride_ = angle_set.GetNumGroups();
+  // This is size of the local_psi_data vector in CBC FLUDS
   group_angle_stride_ = angle_set.GetNumGroups() * angle_set.GetNumAngles();
 }
 
@@ -134,14 +135,8 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
       auto face_nodal_mapping = &fluds_->GetCommonData().GetFaceNodalMapping(cell_local_id_, f);
 
       const std::vector<double>* psi_upwnd_data_block = nullptr;
-      const double* psi_local_face_upwnd_data = nullptr;
-      if (is_local_face)
-      {
-        psi_upwnd_data_block = &fluds_->GetLocalUpwindDataBlock();
-        psi_local_face_upwnd_data = fluds_->GetLocalCellUpwindPsi(
-          *psi_upwnd_data_block, *cell_transport_view_->FaceNeighbor(f));
-      }
-      else if (not is_boundary_face)
+
+      if ((not is_local_face) and (not is_boundary_face))
       {
         psi_upwnd_data_block = &fluds_->GetNonLocalUpwindData(cell_->global_id, f);
       }
@@ -162,10 +157,11 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
           const double* psi = nullptr;
           if (is_local_face)
           {
-            assert(psi_local_face_upwnd_data);
             const unsigned int adj_cell_node = face_nodal_mapping->cell_node_mapping_[fj];
-            psi = &psi_local_face_upwnd_data[adj_cell_node * groupset_angle_group_stride_ +
-                                             direction_num * groupset_group_stride_];
+            const unsigned int adj_cell_node_offset =
+              adj_cell_node * groupset_angle_group_stride_ + direction_num * groupset_group_stride_;
+            psi = fluds_->GetLocalUpwindPsi(*cell_transport_view_->FaceNeighbor(f),
+                                            adj_cell_node_offset);
           }
           else if (not is_boundary_face)
           {
@@ -188,8 +184,8 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
           for (int gsg = 0; gsg < gs_size_; ++gsg)
             b[gsg](i) += psi[gsg] * mu_Nij;
         } // for face node j
-      }   // for face node i
-    }     // for f
+      } // for face node i
+    } // for f
 
     // Looping over groups, assembling mass terms
     for (int gsg = 0; gsg < gs_size_; ++gsg)
@@ -286,6 +282,8 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
 
       for (int fi = 0; fi < num_face_nodes; ++fi)
       {
+        // Given the face index and the face node index, get the index of the
+        // cell node that the face node corresponds to
         const int i = cell_mapping_->MapFaceNode(f, fi);
 
         if (is_boundary_face)
@@ -296,8 +294,16 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
         }
 
         double* psi = nullptr;
+
+        // Map the cell node to the appropriate downwind node if at a local face
+        const unsigned int cell_node_offset =
+          i * groupset_angle_group_stride_ + direction_num * groupset_group_stride_;
+        const unsigned int i_map = is_local_face ? cell_node_offset : 0;
+
         if (is_local_face)
-          psi = nullptr;
+        {
+          psi = fluds_->GetLocalDownwindPsi(*cell_);
+        }
         else if (not is_boundary_face)
         {
           assert(psi_dnwnd_data);
@@ -306,17 +312,18 @@ CbcSweepChunk::Sweep(AngleSet& angle_set)
         }
         else if (is_reflecting_boundary_face)
           psi = angle_set.PsiReflected(face.neighbor_id, direction_num, cell_local_id_, f, fi);
+
         if (psi)
         {
           if (not is_boundary_face or is_reflecting_boundary_face)
           {
             for (int gsg = 0; gsg < gs_size_; ++gsg)
-              psi[gsg] = b[gsg](i);
+              psi[gsg + i_map] = b[gsg](i);
           }
         }
       } // for fi
-    }   // for face
-  }     // for angleset/subset
+    } // for face
+  } // for angleset/subset
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.cc
@@ -25,9 +25,9 @@ SweepChunk::ZeroDestinationPhi()
         {
           (*destination_phi_)[mapping + g] = 0.0;
         } // for g
-      }   // for moment
-    }     // for dof
-  }       // for cell
+      } // for moment
+    } // for dof
+  } // for cell
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_solver/sweep_chunks/sweep_chunk.h
@@ -66,6 +66,12 @@ public:
   /// For cell-by-cell methods or computing the residual on a single cell.
   virtual void SetCell(Cell const* cell_ptr, AngleSet& angle_set) {}
 
+  // Needed to get access to MapDOF
+  const SpatialDiscretization& GetSpatialDiscretization() const { return discretization_; }
+
+  // Needed to get access to psi_uk_man
+  const LBSGroupset& GetGroupset() const { return groupset_; }
+
   virtual ~SweepChunk() = default;
 
 protected:


### PR DESCRIPTION
The CBC FLUDS class now has a member that stores local angular fluxes. This is part of a broader re-factoring of the CBC algorithm so that it does not need to store all local angular fluxes while sweeping. 

The CBC algorithm handles the local angular flux storage separately from that for boundaries and reflecting faces. In the `CBC_AngletSet::AngleSetAdvance` method, cells are solved one-by-one (via a call to `CBC_SweepChunk::Sweep`) in the order given in the task list.

The current CBC algorithm implementation gets local angular fluxes from a vector `psi_new_local_[groupset.id]`, which stores local angular fluxes for a groupset. Here, `psi_new_local_` is a vector of vectors (as many as there are groupsets) and is a member of the LBSSolver class. 

This is not ideal as the CBC FLUDS class does not directly manage `psi_new_local_[groupset.id]`, which is its intended functionality. The vector is also unnecessarily large, as it is partially sized on the number of angles associated with the groupset, instead of the number of angles in an angleset.

 The changes in this commit include:

- In CBC_FLUDS:
    - changed variable `local_psi_data_` to no longer be a reference to `psi_new_local_[groupset.id]` and to be initialized to be of the same size
    - added methods `GetLocalUpwindPsi` and `GetLocalDownwindPsi` to read upwind and write downwind angular fluxes to `local_psi_data_`

- In CBC_SweepChunk:
    - In `Sweep` method and in the surface integrals block, removed first local-face if-block to get local upwind angular fluxes from `psi_new_local_[groupset.id]` (no longer needed)
    - In `Sweep` method and in the outgoing surface operations block, modified the if-else blocks so that at local faces, downwind angular fluxes are written to `local_psi_data_`, regardless if user wants to store angular fluxes, and uses appropriate downwind cell node offsets for indexing into `local_psi_data_` if at local face. That is, **a user no longer needs to save angular fluxes to run a sweep with the CBC algorithm**, but they can still choose to do so.