### PR TITLE
Prevent MPI errors by refactoring PETSc init/finalize so no PETSc objects survive past `PetscFinalize`

### DIFF
--- a/framework/math/linear_solver/petsc_linear_system_solver.cc
+++ b/framework/math/linear_solver/petsc_linear_system_solver.cc
@@ -23,9 +23,10 @@ PETScLinearSolver::PETScLinearSolver(IterativeMethod method,
 
 PETScLinearSolver::~PETScLinearSolver()
 {
+  KSPDestroy(&ksp_);
+  MatDestroy(&A_);
   VecDestroy(&x_);
   VecDestroy(&b_);
-  KSPDestroy(&ksp_);
 }
 
 void

--- a/python/lib/py_app.h
+++ b/python/lib/py_app.h
@@ -20,10 +20,7 @@ public:
   int Run(int argc, char** argv);
 
 private:
-  int InitPETSc(int argc, char** argv) const;
   bool ProcessArguments(int argc, char** argv);
-
-  bool allow_petsc_error_handler_;
 };
 
 } // namespace opensnpy

--- a/python/main.cc
+++ b/python/main.cc
@@ -5,22 +5,31 @@
 #include "mpicpp-lite/mpicpp-lite.h"
 #include <cstdio>
 #include <cstdlib>
+#include "petsc.h"
 
 namespace mpi = mpicpp_lite;
 
 int
 main(int argc, char** argv)
 {
+  mpi::Environment env(argc, argv);
+
+  PetscCall(PetscInitializeNoArguments());
+
+  int retval = EXIT_SUCCESS;
   try
   {
-    mpi::Environment env(argc, argv);
     py::scoped_interpreter guard{};
     opensnpy::PyApp app(MPI_COMM_WORLD);
-    return app.Run(argc, argv);
+    retval = app.Run(argc, argv);
   }
   catch (...)
   {
     std::fprintf(stderr, "Unknown fatal error\n");
-    return EXIT_FAILURE;
+    retval = EXIT_FAILURE;
   }
+
+  PetscFinalize();
+
+  return retval;
 }


### PR DESCRIPTION
This PR moves `PetscInitialize` and `PetscFinalize` to `main` to prevent PETSc objects surviving past `PetscFinalize`. Many PETSc object created during execution will not be destroyed until the `opensnpy::App` object goes out of scope. Important notes about this refactor:

1. We no longer support passing command-line options to PETSc. This is something we've never needed in the past, so I don't consider this a real issue. It's still possible to use the `PETSC_OPTIONS` environment variable, and we can always add a `--petsc` command line option that will allow users to specify PETSc options that are programmatically added to the options database.
2. This may require some minor refactoring for codes that use OpenSn as a library. We don't have any examples of this usage, so it's difficult to say exactly what that refactor would look like. We can certainly provide additional helper functions for library usage if needed.