### PR TITLE
Refactoring `UnitCellMatrices`

### DIFF
--- a/framework/math/geometry.h
+++ b/framework/math/geometry.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/mesh/mesh.h"
+
+namespace opensn
+{
+
+enum class GeometryType
+{
+  NO_GEOMETRY_SET = 0,
+  ONED_SLAB = 1,
+  ONED_CYLINDRICAL = 2,
+  ONED_SPHERICAL = 3,
+  TWOD_CARTESIAN = 4,
+  TWOD_CYLINDRICAL = 5,
+  THREED_CARTESIAN = 6
+};
+
+inline CoordinateSystemType
+MapGeometryTypeToCoordSys(const GeometryType gtype)
+{
+  switch (gtype)
+  {
+    case GeometryType::ONED_SLAB:
+    case GeometryType::TWOD_CARTESIAN:
+    case GeometryType::THREED_CARTESIAN:
+      return CoordinateSystemType::CARTESIAN;
+    case GeometryType::ONED_SPHERICAL:
+      return CoordinateSystemType::SPHERICAL;
+    case GeometryType::ONED_CYLINDRICAL:
+    case GeometryType::TWOD_CYLINDRICAL:
+      return CoordinateSystemType::CYLINDRICAL;
+    default:
+      return CoordinateSystemType::CARTESIAN;
+  }
+}
+
+} // namespace opensn

--- a/framework/math/spatial_weight_function.cc
+++ b/framework/math/spatial_weight_function.cc
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/math/spatial_weight_function.h"
+
+namespace opensn
+{
+
+std::shared_ptr<SpatialWeightFunction>
+SpatialWeightFunction::FromGeometryType(GeometryType geometry_type)
+{
+  if (geometry_type == GeometryType::ONED_SPHERICAL)
+    return std::make_shared<SphericalWeightFunction>();
+  else if (geometry_type == GeometryType::TWOD_CYLINDRICAL)
+    return std::make_shared<CylindricalWeightFunction>();
+  else
+    return std::make_shared<SpatialWeightFunction>();
+}
+
+} // namespace opensn

--- a/framework/math/spatial_weight_function.h
+++ b/framework/math/spatial_weight_function.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/math/vector3.h"
+#include "framework/math/geometry.h"
+
+namespace opensn
+{
+
+// Define spatial weighting functions
+struct SpatialWeightFunction
+{
+  virtual double operator()(const Vector3& pt) const { return 1.0; }
+  virtual ~SpatialWeightFunction() = default;
+
+  static std::shared_ptr<SpatialWeightFunction> FromGeometryType(GeometryType geometry_type);
+};
+
+struct SphericalWeightFunction : public SpatialWeightFunction
+{
+  double operator()(const Vector3& pt) const override { return pt[2] * pt[2]; }
+};
+
+struct CylindricalWeightFunction : public SpatialWeightFunction
+{
+  double operator()(const Vector3& pt) const override { return pt[0]; }
+};
+
+} // namespace opensn

