### PR TITLE
Add set/clear sources and boundary conditions methods to Python interface

### DIFF
--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -115,6 +115,9 @@ public:
   /// Constant accessor to the list of volumetric sources.
   const std::vector<std::shared_ptr<VolumetricSource>>& GetVolumetricSources() const;
 
+  /// Clears all the boundary conditions from the solver.
+  void ClearBoundaries();
+
   size_t& GetLastRestartTime();
 
   /// Returns a reference to the map of material ids to XSs.

--- a/python/lib/py_wrappers.h
+++ b/python/lib/py_wrappers.h
@@ -35,6 +35,9 @@ convert_vector(const Vector<T>& vec)
 
 // Cast kwargs to ParameterBlock
 
+/// Translate a Python object into a ParameterBlock.
+ParameterBlock pyobj_to_param_block(const std::string& key, const py::object& obj);
+
 /// Translate a Python dictionary into a ParameterBlock.
 ParameterBlock kwargs_to_param_block(const py::kwargs& params);
 

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -418,6 +418,94 @@ WrapLBS(py::module& slv)
     )",
     py::arg("file_base")
   );
+  lbs_problem.def(
+    "SetPointSources",
+    [](LBSProblem& self, py::kwargs& params)
+    {
+      for (auto [key, value] : params)
+      {
+        auto c_key = key.cast<std::string>();
+        if (c_key == "clear_point_sources")
+          self.ClearPointSources();
+        else if (c_key == "point_sources")
+        {
+          auto sources = value.cast<py::list>();
+          for (auto source : sources)
+          {
+            self.AddPointSource(source.cast<std::shared_ptr<PointSource>>());
+          }
+        }
+        else
+          throw std::runtime_error("Invalid argument provided to SetPointSources.\n");
+      }
+    },
+    R"(
+    Set or clear point sources.
+
+    Parameters
+    ----------
+    clear_point_sources: bool, default=False
+        If true, all current the point sources of the problem are deleted.
+    point_sources: List[pyopensn.source.PointSource]
+        List of new point sources to be added to the problem.
+    )"
+  );
+  lbs_problem.def(
+    "SetVolumetricSources",
+    [](LBSProblem& self, py::kwargs& params)
+    {
+      for (auto [key, value] : params)
+      {
+        auto c_key = key.cast<std::string>();
+        if (c_key == "clear_volumetric_sources")
+          self.ClearVolumetricSources();
+        else if (c_key == "volumetric_sources")
+        {
+          auto sources = value.cast<py::list>();
+          for (auto source : sources)
+          {
+            self.AddVolumetricSource(source.cast<std::shared_ptr<VolumetricSource>>());
+          }
+        }
+        else
+          throw std::runtime_error("Invalid argument provided to SetVolumetricSources.\n");
+      }
+    },
+    R"(
+    Set or clear volumetric sources.
+
+    Parameters
+    ----------
+    clear_volumetric_sources: bool, default=False
+        If true, all current the volumetric sources of the problem are deleted.
+    volumetric_sources: List[pyopensn.source.VolumetricSource]
+        List of new volumetric sources to be added to the problem.
+    )"
+  );
+  lbs_problem.def(
+    "SetBoundaryOptions",
+    [](LBSProblem& self, py::kwargs& params)
+    {
+      for (auto [key, value] : params)
+      {
+        auto c_key = key.cast<std::string>();
+        if (c_key == "clear_boundary_conditions")
+          self.ClearBoundaries();
+        else if (c_key == "boundary_conditions")
+        {
+          auto boundaries = value.cast<py::list>();
+          for (auto boundary : boundaries)
+          {
+            InputParameters input = LBSProblem::GetBoundaryOptionsBlock();
+            input.AssignParameters(pyobj_to_param_block("", boundary.cast<py::dict>()));
+            self.SetBoundaryOptions(input);
+          }
+        }
+        else
+          throw std::runtime_error("Invalid argument provided to SetBoundaryOptions.\n");
+      }
+    }
+  );
 
   // discrete ordinate solver
   auto do_problem = py::class_<DiscreteOrdinatesProblem, std::shared_ptr<DiscreteOrdinatesProblem>,

--- a/test/python/framework/tutorials/tutorial_93_raytracing.py
+++ b/test/python/framework/tutorials/tutorial_93_raytracing.py
@@ -48,8 +48,8 @@ phys1 = DiscreteOrdinatesProblem(
         {"block_ids": [0], "xs": xs1g},
     ],
     scattering_order=0,
+    point_sources=[pt_src],
     options={
-        "point_sources": [pt_src],
         "field_function_prefix": solver_name,
     },
 )

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_1.py
@@ -139,9 +139,9 @@ if __name__ == "__main__":
         "volumetric_sources": [adj_src],
     }
     phys.SetOptions(
-        adjoint=True,
-        volumetric_sources=[adj_src]
+        adjoint=True
     )
+    phys.SetVolumetricSources(volumetric_sources=[adj_src])
 
     # Adjoint solve and write flux moments
     ss_solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_2.py
@@ -116,7 +116,8 @@ if __name__ == "__main__":
 
     # Create adjoint source and switch to adjoint mode
     adj_src = VolumetricSource(logical_volume=qoi_vol, group_strength=[1.0])
-    phys.SetOptions(adjoint=True, volumetric_sources=[adj_src])
+    phys.SetOptions(adjoint=True)
+    phys.SetVolumetricSources(volumetric_sources=[adj_src])
 
     # Adjoint solve and write flux moments
     ss_solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.py
@@ -148,8 +148,8 @@ if __name__ == "__main__":
     # Switch to adjoint mode
     phys.SetOptions(
         adjoint=True,
-        volumetric_sources=[adjoint_source]
     )
+    phys.SetVolumetricSources(volumetric_sources=[adjoint_source])
 
     # Adjoint solve and write flux moments
     ss_solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_pyramid.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_2g_exo_pyramid.py
@@ -61,15 +61,15 @@ if __name__ == "__main__":
             {"block_ids": [0], "xs": xs_fuel_g2},
         ],
         scattering_order=1,
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+            {"name": "ymax", "type": "reflecting"},
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
         options={
-            "boundary_conditions": [
-                {"name": "xmin", "type": "reflecting"},
-                {"name": "xmax", "type": "reflecting"},
-                {"name": "ymin", "type": "reflecting"},
-                {"name": "ymax", "type": "reflecting"},
-                {"name": "zmin", "type": "reflecting"},
-                {"name": "zmax", "type": "reflecting"},
-            ],
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/wrong_parameter_type.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/wrong_parameter_type.py
@@ -60,10 +60,9 @@ if __name__ == "__main__":
             }
         ],
         scattering_order=0,
+        boundary_conditions=[],
         options={
             "max_mpi_message_size": True,
-            "boundary_conditions": [
-            ],
         }
     )
     ss_solver = SteadyStateSolver(problem=phys)


### PR DESCRIPTION
This PR adds the methods setting/clearing sources and boundary conditions methods to Python interface.

Note: boundary conditions and sources arguments in ``OptionBlock`` to be removed (with regression tests to be updated).