### PR TITLE
Removing extraneous print statements from c5g7_restart.py

### DIFF
--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
@@ -38,7 +38,6 @@ if __name__ == "__main__":
     xss[6].LoadFromOpenSn("c5g7/materials/XS_fission_chamber.xs")
 
     num_groups = xss[0].num_groups
-    print("Num groups: ", num_groups)
 
     # Create materials
     xs_map = []


### PR DESCRIPTION
The print statements were being printed from all ranks and clobbering the elapsed time output that the regression test script depends on.