### PR TITLE
Convert FLUDS vector references into std::span

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
@@ -7,6 +7,7 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
+#include <algorithm>
 
 namespace opensn
 {
@@ -34,11 +35,13 @@ AngleAggregation::ZeroOutgoingDelayedPsi()
   for (auto& angsetgrp : angle_set_groups)
     for (auto& angset : angsetgrp.GetAngleSets())
       for (auto& delayed_data : angset->GetFLUDS().DelayedPrelocIOutgoingPsi())
-        Set(delayed_data, 0.0);
+        std::fill(delayed_data.begin(), delayed_data.end(), 0.0);
 
   for (auto& angsetgrp : angle_set_groups)
     for (auto& angset : angsetgrp.GetAngleSets())
-      Set(angset->GetFLUDS().DelayedLocalPsi(), 0.0);
+      std::fill(angset->GetFLUDS().DelayedLocalPsi().begin(),
+                angset->GetFLUDS().DelayedLocalPsi().end(),
+                0.0);
 }
 
 void
@@ -67,13 +70,15 @@ AngleAggregation::ZeroIncomingDelayedPsi()
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
-      Set(angle_set->GetFLUDS().DelayedLocalPsiOld(), 0.0);
+      std::fill(angle_set->GetFLUDS().DelayedLocalPsiOld().begin(),
+                angle_set->GetFLUDS().DelayedLocalPsiOld().end(),
+                0.0);
 
   // Inter location cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
       for (auto& loc_vector : angle_set->GetFLUDS().DelayedPrelocIOutgoingPsiOld())
-        Set(loc_vector, 0.0);
+        std::fill(loc_vector.begin(), loc_vector.end(), 0.0);
 }
 
 void
@@ -665,13 +670,12 @@ AngleAggregation::SetDelayedPsiOld2New()
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
-      angle_set->GetFLUDS().DelayedLocalPsi() = angle_set->GetFLUDS().DelayedLocalPsiOld();
+      angle_set->GetFLUDS().SetDelayedLocalPsiOldToNew();
 
   // Inter location cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
-      angle_set->GetFLUDS().DelayedPrelocIOutgoingPsi() =
-        angle_set->GetFLUDS().DelayedPrelocIOutgoingPsiOld();
+      angle_set->GetFLUDS().SetDelayedOutgoingPsiOldToNew();
 }
 
 void
@@ -695,13 +699,12 @@ AngleAggregation::SetDelayedPsiNew2Old()
   // Intra-cell cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
-      angle_set->GetFLUDS().DelayedLocalPsiOld() = angle_set->GetFLUDS().DelayedLocalPsi();
+      angle_set->GetFLUDS().SetDelayedLocalPsiNewToOld();
 
   // Inter location cycles
   for (auto& as_group : angle_set_groups)
     for (auto& angle_set : as_group.GetAngleSets())
-      angle_set->GetFLUDS().DelayedPrelocIOutgoingPsiOld() =
-        angle_set->GetFLUDS().DelayedPrelocIOutgoingPsi();
+      angle_set->GetFLUDS().SetDelayedOutgoingPsiNewToOld();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_async_comm.cc
@@ -200,10 +200,8 @@ AAH_ASynchronousCommunicator::BuildMessageStructure()
 void
 AAH_ASynchronousCommunicator::InitializeDelayedUpstreamData()
 {
-  const auto& spds = fluds_.GetSPDS();
-  const auto num_delayed_dependencies = spds.GetDelayedLocationDependencies().size();
-  fluds_.AllocateDelayedPrelocIOutgoingPsi(num_groups_, num_angles_, num_delayed_dependencies);
-  fluds_.AllocateDelayedLocalPsi(num_groups_, num_angles_);
+  fluds_.AllocateDelayedPrelocIOutgoingPsi();
+  fluds_.AllocateDelayedLocalPsi();
 }
 
 bool
