### PR TITLE
Removing legacy clang compilers

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -16,8 +16,6 @@ jobs:
           - gcc/10
           - gcc/12
           - gcc/13
-          - clang/12
-          - clang/14
           - clang/16
           - clang/17
           - clang/19


### PR DESCRIPTION
Removing legacy clang compilers from nighty build workflow that don't fully support c++20.