### PR TITLE
Adding boundary conditions as an optional solver input parameter

### DIFF
--- a/doc/source/tutorials/lbs/mg_keigen/pincell_example.ipynb
+++ b/doc/source/tutorials/lbs/mg_keigen/pincell_example.ipynb
@@ -251,7 +251,7 @@
     "    {\"block_ids\": [3], \"xs\": xs_list[3]}\n",
     "]\n",
     "\n",
-    "phys = DiscreteOrdinatesProblem(mesh=grid, num_groups=num_groups, groupsets=group_sets, xs_map=xs_mapping, scattering_order=scat_order)\n",
+    "phys = DiscreteOrdinatesProblem(mesh=grid, num_groups=num_groups, groupsets=group_sets, xs_map=xs_mapping, scattering_order=scat_order, boundary_conditions=bound_conditions)\n",
     "\n",
     "phys.SetOptions(\n",
     "    verbose_inner_iterations=True,\n",
@@ -260,7 +260,6 @@
     "    power_default_kappa=1.0,\n",
     "    power_normalization=1.0,\n",
     "    save_angular_flux=False,\n",
-    "    boundary_conditions=bound_conditions,\n",
     ")"
    ]
   },

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "modules/problem.h"
-#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/point_source/point_source.h"

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -457,6 +457,8 @@ WrapLBS(py::module& slv)
         A list of mappings from block ids to cross-section definitions.
     scattering_order: int, default=0
         The level of harmonic expansion for the scattering source.
+    boundary_conditions: List[Dict], default=[]
+        A list containing tables for each boundary specification.
     options : Dict, default={}
         A block of optional configuration parameters. See `SetOptions` for available settings.
     sweep_type : str, default="AAH"
@@ -577,6 +579,8 @@ WrapLBS(py::module& slv)
         A list of mappings from block ids to cross-section definitions.
     scattering_order: int, default=0
         The level of harmonic expansion for the scattering source.
+    boundary_conditions: List[Dict], default=[]
+        A list containing tables for each boundary specification.
     options : dict, optional
         A block of optional configuration parameters. See `SetOptions` for available settings.
     sweep_type : str, optional

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7/c5g7.py
@@ -90,11 +90,11 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=0,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
             "verbose_outer_iterations": True,
             "verbose_inner_iterations": True,
             "power_field_function_on": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
@@ -65,11 +65,11 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
             "verbose_outer_iterations": True,
             "verbose_inner_iterations": True,
             "power_field_function_on": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock.py
@@ -70,11 +70,11 @@ if __name__ == "__main__":
             {"block_ids": [1], "xs": xss["1"]},
         ],
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
@@ -43,11 +43,11 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
 
             "use_precursors": False,
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.py
@@ -43,14 +43,12 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-
             "use_precursors": False,
-
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,
         },

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
@@ -43,11 +43,11 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
 
             "use_precursors": False,
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock.py
@@ -44,14 +44,12 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-
             "use_precursors": False,
-
             "verbose_inner_iterations": True,
             "verbose_outer_iterations": True,
             "save_angular_flux": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
@@ -44,14 +44,12 @@ if __name__ == "__main__":
         ],
         xs_map=xs_map,
         scattering_order=2,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-
             "use_precursors": False,
-
             "verbose_inner_iterations": True,
             "verbose_outer_iterations": True,
             "save_angular_flux": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_hex.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_hex.py
@@ -63,15 +63,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_fuel_g2},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_wedge.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_wedge.py
@@ -61,15 +61,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_fuel_g2},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.py
@@ -74,15 +74,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_u235},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_smm.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_smm.py
@@ -75,15 +75,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_u235},
         ],
         scattering_order=0,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.py
@@ -79,15 +79,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_uo2},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2_crichardson.py
@@ -79,15 +79,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_uo2},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/1g_infinite_pure_absorber_balance_gmres.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/1g_infinite_pure_absorber_balance_gmres.py
@@ -69,16 +69,14 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
-        }
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/1g_infinite_pure_absorber_balance_richardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/1g_infinite_pure_absorber_balance_richardson.py
@@ -61,16 +61,14 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
     )
 
     # Initialize and execute solver

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/angular_io_1d.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/angular_io_1d.py
@@ -78,11 +78,11 @@ if __name__ == "__main__":
     solver_dict["xs_map"] = xs_map
     solver_dict["scattering_order"] = 0
     solver_dict["volumetric_sources"] = [src0, src1]