@@ -254,7 +252,7 @@ AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
   // Resize FLUDS non-local incoming data
   if (not upstream_data_initialized_)
   {
-    fluds_.AllocatePrelocIOutgoingPsi(num_groups_, num_angles_, num_dependencies);
+    fluds_.AllocatePrelocIOutgoingPsi();
     upstream_data_initialized_ = true;
   }
 
@@ -321,10 +319,10 @@ AAH_ASynchronousCommunicator::InitializeLocalAndDownstreamBuffers()
     const auto& spds = fluds_.GetSPDS();
 
     // Resize FLUDS local outgoing data
-    fluds_.AllocateInternalLocalPsi(num_groups_, num_angles_);
+    fluds_.AllocateInternalLocalPsi();
 
     // Resize FLUDS non-local outgoing data
-    fluds_.AllocateOutgoingPsi(num_groups_, num_angles_, spds.GetLocationSuccessors().size());
+    fluds_.AllocateOutgoingPsi();
 
     data_initialized_ = true;
   }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
@@ -10,6 +10,16 @@
 namespace opensn
 {
 
+static inline void
+UpdateRange(std::vector<std::vector<double>>& target, std::vector<std::span<double>>& view)
+{
+  view.resize(target.size());
+  for (std::size_t i = 0; i < target.size(); ++i)
+  {
+    view[i] = std::span<double>(target[i]);
+  }
+}
+
 AAH_FLUDS::AAH_FLUDS(size_t num_groups, size_t num_angles, const AAH_FLUDSCommonData& common_data)
   : FLUDS(num_groups, num_angles, common_data.GetSPDS()),
     common_data_(common_data),
@@ -170,17 +180,16 @@ AAH_FLUDS::GetDeplocIFaceDOFCount(int deplocI) const
 void
 AAH_FLUDS::ClearLocalAndReceivePsi()
 {
-  auto empty_vector = std::vector<std::vector<double>>(0);
-  local_psi_.swap(empty_vector);
-
-  empty_vector = std::vector<std::vector<double>>(0);
-  prelocI_outgoing_psi_.swap(empty_vector);
+  local_psi_.clear();
+  prelocI_outgoing_psi_.clear();
+  prelocI_outgoing_psi_view_.clear();
 }
 
 void
 AAH_FLUDS::ClearSendPsi()
 {
   deplocI_outgoing_psi_.clear();
+  deplocI_outgoing_psi_view_.clear();
 }
 
 void
@@ -205,6 +214,7 @@ AAH_FLUDS::AllocateOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_lo
     deplocI_outgoing_psi_[deplocI].resize(
       common_data_.deplocI_face_dof_count_[deplocI] * num_grps * num_angles, 0.0);
   }
+  UpdateRange(deplocI_outgoing_psi_, deplocI_outgoing_psi_view_);
 }
 
 void
@@ -213,11 +223,13 @@ AAH_FLUDS::AllocateDelayedLocalPsi(size_t num_grps, size_t num_angles)
   delayed_local_psi_.resize(common_data_.delayed_local_psi_stride_ *
                               common_data_.delayed_local_psi_max_elements_ * num_grps * num_angles,
                             0.0);
+  delayed_local_psi_view_ = std::span<double>(delayed_local_psi_);
 
   delayed_local_psi_old_.resize(common_data_.delayed_local_psi_stride_ *
                                   common_data_.delayed_local_psi_max_elements_ * num_grps *
                                   num_angles,
                                 0.0);
+  delayed_local_psi_old_view_ = std::span<double>(delayed_local_psi_old_);
 }
 
 void
@@ -229,6 +241,7 @@ AAH_FLUDS::AllocatePrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t
     prelocI_outgoing_psi_[prelocI].resize(
       common_data_.prelocI_face_dof_count_[prelocI] * num_grps * num_angles, 0.0);
   }
+  UpdateRange(prelocI_outgoing_psi_, prelocI_outgoing_psi_view_);
 }
 
 void
