### PR TITLE
Removing forced use of -O0 for Debug config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ function(_add_ld_cfg CFG FLAG)
   endif()
 endfunction()
 
-_add_cxx_cfg(Debug "-O0")
 _add_cxx_cfg(Native "-O3")
 _add_cxx_cfg(Native "-march=native")
 _add_cxx_cfg(Native "-mtune=native")


### PR DESCRIPTION
This PR removes the forcing of -O0 for Debug builds. This was overriding the -O2 in our sanitize and coverage targets and making them exceptionally slow.