### PR TITLE
Refactoring `MultiGroupXS` API

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.cc
+++ b/framework/materials/multi_group_xs/multi_group_xs.cc
@@ -8,18 +8,20 @@
 namespace opensn
 {
 
-void
-MultiGroupXS::Initialize(double sigma_t, double c)
+MultiGroupXS
+MultiGroupXS::CreateSimpleOneGroup(double sigma_t, double c)
 {
-  Reset();
+  MultiGroupXS mgxs;
 
-  num_groups_ = 1;
-  sigma_t_.resize(num_groups_, sigma_t);
-  sigma_a_.resize(num_groups_, sigma_t * (1.0 - c));
-  transfer_matrices_.emplace_back(num_groups_, num_groups_);
-  auto& S = transfer_matrices_.back();
-  S.SetDiagonal(std::vector<double>(num_groups_, sigma_t * c));
-  ComputeDiffusionParameters();
+  mgxs.num_groups_ = 1;
+  mgxs.sigma_t_.resize(mgxs.num_groups_, sigma_t);
+  mgxs.sigma_a_.resize(mgxs.num_groups_, sigma_t * (1.0 - c));
+  mgxs.transfer_matrices_.emplace_back(mgxs.num_groups_, mgxs.num_groups_);
+  auto& S = mgxs.transfer_matrices_.back();
+  S.SetDiagonal(std::vector<double>(mgxs.num_groups_, sigma_t * c));
+  mgxs.ComputeDiffusionParameters();
+
+  return mgxs;
 }
 
 void

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -22,10 +22,6 @@ public:
   {
   }
 
-  /// Populates the cross section from a combination of others.
-  void
-  Initialize(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);
-
   /// A struct containing data for a delayed neutron precursor.
   struct Precursor
   {
@@ -181,6 +177,9 @@ public:
   /// This method populates transport cross sections from an OpenMC cross-section file.
   static MultiGroupXS
   LoadFromOpenMC(const std::string& filename, const std::string& dataset_name, double temperature);
+  /// Populates the cross section from a combination of others.
+  static MultiGroupXS
+  Combine(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);
 };
 
 } // namespace opensn

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -22,9 +22,6 @@ public:
   {
   }
 
-  /// Makes a simple material with a 1-group cross-section set.
-  void Initialize(double sigma_t, double c);
-
   /// Populates the cross section from a combination of others.
   void
   Initialize(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);
@@ -182,6 +179,8 @@ private:
   void TransposeTransferAndProduction();
 
 public:
+  /// Makes a simple material with a 1-group cross-section set.
+  static MultiGroupXS CreateSimpleOneGroup(double sigma_t, double c);
   static MultiGroupXS LoadFromOpenSn(const std::string& filename);
 };
 

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -26,10 +26,6 @@ public:
   void
   Initialize(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);
 
-  /// This method populates transport cross sections from an OpenMC cross-section file.
-  void
-  Initialize(const std::string& file_name, const std::string& dataset_name, double temperature);
-
   /// A struct containing data for a delayed neutron precursor.
   struct Precursor
   {
@@ -182,6 +178,9 @@ public:
   /// Makes a simple material with a 1-group cross-section set.
   static MultiGroupXS CreateSimpleOneGroup(double sigma_t, double c);
   static MultiGroupXS LoadFromOpenSn(const std::string& filename);
+  /// This method populates transport cross sections from an OpenMC cross-section file.
+  static MultiGroupXS
+  LoadFromOpenMC(const std::string& filename, const std::string& dataset_name, double temperature);
 };
 
 } // namespace opensn

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -43,7 +43,7 @@ WrapMultiGroupXS(py::module& xs)
   multigroup_xs.def(
     "CreateSimpleOneGroup",
     [](MultiGroupXS& self, double sigma_t, double c) {
-      self.Initialize(sigma_t, c);
+      self = MultiGroupXS::CreateSimpleOneGroup(sigma_t, c);
     },
     R"(
     Create a one-group cross section.

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -104,7 +104,7 @@ WrapMultiGroupXS(py::module& xs)
     "Combine",
     [](MultiGroupXS& self, const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations)
     {
-      self.Initialize(combinations);
+      self = MultiGroupXS::Combine(combinations);
     },
     R"(
     Combine cross-section

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -136,7 +136,7 @@ WrapMultiGroupXS(py::module& xs)
     [](MultiGroupXS& self, const std::string& file_name, const std::string& dataset_name,
        double temperature)
     {
-      self.Initialize(file_name, dataset_name, temperature);
+      self = MultiGroupXS::LoadFromOpenMC(file_name, dataset_name, temperature);
     },
     "Load multi-group cross sections from an OpenMC cross-section file.",
     py::arg("file_name"),


### PR DESCRIPTION
All the `Initialize` methods were converted into static methods with a better name. This matches better what users see in the python space.