@@ -236,10 +249,7 @@ AAH_FLUDS::AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
                                              size_t num_angles,
                                              size_t num_loc_deps)
 {
-  delayed_prelocI_outgoing_psi_.clear();
   delayed_prelocI_outgoing_psi_.resize(num_loc_deps);
-
-  delayed_prelocI_outgoing_psi_old_.clear();
   delayed_prelocI_outgoing_psi_old_.resize(num_loc_deps);
 
   for (size_t prelocI = 0; prelocI < num_loc_deps; ++prelocI)
@@ -251,41 +261,36 @@ AAH_FLUDS::AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
     delayed_prelocI_outgoing_psi_[prelocI].resize(buff_size, 0.0);
     delayed_prelocI_outgoing_psi_old_[prelocI].resize(buff_size, 0.0);
   }
+  UpdateRange(delayed_prelocI_outgoing_psi_, delayed_prelocI_outgoing_psi_view_);
+  UpdateRange(delayed_prelocI_outgoing_psi_old_, delayed_prelocI_outgoing_psi_old_view_);
 }
 
-std::vector<double>&
-AAH_FLUDS::DelayedLocalPsi()
+void
+AAH_FLUDS::SetDelayedOutgoingPsiNewToOld()
 {
-  return delayed_local_psi_;
+  delayed_prelocI_outgoing_psi_old_ = delayed_prelocI_outgoing_psi_;
+  UpdateRange(delayed_prelocI_outgoing_psi_old_, delayed_prelocI_outgoing_psi_old_view_);
 }
 
-std::vector<double>&
-AAH_FLUDS::DelayedLocalPsiOld()
+void
+AAH_FLUDS::SetDelayedOutgoingPsiOldToNew()
 {
-  return delayed_local_psi_old_;
+  delayed_prelocI_outgoing_psi_ = delayed_prelocI_outgoing_psi_old_;
+  UpdateRange(delayed_prelocI_outgoing_psi_, delayed_prelocI_outgoing_psi_view_);
 }
 
-std::vector<std::vector<double>>&
-AAH_FLUDS::DeplocIOutgoingPsi()
+void
+AAH_FLUDS::SetDelayedLocalPsiNewToOld()
 {
-  return deplocI_outgoing_psi_;
+  delayed_local_psi_old_ = delayed_local_psi_;
+  delayed_local_psi_old_view_ = std::span<double>(delayed_local_psi_old_);
 }
 
-std::vector<std::vector<double>>&
-AAH_FLUDS::PrelocIOutgoingPsi()
+void
+AAH_FLUDS::SetDelayedLocalPsiOldToNew()
 {
-  return prelocI_outgoing_psi_;
-}
-
-std::vector<std::vector<double>>&
-AAH_FLUDS::DelayedPrelocIOutgoingPsi()
-{
-  return delayed_prelocI_outgoing_psi_;
-}
-std::vector<std::vector<double>>&
-AAH_FLUDS::DelayedPrelocIOutgoingPsiOld()
-{
-  return delayed_prelocI_outgoing_psi_old_;
+  delayed_local_psi_ = delayed_local_psi_old_;
+  delayed_local_psi_view_ = std::span<double>(delayed_local_psi_);
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
@@ -193,62 +193,61 @@ AAH_FLUDS::ClearSendPsi()
 }
 
 void
-AAH_FLUDS::AllocateInternalLocalPsi(size_t num_grps, size_t num_angles)
+AAH_FLUDS::AllocateInternalLocalPsi()
 {
   local_psi_.resize(common_data_.num_face_categories_);
   // fc = face category
   for (size_t fc = 0; fc < common_data_.num_face_categories_; ++fc)
   {
     local_psi_[fc].resize(common_data_.local_psi_stride_[fc] *
-                            common_data_.local_psi_max_elements_[fc] * num_grps * num_angles,
+                            common_data_.local_psi_max_elements_[fc] * num_groups_and_angles_,
                           0.0);
   }
 }
 
 void
