### PR TITLE
`CBC_FLUDS` uses memory pool allocator to minimize memory usage for cell angular fluxes during sweeps

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -1022,16 +1022,18 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
       }
       else if (sweep_type_ == "CBC")
       {
-        OpenSnLogicalErrorIf(not options_.save_angular_flux,
-                             "When using sweep_type \"CBC\" then "
-                             "\"save_angular_flux\" must be true.");
+        const size_t num_local_cells = grid_->local_cells.size();
+        const auto cbc_sweep_ordering = std::static_pointer_cast<CBC_SPDS>(sweep_ordering);
+        const auto& min_num_pool_allocator_slots =
+          cbc_sweep_ordering->GetMinNumPoolAllocatorSlots();
+
         std::shared_ptr<FLUDS> fluds =
           std::make_shared<CBC_FLUDS>(gs_num_grps,
                                       angle_indices.size(),
                                       dynamic_cast<const CBC_FLUDSCommonData&>(fluds_common_data),
-                                      psi_new_local_[groupset.id],
-                                      groupset.psi_uk_man_,
-                                      *discretization_);
+                                      num_local_cells,
+                                      max_cell_dof_count_,
+                                      min_num_pool_allocator_slots);
 
         auto angle_set = std::make_shared<CBC_AngleSet>(angle_set_id++,
                                                         gs_num_grps,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.h
@@ -18,6 +18,7 @@ protected:
   const CBC_SPDS& cbc_spds_;
   std::vector<Task> current_task_list_;
   CBC_ASynchronousCommunicator async_comm_;
+  CBC_FLUDS& cbc_fluds_;
 
 public:
   CBC_AngleSet(size_t id,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
@@ -5,6 +5,8 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h"
+#include "boost/pool/simple_segregated_storage.hpp"
+#include <cstddef>
 #include <map>
 #include <functional>
 
@@ -15,28 +17,73 @@ class UnknownManager;
 class SpatialDiscretization;
 class Cell;
 
+/**
+ * Flux data structures (FLUDS) specific to the cell-by-cell (CBC) sweep algorithm
+ *
+ * This class manages the storage and access of angular flux data during a CBC sweep
+ *
+ * It provides methods to access:
+ * - Upwind angular flux data from local neighbor cells
+ * - Storage locations for downwind angular flux data for the current cell
+ * - Upwind angular flux data received from remote MPI ranks
+ */
 class CBC_FLUDS : public FLUDS
 {
 public:
   CBC_FLUDS(size_t num_groups,
             size_t num_angles,
             const CBC_FLUDSCommonData& common_data,
-            std::vector<double>& local_psi_data,
-            const UnknownManager& psi_uk_man,
-            const SpatialDiscretization& sdm);
+            size_t num_local_cells,
+            size_t max_cell_dof_count,
+            size_t min_num_pool_allocator_slots);
 
   const FLUDSCommonData& GetCommonData() const;
 
-  const std::vector<double>& GetLocalUpwindDataBlock() const;
+  /**
+   * Given a cell's local ID, retrieve a free slot in the pool allocator for storing
+   * the cell's angular flux data and map the cell's local ID to the slot
+   */
+  void Allocate(uint64_t cell_local_ID);
 
-  const double* GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell);
+  /**
+   * Given a cell's local ID, deallocate the memory used for the cell's angular flux data
+   * and remove the mapping from the cell's local ID to the slot
+   */
+  void Deallocate(uint64_t cell_local_ID);
 
-  const std::vector<double>& GetNonLocalUpwindData(uint64_t cell_global_id,
-                                                   unsigned int face_id) const;
+  /**
+   * Given a local upwind neighbor cell local cell ID, a node index on this cell, and an
+   * angleset subset index, this function returns a pointer to
+   * the start of the group data for the specified node and angle.
+   */
+  double* UpwindPsi(uint64_t cell_local_id, unsigned int adj_cell_node, size_t as_ss_idx);
 
-  const double* GetNonLocalUpwindPsi(const std::vector<double>& psi_data,
-                                     unsigned int face_node_mapped,
-                                     unsigned int angle_set_index);
+  /**
+   * Given a local cell's local ID, a node index on this cell, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * node and angle for writing its just solved angular fluxes.
+   */
+  double* OutgoingPsi(uint64_t cell_local_id, unsigned int cell_node, size_t as_ss_idx);
+
+  /**
+   * Given a remote upwind cell's global ID, a face ID on this cell,
+   * a node index on this face, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * face node and angle.
+   */
+  double* NLUpwindPsi(uint64_t cell_global_id,
+                      unsigned int face_id,
+                      unsigned int face_node_mapped,
+                      size_t as_ss_idx);
+
+  /**
+   * Given a pointer to a vector holding the non-local outgoing psi data for a face,
+   * a node index on this face, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * face node and angle.
+   */
+  double*
+  NLOutgoingPsi(std::vector<double>* psi_nonlocal_outgoing, size_t face_node, size_t as_ss_idx);
 
   void ClearLocalAndReceivePsi() override { deplocs_outgoing_messages_.clear(); }
   void ClearSendPsi() override {}
@@ -57,9 +104,10 @@ public:
 
 private:
   const CBC_FLUDSCommonData& common_data_;
-  std::reference_wrapper<std::vector<double>> local_psi_data_;
-  const UnknownManager& psi_uk_man_;
-  const SpatialDiscretization& sdm_;
+  size_t slot_size_;
+  std::vector<double*> cell_local_ID_to_psi_map_;
+  std::vector<double> local_psi_data_backing_buffer_;
+  boost::simple_segregated_storage<size_t> local_psi_data_;
 
   std::vector<std::vector<double>> boundryI_incoming_psi_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.h
@@ -24,9 +24,25 @@ public:
   /// Returns the cell-by-cell task list.
   const std::vector<Task>& GetTaskList() const;
 
+  /// Returns the minimum number of slots needed for the pool allocator in CBC_FLUDS.
+  size_t GetMinNumPoolAllocatorSlots() const { return min_num_pool_allocator_slots_; }
+
+private:
+  /**
+   * Simulates a sweep over the local cells to calculate the minimum number of slots needed for
+   * the pool allocator in CBC_FLUDS.
+   * Due to the asynchronous nature of communication of the CBC algorithm, the simulated sweep sets
+   * aside a slot for each cell that has either remote upwind or downwind dependencies, which cannot
+   * be reused during a sweep. For cells that have only local dependencies, slots can be reused.
+   */
+  size_t SimulateLocalSweep() const;
+
 protected:
   /// Cell-by-cell task list.
   std::vector<Task> task_list_;
+
+  /// Minimum number of slots needed for CBC_FLUDS pool allocator.
+  size_t min_num_pool_allocator_slots_ = 0;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
@@ -36,7 +36,11 @@ enum class AngleSetStatus
 struct Task
 {
   unsigned int num_dependencies;
-  std::vector<uint64_t> successors;
+  unsigned int num_satisfied_downwind_deps;
+  unsigned int num_remote_predecessors;
+  unsigned int num_remote_successors;
+  std::vector<uint64_t> local_predecessors;
+  std::vector<uint64_t> local_successors;
   uint64_t reference_id;
   const Cell* cell_ptr;
   bool completed = false;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
@@ -41,6 +41,7 @@ CBCSweepChunk::CBCSweepChunk(std::vector<double>& destination_phi,
     fluds_(nullptr),
     gs_size_(0),
     gs_gi_(0),
+    num_angles_in_as_(0),
     group_stride_(0),
     group_angle_stride_(0),
     surface_source_active_(false),
@@ -64,8 +65,9 @@ CBCSweepChunk::SetAngleSet(AngleSet& angle_set)
   gs_gi_ = groupset_.groups.front().id;
 
   surface_source_active_ = IsSurfaceSourceActive();
+  num_angles_in_as_ = angle_set.GetNumAngles();
   group_stride_ = angle_set.GetNumGroups();
-  group_angle_stride_ = angle_set.GetNumGroups() * angle_set.GetNumAngles();
+  group_angle_stride_ = group_stride_ * num_angles_in_as_;
 }
 
 void
@@ -93,7 +95,7 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
 
   DenseMatrix<double> Amat(max_num_cell_dofs_, max_num_cell_dofs_);
   DenseMatrix<double> Atemp(max_num_cell_dofs_, max_num_cell_dofs_);
-  std::vector<Vector<double>> b(groupset_.groups.size(), Vector<double>(max_num_cell_dofs_));
+  std::vector<Vector<double>> b(gs_size_, Vector<double>(max_num_cell_dofs_));
   std::vector<double> source(max_num_cell_dofs_);
 
   const auto& face_orientations = angle_set.GetSPDS().GetCellFaceOrientations()[cell_local_id_];
@@ -105,7 +107,8 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
   // as = angle set
   // ss = subset
   const std::vector<std::uint32_t>& as_angle_indices = angle_set.GetAngleIndices();
-  for (size_t as_ss_idx = 0; as_ss_idx < as_angle_indices.size(); ++as_ss_idx)
+
+  for (size_t as_ss_idx = 0; as_ss_idx < num_angles_in_as_; ++as_ss_idx)
   {
     auto direction_num = as_angle_indices[as_ss_idx];
     auto omega = groupset_.quadrature->omegas[direction_num];
@@ -136,19 +139,6 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       const auto* face_nodal_mapping =
         &fluds_->GetCommonData().GetFaceNodalMapping(cell_local_id_, f);
 
-      const std::vector<double>* psi_upwnd_data_block = nullptr;
-      const double* psi_local_face_upwnd_data = nullptr;
-      if (is_local_face)
-      {
-        psi_upwnd_data_block = &fluds_->GetLocalUpwindDataBlock();
-        psi_local_face_upwnd_data = fluds_->GetLocalCellUpwindPsi(
-          *psi_upwnd_data_block, *cell_transport_view_->FaceNeighbor(f));
-      }
-      else if (not is_boundary_face)
-      {
-        psi_upwnd_data_block = &fluds_->GetNonLocalUpwindData(cell_->global_id, f);
-      }
-
       // IntSf_mu_psi_Mij_dA
       const size_t num_face_nodes = cell_mapping_->GetNumFaceNodes(f);
       for (size_t fi = 0; fi < num_face_nodes; ++fi)
@@ -163,19 +153,14 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
           Amat(i, j) += mu_Nij;
 
           const double* psi = nullptr;
+
           if (is_local_face)
-          {
-            assert(psi_local_face_upwnd_data);
-            const unsigned int adj_cell_node = face_nodal_mapping->cell_node_mapping_[fj];
-            psi = &psi_local_face_upwnd_data[adj_cell_node * groupset_angle_group_stride_ +
-                                             direction_num * groupset_group_stride_];
-          }
+            psi = fluds_->UpwindPsi(cell_transport_view_->FaceNeighbor(f)->local_id,
+                                    face_nodal_mapping->cell_node_mapping_[fj],
+                                    as_ss_idx);
           else if (not is_boundary_face)
-          {
-            assert(psi_upwnd_data_block);
-            const unsigned int adj_face_node = face_nodal_mapping->face_node_mapping_[fj];
-            psi = fluds_->GetNonLocalUpwindPsi(*psi_upwnd_data_block, adj_face_node, as_ss_idx);
-          }
+            psi = fluds_->NLUpwindPsi(
+              cell_->global_id, f, face_nodal_mapping->face_node_mapping_[fj], as_ss_idx);
           else
             psi = angle_set.PsiBoundary(face.neighbor_id,
                                         direction_num,
@@ -185,11 +170,9 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
                                         gs_gi_,
                                         surface_source_active_);
 
-          if (not psi)
-            continue;
-
-          for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-            b[gsg](i) += psi[gsg] * mu_Nij;
+          if (psi != nullptr)
+            for (size_t gsg = 0; gsg < gs_size_; ++gsg)
+              b[gsg](i) += psi[gsg] * mu_Nij;
         } // for face node j
       } // for face node i
     } // for f
