### PR TITLE
Refactoring opensn native cross-section file reader in its own class

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -29,9 +29,6 @@ public:
   void
   Initialize(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);
 
-  /// This method populates transport cross sections from an OpenSn cross-section file.
-  void Initialize(const std::string& file_name);
-
   /// This method populates transport cross sections from an OpenMC cross-section file.
   void
   Initialize(const std::string& file_name, const std::string& dataset_name, double temperature);
@@ -184,23 +181,7 @@ private:
 
   void TransposeTransferAndProduction();
 
-  /// Check vector for all non-negative values
-  bool IsNonNegative(const std::vector<double>& vec)
-  {
-    return not std::any_of(vec.begin(), vec.end(), [](double x) { return x < 0.0; });
-  }
-
-  /// Check vector for all strictly positive values
-  bool IsPositive(const std::vector<double>& vec)
-  {
-    return not std::any_of(vec.begin(), vec.end(), [](double x) { return x <= 0.0; });
-  }
-
-  /// Check vector for any non-zero values
-  bool HasNonZero(const std::vector<double>& vec)
-  {
-    return std::any_of(vec.begin(), vec.end(), [](double x) { return x > 0.0; });
-  }
+  friend class XSFile;
 };
 
 } // namespace opensn

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -181,7 +181,8 @@ private:
 
   void TransposeTransferAndProduction();
 
-  friend class XSFile;
+public:
+  static MultiGroupXS LoadFromOpenSn(const std::string& filename);
 };
 
 } // namespace opensn

--- a/framework/materials/multi_group_xs/openmc_import.cc
+++ b/framework/materials/multi_group_xs/openmc_import.cc
@@ -5,6 +5,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/hdf_utils.h"
+#include "framework/utils/utils.h"
 #include <numeric>
 #include <algorithm>
 

--- a/framework/materials/multi_group_xs/opensn_import.cc
+++ b/framework/materials/multi_group_xs/opensn_import.cc
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/materials/multi_group_xs/xsfile.h"
+#include "framework/runtime.h"
+#include "framework/logging/log.h"
+#include "framework/utils/utils.h"
+
+namespace opensn
+{
+
+MultiGroupXS
+MultiGroupXS::LoadFromOpenSn(const std::string& filename)
+{
+  XSFile xsf(filename);
+  xsf.Read();
+
+  MultiGroupXS mgxs;
+  mgxs.num_groups_ = xsf.num_groups_;
+  mgxs.scattering_order_ = xsf.scattering_order_;
+  mgxs.num_precursors_ = xsf.num_precursors_;
+  mgxs.inv_velocity_ = xsf.inv_velocity_;
+  mgxs.e_bounds_ = xsf.e_bounds_;
+  mgxs.sigma_t_ = xsf.sigma_t_;
+  mgxs.sigma_a_ = xsf.sigma_a_;
+  mgxs.chi_ = xsf.chi_;
+  mgxs.transfer_matrices_ = xsf.transfer_matrices_;
+
+  // Determine if the material is fissionable
+  mgxs.is_fissionable_ =
+    not xsf.sigma_f_.empty() or not xsf.nu_sigma_f_.empty() or not xsf.production_matrix_.empty();
+
+  // Check and set the fission data
+  if (mgxs.is_fissionable_)
+  {
+    // Check vector data inputs
+    if (xsf.production_matrix_.empty())
+    {
+      // Check for non-delayed fission neutron yield data
+      OpenSnLogicalErrorIf(xsf.nu_.empty() and xsf.nu_prompt_.empty(),
+                           "Either the total or prompt fission neutron yield must be specified "
+                           "for fissionable materials.");
+      OpenSnLogicalErrorIf(not xsf.nu_.empty() and not xsf.nu_prompt_.empty(),
+                           "Ambiguous fission neutron yield. Only one of the total and prompt "
+                           "fission neutron yield should be specified.");
+
+      // Check for fission spectrum data
+      OpenSnLogicalErrorIf(xsf.chi_.empty() and xsf.chi_prompt_.empty(),
+                           "Either the steady-state or prompt fission spectrum must be specified "
+                           "for fissionable materials.");
+      OpenSnLogicalErrorIf(not xsf.chi_.empty() and not xsf.chi_prompt_.empty(),
+                           "Ambiguous fission spectrum data. Only one of the steady-state and "
+                           "prompt fission spectrum should be specified.");
+
+      // Check for compatibility
+      if ((not xsf.nu_.empty() and xsf.chi_.empty()) or
+          (xsf.nu_.empty() and not xsf.chi_.empty()) or
+          (not xsf.nu_prompt_.empty() and xsf.chi_prompt_.empty()) or
+          (xsf.nu_prompt_.empty() and not xsf.chi_prompt_.empty()))
+        OpenSnLogicalError(
+          "Ambiguous fission data. Either the total fission neutron yield with the "
+          "steady-state fission spectrum or the prompt fission neutron yield with "
+          "the prompt fission spectrum should be specified.");
+
+      // Initialize total fission neutron yield from prompt
+      if (not xsf.nu_prompt_.empty())
+        xsf.nu_ = xsf.nu_prompt_;
+
+      // Check delayed neutron data
+      if (xsf.num_precursors_ > 0)
+      {
+        // Check that decay data was specified
+        OpenSnLogicalErrorIf(
+          xsf.decay_constants_.empty(),
+          "Precursor decay constants are required when precursors are specified.");
+
+        // Check that yield data was specified
+        OpenSnLogicalErrorIf(xsf.fractional_yields_.empty(),
+                             "Precursor yields are required when precursors are specified.");
+
+        // Check that prompt data was specified
+        OpenSnLogicalErrorIf(xsf.chi_prompt_.empty() or xsf.nu_prompt_.empty(),
+                             "Both the prompt fission spectrum and prompt fission neutron yield "
+                             "must be specified when delayed neutron precursors are specified.");
+
+        // Check that delayed neutron production and emission spectra were specified
+        OpenSnLogicalErrorIf(xsf.nu_delayed_.empty() or
+                               std::any_of(xsf.emission_spectra_.begin(),
+                                           xsf.emission_spectra_.end(),
+                                           [](const std::vector<double>& x) { return x.empty(); }),
+                             "Both the delay emission spectra and delayed fission neutron yield "
+                             "must be specified when precursors are specified.");
+
+        // Add delayed fission neutron yield to total
+        for (size_t g = 0; g < xsf.num_groups_; ++g)
+          xsf.nu_[g] += xsf.nu_delayed_[g];
+
+        // Add data to precursor structs
+        mgxs.num_precursors_ = xsf.num_precursors_;
+        mgxs.precursors_.resize(xsf.num_precursors_);
+        for (size_t j = 0; j < xsf.num_precursors_; ++j)
+        {
+          mgxs.precursors_[j].decay_constant = xsf.decay_constants_[j];
+          mgxs.precursors_[j].fractional_yield = xsf.fractional_yields_[j];
+          mgxs.precursors_[j].emission_spectrum = xsf.emission_spectra_[j];
+        }
+      }
+
+      // Compute fission cross section
+      if (xsf.sigma_f_.empty() and not xsf.nu_sigma_f_.empty())
+      {
+        xsf.sigma_f_ = xsf.nu_sigma_f_;
+        for (size_t g = 0; g < xsf.num_groups_; ++g)
+          if (xsf.nu_sigma_f_[g] > 0.0)
+            xsf.sigma_f_[g] /= xsf.nu_[g];
+      }
+      mgxs.sigma_f_ = xsf.sigma_f_;
+
+      // Compute total production cross section
+      xsf.nu_sigma_f_ = xsf.sigma_f_;
+      for (size_t g = 0; g < xsf.num_groups_; ++g)
+        xsf.nu_sigma_f_[g] *= xsf.nu_[g];
+      mgxs.nu_sigma_f_ = xsf.nu_sigma_f_;
+
+      // Compute prompt production cross section
+      if (not xsf.nu_prompt_.empty())
+      {
+        mgxs.nu_prompt_sigma_f_ = xsf.sigma_f_;
+        for (size_t g = 0; g < xsf.num_groups_; ++g)
+          mgxs.nu_prompt_sigma_f_[g] *= xsf.nu_prompt_[g];
+      }
+
+      // Compute delayed production cross section
+      if (not xsf.nu_delayed_.empty())
+      {
+        mgxs.nu_delayed_sigma_f_ = xsf.sigma_f_;
+        for (size_t g = 0; g < xsf.num_groups_; ++g)
+          mgxs.nu_delayed_sigma_f_[g] *= xsf.nu_delayed_[g];
+      }
+
+      // Compute production matrix
+      const auto fis_spec = not xsf.chi_prompt_.empty() ? xsf.chi_prompt_ : xsf.chi_;
+      const auto nu_sigma_f =
+        not xsf.nu_prompt_.empty() ? mgxs.nu_prompt_sigma_f_ : xsf.nu_sigma_f_;
+
+      mgxs.production_matrix_.resize(xsf.num_groups_);
+      for (size_t g = 0; g < xsf.num_groups_; ++g)
+        for (size_t gp = 0.0; gp < xsf.num_groups_; ++gp)
+          mgxs.production_matrix_[g].push_back(fis_spec[g] * nu_sigma_f[gp]);
+    } // if production_matrix empty
+
+    else
+    {
+      // TODO: Develop an implementation for multi-particle delayed neutron data.
+      //       The primary challenge in this is that different precursor species exist for
+      //       neutron-induced fission than for photo-fission.
+
+      OpenSnLogicalErrorIf(xsf.num_precursors_ > 0,
+                           "Currently, production matrix specification is not allowed when "
+                           "delayed neutrons are present.");
+
+      // Check for fission cross sections
+      OpenSnLogicalErrorIf(xsf.sigma_f_.empty(),
+                           "When a production matrix is specified, it must "
+                           "be accompanied with a fission cross section.");
+
+      // Compute production cross section
+      mgxs.nu_sigma_f_.assign(xsf.num_groups_, 0.0);
+      for (size_t g = 0; g < xsf.num_groups_; ++g)
+        for (size_t gp = 0; gp < xsf.num_groups_; ++gp)
+          mgxs.nu_sigma_f_[gp] += xsf.production_matrix_[g][gp];
+
+      // Check for reasonable fission neutron yield
+      auto nu = xsf.nu_sigma_f_;
+      for (size_t g = 0; g < xsf.num_groups_; ++g)
+        if (xsf.sigma_f_[g] > 0.0)
+          nu[g] /= xsf.sigma_f_[g];
+
+      OpenSnLogicalErrorIf(
+        not IsNonNegative(nu),
+        "The production matrix implies an invalid negative average fission neutron yield.");
+      OpenSnLogicalErrorIf(
+        not std::all_of(nu.begin(), nu.end(), [](double x) { return x == 0.0 and x > 1.0; }),
+        "Incompatible fission data encountered. The computed nu is not either zero or "
+        "greater than one.");
+
+      if (std::any_of(nu.begin(), nu.end(), [](double x) { return x > 8.0; }))
+        log.Log0Warning() << "A computed nu of greater than 8.0 was encountered. ";
+    }
+
+    OpenSnLogicalErrorIf(
+      xsf.sigma_f_.empty(),
+      "Fissionable materials are required to have a defined fission cross section.");
+  } // if fissionable
+
+  // Clear fission data if not fissionable
+  else
+  {
+    // this is not needed
+    mgxs.sigma_f_.clear();
+    mgxs.nu_sigma_f_.clear();
+    mgxs.nu_prompt_sigma_f_.clear();
+    mgxs.nu_delayed_sigma_f_.clear();
+    mgxs.production_matrix_.clear();
+    mgxs.precursors_.clear();
+  } // if not fissionable
+
+  if (mgxs.sigma_a_.empty())
+    mgxs.ComputeAbsorption();
+  mgxs.ComputeDiffusionParameters();
+
+  return mgxs;
+}
+
+} // namespace opensn