--- a/framework/math/unit_cell_matrices/unit_cell_matrices.cc
+++ b/framework/math/unit_cell_matrices/unit_cell_matrices.cc
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
+#include "framework/math/spatial_discretization/spatial_discretization.h"
+#include "framework/math/spatial_weight_function.h"
+#include "framework/math/spatial_discretization/finite_element/finite_element_data.h"
+
+namespace opensn
+{
+
+UnitCellMatrices
+ComputeCellUnitIntegrals(const SpatialDiscretization& sdm,
+                         const Cell& cell,
+                         const SpatialWeightFunction& swf)
+{
+  const auto& cell_mapping = sdm.GetCellMapping(cell);
+  const size_t cell_num_faces = cell.faces.size();
+  const size_t cell_num_nodes = cell_mapping.GetNumNodes();
+  const auto fe_vol_data = cell_mapping.MakeVolumetricFiniteElementData();
+
+  DenseMatrix<double> IntV_gradshapeI_gradshapeJ(cell_num_nodes, cell_num_nodes, 0.0);
+  DenseMatrix<Vector3> IntV_shapeI_gradshapeJ(cell_num_nodes, cell_num_nodes);
+  DenseMatrix<double> IntV_shapeI_shapeJ(cell_num_nodes, cell_num_nodes, 0.0);
+  Vector<double> IntV_shapeI(cell_num_nodes, 0.);
+  std::vector<DenseMatrix<double>> IntS_shapeI_shapeJ(cell_num_faces);
+  std::vector<DenseMatrix<Vector3>> IntS_shapeI_gradshapeJ(cell_num_faces);
+  std::vector<Vector<double>> IntS_shapeI(cell_num_faces);
+
+  // Volume integrals
+  for (unsigned int i = 0; i < cell_num_nodes; ++i)
+  {
+    for (unsigned int j = 0; j < cell_num_nodes; ++j)
+    {
+      for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
+      {
+        IntV_gradshapeI_gradshapeJ(i, j) +=
+          swf(fe_vol_data.QPointXYZ(qp)) *
+          fe_vol_data.ShapeGrad(i, qp).Dot(fe_vol_data.ShapeGrad(j, qp)) *
+          fe_vol_data.JxW(qp); // K-matrix
+
+        IntV_shapeI_gradshapeJ(i, j) +=
+          swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) *
+          fe_vol_data.ShapeGrad(j, qp) * fe_vol_data.JxW(qp); // G-matrix
+
+        IntV_shapeI_shapeJ(i, j) += swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) *
+                                    fe_vol_data.ShapeValue(j, qp) * fe_vol_data.JxW(qp); // M-matrix
+      }                                                                                  // for qp
+    }                                                                                    // for j
+
+    for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
+    {
+      IntV_shapeI(i) +=
+        swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) * fe_vol_data.JxW(qp);
+    } // for qp
+  }   // for i
+
+  //  surface integrals
+  for (size_t f = 0; f < cell_num_faces; ++f)
+  {
+    const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
+    IntS_shapeI_shapeJ[f] = DenseMatrix<double>(cell_num_nodes, cell_num_nodes, 0.0);
+    IntS_shapeI[f] = Vector<double>(cell_num_nodes, 0.);
+    IntS_shapeI_gradshapeJ[f] = DenseMatrix<Vector3>(cell_num_nodes, cell_num_nodes);
+
+    for (unsigned int i = 0; i < cell_num_nodes; ++i)
+    {
+      for (unsigned int j = 0; j < cell_num_nodes; ++j)
+      {
+        for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
+        {
+          IntS_shapeI_shapeJ[f](i, j) += swf(fe_srf_data.QPointXYZ(qp)) *
+                                         fe_srf_data.ShapeValue(i, qp) *
+                                         fe_srf_data.ShapeValue(j, qp) * fe_srf_data.JxW(qp);
+          IntS_shapeI_gradshapeJ[f](i, j) += swf(fe_srf_data.QPointXYZ(qp)) *
+                                             fe_srf_data.ShapeValue(i, qp) *
+                                             fe_srf_data.ShapeGrad(j, qp) * fe_srf_data.JxW(qp);
+        } // for qp
+      }   // for j
+
+      for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
+      {
+        IntS_shapeI[f](i) +=
+          swf(fe_srf_data.QPointXYZ(qp)) * fe_srf_data.ShapeValue(i, qp) * fe_srf_data.JxW(qp);
+      } // for qp
+    }   // for i
+  }     // for f
+
+  return UnitCellMatrices{IntV_gradshapeI_gradshapeJ,
+                          IntV_shapeI_gradshapeJ,
+                          IntV_shapeI_shapeJ,
+                          IntV_shapeI,
+
+                          IntS_shapeI_shapeJ,
+                          IntS_shapeI_gradshapeJ,
+                          IntS_shapeI};
+}
+
+UnitCellMatrices
+UnitCellMatrices::Compute(const SpatialDiscretization& sdm,
+                          const Cell& cell,
+                          GeometryType geometry_type)
+{
+  auto swf_ptr = SpatialWeightFunction::FromGeometryType(geometry_type);
+  return ComputeCellUnitIntegrals(sdm, cell, *swf_ptr);
+}
+
+UnitCellMatrices
+UnitCellMatrices::Compute(const SpatialDiscretization& sdm, const Cell& cell)
+{
+  auto swf_ptr = std::make_shared<SpatialWeightFunction>();
+  return ComputeCellUnitIntegrals(sdm, cell, *swf_ptr);
+}
+
+} // namespace opensn