-AAH_FLUDS::AllocateOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_sucs)
+AAH_FLUDS::AllocateOutgoingPsi()
 {
+  std::size_t num_loc_sucs = spds_.GetLocationSuccessors().size();
   deplocI_outgoing_psi_.resize(num_loc_sucs, std::vector<double>());
   for (size_t deplocI = 0; deplocI < num_loc_sucs; ++deplocI)
   {
     deplocI_outgoing_psi_[deplocI].resize(
-      common_data_.deplocI_face_dof_count_[deplocI] * num_grps * num_angles, 0.0);
+      common_data_.deplocI_face_dof_count_[deplocI] * num_groups_and_angles_, 0.0);
   }
   UpdateRange(deplocI_outgoing_psi_, deplocI_outgoing_psi_view_);
 }
 
 void
-AAH_FLUDS::AllocateDelayedLocalPsi(size_t num_grps, size_t num_angles)
+AAH_FLUDS::AllocateDelayedLocalPsi()
 {
-  delayed_local_psi_.resize(common_data_.delayed_local_psi_stride_ *
-                              common_data_.delayed_local_psi_max_elements_ * num_grps * num_angles,
-                            0.0);
+  std::size_t delayed_local_psi_size = common_data_.delayed_local_psi_stride_ *
+                                       common_data_.delayed_local_psi_max_elements_ *
+                                       num_groups_and_angles_;
+  delayed_local_psi_.resize(delayed_local_psi_size, 0.0);
   delayed_local_psi_view_ = std::span<double>(delayed_local_psi_);
 
-  delayed_local_psi_old_.resize(common_data_.delayed_local_psi_stride_ *
-                                  common_data_.delayed_local_psi_max_elements_ * num_grps *
-                                  num_angles,
-                                0.0);
+  delayed_local_psi_old_.resize(delayed_local_psi_size, 0.0);
   delayed_local_psi_old_view_ = std::span<double>(delayed_local_psi_old_);
 }
 
 void
-AAH_FLUDS::AllocatePrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_deps)
+AAH_FLUDS::AllocatePrelocIOutgoingPsi()
 {
+  std::size_t num_loc_deps = spds_.GetLocationDependencies().size();
   prelocI_outgoing_psi_.resize(num_loc_deps, std::vector<double>());
   for (size_t prelocI = 0; prelocI < num_loc_deps; ++prelocI)
   {
     prelocI_outgoing_psi_[prelocI].resize(
-      common_data_.prelocI_face_dof_count_[prelocI] * num_grps * num_angles, 0.0);
+      common_data_.prelocI_face_dof_count_[prelocI] * num_groups_and_angles_, 0.0);
   }
   UpdateRange(prelocI_outgoing_psi_, prelocI_outgoing_psi_view_);
 }
 
 void
-AAH_FLUDS::AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
-                                             size_t num_angles,
-                                             size_t num_loc_deps)
+AAH_FLUDS::AllocateDelayedPrelocIOutgoingPsi()
 {
+  std::size_t num_loc_deps = spds_.GetDelayedLocationDependencies().size();
   delayed_prelocI_outgoing_psi_.resize(num_loc_deps);
   delayed_prelocI_outgoing_psi_old_.resize(num_loc_deps);
 
@@ -256,7 +255,7 @@ AAH_FLUDS::AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
   {
     const int num_nodes = common_data_.delayed_prelocI_face_dof_count_[prelocI];
 
-    uint64_t buff_size = num_nodes * num_grps * num_angles;
+    uint64_t buff_size = num_nodes * num_groups_and_angles_;
 
     delayed_prelocI_outgoing_psi_[prelocI].resize(buff_size, 0.0);
     delayed_prelocI_outgoing_psi_old_[prelocI].resize(buff_size, 0.0);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h
@@ -69,14 +69,12 @@ public:
 
   void ClearLocalAndReceivePsi() override;
   void ClearSendPsi() override;
-  void AllocateInternalLocalPsi(size_t num_grps, size_t num_angles) override;
-  void AllocateOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_sucs) override;
+  void AllocateInternalLocalPsi() override;
+  void AllocateOutgoingPsi() override;
 
-  void AllocateDelayedLocalPsi(size_t num_grps, size_t num_angles) override;
-  void AllocatePrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_deps) override;
-  void AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
-                                         size_t num_angles,
-                                         size_t num_loc_deps) override;
+  void AllocateDelayedLocalPsi() override;
+  void AllocatePrelocIOutgoingPsi() override;
+  void AllocateDelayedPrelocIOutgoingPsi() override;
 
   void SetDelayedOutgoingPsiOldToNew() override;
   void SetDelayedOutgoingPsiNewToOld() override;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h