--- a/framework/materials/multi_group_xs/xsfile.cc
+++ b/framework/materials/multi_group_xs/xsfile.cc
@@ -1,174 +1,29 @@
-// SPDX-FileCopyrightText: 2024 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/materials/multi_group_xs/xsfile.h"
+#include "framework/utils/utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include <numeric>
+#include <fstream>
 
 namespace opensn
 {
 
-// Read xs data from an OpenSn data file
-void
-MultiGroupXS::Initialize(const std::string& file_name)
+XSFile::XSFile(const std::string& file_name) : file_name_(file_name)
 {
-  Reset();
+}
+
+MultiGroupXS
+XSFile::Read()
+{
+  MultiGroupXS mgxs;
 
   // Open OpenSn XS file
   std::ifstream file;
-  file.open(file_name);
-  OpenSnLogicalErrorIf(not file.is_open(), "Failed to open cross-section file " + file_name + ".");
-  log.Log() << "Reading OpenSn cross-section file \"" << file_name << "\"\n";
-
-  // Lambda for reading group structure data.
-  auto ReadGroupStructure = [](const std::string& keyword,
-                               std::vector<double>& destination,
-                               const size_t n_grps,
-                               std::ifstream& file,
-                               std::istringstream& line_stream,
-                               size_t& line_number)
-  {
-    destination.reserve(n_grps + 1);
-
-    std::string line;
-    double bound;
-    size_t count = 0;
-
-    // Read the block
-    std::getline(file, line);
-    line_stream = std::istringstream(line);
-    ++line_number;
-    while (line != keyword + "_END")
-    {
-      // Get data from current line
-      line_stream >> bound;
-      destination.push_back(bound);
-      OpenSnLogicalErrorIf(count++ >= n_grps + 1,
-                           "Too many entries encountered when parsing group structure.\n"
-                           "The expected number of entries is " +
-                             std::to_string(n_grps + 1) + ".");
-
-      // Go to next line
-      std::getline(file, line);
-      line_stream = std::istringstream(line);
-      ++line_number;
-    }
-  };
-
-  // Lambda for reading vector data.
-  auto Read1DData = [](const std::string& keyword,
-                       std::vector<double>& destination,
-                       const size_t n_entries,
-                       std::ifstream& file,
-                       std::istringstream& line_stream,
-                       size_t& line_number)
-  {
-    destination.assign(n_entries, 0.0);
-
-    std::string line;
-    int i;
-    double value;
-    size_t count = 0;
-
-    // Read the bloc
-    std::getline(file, line);
-    line_stream = std::istringstream(line);
-    ++line_number;
-    while (line != keyword + "_END")
-    {
-      // get data from current line
-      line_stream >> i >> value;
-      destination.at(i) = value;
-      OpenSnLogicalErrorIf(count++ >= n_entries,
-                           "Too many entries encountered when parsing 1D data.\n"
-                           "The expected number of entries is " +
-                             std::to_string(n_entries) + ".");
-
-      // Go to next line
-      std::getline(file, line);
-      line_stream = std::istringstream(line);
-      ++line_number;
-    }
-  };
-
-  // Lambda for reading 2D data
-  auto Read2DData = [](const std::string& keyword,
-                       const std::string& entry_prefix,
-                       std::vector<std::vector<double>>& destination,
-                       const size_t n_rows,
-                       const size_t n_cols,
-                       std::ifstream& file,
-                       std::istringstream& line_stream,
-                       size_t& line_number)
-  {
-    destination.assign(n_rows, std::vector<double>(n_cols, 0.0));
-
-    std::string word, line;
-    double value;
-    size_t i, j;
-
-    // Read the block
-    std::getline(file, line);
-    line_stream = std::istringstream(line);
-    ++line_number;
-    while (line != keyword + "_END")
-    {
-      // Check that this line contains an entry
-      line_stream >> word;
-      if (word == entry_prefix)
-      {
-        // Get data from current line
-        line_stream >> i >> j >> value;
-        if (entry_prefix == "G_PRECURSOR_VAL")
-          destination.at(j).at(i) = value; // hack
-        else
-          destination.at(i).at(j) = value;
-      }
-
-      // Go to next line
-      std::getline(file, line);
-      line_stream = std::istringstream(line);
-      ++line_number;
-    }
-  };
-
-  // Lambda for reading transfer matrix data.
-  auto ReadTransferMatrices = [](const std::string& keyword,
-                                 std::vector<SparseMatrix>& destination,
-                                 const size_t n_moms,
-                                 const size_t n_grps,
-                                 std::ifstream& file,
-                                 std::istringstream& line_stream,
-                                 size_t& line_number)
-  {
-    destination.assign(n_moms, SparseMatrix(n_grps, n_grps));
-
-    std::string word, line;
-    double value;
-    size_t ell, group, gprime;
-
-    // Read the block
-    std::getline(file, line);
-    line_stream = std::istringstream(line);
-    ++line_number;
-    while (line != keyword + "_END")
-    {
-      // Check that this line contains an entry
-      line_stream >> word;
-      if (word == "M_GPRIME_G_VAL")
-      {
-        // Get data from current line
-        line_stream >> ell >> gprime >> group >> value;
-        destination.at(ell).Insert(group, gprime, value);
-      }
-
-      // Go to next line
-      std::getline(file, line);
-      line_stream = std::istringstream(line);
-      ++line_number;
-    }
-  };
+  file.open(file_name_);
+  OpenSnLogicalErrorIf(not file.is_open(), "Failed to open cross-section file " + file_name_ + ".");
+  opensn::log.Log() << "Reading OpenSn cross-section file \"" << file_name_ << "\"\n";
 
   // Read the OpenSn XS file
   // TODO: Determine whether or not to allow specification of a
@@ -195,7 +50,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
       int n_groups;
       line_stream >> n_groups;
       OpenSnLogicalErrorIf(n_groups <= 0, "The number of energy groups must be positive.");
-      num_groups_ = n_groups;
+      mgxs.num_groups_ = n_groups;
     }
 
     // Parse the number of scattering moments
@@ -204,7 +59,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
       int n_moments;
       line_stream >> n_moments;
       OpenSnLogicalErrorIf(n_moments < 0, "The number of scattering moments must be non-negative.");
-      scattering_order_ = std::max(0, n_moments - 1);
+      mgxs.scattering_order_ = std::max(0, n_moments - 1);
     }
 
     // Parse the number of precursors species