--- a/framework/math/unit_cell_matrices/unit_cell_matrices.h
+++ b/framework/math/unit_cell_matrices/unit_cell_matrices.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/math/dense_matrix.h"
+#include "framework/math/geometry.h"
+#include "framework/mesh/cell/cell.h"
+#include "framework/math/spatial_discretization/spatial_discretization.h"
+#include "framework/math/vector3.h"
+
+namespace opensn
+{
+
+struct UnitCellMatrices
+{
+  DenseMatrix<double> intV_gradshapeI_gradshapeJ;
+  DenseMatrix<Vector3> intV_shapeI_gradshapeJ;
+  DenseMatrix<double> intV_shapeI_shapeJ;
+  Vector<double> intV_shapeI;
+
+  std::vector<DenseMatrix<double>> intS_shapeI_shapeJ;
+  std::vector<DenseMatrix<Vector3>> intS_shapeI_gradshapeJ;
+  std::vector<Vector<double>> intS_shapeI;
+
+  /// Compute unit cell matrices for a given cell
+  static UnitCellMatrices
+  Compute(const SpatialDiscretization& sdm, const Cell& cell, GeometryType geometry_type);
+
+  /// Compute unit cell matrices for a given cell assuming cartesian geometry
+  static UnitCellMatrices Compute(const SpatialDiscretization& sdm, const Cell& cell);
+};
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/diffusion_mip_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/diffusion_mip_solver.cc
@@ -7,6 +7,7 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/finite_element/finite_element_data.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "framework/math/functions/function.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/diffusion_pwlc_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/diffusion_pwlc_solver.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/acceleration/acceleration.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/vacuum_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.h"
@@ -1019,124 +1020,17 @@ LBSProblem::ComputeUnitIntegrals()
   log.Log() << "Computing unit integrals.\n";
   const auto& sdm = *discretization_;
 
-  // Define spatial weighting functions
-  struct SpatialWeightFunction // SWF
-  {
-    virtual double operator()(const Vector3& pt) const { return 1.0; }
-    virtual ~SpatialWeightFunction() = default;
-  };
-
-  struct SphericalSWF : public SpatialWeightFunction
-  {
-    double operator()(const Vector3& pt) const override { return pt[2] * pt[2]; }
-  };
-
-  struct CylindricalSWF : public SpatialWeightFunction
-  {
-    double operator()(const Vector3& pt) const override { return pt[0]; }
-  };
-
-  auto swf_ptr = std::make_shared<SpatialWeightFunction>();
-  if (options_.geometry_type == GeometryType::ONED_SPHERICAL)
-    swf_ptr = std::make_shared<SphericalSWF>();
-  if (options_.geometry_type == GeometryType::TWOD_CYLINDRICAL)
-    swf_ptr = std::make_shared<CylindricalSWF>();
-
-  auto ComputeCellUnitIntegrals = [&sdm](const Cell& cell, const SpatialWeightFunction& swf)
-  {
-    const auto& cell_mapping = sdm.GetCellMapping(cell);
-    const size_t cell_num_faces = cell.faces.size();
-    const size_t cell_num_nodes = cell_mapping.GetNumNodes();
-    const auto fe_vol_data = cell_mapping.MakeVolumetricFiniteElementData();
-
-    DenseMatrix<double> IntV_gradshapeI_gradshapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    DenseMatrix<Vector3> IntV_shapeI_gradshapeJ(cell_num_nodes, cell_num_nodes);
-    DenseMatrix<double> IntV_shapeI_shapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    Vector<double> IntV_shapeI(cell_num_nodes, 0.);
-    std::vector<DenseMatrix<double>> IntS_shapeI_shapeJ(cell_num_faces);
-    std::vector<DenseMatrix<Vector3>> IntS_shapeI_gradshapeJ(cell_num_faces);
-    std::vector<Vector<double>> IntS_shapeI(cell_num_faces);
-
-    // Volume integrals
-    for (unsigned int i = 0; i < cell_num_nodes; ++i)
-    {
-      for (unsigned int j = 0; j < cell_num_nodes; ++j)
-      {
-        for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-        {
-          IntV_gradshapeI_gradshapeJ(i, j) +=
-            swf(fe_vol_data.QPointXYZ(qp)) *
-            fe_vol_data.ShapeGrad(i, qp).Dot(fe_vol_data.ShapeGrad(j, qp)) *
-            fe_vol_data.JxW(qp); // K-matrix
-
-          IntV_shapeI_gradshapeJ(i, j) +=
-            swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) *
-            fe_vol_data.ShapeGrad(j, qp) * fe_vol_data.JxW(qp); // G-matrix
-
-          IntV_shapeI_shapeJ(i, j) +=
-            swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) *
-            fe_vol_data.ShapeValue(j, qp) * fe_vol_data.JxW(qp); // M-matrix
-        }                                                        // for qp
-      }                                                          // for j
-
-      for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-      {
-        IntV_shapeI(i) +=
-          swf(fe_vol_data.QPointXYZ(qp)) * fe_vol_data.ShapeValue(i, qp) * fe_vol_data.JxW(qp);
-      } // for qp
-    }   // for i
-
-    //  surface integrals
-    for (size_t f = 0; f < cell_num_faces; ++f)
-    {
-      const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
-      IntS_shapeI_shapeJ[f] = DenseMatrix<double>(cell_num_nodes, cell_num_nodes, 0.0);
-      IntS_shapeI[f] = Vector<double>(cell_num_nodes, 0.);
-      IntS_shapeI_gradshapeJ[f] = DenseMatrix<Vector3>(cell_num_nodes, cell_num_nodes);
-
-      for (unsigned int i = 0; i < cell_num_nodes; ++i)
-      {
-        for (unsigned int j = 0; j < cell_num_nodes; ++j)
-        {
-          for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-          {
-            IntS_shapeI_shapeJ[f](i, j) += swf(fe_srf_data.QPointXYZ(qp)) *
-                                           fe_srf_data.ShapeValue(i, qp) *
-                                           fe_srf_data.ShapeValue(j, qp) * fe_srf_data.JxW(qp);
-            IntS_shapeI_gradshapeJ[f](i, j) += swf(fe_srf_data.QPointXYZ(qp)) *
-                                               fe_srf_data.ShapeValue(i, qp) *
-                                               fe_srf_data.ShapeGrad(j, qp) * fe_srf_data.JxW(qp);
-          } // for qp
-        }   // for j
-
-        for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-        {
-          IntS_shapeI[f](i) +=
-            swf(fe_srf_data.QPointXYZ(qp)) * fe_srf_data.ShapeValue(i, qp) * fe_srf_data.JxW(qp);
-        } // for qp
-      }   // for i
-    }     // for f
-
-    return UnitCellMatrices{IntV_gradshapeI_gradshapeJ,
-                            IntV_shapeI_gradshapeJ,
-                            IntV_shapeI_shapeJ,
-                            IntV_shapeI,
-
-                            IntS_shapeI_shapeJ,
-                            IntS_shapeI_gradshapeJ,
-                            IntS_shapeI};
-  };
-
   const size_t num_local_cells = grid_->local_cells.size();
   unit_cell_matrices_.resize(num_local_cells);
 
   for (const auto& cell : grid_->local_cells)
