### PR TITLE
Update compiler matrix for builds workflow

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - gcc/9
           - gcc/10
           - gcc/12
           - gcc/13
@@ -21,6 +20,7 @@ jobs:
           - clang/14
           - clang/16
           - clang/17
+          - clang/19
           - intel/oneapi
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
 Deprecating GCC 9.5 due to lack of c++20 support. Adding Clang 19.