+    solver_dict["boundary_conditions"] = [
+        {"name": "zmin", "type": "vacuum"},
+        {"name": "zmax", "type": "vacuum"}
+    ]
     solver_dict["options"] = {
-        "boundary_conditions": [
-            {"name": "zmin", "type": "vacuum"},
-            {"name": "zmax", "type": "vacuum"}
-        ],
         "save_angular_flux": True,
     }
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/hdpe_balance.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/hdpe_balance.py
@@ -66,16 +66,16 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
             "save_angular_flux": True,
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/reed_balance.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/reed_balance.py
@@ -78,12 +78,10 @@ if __name__ == "__main__":
         xs_map=xs_map,
         scattering_order=0,
         volumetric_sources=[src0, src1],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "vacuum"},
-                {"name": "zmax", "type": "vacuum"}
-            ],
-        }
+        boundary_conditions=[
+            {"name": "zmin", "type": "vacuum"},
+            {"name": "zmax", "type": "vacuum"}
+        ],
     )
 
     # Initialize and execute solver

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/reed_balance_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/reed_balance_crichardson.py
@@ -78,12 +78,10 @@ if __name__ == "__main__":
         xs_map=xs_map,
         scattering_order=0,
         volumetric_sources=[src0, src1],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "vacuum"},
-                {"name": "zmax", "type": "vacuum"}
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmin", "type": "vacuum"},
+            {"name": "zmax", "type": "vacuum"}
+        ],
     )
 
     # Initialize and execute solver

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_1d_1.py
@@ -95,10 +95,10 @@ if __name__ == "__main__":
         ],
         scattering_order=5,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "max_ags_iterations": 1
         }
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_1d_leakage.py
@@ -65,14 +65,14 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs1g},
         ],
         scattering_order=0,
+        boundary_conditions=[
+            {
+                "name": "zmin",
+                "type": "isotropic",
+                "group_strength": bsrc,
+            },
+        ],
         options={
-            "boundary_conditions": [
-                {
-                    "name": "zmin",
-                    "type": "isotropic",
-                    "group_strength": bsrc,
-                },
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly.py
@@ -97,10 +97,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "max_ags_iterations": 1
         }
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.py
@@ -88,14 +88,14 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src0, mg_src1],
+        boundary_conditions=[
+            {
+                "name": "xmin",
+                "type": "isotropic",
+                "group_strength": bsrc,
+            },
+        ],
         options={
-            "boundary_conditions": [
-                {
-                    "name": "xmin",
-                    "type": "isotropic",
-                    "group_strength": bsrc,
-                },
-            ],
             "verbose_ags_iterations": True,
             "max_ags_iterations": 100,
             "ags_tolerance": 1.0e-6,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured.py
@@ -93,14 +93,14 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {
+                "name": "xmin",
+                "type": "isotropic",
+                "group_strength": bsrc,
+            },
+        ],
         options={
-            "boundary_conditions": [
-                {
-                    "name": "xmin",
-                    "type": "isotropic",
-                    "group_strength": bsrc,
-                },
-            ],
             "max_ags_iterations": 1,
         }
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_2_unstructured_crichardson.py
@@ -88,15 +88,13 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
-        options={
-            "boundary_conditions": [
-                {
-                    "name": "xmin",
-                    "type": "isotropic",
-                    "group_strength": bsrc,
-                },
-            ],
-        },
+        boundary_conditions=[
+            {
+                "name": "xmin",
+                "type": "isotropic",
+                "group_strength": bsrc,
+            },
+        ],
     )
 
     # Initialize and Execute Solver

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_3_poly_quad_mod.py
@@ -89,14 +89,14 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {
+                "name": "xmin",
+                "type": "isotropic",
+                "group_strength": bsrc,
+            },
+        ],
         options={
-            "boundary_conditions": [
-                {
-                    "name": "xmin",
-                    "type": "isotropic",
-                    "group_strength": bsrc,
-                },
-            ],
             "max_ags_iterations": 1,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.py
@@ -102,11 +102,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src0, mg_src1],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
             "max_ags_iterations": 1,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v2.py