@@ -78,15 +78,11 @@ public:
                                          size_t num_angles,
                                          size_t num_loc_deps) override;
 
-  std::vector<double>& DelayedLocalPsi() override;
-  std::vector<double>& DelayedLocalPsiOld() override;
+  void SetDelayedOutgoingPsiOldToNew() override;
+  void SetDelayedOutgoingPsiNewToOld() override;
 
-  std::vector<std::vector<double>>& DeplocIOutgoingPsi() override;
-
-  std::vector<std::vector<double>>& PrelocIOutgoingPsi() override;
-
-  std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsi() override;
-  std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsiOld() override;
+  void SetDelayedLocalPsiOldToNew() override;
+  void SetDelayedLocalPsiNewToOld() override;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
@@ -40,18 +40,12 @@ public:
 
   void ClearLocalAndReceivePsi() override { deplocs_outgoing_messages_.clear(); }
   void ClearSendPsi() override {}
-  void AllocateInternalLocalPsi(size_t num_grps, size_t num_angles) override {}
-  void AllocateOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_sucs) override {}
+  void AllocateInternalLocalPsi() override {}
+  void AllocateOutgoingPsi() override {}
 
-  void AllocateDelayedLocalPsi(size_t num_grps, size_t num_angles) override {}
-  void AllocatePrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_deps) override
-  {
-  }
-  void AllocateDelayedPrelocIOutgoingPsi(size_t num_grps,
-                                         size_t num_angles,
-                                         size_t num_loc_deps) override
-  {
-  }
+  void AllocateDelayedLocalPsi() override {}
+  void AllocatePrelocIOutgoingPsi() override {}
+  void AllocateDelayedPrelocIOutgoingPsi() override {}
 
   // cell_global_id, face_id
   using CellFaceKey = std::pair<uint64_t, unsigned int>;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
@@ -53,22 +53,6 @@ public:
   {
   }
 
-  std::vector<double>& DelayedLocalPsi() override { return delayed_local_psi_; }
-  std::vector<double>& DelayedLocalPsiOld() override { return delayed_local_psi_old_; }
-
-  std::vector<std::vector<double>>& DeplocIOutgoingPsi() override { return deplocI_outgoing_psi_; }
-
-  std::vector<std::vector<double>>& PrelocIOutgoingPsi() override { return prelocI_outgoing_psi_; }
-
-  std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsi() override
-  {
-    return delayed_prelocI_outgoing_psi_;
-  }
-  std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsiOld() override
-  {
-    return delayed_prelocI_outgoing_psi_old_;
-  }
-
   // cell_global_id, face_id
   using CellFaceKey = std::pair<uint64_t, unsigned int>;
 
@@ -83,14 +67,7 @@ private:
   const UnknownManager& psi_uk_man_;
   const SpatialDiscretization& sdm_;
 
-  std::vector<double> delayed_local_psi_;
-  std::vector<double> delayed_local_psi_old_;
-  std::vector<std::vector<double>> deplocI_outgoing_psi_;
-  std::vector<std::vector<double>> prelocI_outgoing_psi_;
   std::vector<std::vector<double>> boundryI_incoming_psi_;
-
-  std::vector<std::vector<double>> delayed_prelocI_outgoing_psi_;
-  std::vector<std::vector<double>> delayed_prelocI_outgoing_psi_old_;
 
   std::map<CellFaceKey, std::vector<double>> deplocs_outgoing_messages_;
 };

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds_common_data.h"
-#include <vector>
 #include <set>
