### PR TITLE
Add Event for caribou

### DIFF
--- a/external/caribou/cuda/event.hpp
+++ b/external/caribou/cuda/event.hpp
@@ -1,0 +1,123 @@
+/*
+ * Created on Fri, April 11 2025
+ *
+ * Copyright (c) 2025 quocdang1998
+ */
+#pragma once
+
+#include <chrono>       // std::chrono::duration, std::milli
+#include <memory>       // std::shared_ptr
+#include <type_traits>  // std::remove_pointer_t
+
+#include "exception.hpp"  // cuda::check_cuda_error
+
+namespace caribou {
+
+// CUDA Event
+// ----------
+
+namespace cuda {
+using EventImpl = std::shared_ptr<std::remove_pointer<::cudaEvent_t>::type>;
+}  // namespace cuda
+
+struct InterprocedualEventHandle {
+    ::cudaIpcEventHandle_t ptr;
+};
+
+class Event : public cuda::EventImpl {
+  public:
+    /**
+     * @brief Default constructor.
+     * @details Create an event with a given flag.
+     * @param blocking_sync If true, the host thread calling the event synchronization is blocked until the event
+     * occurs.
+     * @param disable_timing If true, the event does not record timing data.
+     * @param interprocess If true, the event can be converted to interprocess event. This flag must be enabled along with
+     * disable timing.
+     */
+    inline Event(bool blocking_sync = false, bool disable_timing = true, bool interprocess = false) :
+    cuda::EventImpl(Event::create_event(blocking_sync, disable_timing, interprocess), ::cudaEventDestroy) {}
+    /** @brief Take ownership from another pre-created CUDA event.*/
+    inline Event(::cudaEvent_t event_ptr) : cuda::EventImpl(event_ptr, ::cudaEventDestroy) {}
+    /** @brief Construct an event from an interprocess event handle.*/
+    inline Event(const InterprocedualEventHandle & ipc_handle) :
+    cuda::EventImpl(Event::create_event_from_ipc(ipc_handle), ::cudaEventDestroy) {}
+
+    /** @brief Query event status.*/
+    inline bool is_completed() const {
+        ::cudaError_t status = ::cudaEventQuery(this->get());
+        if (status == ::cudaSuccess) {
+            return true;
+        } else if (status == ::cudaErrorNotReady) {
+            return false;
+        } else {
+            cuda::check_cuda_error(status);
+            return false;  // Unreachable
+        }
+    }
+
+    /**
+     * @brief Synchronize with an event.
+     * @details Wait until all works recorded in the event are completed.
+     *
+     * If the event was created with the `blocking_sync` flag set to true, the host thread calling this function is
+     * blocked until the event occurs. Otherwise, the host thread will be busy-waiting until the event has been
+     * completed by the device.
+     */
+    inline void synchronize() const { cuda::check_cuda_error(::cudaEventSynchronize(this->get())); }
+
+    /**
+     * @brief Get interprocess event handle.
+     * @details Get the interprocess event handle for this event. The event must be created with the `interprocess` and
+     * `disable_timing` flags set to true.
+     *
+     * The generated handle can be copied to another process and used to open the event in that process.
+     */
+    inline InterprocedualEventHandle get_ipc_handle() const {
+        ::cudaIpcEventHandle_t handle;
+        cuda::check_cuda_error(::cudaIpcGetEventHandle(&handle, this->get()));
+        return InterprocedualEventHandle{handle};
+    }
+
+  private:
+    /**
+     * @brief Create an event.
+     * @param blocking_sync If true, the host thread calling the event synchronization is blocked until the event occurs.
+     * @param disable_timing If true, the event does not record timing data.
+     * @param interprocess If true, the event can be used for interprocess event.
+     */
+    static inline ::cudaEvent_t create_event(bool blocking_sync, bool disable_timing, bool interprocess) {
+        ::cudaEvent_t result;
+        unsigned int flag = 0;
+        if (blocking_sync) {
+            flag |= cudaEventBlockingSync;
+        }
+        if (disable_timing) {
+            flag |= cudaEventDisableTiming;
+        }
+        if (interprocess) {
+            flag |= cudaEventInterprocess;
+        }
+        cuda::check_cuda_error(::cudaEventCreateWithFlags(&result, flag));
+        return result;
+    }
+
+    /**
+     * @brief Create an event from an interprocess event handle.
+     * @param ipc_handle The interprocess event handle.
+     */
+    static inline ::cudaEvent_t create_event_from_ipc(const InterprocedualEventHandle & ipc_handle) {
+        ::cudaEvent_t result;
+        cuda::check_cuda_error(::cudaIpcOpenEventHandle(&result, ipc_handle.ptr));
+        return result;
+    }
+};
+
+/** @brief Measure the elapsed time between 2 events (resolution ~0.5ms).*/
+inline std::chrono::duration<float, std::milli> operator-(const Event & end, const Event & start) {
+    float time_in_ms = 0.0f;
+    cuda::check_cuda_error(::cudaEventElapsedTime(&time_in_ms, start.get(), end.get()));
+    return std::chrono::duration<float, std::milli>(time_in_ms);
+}
+
+}  // namespace caribou