@@ -61,12 +61,10 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
     )
 
     ss_solver = SteadyStateSourceSolver(problem=phys)

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v4.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_gmsh_v4.py
@@ -61,12 +61,10 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
     )
 
     ss_solver = SteadyStateSourceSolver(problem=phys)

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis.py
@@ -86,13 +86,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src0, mg_src1],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin",
-                 "type": "isotropic",
-                 "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmin",
+             "type": "isotropic",
+             "group_strength": bsrc},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_parmetis_crichardson.py
@@ -85,13 +85,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src0, mg_src1],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin",
-                 "type": "isotropic",
-                 "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmin",
+             "type": "isotropic",
+             "group_strength": bsrc},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1_poly_scotch.py
@@ -90,13 +90,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin",
-                 "type": "isotropic",
-                 "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmin",
+             "type": "isotropic",
+             "group_strength": bsrc},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1a_extruder.py
@@ -96,13 +96,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
-        options={
-            "boundary_conditions": [
-                {"name": "zmin",
-                 "type": "isotropic",
-                 "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmin",
+             "type": "isotropic",
+             "group_strength": bsrc},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_1b_ortho.py
@@ -84,13 +84,11 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin",
-                 "type": "isotropic",
-                 "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin",
+             "type": "isotropic",
+             "group_strength": bsrc},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured.py
@@ -94,10 +94,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         }
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_crichardson.py
@@ -94,10 +94,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_2_unstructured_restart.py
@@ -93,10 +93,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {"name": "zmax", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "zmax", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
             # restart_writes_enabled = True,
             # write_delayed_psi_to_restart = True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_4_cycles_1.py
@@ -94,11 +94,9 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
-        options={
-            "boundary_conditions": [
-                {"name": "zmax", "type": "isotropic", "group_strength": bsrc},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "zmax", "type": "isotropic", "group_strength": bsrc},
+        ],
     )
 
     # Initialize and Execute Solver

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_dist_mesh.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_dist_mesh.py
@@ -102,10 +102,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6a_split_mesh.py
@@ -101,10 +101,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_dist_mesh.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_dist_mesh.py
@@ -106,10 +106,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_6b_split_mesh.py
@@ -105,10 +105,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "save_angular_flux": True,
         },
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v2.py
@@ -62,12 +62,10 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v4.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_gmsh_v4.py
@@ -62,12 +62,10 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-            ],
-        },
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
     )
 
     ss_solver = SteadyStateSourceSolver(problem=phys)

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
@@ -66,16 +66,16 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
             "save_angular_flux": True,
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
         },
         sweep_type="CBC"
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
@@ -93,12 +93,12 @@ if __name__ == "__main__":
                 "xs": xs_3_170
             }
         ],
+        boundary_conditions=[
+            {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         scattering_order=5,
         volumetric_sources=[mg_src],
         options={
-            "boundary_conditions": [
-                {"name": "zmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "max_ags_iterations": 1,
             "save_angular_flux": True
         },

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
@@ -98,10 +98,10 @@ if __name__ == "__main__":
         ],
         scattering_order=1,
         volumetric_sources=[mg_src1, mg_src2],
+        boundary_conditions=[
+            {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
-            ],
             "max_ags_iterations": 1,
             "save_angular_flux": True
         },

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_1_monoenergetic.py
@@ -86,9 +86,7 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [{"name": "xmin", "type": "reflecting"}],
-        }
+        boundary_conditions=[{"name": "xmin", "type": "reflecting"}],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/transport_2d_cyl_2_multigroup.py
@@ -86,9 +86,7 @@ if __name__ == "__main__":
         ],
         scattering_order=0,
         volumetric_sources=[mg_src],
-        options={
-            "boundary_conditions": [{"name": "xmin", "type": "reflecting"}],
-        }
+        boundary_conditions=[{"name": "xmin", "type": "reflecting"}],
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)
     ss_solver.Initialize()


### PR DESCRIPTION
Boundary conditions are now passed to the solver via the lbs_solver block and not the lbs_options block. BCs are still an optional parameter. If a BC block is not supplied, vacuum boundary conditions are used. This PR leaves the `clear_boundary_conditions` parameter in lbs_options (although it's unclear to me how useful this is).