### PR TITLE
Updating parameter tests to reflect changes in Lua error formatting.

### DIFF
--- a/lua/lib/console.cc
+++ b/lua/lib/console.cc
@@ -112,7 +112,7 @@ Console::ExecuteFile(const std::string& fileName, int argc, char** argv) const
 
     if (error > 0)
     {
-      opensn::log.LogAllError() << "LuaError: " << lua_tostring(this->console_state_, -1);
+      opensn::log.LogAllError() << lua_tostring(this->console_state_, -1);
       return EXIT_FAILURE;
     }
   }

--- a/test/lua/framework/parameters/tests.json
+++ b/test/lua/framework/parameters/tests.json
@@ -11,14 +11,14 @@
     "file" : "params_test_01a.lua", "num_procs" : 1, "checks" :
     [
       { "type" : "StrCompare", "key" : "*** WARNING ***  Parameter \"limiter_type\"" },
-      { "type" : "StrCompare", "key" : "**** ERROR ****  Parameter \"scheme\" has been deprecated." }
+      { "type" : "StrCompare", "key" : "**** ERROR ****  params_test_01a.lua:14: Parameter \"scheme\" has been deprecated." }
     ]
   },
   {
     "file" : "params_test_01b.lua", "num_procs" : 1, "checks" :
     [
       { "type" : "StrCompare", "key" : "TestSubObject created num_groups=99" },
-      { "type" : "StrCompare", "key" : "**** ERROR ****  Parameter \"format\" has been deprecated." }
+      { "type" : "StrCompare", "key" : "**** ERROR ****  params_test_01b.lua:13: Parameter \"format\" has been deprecated." }
     ]
   },
   {


### PR DESCRIPTION
This gets nightly tests back on track.