-    unit_cell_matrices_[cell.local_id] = ComputeCellUnitIntegrals(cell, *swf_ptr);
+    unit_cell_matrices_[cell.local_id] =
+      UnitCellMatrices::Compute(sdm, cell, options_.geometry_type);
 
   const auto ghost_ids = grid_->cells.GetGhostGlobalIDs();
   for (uint64_t ghost_id : ghost_ids)
     unit_ghost_cell_matrices_[ghost_id] =
-      ComputeCellUnitIntegrals(grid_->cells[ghost_id], *swf_ptr);
+      UnitCellMatrices::Compute(sdm, grid_->cells[ghost_id], options_.geometry_type);
 
   // Assessing global unit cell matrix storage
   std::array<size_t, 2> num_local_ucms = {unit_cell_matrices_.size(),

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -12,6 +12,7 @@
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/linear_solver/linear_solver.h"
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "framework/physics/problem.h"
 #include <petscksp.h>
 #include <chrono>

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
@@ -5,6 +5,7 @@
 
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include "framework/math/math.h"
+#include "framework/math/geometry.h"
 #include <functional>
 #include <chrono>
 #include <map>
@@ -24,36 +25,6 @@ enum class SolverType
   DIFFUSION_DFEM = 2,
   DIFFUSION_CFEM = 3,
 };
