### PR TITLE
Don't call `InitializeBoundaries` from a ctor

### DIFF
--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -716,10 +716,6 @@ LBSProblem::SetOptions(const InputParameters& input)
         bndry_params.AssignParameters(spec.GetParam(b));
         SetBoundaryOptions(bndry_params);
       }
-
-      // If a discretization exists, initialize the boundaries.
-      if (discretization_)
-        InitializeBoundaries();
     }
 
     else if (spec.GetName() == "point_sources")


### PR DESCRIPTION
1) It is a virtual method
2) It is called from `Initialize`, so no need to have it called twice.

Closes #740