### PR TITLE
Updates to CurvilinearQuadrature

### DIFF
--- a/framework/math/quadratures/angular/curvilinear_product_quadrature.cc
+++ b/framework/math/quadratures/angular/curvilinear_product_quadrature.cc
@@ -15,7 +15,7 @@ namespace opensn
 GLProductQuadrature1DSpherical::GLProductQuadrature1DSpherical(int Npolar,
                                                                int scattering_order,
                                                                bool verbose)
-  : CurvilinearQuadrature(1, scattering_order)
+  : CurvilinearProductQuadrature(1, scattering_order)
 {
   if (Npolar % 2 != 0)
     throw std::invalid_argument("GLProductQuadrature1DSpherical: Npolar must be even.");
@@ -187,7 +187,7 @@ GLCProductQuadrature2DRZ::GLCProductQuadrature2DRZ(int Npolar,
                                                    int Nazimuthal,
                                                    int scattering_order,
                                                    bool verbose)
-  : CurvilinearQuadrature(2, scattering_order)
+  : CurvilinearProductQuadrature(2, scattering_order)
 {
   if (Npolar % 2 != 0)
     throw std::invalid_argument("GLCProductQuadraturee2DRZ: Npolar must be even.");

--- a/framework/math/quadratures/angular/curvilinear_product_quadrature.h
+++ b/framework/math/quadratures/angular/curvilinear_product_quadrature.h
@@ -13,7 +13,7 @@ namespace opensn
  * Base class for curvilinear angular quadratures (product angular quadratures with additional
  * direction-dependent parameters).
  */
-class CurvilinearQuadrature : public ProductQuadrature
+class CurvilinearProductQuadrature : public ProductQuadrature
 {
 protected:
   /// Factor to account for angular diamond differencing.
@@ -25,7 +25,7 @@ protected:
    */
   std::vector<double> fac_streaming_operator_;
 
-  CurvilinearQuadrature(int dimension, int scattering_order)
+  CurvilinearProductQuadrature(int dimension, int scattering_order)
     : ProductQuadrature(dimension, scattering_order)
   {
   }
@@ -35,10 +35,10 @@ public:
 
   const std::vector<double>& GetStreamingOperatorFactor() const { return fac_streaming_operator_; }
 
-  virtual ~CurvilinearQuadrature() = default;
+  virtual ~CurvilinearProductQuadrature() = default;
 };
 
-class GLCProductQuadrature2DRZ : public CurvilinearQuadrature
+class GLCProductQuadrature2DRZ : public CurvilinearProductQuadrature
 {
 private:
   /**
@@ -63,7 +63,7 @@ public:
   void MakeHarmonicIndices();
 };
 
-class GLProductQuadrature1DSpherical : public CurvilinearQuadrature
+class GLProductQuadrature1DSpherical : public CurvilinearProductQuadrature
 {
 private:
   /// Initialize with one-dimensional quadrature.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
@@ -42,7 +42,7 @@ AAHSweepChunkRZ::AAHSweepChunkRZ(const std::shared_ptr<MeshContinuum> grid,
     normal_vector_boundary_()
 {
   const auto curvilinear_product_quadrature =
-    std::dynamic_pointer_cast<CurvilinearQuadrature>(groupset_.quadrature);
+    std::dynamic_pointer_cast<CurvilinearProductQuadrature>(groupset_.quadrature);
 
   if (curvilinear_product_quadrature == nullptr)
     throw std::invalid_argument("D_DO_RZ_SteadyState::SweepChunkPWL::SweepChunkPWL : "
@@ -87,7 +87,7 @@ AAHSweepChunkRZ::Sweep(AngleSet& angle_set)
   std::vector<double> source(max_num_cell_dofs_);
 
   const auto curvilinear_product_quadrature =
-    std::dynamic_pointer_cast<opensn::CurvilinearQuadrature>(groupset_.quadrature);
+    std::dynamic_pointer_cast<opensn::CurvilinearProductQuadrature>(groupset_.quadrature);
 
   // Loop over each cell
   const auto& spds = angle_set.GetSPDS();

--- a/python/lib/aquad.cc
+++ b/python/lib/aquad.cc
@@ -205,32 +205,32 @@ WrapProductQuadrature(py::module& aquad)
   // clang-format on
 }
 
-// Wrap curvilinear quadrature
+// Wrap curvilinear product quadrature
 void
-WrapCurvilinearQuadrature(py::module& aquad)
+WrapCurvilinearProductQuadrature(py::module& aquad)
 {
   // clang-format off
-  // curvilinear quadrature
-  auto curvilinear_quadrature = py::class_<CurvilinearQuadrature,
-                                           std::shared_ptr<CurvilinearQuadrature>,
-                                           ProductQuadrature>(
+  // curvilinear product quadrature
+  auto curvilinear_product_quadrature = py::class_<CurvilinearProductQuadrature,
+                                                   std::shared_ptr<CurvilinearProductQuadrature>,
+                                                   ProductQuadrature>(
     aquad,
-    "CurvilinearQuadrature",
+    "CurvilinearPrductQuadrature",
     R"(
-    Curvilinear quadrature.
+    Curvilinear product quadrature.
 
-    Wrapper of :cpp:class:`opensn::CurvilinearQuadrature`.
+    Wrapper of :cpp:class:`opensn::CurvilinearProductQuadrature`.
     )"
   );
 
-  // Gauss-Legendre-Chebyshev 2D RZ curvilinear quadrature
+  // Gauss-Legendre-Chebyshev 2D RZ curvilinear product quadrature
   auto curvilinear_quadrature_glc_2d_rz = py::class_<GLCProductQuadrature2DRZ,
                                                      std::shared_ptr<GLCProductQuadrature2DRZ>,
-                                                     CurvilinearQuadrature>(
+                                                     CurvilinearProductQuadrature>(
     aquad,
     "GLCProductQuadrature2DRZ",
     R"(
-    Gauss-Legendre-Chebyshev quadrature for 2D, RZ geometry.
+    Gauss-Legendre-Chebyshev product quadrature for 2D, RZ geometry.
 
     Wrapper of :cpp:class:`opensn::GLCProductQuadrature2DRZ`.
     )"
@@ -341,7 +341,7 @@ py_aquad(py::module& pyopensn)
   WrapQuadraturePointPhiTheta(aquad);
   WrapQuadrature(aquad);
   WrapProductQuadrature(aquad);
-  WrapCurvilinearQuadrature(aquad);
+  WrapCurvilinearProductQuadrature(aquad);
   WrapSLDFESQuadrature(aquad);
 }
 

--- a/python/lib/py_app.cc
+++ b/python/lib/py_app.cc
@@ -37,7 +37,7 @@ PyApp::PyApp(const mpi::Communicator& comm) : allow_petsc_error_handler_(false)
   console.BindModule(WrapQuadraturePointPhiTheta);
   console.BindModule(WrapQuadrature);
   console.BindModule(WrapProductQuadrature);
-  console.BindModule(WrapCurvilinearQuadrature);
+  console.BindModule(WrapCurvilinearProductQuadrature);
   console.BindModule(WrapSLDFESQuadrature);
 
   console.BindModule(WrapMesh);

--- a/python/lib/py_wrappers.h
+++ b/python/lib/py_wrappers.h
@@ -183,7 +183,7 @@ void py_aquad(py::module& pyopensn);
 void WrapQuadraturePointPhiTheta(py::module& aquad);
 void WrapQuadrature(py::module& aquad);
 void WrapProductQuadrature(py::module& aquad);
-void WrapCurvilinearQuadrature(py::module& aquad);
+void WrapCurvilinearProductQuadrature(py::module& aquad);
 void WrapSLDFESQuadrature(py::module& aquad);
 
 /// Wrap the field function components of OpenSn.


### PR DESCRIPTION
Renames CurvilinearQuadrature to CurvilinearProductQuadrature and derives it from ProductQuadrature.  Partially addresses #658.