-
-enum class GeometryType
-{
-  NO_GEOMETRY_SET = 0,
-  ONED_SLAB = 1,
-  ONED_CYLINDRICAL = 2,
-  ONED_SPHERICAL = 3,
-  TWOD_CARTESIAN = 4,
-  TWOD_CYLINDRICAL = 5,
-  THREED_CARTESIAN = 6
-};
-
-inline CoordinateSystemType
-MapGeometryTypeToCoordSys(const GeometryType gtype)
-{
-  switch (gtype)
-  {
-    case GeometryType::ONED_SLAB:
-    case GeometryType::TWOD_CARTESIAN:
-    case GeometryType::THREED_CARTESIAN:
-      return CoordinateSystemType::CARTESIAN;
-    case GeometryType::ONED_SPHERICAL:
-      return CoordinateSystemType::SPHERICAL;
-    case GeometryType::ONED_CYLINDRICAL:
-    case GeometryType::TWOD_CYLINDRICAL:
-      return CoordinateSystemType::CYLINDRICAL;
-    default:
-      return CoordinateSystemType::CARTESIAN;
-  }
-}
 
 enum class AngleAggregationType
 {
@@ -318,18 +289,6 @@ public:
   }
 
   void ReassignXS(const MultiGroupXS& xs) { xs_ = &xs; }