+#include <span>
+#include <vector>
 #include <cstddef>
 #include <cstdint>
 
@@ -40,16 +41,25 @@ public:
   {
   }
 
-  virtual std::vector<double>& DelayedLocalPsi() = 0;
-  virtual std::vector<double>& DelayedLocalPsiOld() = 0;
+  std::span<double>& DelayedLocalPsi() { return delayed_local_psi_view_; }
+  std::span<double>& DelayedLocalPsiOld() { return delayed_local_psi_old_view_; }
+  virtual void SetDelayedLocalPsiOldToNew() {}
+  virtual void SetDelayedLocalPsiNewToOld() {}
 
-  virtual std::vector<std::vector<double>>& DeplocIOutgoingPsi() = 0;
+  std::vector<std::span<double>>& DeplocIOutgoingPsi() { return deplocI_outgoing_psi_view_; }
 
-  virtual std::vector<std::vector<double>>& PrelocIOutgoingPsi() = 0;
+  std::vector<std::span<double>>& PrelocIOutgoingPsi() { return prelocI_outgoing_psi_view_; }
 
-  virtual std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsi() = 0;
-
-  virtual std::vector<std::vector<double>>& DelayedPrelocIOutgoingPsiOld() = 0;
+  std::vector<std::span<double>>& DelayedPrelocIOutgoingPsi()
+  {
+    return delayed_prelocI_outgoing_psi_view_;
+  }
+  std::vector<std::span<double>>& DelayedPrelocIOutgoingPsiOld()
+  {
+    return delayed_prelocI_outgoing_psi_old_view_;
+  }
+  virtual void SetDelayedOutgoingPsiOldToNew() {}
+  virtual void SetDelayedOutgoingPsiNewToOld() {}
 
   virtual ~FLUDS() = default;
 
@@ -58,6 +68,13 @@ protected:
   const size_t num_angles_;
   const size_t num_groups_and_angles_;
   const SPDS& spds_;
+
+  std::span<double> delayed_local_psi_view_;
+  std::span<double> delayed_local_psi_old_view_;
+  std::vector<std::span<double>> deplocI_outgoing_psi_view_;
+  std::vector<std::span<double>> prelocI_outgoing_psi_view_;
+  std::vector<std::span<double>> delayed_prelocI_outgoing_psi_view_;
+  std::vector<std::span<double>> delayed_prelocI_outgoing_psi_old_view_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds_common_data.h"
 #include <set>
 #include <span>
@@ -29,17 +30,12 @@ public:
 
   virtual void ClearLocalAndReceivePsi() {}
   virtual void ClearSendPsi() {}
-  virtual void AllocateInternalLocalPsi(size_t num_grps, size_t num_angles) {}
-  virtual void AllocateOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_sucs) {}
+  virtual void AllocateInternalLocalPsi() {}
+  virtual void AllocateOutgoingPsi() {}
 
-  virtual void AllocateDelayedLocalPsi(size_t num_grps, size_t num_angles) {}
-  virtual void AllocatePrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_deps)
-  {
-  }
-  virtual void
-  AllocateDelayedPrelocIOutgoingPsi(size_t num_grps, size_t num_angles, size_t num_loc_deps)
-  {
-  }
+  virtual void AllocateDelayedLocalPsi() {}
+  virtual void AllocatePrelocIOutgoingPsi() {}
+  virtual void AllocateDelayedPrelocIOutgoingPsi() {}
 
   std::span<double>& DelayedLocalPsi() { return delayed_local_psi_view_; }
   std::span<double>& DelayedLocalPsiOld() { return delayed_local_psi_old_view_; }


### PR DESCRIPTION
In this PR, references to `std::vector<double>` are replaced with the non-owning view `std::span<double>`.

This change prepares the codebase for supporting non-standard containers for angular flux data, such as GPU host vectors.