### PR TITLE
Fix CMake generator option in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class CMakeBuilder(build_ext):
         # get generator from environment if precised
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
         if cmake_generator:
-            cmake_args += ["-G {cmake_generator}"]
+            cmake_args += [f"-G {cmake_generator}"]
         # get extra CMake arguments
         if "CMAKE_ARGS" in os.environ:
             cmake_args += [


### PR DESCRIPTION
## Summary
- fix string formatting for generator option in `setup.py`

## Testing
- `pytest -q` *(fails: SLDFESQuadrature undefined)*
- `pip install -e .` *(fails: cannot compile mpi4py due to missing MPI implementation)*

------
https://chatgpt.com/codex/tasks/task_e_683f50b4a23c8321b938d0423f27f3be