-};
-
-struct UnitCellMatrices
-{
-  DenseMatrix<double> intV_gradshapeI_gradshapeJ;
-  DenseMatrix<Vector3> intV_shapeI_gradshapeJ;
-  DenseMatrix<double> intV_shapeI_shapeJ;
-  Vector<double> intV_shapeI;
-
-  std::vector<DenseMatrix<double>> intS_shapeI_shapeJ;
-  std::vector<DenseMatrix<Vector3>> intS_shapeI_gradshapeJ;
-  std::vector<Vector<double>> intS_shapeI;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_smm_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_smm_solver.cc
@@ -11,6 +11,7 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
 #include "framework/math/parallel_vector/ghosted_parallel_stl_vector.h"
+#include "framework/math/spatial_weight_function.h"
 #include "framework/object_factory.h"
 #include "framework/utils/timer.h"
 #include "framework/logging/log.h"
@@ -852,29 +853,7 @@ PowerIterationKEigenSMMSolver::ComputeAuxiliaryUnitCellMatrices()
 {
   const auto& discretization = lbs_problem_->GetSpatialDiscretization();
 
-  // Spatial weight functions
-  struct SpatialWeightFunction
-  {
-    virtual ~SpatialWeightFunction() = default;
-    virtual double operator()(const Vector3& p) const { return 1.0; }
-  };
-
-  struct CylindricalWeightFunction : public SpatialWeightFunction
-  {
-    double operator()(const Vector3& p) const override { return p[0]; }
-  };
-
-  struct SphericalWeightFunction : public SpatialWeightFunction
-  {
-    double operator()(const Vector3& p) const override { return p[2] * p[2]; }
-  };
-
-  auto swf = std::make_shared<SpatialWeightFunction>();
-  const auto geom_type = lbs_problem_->GetOptions().geometry_type;
-  if (geom_type == GeometryType::ONED_SPHERICAL)
-    swf = std::make_shared<SphericalWeightFunction>();
-  else if (geom_type == GeometryType::TWOD_CYLINDRICAL)
-    swf = std::make_shared<CylindricalWeightFunction>();
+  auto swf = SpatialWeightFunction::FromGeometryType(lbs_problem_->GetOptions().geometry_type);
 
   // Compute integrals
   const auto num_local_cells = lbs_problem_->GetGrid()->local_cells.size();

--- a/test/python/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
+++ b/test/python/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_cfem.cc
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/acceleration/acceleration.h"
@@ -51,79 +52,8 @@ acceleration_Diffusion_CFEM(std::shared_ptr<MeshContinuum> grid)
   // Build unit integrals
   for (const auto& cell : grid->local_cells)
   {
-    const auto& cell_mapping = sdm.GetCellMapping(cell);
-    const size_t cell_num_faces = cell.faces.size();
-    const size_t cell_num_nodes = cell_mapping.GetNumNodes();
-    const auto fe_vol_data = cell_mapping.MakeVolumetricFiniteElementData();
-
-    DenseMatrix<double> IntV_gradshapeI_gradshapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    DenseMatrix<double> IntV_shapeI_shapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    Vector<double> IntV_shapeI(cell_num_nodes, 0.0);
-
-    std::vector<DenseMatrix<double>> IntS_shapeI_shapeJ(cell_num_faces);
-    std::vector<DenseMatrix<Vector3>> IntS_shapeI_gradshapeJ(cell_num_faces);
-    std::vector<Vector<double>> IntS_shapeI(cell_num_faces);
-
-    // Volume integrals
-    for (unsigned int i = 0; i < cell_num_nodes; ++i)
-    {
-      for (unsigned int j = 0; j < cell_num_nodes; ++j)
-      {
-        for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-        {
-          IntV_gradshapeI_gradshapeJ(i, j) +=
-            fe_vol_data.ShapeGrad(i, qp).Dot(fe_vol_data.ShapeGrad(j, qp)) *
-            fe_vol_data.JxW(qp); // K-matrix
-
-          IntV_shapeI_shapeJ(i, j) += fe_vol_data.ShapeValue(i, qp) *
-                                      fe_vol_data.ShapeValue(j, qp) *
-                                      fe_vol_data.JxW(qp); // M-matrix
-        }                                                  // for qp
-      }                                                    // for j
-
-      for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-      {
-        IntV_shapeI(i) += fe_vol_data.ShapeValue(i, qp) * fe_vol_data.JxW(qp);
-      } // for qp
-    }   // for i
-
-    //  surface integrals
-    for (size_t f = 0; f < cell_num_faces; ++f)
-    {
-      const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
-      IntS_shapeI_shapeJ[f] = DenseMatrix<double>(cell_num_nodes, cell_num_nodes, 0.0);
-      IntS_shapeI[f] = Vector<double>(cell_num_nodes, 0.0);
-      IntS_shapeI_gradshapeJ[f] = DenseMatrix<Vector3>(cell_num_nodes, cell_num_nodes);
-
-      for (unsigned int i = 0; i < cell_num_nodes; ++i)
-      {
-        for (unsigned int j = 0; j < cell_num_nodes; ++j)
-        {
-          for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-          {
-            IntS_shapeI_shapeJ[f](i, j) +=
-              fe_srf_data.ShapeValue(i, qp) * fe_srf_data.ShapeValue(j, qp) * fe_srf_data.JxW(qp);
-            IntS_shapeI_gradshapeJ[f](i, j) +=
-              fe_srf_data.ShapeValue(i, qp) * fe_srf_data.ShapeGrad(j, qp) * fe_srf_data.JxW(qp);
-          } // for qp
-        }   // for j
-
-        for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-        {
-          IntS_shapeI[f](i) += fe_srf_data.ShapeValue(i, qp) * fe_srf_data.JxW(qp);
-        } // for qp
-      }   // for i
-    }     // for f
-
-    unit_cell_matrices[cell.local_id] = UnitCellMatrices{IntV_gradshapeI_gradshapeJ,
-                                                         {},
-                                                         IntV_shapeI_shapeJ,
-                                                         IntV_shapeI,
-
-                                                         IntS_shapeI_shapeJ,
-                                                         IntS_shapeI_gradshapeJ,
-                                                         IntS_shapeI};
-  } // for cell
+    unit_cell_matrices[cell.local_id] = UnitCellMatrices::Compute(sdm, cell);
+  }
 
   // Make solver
   DiffusionPWLCSolver solver("SimTest92b_DSA_PWLC",

--- a/test/python/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
+++ b/test/python/modules/linear_boltzmann_solvers/dsa/acceleration_diffusion_dfem.cc
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
+#include "framework/math/unit_cell_matrices/unit_cell_matrices.h"
 #include "framework/math/dense_matrix.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h"
@@ -52,78 +53,8 @@ acceleration_Diffusion_DFEM(std::shared_ptr<MeshContinuum> grid)
   // Build unit integrals
   for (const auto& cell : grid->local_cells)
   {
-    const auto& cell_mapping = sdm.GetCellMapping(cell);
-    const size_t cell_num_faces = cell.faces.size();
-    const size_t cell_num_nodes = cell_mapping.GetNumNodes();
-    const auto fe_vol_data = cell_mapping.MakeVolumetricFiniteElementData();
-
-    DenseMatrix<double> IntV_gradshapeI_gradshapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    DenseMatrix<double> IntV_shapeI_shapeJ(cell_num_nodes, cell_num_nodes, 0.0);
-    Vector<double> IntV_shapeI(cell_num_nodes, 0.0);
-
-    std::vector<DenseMatrix<double>> IntS_shapeI_shapeJ(cell_num_faces);
-    std::vector<DenseMatrix<Vector3>> IntS_shapeI_gradshapeJ(cell_num_faces);
-    std::vector<Vector<double>> IntS_shapeI(cell_num_faces);
-
-    // Volume integrals
-    for (unsigned int i = 0; i < cell_num_nodes; ++i)
-    {
-      for (unsigned int j = 0; j < cell_num_nodes; ++j)
-      {
-        for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-        {
-          IntV_gradshapeI_gradshapeJ(i, j) +=
-            fe_vol_data.ShapeGrad(i, qp).Dot(fe_vol_data.ShapeGrad(j, qp)) *
-            fe_vol_data.JxW(qp); // K-matrix
-
-          IntV_shapeI_shapeJ(i, j) += fe_vol_data.ShapeValue(i, qp) *
-                                      fe_vol_data.ShapeValue(j, qp) *
-                                      fe_vol_data.JxW(qp); // M-matrix
-        }                                                  // for qp
-      }                                                    // for j
-
-      for (const auto& qp : fe_vol_data.GetQuadraturePointIndices())
-      {
-        IntV_shapeI(i) += fe_vol_data.ShapeValue(i, qp) * fe_vol_data.JxW(qp);
-      } // for qp
-    }   // for i
-
-    //  surface integrals
-    for (size_t f = 0; f < cell_num_faces; ++f)
-    {
-      const auto fe_srf_data = cell_mapping.MakeSurfaceFiniteElementData(f);
-      IntS_shapeI_shapeJ[f] = DenseMatrix<double>(cell_num_nodes, cell_num_nodes, 0.0);
-      IntS_shapeI[f] = Vector<double>(cell_num_nodes, 0.0);
-      IntS_shapeI_gradshapeJ[f] = DenseMatrix<Vector3>(cell_num_nodes, cell_num_nodes);
-
-      for (unsigned int i = 0; i < cell_num_nodes; ++i)
-      {
-        for (unsigned int j = 0; j < cell_num_nodes; ++j)
-        {
-          for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-          {
-            IntS_shapeI_shapeJ[f](i, j) +=
-              fe_srf_data.ShapeValue(i, qp) * fe_srf_data.ShapeValue(j, qp) * fe_srf_data.JxW(qp);
-            IntS_shapeI_gradshapeJ[f](i, j) +=
-              fe_srf_data.ShapeValue(i, qp) * fe_srf_data.ShapeGrad(j, qp) * fe_srf_data.JxW(qp);
-          } // for qp
-        }   // for j
-
-        for (const auto& qp : fe_srf_data.GetQuadraturePointIndices())
-        {
-          IntS_shapeI[f](i) += fe_srf_data.ShapeValue(i, qp) * fe_srf_data.JxW(qp);
-        } // for qp
-      }   // for i
-    }     // for f
-
-    unit_cell_matrices[cell.local_id] = UnitCellMatrices{IntV_gradshapeI_gradshapeJ,
-                                                         {},
-                                                         IntV_shapeI_shapeJ,
-                                                         IntV_shapeI,
-                                                         IntS_shapeI_shapeJ,
-                                                         IntS_shapeI_gradshapeJ,
-                                                         IntS_shapeI};
-  } // for cell
+    unit_cell_matrices[cell.local_id] = UnitCellMatrices::Compute(sdm, cell);
+  }
 
   // Retrieve the functions defined in the global namespace.
   py::module main_module = py::module::import("__main__");


### PR DESCRIPTION
- moved into a separate file in framework (this is not LBS-specific)
- moved GeometryType into framework (not LBS-specific)
- removed duplicate comutations of unit cell matrices, all is done inside the UnitCellMatrices class
- moved SpatialWeightFunction into a separate file and removed its copies