### PR TITLE
cmake: correcting file names for the opensn library files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set_target_properties(
     PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
+        OUTPUT_NAME opensn
 )
 
 if(OPENSN_WITH_PYTHON)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -39,6 +39,7 @@ set_target_properties(
         SOVERSION ${PROJECT_VERSION_MAJOR}
         POSITION_INDEPENDENT_CODE ON
         INTERPROCEDURAL_OPTIMIZATION OFF
+        OUTPUT_NAME opensnpy
 )
 
 # opensn binary


### PR DESCRIPTION
This restores the functionality that was accidently removed by #760. If the target name is `libNAME` then cmake creates a `liblibNAME` file. Thus, we need to set the correct file name via the OUPUT_NAME property.