@@ -242,18 +225,19 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       }
     }
 
-    // Save angular flux during sweep
+    // If requested, save angular fluxes during sweep
     if (save_angular_flux_)
     {
-      double* cell_psi_data =
+      double* cell_psi =
         &destination_psi_[discretization_.MapDOFLocal(*cell_, 0, groupset_.psi_uk_man_, 0, 0)];
 
       for (size_t i = 0; i < cell_num_nodes_; ++i)
       {
-        const size_t imap =
+        const size_t addr_offset =
           i * groupset_angle_group_stride_ + direction_num * groupset_group_stride_;
+
         for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-          cell_psi_data[imap + gsg] = b[gsg](i);
+          cell_psi[addr_offset + gsg] = b[gsg](i);
       }
     }
 
@@ -274,22 +258,25 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       const size_t num_face_nodes = cell_mapping_->GetNumFaceNodes(f);
       const auto& face_nodal_mapping =
         fluds_->GetCommonData().GetFaceNodalMapping(cell_local_id_, f);
-      std::vector<double>* psi_dnwnd_data = nullptr;
-      if (not is_boundary_face and not is_local_face)
+      std::vector<double>* psi_nonlocal_outgoing = nullptr;
+
+      if ((not is_boundary_face) and (not is_local_face))
       {
         auto& async_comm = *angle_set.GetCommunicator();
-        size_t data_size = num_face_nodes * group_angle_stride_;
-        psi_dnwnd_data = &async_comm.InitGetDownwindMessageData(locality,
-                                                                face.neighbor_id,
-                                                                face_nodal_mapping.associated_face_,
-                                                                angle_set.GetID(),
-                                                                data_size);
+        const size_t data_size_for_msg = num_face_nodes * group_angle_stride_;
+        psi_nonlocal_outgoing =
+          &async_comm.InitGetDownwindMessageData(locality,
+                                                 face.neighbor_id,
+                                                 face_nodal_mapping.associated_face_,
+                                                 angle_set.GetID(),
+                                                 data_size_for_msg);
       }
 
       for (size_t fi = 0; fi < num_face_nodes; ++fi)
       {
         const int i = cell_mapping_->MapFaceNode(f, fi);
 
+        // Tally outflow for particle balance
         if (is_boundary_face)
         {
           for (size_t gsg = 0; gsg < gs_size_; ++gsg)
@@ -298,24 +285,18 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
         }
 
         double* psi = nullptr;
+
         if (is_local_face)
-          psi = nullptr;
+          psi = fluds_->OutgoingPsi(cell_local_id_, i, as_ss_idx);
         else if (not is_boundary_face)
-        {
-          assert(psi_dnwnd_data);
-          const size_t addr_offset = fi * group_angle_stride_ + as_ss_idx * group_stride_;
-          psi = &(*psi_dnwnd_data)[addr_offset];
-        }
+          psi = fluds_->NLOutgoingPsi(psi_nonlocal_outgoing, fi, as_ss_idx);
         else if (is_reflecting_boundary_face)
           psi = angle_set.PsiReflected(face.neighbor_id, direction_num, cell_local_id_, f, fi);
-        if (psi)
-        {
-          if (not is_boundary_face or is_reflecting_boundary_face)
-          {
-            for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-              psi[gsg] = b[gsg](i);
-          }
-        }
+
+        // Write the solved angular flux to the determined location
+        if (psi != nullptr)
+          for (size_t gsg = 0; gsg < gs_size_; ++gsg)
+            psi[gsg] = b[gsg](i);
       } // for fi
     } // for face
   } // for angleset/subset

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
@@ -10,6 +10,17 @@ namespace opensn
 {
 class CellMapping;
 
+/**
+ * Implements the core sweep operation for a single cell within the
+ *        cell-by-cell (CBC) sweep algorithm
+ *
+ * This class is responsible for performing the discrete ordinates transport
+ * calculation on a given cell for all angles and groups managed by its
+ * current AngleSet
+ * It interacts with a CBC_FLUDS object to obtain upwind angular flux data
+ * (from local neighbors, MPI remote buffers, or boundaries) and to store
+ * outgoing angular flux data (to local neighbors or MPI send buffers)
+ */
 class CBCSweepChunk : public SweepChunk
 {
 public:
@@ -31,13 +42,31 @@ public:
 
   void SetCell(Cell const* cell_ptr, AngleSet& angle_set) override;
 
+  /**
+   * Performs the discrete ordinates sweep calculation for the currently
+   *        set cell, for all angles and groups within the provided AngleSet
+   *
+   * It:
+   * - Assembles the local transport equation system for each angle and group
+   * - Retrieves upwind angular fluxes from local neighbors, remote locations
+   *   (via MPI data managed by CBC_FLUDS), or boundaries
+   * - Solves the local system for the outgoing angular fluxes at the cell nodes
+   * - Updates the global scalar flux moments
+   * - If save_angular_flux_ is true, stores the computed angular fluxes into
+   *   the global angular flux vector
+   * - Propagates outgoing angular fluxes to local downwind neighbors or stages
+   *   them for MPI transmission to remote downwind neighbors
+   */
   void Sweep(AngleSet& angle_set) override;
 
 private:
   CBC_FLUDS* fluds_;
   size_t gs_size_;
   int gs_gi_;
+  size_t num_angles_in_as_;
+  /// Stride for consecutive angles
   size_t group_stride_;
+  /// Stride for consecutive spatial DOFs
   size_t group_angle_stride_;
   bool surface_source_active_;
 


### PR DESCRIPTION
This PR introduces a free-list memory pool allocator using the Boost Pool's simple segregated storage class to manage angular flux data within the `CBC_FLUDS` class. During a sweep, as soon as the CBC algorithm sends a cell's angular flux data to all of its local downwind dependencies, the storage for that cell's angular flux data can be reused for another
local cell that has not yet been solved.

For a given `CBC_SPDS`, the CBC algorithm currently stores angular fluxes for all cells in the `CBC_SPDS`, for angles in the quadrature, and for all groups in a given group set, which results in high memory intensity during sweeps. The changes in this commit include the following:
- The `CBC_SPDS` class has a new method to simulate a local sweep, which determines the minimum number of free slots (blocks of memory) that the `CBC_FLUDS` class needs to properly store cell angular fluxes during a given sweep. The simulated sweep iterates through the `CBC_SPDS`'s task list in the same manner as in the `CBC_AngleSet::AngleSetAdvance` method, and tracks when cells need to have a free slot assigned to them, and when cells with associated slots can return said slots back to the pool. This is done for cells that have purely local upwind and downwind dependencies. For cells that have either remote upwind or remote downwind dependencies, the simulated
sweep sets aside a permanent slot for each one of these cells. Cells with either remote upwind or remote downwind dependencies cannot cannot have their corresponding memory blocks be returned to the free pool even after all of their local downwind dependencies have received the appropriate angular fluxes. This is due to the non-deterministic and asynchronous nature of the CBC algorithm's communication patterns. A simulated sweep can neither determine ahead of time when a cell with remote upwind dependencies will get its necessary angular fluxes nor determine ahead of time when a cell with remote downwind dependencies communicates its fluxes to said dependencies.
- The `CBC_FLUDS` class uses the Boost Pool's library simple segregated storage class to implement a free-list pool allocator. Using the minimum number of slots calculated by the simulated sweep, the `CBC_FLUDS` class constructs a backing buffer with as many elements as the product of the minimum number of pool slots, the number of angles in the associated angle set, and the number of groups in the associated group set. The simple segregated storage object manages this backing buffer, and uses an internal free-list to hand out free pool slots and return slots back to the pool for cells whose angular flux data no longer needs to be stored during the sweep.
- The `CBC_AngleSet::AngleSetAdvance` method uses the `CBC_FLUDS::Allocate` method to associate a free slot to a cell that is ready to be solved. After a cell has been swept, its local predecessors have their dependency consumption counts incremented. When a local predecessor's dependency consumption count equals or exceeds its local downwind dependency count, its corresponding slot is returned back to the pool via the `CBC_FLUDS::Deallocate` method.

Below is a strong-scaling plot for the CBC algorithm run with the `CBC_FLUDS` class with this pool allocator on LLNL Dane, whose node specs are given below.
- 112 Intel Sapphire Rapids cores/node
- 105MB cache/CPU
- 2.28GB DDR5 per core

The scaling study was run on 1, 2, 4, 8, 16, 32, 64, and 128 nodes, with 64 ranks per node (rpn).

<img width="1002" height="485" alt="opensn-strong-scaling-cbc-pool-allocator" src="https://github.com/user-attachments/assets/91917a7c-8108-4966-a711-4798fc7d32d4" />

Below is a plot showing the strong-scaling results from [PR 808](https://github.com/Open-Sn/opensn/pull/808) and this PR for 2, 4, 8, 16, 32, and 128 nodes. The 1-node results for both PRs have been omitted on this plot as PR 808 is not able to run on 1 node on LLNL Dane due to memory limitations.

<img width="1002" height="485" alt="image" src="https://github.com/user-attachments/assets/ca1ec310-8d31-4049-9e9f-e7f473296583" />


Below is a weak-scaling plot for the CBC algorithm run with the `CBC_FLUDS` class with this pool allocator on LLNL Dane.

<img width="985" height="485" alt="opensn-weak-scaling-cbc-pool-allocator" src="https://github.com/user-attachments/assets/3c023a9c-fee9-4f3d-88bf-fa112555deeb" />

The weak-scaling study was run on 1, 2, 4, 8, 16, 32, and 64 nodes, with 64 rpn.
