### PR TITLE
Add nbconvert to requirement

### DIFF
--- a/doc/install/easy_install.rst
+++ b/doc/install/easy_install.rst
@@ -109,6 +109,13 @@ To compile the module and install in the Python ``site-packages`` path:
 
    pip install .
 
+For developers, it is recommended to use the following command to install the
+additional packages required for running regression tests:
+
+.. code-block:: bash
+
+   pip install .[dev]
+
 .. tip::
 
    Unlike the console, the Python interface is fully compatible with ``mpi4py``.
@@ -148,7 +155,7 @@ Install the required Python packages to the virtual environment using ``pip``:
 
 .. important::
 
-   Compiling documentation requires the Python module of OpenSn.
+   Compiling documentation requires the **Python module of OpenSn**.
 
 Then, from your ``build`` directory, generate the documentation with:
 

--- a/doc/install/install.rst
+++ b/doc/install/install.rst
@@ -281,6 +281,13 @@ To compile the module and install in the Python ``site-packages`` path:
 
    pip install .
 
+For developers, it is recommended to use the following command to install the
+additional packages required for running regression tests:
+
+.. code-block:: bash
+
+   pip install .[dev]
+
 .. tip::
 
    Unlike the console, the Python interface is fully compatible with ``mpi4py``.
@@ -320,7 +327,7 @@ Install the required Python packages to the virtual environment using ``pip``:
 
 .. important::
 
-   Compiling documentation requires the Python module of OpenSn.
+   Compiling documentation requires the **Python module of OpenSn**.
 
 Then, from your ``build`` directory, generate the documentation with:
 

--- a/setup.py
+++ b/setup.py
@@ -126,5 +126,8 @@ if __name__ == "__main__":
         packages=["pyopensn"],
         ext_modules=[CMakeExtension("pyopensn.__init__")],
         cmdclass={"build_ext": CMakeBuilder},
-        install_requires=["mpi4py", "numpy"]
+        install_requires=["mpi4py", "numpy"],
+        extras_require={
+            "dev": ["matplotlib", "nbconvert"],
+        }
     )


### PR DESCRIPTION
This PR adds `nbconvert` to install dependencies.

When regression tests are needed, OpenSn must be installed using ``pip install .[dev]``.