--- a/external/caribou/cuda/stream.hpp
+++ b/external/caribou/cuda/stream.hpp
@@ -5,12 +5,33 @@
  */
 #pragma once
 
+#include <cstdint>      // std::uintptr_t
 #include <memory>       // std::shared_ptr
-#include <type_traits>  // std::remove_pointer_t
+#include <tuple>        // std::tuple, std::apply
+#include <type_traits>  // std::remove_pointer_t, std::decay_t
+#include <utility>      // std::forward
 
+#include "event.hpp"      // caribou::Event
 #include "exception.hpp"  // cuda::check_cuda_error
 
 namespace caribou {
+
+// Callback wrapper for CUDA Stream
+// --------------------------------
+
+namespace cuda {
+/** @brief Callback wrapper for an arbitrary callback to be executed on a CUDA stream.*/
+template <typename Function, typename... Args>
+void stream_callback_wrapper(::cudaStream_t stream, ::cudaError_t status, void * data) {
+    std::uintptr_t * data_ptr = reinterpret_cast<std::uintptr_t *>(data);
+    std::decay_t<Function> * p_callback = reinterpret_cast<std::decay_t<Function> *>(data_ptr[0]);
+    std::tuple<Args...> * p_args = reinterpret_cast<std::tuple<Args...> *>(data_ptr[1]);
+    std::apply(*p_callback, std::forward<std::tuple<Args...>>(*p_args));
+    delete p_callback;
+    delete p_args;
+    delete[] data_ptr;
+}
+}  // namespace cuda
 
 // CUDA Stream
 // -----------
@@ -29,13 +50,94 @@ class Stream : public cuda::StreamImpl {
      * @brief Default constructor.
      * @details Create a stream with default settings.
      */
-    inline Stream(void) : cuda::StreamImpl(Stream::create_(), ::cudaStreamDestroy) {}
+    inline Stream(void) : cuda::StreamImpl(Stream::create_stream(), ::cudaStreamDestroy) {}
     /** @brief Take ownership from another pre-created CUDA stream.*/
     inline Stream(::cudaStream_t stream_ptr) : cuda::StreamImpl(stream_ptr, ::cudaStreamDestroy) {}
 
+    /**
+     * @brief Record an event in the stream.
+     * @param event The event to be recorded.
+     * @details Record the given event in this stream. The event will be marked as completed when all previous
+     * operations in this stream have been completed.
+     */
+    inline void record_event(const Event & event) const {
+        cuda::check_cuda_error(::cudaEventRecord(event.get(), this->get()));
+    }
+
+    /**
+     * @brief Wait for an event in the stream.
+     * @param event The event to wait for.
+     * @details Make this stream wait until the given event is completed before executing any further operations
+     */
+    inline void wait_event(const Event & event) const {
+        cuda::check_cuda_error(::cudaStreamWaitEvent(this->get(), event.get(), 0));
+    }
+
+    /**
+     * @brief Add a host callback to the stream.
+     * @details This function will be launched after the stream has finished its previous tasks. The callback
+     * function can have arbitrary arguments and return type (the return value will be ignored).
+     *
+     * Note that all arguments will be copied into internal storage before being passed to the callback function, so
+     * references and pointers should be used with caution. They must outlive the callback execution.
+     *
+     * CUDA API functions cannot be called inside the callback function.
+     * @param callback Function to be launched.
+     * @param args Argument list to be provided to the function.
+     * @details Example:
+     * @code {.cu}
+     * // function declaration with r-value, l-value, const l-value references and primitive types
+     * void stream_callback(std::vector<int> && a, const std::string & b, int & c, double d) {
+     *     std::printf("Stream callback arguments: %zu, \"%s\", %d, and %f\n", a.size(), b.c_str(), c, d);
+     *     c += 1;
+     * }
+     *
+     * // usage
+     * std::string b = "a dummy message!";
+     * int c = 1;
+     * caribou::Stream s();
+     * s.add_callback(str_callback, std::vector<int>({1, 2, 3}), std::cref(b), std::ref(c), 0.5);
+     *
+     * // stdout result:
+     * // Stream callback arguments: 3, "a dummy message!", 1 and 0.5
+     * @endcode
+     */
+    template <typename Function, typename... Args>
+    inline void add_callback(Function && callback, Args &&... args) const {
+        std::decay_t<Function> * p_callback = new std::decay_t<Function>(std::forward<Function>(callback));
+        std::tuple<Args...> * p_args = new std::tuple<Args...>(std::forward<Args>(args)...);
+        std::uintptr_t * data = new std::uintptr_t[2];
+        data[0] = reinterpret_cast<std::uintptr_t>(p_callback);
+        data[1] = reinterpret_cast<std::uintptr_t>(p_args);
+        cuda::check_cuda_error(::cudaStreamAddCallback(this->get(), cuda::stream_callback_wrapper<Function, Args...>,
+                                                       reinterpret_cast<void *>(data), 0));
+    }
+
+    /**
+     * @brief Synchronize with the stream.
+     * @details Wait until all works submitted to this stream are completed.
+     */
+    inline void synchronize() const { cuda::check_cuda_error(::cudaStreamSynchronize(this->get())); }
+
+    /**
+     * @brief Query stream status.
+     * @return True if all works submitted to this stream are completed, false otherwise.
+     */
+    inline bool is_completed() const {
+        ::cudaError_t status = ::cudaStreamQuery(this->get());
+        if (status == ::cudaSuccess) {
+            return true;
+        } else if (status == ::cudaErrorNotReady) {
+            return false;
+        } else {
+            cuda::check_cuda_error(status);
+            return false;  // Unreachable
+        }
+    }
+
   private:
     /** @brief Create a stream with default settings.*/
-    static inline ::cudaStream_t create_(void) {
+    static inline ::cudaStream_t create_stream(void) {
         ::cudaStream_t result;
         cuda::check_cuda_error(::cudaStreamCreate(&result));
         return result;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cu
@@ -14,6 +14,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/view/quadrature_view.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/view/xs_view.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/runtime.h"
 #include "caliper/cali.h"
 #include "caribou/caribou.h"
 


### PR DESCRIPTION
In this PR, Event is implemented for the external library `caribou`.

Notable changes:

- `cudaEvent` wrapper is implemented, including:

  * create with flag
  * query
  * synchronize
  * time-measurement
  * create interprocess handle (for copying across multiple MPI ranks)
  * convert interprocess handle back to event.

- `cudaStream` wrapper implementation is expanded, notably:

  * query
  * synchronize
  * record event
  * wait for event
  * add asynchronous callback to the stream (pure host function to be executed in the stream)