@@ -214,8 +69,8 @@ MultiGroupXS::Initialize(const std::string& file_name)
       line_stream >> n_prec;
       OpenSnLogicalErrorIf(n_prec < 0,
                            "The number of delayed neutron precursors must be non-negative.");
-      num_precursors_ = n_prec;
-      precursors_.resize(num_precursors_);
+      mgxs.num_precursors_ = n_prec;
+      mgxs.precursors_.resize(mgxs.num_precursors_);
     }
 
     // Parse nuclear data
@@ -231,22 +86,22 @@ MultiGroupXS::Initialize(const std::string& file_name)
       //
 
       if (fw == "GROUP_STRUCTURE_BEGIN")
-        ReadGroupStructure("GROUP_STRUCTURE", e_bounds_, num_groups_, f, ls, ln);
+        ReadGroupStructure("GROUP_STRUCTURE", mgxs.e_bounds_, mgxs.num_groups_, f, ls, ln);
       if (fw == "INV_VELOCITY_BEGIN")
       {
-        Read1DData("INV_VELOCITY", inv_velocity_, num_groups_, f, ls, ln);
-        OpenSnLogicalErrorIf(not IsPositive(inv_velocity_),
+        Read1DData("INV_VELOCITY", mgxs.inv_velocity_, mgxs.num_groups_, f, ls, ln);
+        OpenSnLogicalErrorIf(not IsPositive(mgxs.inv_velocity_),
                              "Only positive inverse velocity values are permitted.");
       }
-      if (fw == "VELOCITY_BEGIN" and inv_velocity_.empty())
+      if (fw == "VELOCITY_BEGIN" and mgxs.inv_velocity_.empty())
       {
-        Read1DData("VELOCITY", inv_velocity_, num_groups_, f, ls, ln);
-        OpenSnLogicalErrorIf(not IsPositive(inv_velocity_),
+        Read1DData("VELOCITY", mgxs.inv_velocity_, mgxs.num_groups_, f, ls, ln);
+        OpenSnLogicalErrorIf(not IsPositive(mgxs.inv_velocity_),
                              "Only positive velocity values are permitted.");
 
         // Compute inverse velocity
-        for (size_t g = 0; g < num_groups_; ++g)
-          inv_velocity_[g] = 1.0 / inv_velocity_[g];
+        for (size_t g = 0; g < mgxs.num_groups_; ++g)
+          mgxs.inv_velocity_[g] = 1.0 / mgxs.inv_velocity_[g];
       }
 
       //
@@ -255,42 +110,42 @@ MultiGroupXS::Initialize(const std::string& file_name)
 
       if (fw == "SIGMA_T_BEGIN")
       {
-        Read1DData("SIGMA_T", sigma_t_, num_groups_, f, ls, ln);
-        OpenSnLogicalErrorIf(not IsNonNegative(sigma_t_),
+        Read1DData("SIGMA_T", mgxs.sigma_t_, mgxs.num_groups_, f, ls, ln);
+        OpenSnLogicalErrorIf(not IsNonNegative(mgxs.sigma_t_),
                              "Only non-negative total cross-section values are permitted.");
       } // if sigma_t
 
       if (fw == "SIGMA_A_BEGIN")
       {
-        Read1DData("SIGMA_A", sigma_a_, num_groups_, f, ls, ln);
-        OpenSnLogicalErrorIf(not IsNonNegative(sigma_a_),
+        Read1DData("SIGMA_A", mgxs.sigma_a_, mgxs.num_groups_, f, ls, ln);
+        OpenSnLogicalErrorIf(not IsNonNegative(mgxs.sigma_a_),
                              "Only non-negative absorption cross-section values are permitted.");
       } // if sigma_a
 
       if (fw == "SIGMA_F_BEGIN")
       {
-        Read1DData("SIGMA_F", sigma_f_, num_groups_, f, ls, ln);
-        OpenSnLogicalErrorIf(not IsNonNegative(sigma_f_),
+        Read1DData("SIGMA_F", mgxs.sigma_f_, mgxs.num_groups_, f, ls, ln);
+        OpenSnLogicalErrorIf(not IsNonNegative(mgxs.sigma_f_),
                              "Only non-negative fission cross-section values are permitted.");
-        if (not HasNonZero(sigma_f_))
+        if (not HasNonZero(mgxs.sigma_f_))
         {
           log.Log0Warning() << "The fission cross section specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
-          sigma_f_.clear();
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
+          mgxs.sigma_f_.clear();
         }
       } // if sigma_f
 
       if (fw == "NU_SIGMA_F_BEGIN")
       {
-        Read1DData("NU_SIGMA_F", nu_sigma_f_, num_groups_, f, ls, ln);
+        Read1DData("NU_SIGMA_F", mgxs.nu_sigma_f_, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(
-          not IsNonNegative(nu_sigma_f_),
+          not IsNonNegative(mgxs.nu_sigma_f_),
           "Only non-negative total fission multiplication cross-section values are permitted.");
-        if (not HasNonZero(nu_sigma_f_))
+        if (not HasNonZero(mgxs.nu_sigma_f_))
         {
           log.Log0Warning() << "The production cross section specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
-          nu_sigma_f_.clear();
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
+          mgxs.nu_sigma_f_.clear();
         }
       } // if nu_sigma_f
 
@@ -300,24 +155,24 @@ MultiGroupXS::Initialize(const std::string& file_name)
 
       if (fw == "NU_BEGIN")
       {
-        Read1DData("NU", nu, num_groups_, f, ls, ln);
+        Read1DData("NU", nu, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(
           not std::all_of(nu.begin(), nu.end(), [](double x) { return x == 0.0 or x > 1.0; }),
           "Total fission neutron yield values must be either zero, or greater than one.");
         if (not HasNonZero(nu))
         {
           log.Log0Warning() << "The total fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
           nu.clear();
         }
 
         // Compute prompt/delayed nu, if needed
-        if (num_precursors_ > 0 and not nu.empty() and not beta.empty() and nu_prompt.empty() and
-            nu_delayed.empty())
+        if (mgxs.num_precursors_ > 0 and not nu.empty() and not beta.empty() and
+            nu_prompt.empty() and nu_delayed.empty())
         {
-          nu_prompt.assign(num_groups_, 0.0);
-          nu_delayed.assign(num_groups_, 0.0);
-          for (size_t g = 0; g < num_groups_; ++g)
+          nu_prompt.assign(mgxs.num_groups_, 0.0);
+          nu_delayed.assign(mgxs.num_groups_, 0.0);
+          for (size_t g = 0; g < mgxs.num_groups_; ++g)
           {
             nu_prompt[g] = (1.0 - beta[g]) * nu[g];
             nu_delayed[g] = beta[g] * nu[g];
@@ -327,7 +182,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
 
       if (fw == "NU_PROMPT_BEGIN")
       {
-        Read1DData("NU_PROMPT", nu_prompt, num_groups_, f, ls, ln);
+        Read1DData("NU_PROMPT", nu_prompt, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(not std::all_of(nu_prompt.begin(),
                                              nu_prompt.end(),
                                              [](double x) { return x == 0.0 or x > 1.0; }),
@@ -336,45 +191,45 @@ MultiGroupXS::Initialize(const std::string& file_name)
         if (not HasNonZero(nu_prompt))
         {
           log.Log0Warning() << "The prompt fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
           nu_prompt.clear();
         }
       } // if nu_prompt
 
       if (fw == "NU_DELAYED_BEGIN")
       {
-        Read1DData("NU_DELAYED", nu_delayed, num_groups_, f, ls, ln);
+        Read1DData("NU_DELAYED", nu_delayed, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(not IsNonNegative(nu_delayed),
                              "Average delayed fission neutron yield values "
                              "must be non-negative.");
         if (not HasNonZero(nu_delayed))
         {
           log.Log0Warning() << "The delayed fission neutron yield specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
           nu_prompt.clear();
         }
       } // if nu_delayed
 
       if (fw == "BETA_BEGIN")
       {
-        Read1DData("BETA", beta, num_groups_, f, ls, ln);
+        Read1DData("BETA", beta, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(
           not std::all_of(beta.begin(), beta.end(), [](double x) { return x >= 0.0 and x <= 1.0; }),
           "Delayed neutron fraction values must be in the range [0.0, 1.0].");
         if (not HasNonZero(beta))
         {
           log.Log0Warning() << "The delayed neutron fraction specified in "
-                            << "\"" << file_name << "\" is uniformly zero... Clearing it.";
+                            << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
           beta.clear();
         }
 
         // Compute prompt/delayed nu, if needed
-        if (num_precursors_ > 0 and not nu.empty() and not beta.empty() and nu_prompt.empty() and
-            nu_delayed.empty())
+        if (mgxs.num_precursors_ > 0 and not nu.empty() and not beta.empty() and
+            nu_prompt.empty() and nu_delayed.empty())
         {
-          nu_prompt.assign(num_groups_, 0.0);
-          nu_delayed.assign(num_groups_, 0.0);
-          for (unsigned int g = 0; g < num_groups_; ++g)
+          nu_prompt.assign(mgxs.num_groups_, 0.0);
+          nu_delayed.assign(mgxs.num_groups_, 0.0);
+          for (unsigned int g = 0; g < mgxs.num_groups_; ++g)
           {
             nu_prompt[g] = (1.0 - beta[g]) * nu[g];
             nu_delayed[g] = beta[g] * nu[g];
@@ -388,22 +243,24 @@ MultiGroupXS::Initialize(const std::string& file_name)
 
       if (fw == "CHI_BEGIN")
       {
-        Read1DData("CHI", chi_, num_groups_, f, ls, ln);
+        Read1DData("CHI", mgxs.chi_, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(
-          not HasNonZero(chi_),
+          not HasNonZero(mgxs.chi_),
           "The steady-state fission spectrum must have at least one non-zero value.");
-        OpenSnLogicalErrorIf(not IsNonNegative(chi_),
+        OpenSnLogicalErrorIf(not IsNonNegative(mgxs.chi_),
                              "The steady-state fission spectrum must be non-negative.");
 
         // Normalizing
-        const auto sum = std::accumulate(chi_.begin(), chi_.end(), 0.0);
-        std::transform(
-          chi_.begin(), chi_.end(), chi_.begin(), [sum](double& x) { return x / sum; });
+        const auto sum = std::accumulate(mgxs.chi_.begin(), mgxs.chi_.end(), 0.0);
+        std::transform(mgxs.chi_.begin(),
+                       mgxs.chi_.end(),
+                       mgxs.chi_.begin(),
+                       [sum](double& x) { return x / sum; });
       } // if chi
 
       if (fw == "CHI_PROMPT_BEGIN")
       {
-        Read1DData("CHI_PROMPT", chi_prompt, num_groups_, f, ls, ln);
+        Read1DData("CHI_PROMPT", chi_prompt, mgxs.num_groups_, f, ls, ln);
         OpenSnLogicalErrorIf(not HasNonZero(chi_prompt),
                              "The prompt fission spectrum must have at least one non-zero value.");
         OpenSnLogicalErrorIf(not IsNonNegative(chi_prompt),
@@ -418,19 +275,19 @@ MultiGroupXS::Initialize(const std::string& file_name)
 
       } // if prompt chi
 
-      if (num_precursors_ > 0 and fw == "CHI_DELAYED_BEGIN")
+      if (mgxs.num_precursors_ > 0 and fw == "CHI_DELAYED_BEGIN")
       {
         // TODO: Should the be flipped to PRECURSOR_G_VAL?
         Read2DData("CHI_DELAYED",
                    "G_PRECURSOR_VAL",
                    emission_spectra,
-                   num_precursors_,
-                   num_groups_,
+                   mgxs.num_precursors_,
+                   mgxs.num_groups_,
                    f,
                    ls,
                    ln);
 
-        for (size_t j = 0; j < num_precursors_; ++j)
+        for (size_t j = 0; j < mgxs.num_precursors_; ++j)
         {
           OpenSnLogicalErrorIf(not HasNonZero(emission_spectra[j]),
                                "Delayed emission spectrum for precursor " + std::to_string(j) +
@@ -453,18 +310,19 @@ MultiGroupXS::Initialize(const std::string& file_name)
       // Read delayed neutron precursor data
       //
 
-      if (num_precursors_ > 0)
+      if (mgxs.num_precursors_ > 0)
       {
         if (fw == "PRECURSOR_DECAY_CONSTANTS_BEGIN")
         {
-          Read1DData("PRECURSOR_DECAY_CONSTANTS", decay_constants, num_precursors_, f, ls, ln);
+          Read1DData("PRECURSOR_DECAY_CONSTANTS", decay_constants, mgxs.num_precursors_, f, ls, ln);
           OpenSnLogicalErrorIf(not IsPositive(decay_constants),
                                "Delayed neutron precursor decay constants must be positive.");
         } // if decay constants
 
         if (fw == "PRECURSOR_FRACTIONAL_YIELDS_BEGIN")
         {
-          Read1DData("PRECURSOR_FRACTIONAL_YIELDS", fractional_yields, num_precursors_, f, ls, ln);
+          Read1DData(
+            "PRECURSOR_FRACTIONAL_YIELDS", fractional_yields, mgxs.num_precursors_, f, ls, ln);
           OpenSnLogicalErrorIf(
             not HasNonZero(fractional_yields),
             "Delayed neutron precursor fractional yields must contain at least one non-zero.");
@@ -488,15 +346,20 @@ MultiGroupXS::Initialize(const std::string& file_name)
       //
 
       if (fw == "TRANSFER_MOMENTS_BEGIN")
-        ReadTransferMatrices(
-          "TRANSFER_MOMENTS", transfer_matrices_, scattering_order_ + 1, num_groups_, f, ls, ln);
+        ReadTransferMatrices("TRANSFER_MOMENTS",
+                             mgxs.transfer_matrices_,
+                             mgxs.scattering_order_ + 1,
+                             mgxs.num_groups_,
+                             f,
+                             ls,
+                             ln);
 
       if (fw == "PRODUCTION_MATRIX_BEGIN")
         Read2DData("PRODUCTION_MATRIX",
                    "GPRIME_G_VAL",
-                   production_matrix_,
-                   num_groups_,
-                   num_groups_,
+                   mgxs.production_matrix_,
+                   mgxs.num_groups_,
+                   mgxs.num_groups_,
                    f,
                    ls,
                    ln);
@@ -506,7 +369,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
     {
       throw std::runtime_error("Error reading OpenSn cross-section file "
                                "\"" +
-                               file_name + "\".\n" + "Line number " + std::to_string(line_number) +
+                               file_name_ + "\".\n" + "Line number " + std::to_string(line_number) +
                                "\n" + err.what());
     }
 
@@ -514,7 +377,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
     {
       throw std::logic_error("Error reading OpenSn cross-section file "
                              "\"" +
-                             file_name + "\".\n" + "Line number " + std::to_string(line_number) +
+                             file_name_ + "\".\n" + "Line number " + std::to_string(line_number) +
                              "\n" + err.what());
     }
 
@@ -527,23 +390,23 @@ MultiGroupXS::Initialize(const std::string& file_name)
   } // while not EOF, read each lines
   file.close();
 
-  if (sigma_a_.empty())
-    ComputeAbsorption();
-  ComputeDiffusionParameters();
+  if (mgxs.sigma_a_.empty())
+    mgxs.ComputeAbsorption();
+  mgxs.ComputeDiffusionParameters();
 
   //
   // Compute and check fission data
   //
 
   // Determine if the material is fissionable
-  is_fissionable_ =
-    not sigma_f_.empty() or not nu_sigma_f_.empty() or not production_matrix_.empty();
+  mgxs.is_fissionable_ = not mgxs.sigma_f_.empty() or not mgxs.nu_sigma_f_.empty() or
+                         not mgxs.production_matrix_.empty();
 
   // Check and set the fission data
-  if (is_fissionable_)
+  if (mgxs.is_fissionable_)
   {
     // Check vector data inputs
-    if (production_matrix_.empty())
+    if (mgxs.production_matrix_.empty())
     {
       // Check for non-delayed fission neutron yield data
       OpenSnLogicalErrorIf(nu.empty() and nu_prompt.empty(),
@@ -554,15 +417,15 @@ MultiGroupXS::Initialize(const std::string& file_name)
                            "fission neutron yield should be specified.");
 
       // Check for fission spectrum data
-      OpenSnLogicalErrorIf(chi_.empty() and chi_prompt.empty(),
+      OpenSnLogicalErrorIf(mgxs.chi_.empty() and chi_prompt.empty(),
                            "Either the steady-state or prompt fission spectrum must be specified "
                            "for fissionable materials.");
-      OpenSnLogicalErrorIf(not chi_.empty() and not chi_prompt.empty(),
+      OpenSnLogicalErrorIf(not mgxs.chi_.empty() and not chi_prompt.empty(),
                            "Ambiguous fission spectrum data. Only one of the steady-state and "
                            "prompt fission spectrum should be specified.");
 
       // Check for compatibility
-      if ((not nu.empty() and chi_.empty()) or (nu.empty() and not chi_.empty()) or
+      if ((not nu.empty() and mgxs.chi_.empty()) or (nu.empty() and not mgxs.chi_.empty()) or
           (not nu_prompt.empty() and chi_prompt.empty()) or
           (nu_prompt.empty() and not chi_prompt.empty()))
         OpenSnLogicalError(
@@ -575,7 +438,7 @@ MultiGroupXS::Initialize(const std::string& file_name)
         nu = nu_prompt;
 
       // Check delayed neutron data
-      if (num_precursors_ > 0)
+      if (mgxs.num_precursors_ > 0)
       {
         // Check that decay data was specified
         OpenSnLogicalErrorIf(
@@ -600,56 +463,56 @@ MultiGroupXS::Initialize(const std::string& file_name)
                              "must be specified when precursors are specified.");
 
         // Add delayed fission neutron yield to total
-        for (size_t g = 0; g < num_groups_; ++g)
+        for (size_t g = 0; g < mgxs.num_groups_; ++g)
           nu[g] += nu_delayed[g];
 
         // Add data to precursor structs
-        for (size_t j = 0; j < num_precursors_; ++j)
+        for (size_t j = 0; j < mgxs.num_precursors_; ++j)
         {
-          precursors_[j].decay_constant = decay_constants[j];
-          precursors_[j].fractional_yield = fractional_yields[j];
-          precursors_[j].emission_spectrum = emission_spectra[j];
+          mgxs.precursors_[j].decay_constant = decay_constants[j];
+          mgxs.precursors_[j].fractional_yield = fractional_yields[j];
+          mgxs.precursors_[j].emission_spectrum = emission_spectra[j];
         }
       }
 
       // Compute fission cross section
-      if (sigma_f_.empty() and not nu_sigma_f_.empty())
+      if (mgxs.sigma_f_.empty() and not mgxs.nu_sigma_f_.empty())
       {
-        sigma_f_ = nu_sigma_f_;
-        for (size_t g = 0; g < num_groups_; ++g)
-          if (nu_sigma_f_[g] > 0.0)
-            sigma_f_[g] /= nu[g];
+        mgxs.sigma_f_ = mgxs.nu_sigma_f_;
+        for (size_t g = 0; g < mgxs.num_groups_; ++g)
+          if (mgxs.nu_sigma_f_[g] > 0.0)
+            mgxs.sigma_f_[g] /= nu[g];
       }
 
       // Compute total production cross section
-      nu_sigma_f_ = sigma_f_;
-      for (size_t g = 0; g < num_groups_; ++g)
-        nu_sigma_f_[g] *= nu[g];
+      mgxs.nu_sigma_f_ = mgxs.sigma_f_;
+      for (size_t g = 0; g < mgxs.num_groups_; ++g)
+        mgxs.nu_sigma_f_[g] *= nu[g];
 
       // Compute prompt production cross section
       if (not nu_prompt.empty())
       {
-        nu_prompt_sigma_f_ = sigma_f_;
-        for (size_t g = 0; g < num_groups_; ++g)
-          nu_prompt_sigma_f_[g] *= nu_prompt[g];
+        mgxs.nu_prompt_sigma_f_ = mgxs.sigma_f_;
+        for (size_t g = 0; g < mgxs.num_groups_; ++g)
+          mgxs.nu_prompt_sigma_f_[g] *= nu_prompt[g];
       }
 
       // Compute delayed production cross section
       if (not nu_delayed.empty())
       {
-        nu_delayed_sigma_f_ = sigma_f_;
-        for (size_t g = 0; g < num_groups_; ++g)
-          nu_delayed_sigma_f_[g] *= nu_delayed[g];
+        mgxs.nu_delayed_sigma_f_ = mgxs.sigma_f_;
+        for (size_t g = 0; g < mgxs.num_groups_; ++g)
+          mgxs.nu_delayed_sigma_f_[g] *= nu_delayed[g];
       }
 
       // Compute production matrix
-      const auto fis_spec = not chi_prompt.empty() ? chi_prompt : chi_;
-      const auto nu_sigma_f = not nu_prompt.empty() ? nu_prompt_sigma_f_ : nu_sigma_f_;
+      const auto fis_spec = not chi_prompt.empty() ? chi_prompt : mgxs.chi_;
+      const auto nu_sigma_f = not nu_prompt.empty() ? mgxs.nu_prompt_sigma_f_ : mgxs.nu_sigma_f_;
 
-      production_matrix_.resize(num_groups_);
-      for (size_t g = 0; g < num_groups_; ++g)
-        for (size_t gp = 0.0; gp < num_groups_; ++gp)
-          production_matrix_[g].push_back(fis_spec[g] * nu_sigma_f[gp]);
+      mgxs.production_matrix_.resize(mgxs.num_groups_);
+      for (size_t g = 0; g < mgxs.num_groups_; ++g)
+        for (size_t gp = 0.0; gp < mgxs.num_groups_; ++gp)
+          mgxs.production_matrix_[g].push_back(fis_spec[g] * nu_sigma_f[gp]);
     } // if production_matrix empty
 
     else
@@ -658,26 +521,26 @@ MultiGroupXS::Initialize(const std::string& file_name)
       //       The primary challenge in this is that different precursor species exist for
       //       neutron-induced fission than for photo-fission.
 
-      OpenSnLogicalErrorIf(num_precursors_ > 0,
+      OpenSnLogicalErrorIf(mgxs.num_precursors_ > 0,
                            "Currently, production matrix specification is not allowed when "
                            "delayed neutrons are present.");
 
       // Check for fission cross sections
-      OpenSnLogicalErrorIf(sigma_f_.empty(),
+      OpenSnLogicalErrorIf(mgxs.sigma_f_.empty(),
                            "When a production matrix is specified, it must "
                            "be accompanied with a fission cross section.");
 
       // Compute production cross section
-      nu_sigma_f_.assign(num_groups_, 0.0);
-      for (size_t g = 0; g < num_groups_; ++g)
-        for (size_t gp = 0; gp < num_groups_; ++gp)
-          nu_sigma_f_[gp] += production_matrix_[g][gp];
+      mgxs.nu_sigma_f_.assign(mgxs.num_groups_, 0.0);
+      for (size_t g = 0; g < mgxs.num_groups_; ++g)
+        for (size_t gp = 0; gp < mgxs.num_groups_; ++gp)
+          mgxs.nu_sigma_f_[gp] += mgxs.production_matrix_[g][gp];
 
       // Check for reasonable fission neutron yield
-      nu = nu_sigma_f_;
-      for (size_t g = 0; g < num_groups_; ++g)
-        if (sigma_f_[g] > 0.0)
-          nu[g] /= sigma_f_[g];
+      nu = mgxs.nu_sigma_f_;
+      for (size_t g = 0; g < mgxs.num_groups_; ++g)
+        if (mgxs.sigma_f_[g] > 0.0)
+          nu[g] /= mgxs.sigma_f_[g];
 
       OpenSnLogicalErrorIf(
         not IsNonNegative(nu),
@@ -692,20 +555,172 @@ MultiGroupXS::Initialize(const std::string& file_name)
     }
 
     OpenSnLogicalErrorIf(
-      sigma_f_.empty(),
+      mgxs.sigma_f_.empty(),
       "Fissionable materials are required to have a defined fission cross section.");
   } // if fissionable
 
   // Clear fission data if not fissionable
   else
   {
-    sigma_f_.clear();
-    nu_sigma_f_.clear();
-    nu_prompt_sigma_f_.clear();
-    nu_delayed_sigma_f_.clear();
-    production_matrix_.clear();
-    precursors_.clear();
+    mgxs.sigma_f_.clear();
+    mgxs.nu_sigma_f_.clear();
+    mgxs.nu_prompt_sigma_f_.clear();
+    mgxs.nu_delayed_sigma_f_.clear();
+    mgxs.production_matrix_.clear();
+    mgxs.precursors_.clear();
   } // if not fissionable
+
+  return mgxs;
+}
+
+void
+XSFile::ReadGroupStructure(const std::string& keyword,
+                           std::vector<double>& destination,
+                           const size_t n_grps,
+                           std::ifstream& file,
+                           std::istringstream& line_stream,
+                           size_t& line_number)
+{
+  destination.reserve(n_grps + 1);
+
+  std::string line;
+  double bound;
+  size_t count = 0;
+
+  // Read the block
+  std::getline(file, line);
+  line_stream = std::istringstream(line);
+  ++line_number;
+  while (line != keyword + "_END")
+  {
+    // Get data from current line
+    line_stream >> bound;
+    destination.push_back(bound);
+    OpenSnLogicalErrorIf(count++ >= n_grps + 1,
+                         "Too many entries encountered when parsing group structure.\n"
+                         "The expected number of entries is " +
+                           std::to_string(n_grps + 1) + ".");
+
+    // Go to next line
+    std::getline(file, line);
+    line_stream = std::istringstream(line);
+    ++line_number;
+  }
+}
+
+void
+XSFile::Read1DData(const std::string& keyword,
+                   std::vector<double>& destination,
+                   const size_t n_entries,
+                   std::ifstream& file,
+                   std::istringstream& line_stream,
+                   size_t& line_number)
+{
+  destination.assign(n_entries, 0.0);
+
+  std::string line;
+  int i;
+  double value;
+  size_t count = 0;
+
+  // Read the bloc
+  std::getline(file, line);
+  line_stream = std::istringstream(line);
+  ++line_number;
+  while (line != keyword + "_END")
+  {
+    // get data from current line
+    line_stream >> i >> value;
+    destination.at(i) = value;
+    OpenSnLogicalErrorIf(count++ >= n_entries,
+                         "Too many entries encountered when parsing 1D data.\n"
+                         "The expected number of entries is " +
+                           std::to_string(n_entries) + ".");
+
+    // Go to next line
+    std::getline(file, line);
+    line_stream = std::istringstream(line);
+    ++line_number;
+  }
+}
+
+void
+XSFile::Read2DData(const std::string& keyword,
+                   const std::string& entry_prefix,
+                   std::vector<std::vector<double>>& destination,
+                   const size_t n_rows,
+                   const size_t n_cols,
+                   std::ifstream& file,
+                   std::istringstream& line_stream,
+                   size_t& line_number)
+{
+  destination.assign(n_rows, std::vector<double>(n_cols, 0.0));
+
+  std::string word, line;
+  double value;
+  size_t i, j;
+
+  // Read the block
+  std::getline(file, line);
+  line_stream = std::istringstream(line);
+  ++line_number;
+  while (line != keyword + "_END")
+  {
+    // Check that this line contains an entry
+    line_stream >> word;
+    if (word == entry_prefix)
+    {
+      // Get data from current line
+      line_stream >> i >> j >> value;
+      if (entry_prefix == "G_PRECURSOR_VAL")
+        destination.at(j).at(i) = value; // hack
+      else
+        destination.at(i).at(j) = value;
+    }
+
+    // Go to next line
+    std::getline(file, line);
+    line_stream = std::istringstream(line);
+    ++line_number;
+  }
+}
+
+// Lambda for reading transfer matrix data.
+void
+XSFile::ReadTransferMatrices(const std::string& keyword,
+                             std::vector<SparseMatrix>& destination,
+                             const size_t n_moms,
+                             const size_t n_grps,
+                             std::ifstream& file,
+                             std::istringstream& line_stream,
+                             size_t& line_number)
+{
+  destination.assign(n_moms, SparseMatrix(n_grps, n_grps));
+
+  std::string word, line;
+  double value;
+  size_t ell, group, gprime;
+
+  // Read the block
+  std::getline(file, line);
+  line_stream = std::istringstream(line);
+  ++line_number;
+  while (line != keyword + "_END")
+  {
+    // Check that this line contains an entry
+    line_stream >> word;
+    if (word == "M_GPRIME_G_VAL")
+    {
+      // Get data from current line
+      line_stream >> ell >> gprime >> group >> value;
+      destination.at(ell).Insert(group, gprime, value);
+    }
+
+    // Go to next line
+    std::getline(file, line);
+    line_stream = std::istringstream(line);
+    ++line_number;
+  }
 }
 
 } // namespace opensn

--- a/framework/materials/multi_group_xs/xsfile.h
+++ b/framework/materials/multi_group_xs/xsfile.h
@@ -4,10 +4,14 @@
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include <vector>
 #include <string>
+#include <fstream>
 
 namespace opensn
 {
 
+/**
+ * Class for reading cross-section data from a native OpenSn file.
+ */
 class XSFile
 {
 public:
@@ -19,7 +23,31 @@ public:
   XSFile(const std::string& file_name);
 
   /// Read the file
-  MultiGroupXS Read();
+  void Read();
+
+  std::string file_name_;
+  std::ifstream file_;
+  size_t num_groups_;
+  size_t scattering_order_;
+  size_t num_precursors_;
+  std::vector<MultiGroupXS::Precursor> precursors_;
+  std::vector<double> inv_velocity_;
+  std::vector<double> e_bounds_;
+  std::vector<double> sigma_t_;
+  std::vector<double> sigma_a_;
+  std::vector<double> sigma_f_;
+  std::vector<double> nu_;
+  std::vector<double> nu_prompt_;
+  std::vector<double> nu_delayed_;
+  std::vector<double> beta_;
+  std::vector<double> chi_prompt_;
+  std::vector<double> nu_sigma_f_;
+  std::vector<double> chi_;
+  std::vector<double> decay_constants_;
+  std::vector<double> fractional_yields_;
+  std::vector<std::vector<double>> emission_spectra_;
+  std::vector<SparseMatrix> transfer_matrices_;
+  std::vector<std::vector<double>> production_matrix_;
 
 private:
   /// Reading group structure data.
@@ -56,8 +84,6 @@ private:
                             std::ifstream& file,
                             std::istringstream& line_stream,
                             size_t& line_number);
-
-  std::string file_name_;
 };
 
 } // namespace opensn

--- a/framework/materials/multi_group_xs/xsfile.h
+++ b/framework/materials/multi_group_xs/xsfile.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include <vector>
+#include <string>
+
+namespace opensn
+{
+
+class XSFile
+{
+public:
+  /**
+   * Create a cross-section file
+   *
+   * @param file_name File name
+   */
+  XSFile(const std::string& file_name);
+
+  /// Read the file
+  MultiGroupXS Read();
+
+private:
+  /// Reading group structure data.
+  void ReadGroupStructure(const std::string& keyword,
+                          std::vector<double>& destination,
+                          const size_t n_grps,
+                          std::ifstream& file,
+                          std::istringstream& line_stream,
+                          size_t& line_number);
+
+  /// Lambda for reading vector data.
+  void Read1DData(const std::string& keyword,
+                  std::vector<double>& destination,
+                  const size_t n_entries,
+                  std::ifstream& file,
+                  std::istringstream& line_stream,
+                  size_t& line_number);
+
+  /// Lambda for reading 2D data
+  void Read2DData(const std::string& keyword,
+                  const std::string& entry_prefix,
+                  std::vector<std::vector<double>>& destination,
+                  const size_t n_rows,
+                  const size_t n_cols,
+                  std::ifstream& file,
+                  std::istringstream& line_stream,
+                  size_t& line_number);
+
+  /// Lambda for reading transfer matrix data.
+  void ReadTransferMatrices(const std::string& keyword,
+                            std::vector<SparseMatrix>& destination,
+                            const size_t n_moms,
+                            const size_t n_grps,
+                            std::ifstream& file,
+                            std::istringstream& line_stream,
+                            size_t& line_number);
+
+  std::string file_name_;
+};
+
+} // namespace opensn

--- a/framework/utils/utils.h
+++ b/framework/utils/utils.h
@@ -117,4 +117,25 @@ ReadBinaryValue(std::ifstream& input_file)
   return value;
 }
 
+/// Check vector for all non-negative values
+inline bool
+IsNonNegative(const std::vector<double>& vec)
+{
+  return not std::any_of(vec.begin(), vec.end(), [](double x) { return x < 0.0; });
+}
+
+/// Check vector for all strictly positive values
+inline bool
+IsPositive(const std::vector<double>& vec)
+{
+  return not std::any_of(vec.begin(), vec.end(), [](double x) { return x <= 0.0; });
+}
+
+/// Check vector for any non-zero values
+inline bool
+HasNonZero(const std::vector<double>& vec)
+{
+  return std::any_of(vec.begin(), vec.end(), [](double x) { return x > 0.0; });
+}
+
 } // namespace opensn

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -4,6 +4,7 @@
 #include "python/lib/py_wrappers.h"
 #include "framework/runtime.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/materials/multi_group_xs/xsfile.h"
 #include <pybind11/stl.h>
 #include <memory>
 #include <string>
@@ -61,7 +62,8 @@ WrapMultiGroupXS(py::module& xs)
     "LoadFromOpenSn",
     [](MultiGroupXS& self, const std::string& file_name)
     {
-      self.Initialize(file_name);
+      XSFile xs_file(file_name);
+      self = xs_file.Read();
     },
     py::arg("file_name"),
     R"(

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -62,8 +62,7 @@ WrapMultiGroupXS(py::module& xs)
     "LoadFromOpenSn",
     [](MultiGroupXS& self, const std::string& file_name)
     {
-      XSFile xs_file(file_name);
-      self = xs_file.Read();
+      self = MultiGroupXS::LoadFromOpenSn(file_name);
     },
     py::arg("file_name"),
     R"(

--- a/test/python/framework/tutorials/tutorial_06_wdd.cc
+++ b/test/python/framework/tutorials/tutorial_06_wdd.cc
@@ -112,8 +112,7 @@ SimTest06_WDD(std::shared_ptr<MeshContinuum> grid)
   opensn::log.Log() << "End ukmanagers." << std::endl;
 
   // Make XSs
-  XSFile xs_file("xs_graphite_pure.xs");
-  MultiGroupXS xs = xs_file.Read();
+  MultiGroupXS xs = MultiGroupXS::LoadFromOpenSn("xs_graphite_pure.xs");
 
   // Initializes vectors
   std::vector<double> phi_old(num_local_phi_dofs, 0.0);

--- a/test/python/framework/tutorials/tutorial_06_wdd.cc
+++ b/test/python/framework/tutorials/tutorial_06_wdd.cc
@@ -3,6 +3,7 @@
 
 #include "framework/math/spatial_discretization/finite_volume/finite_volume.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/materials/multi_group_xs/xsfile.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
@@ -111,8 +112,8 @@ SimTest06_WDD(std::shared_ptr<MeshContinuum> grid)
   opensn::log.Log() << "End ukmanagers." << std::endl;
 
   // Make XSs
-  MultiGroupXS xs;
-  xs.Initialize("xs_graphite_pure.xs");
+  XSFile xs_file("xs_graphite_pure.xs");
+  MultiGroupXS xs = xs_file.Read();
 
   // Initializes vectors
   std::vector<double> phi_old(num_local_phi_dofs, 0.0);

--- a/test/python/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/python/framework/tutorials/tutorial_91a_pwld.cc
@@ -3,6 +3,7 @@
 
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/materials/multi_group_xs/xsfile.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
@@ -97,8 +98,8 @@ SimTest91_PWLD(std::shared_ptr<MeshContinuum> grid)
   opensn::log.Log() << "End ukmanagers." << std::endl;
 
   // Make XSs
-  MultiGroupXS xs;
-  xs.Initialize("xs_graphite_pure.xs");
+  XSFile xs_file("xs_graphite_pure.xs");
+  MultiGroupXS xs = xs_file.Read();
 
   // Initializes vectors
   std::vector<double> phi_old(num_local_phi_dofs, 0.0);

--- a/test/python/framework/tutorials/tutorial_91a_pwld.cc
+++ b/test/python/framework/tutorials/tutorial_91a_pwld.cc
@@ -98,8 +98,7 @@ SimTest91_PWLD(std::shared_ptr<MeshContinuum> grid)
   opensn::log.Log() << "End ukmanagers." << std::endl;
 
   // Make XSs
-  XSFile xs_file("xs_graphite_pure.xs");
-  MultiGroupXS xs = xs_file.Read();
+  MultiGroupXS xs = MultiGroupXS::LoadFromOpenSn("xs_graphite_pure.xs");
 
   // Initializes vectors
   std::vector<double> phi_old(num_local_phi_dofs, 0.0);


### PR DESCRIPTION
This:
- introduces `XSFile` class which has the cross-section file reading logic
- removes `MultiGroupXS::Initialize` and replaces it with `MultiGroupXS::LoadFromOpenSn` which better matches the python API
- all "business" logic is inside `MultiGroupXS::LoadFromOpenSn` where we read from `XSFile` and then process the data

Closes #218