### PR TITLE
Minor refactoring of problem classes

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.cc
@@ -46,15 +46,12 @@ DiscreteOrdinatesCurvilinearProblem::DiscreteOrdinatesCurvilinearProblem(
   const InputParameters& params)
   : DiscreteOrdinatesProblem(params)
 {
+  PerformInputChecks();
 }
 
 void
 DiscreteOrdinatesCurvilinearProblem::PerformInputChecks()
 {
-  log.Log() << "DiscreteOrdinatesCurvilinearSolver::PerformInputChecks : enter";
-
-  DiscreteOrdinatesProblem::PerformInputChecks();
-
   // perform additional verifications for curvilinear LBS
   // coordinate system must be curvilinear
   if (grid_->GetCoordinateSystem() != CoordinateSystemType::CYLINDRICAL and
@@ -237,7 +234,6 @@ DiscreteOrdinatesCurvilinearProblem::PerformInputChecks()
       }
     }
   }
-  log.Log() << "DiscreteOrdinatesCurvilinearSolver::PerformInputChecks : exit";
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/discrete_ordinates_curvilinear_problem.h
@@ -31,7 +31,7 @@ public:
   operator=(const DiscreteOrdinatesCurvilinearProblem&) = delete;
 
 protected:
-  void PerformInputChecks() override;
+  void PerformInputChecks();
   void InitializeSpatialDiscretization() override;
   void ComputeSecondaryUnitIntegrals();
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -35,6 +35,8 @@ public:
   /// Read access to newest updated angular flux vector.
   const std::vector<std::vector<double>>& GetPsiNewLocal() const;
 
+  void PrintSimHeader() override;
+
   void Initialize() override;
 
   /// Returns the sweep boundaries as a read only reference
@@ -106,12 +108,15 @@ public:
   static InputParameters GetInputParameters();
   static std::shared_ptr<DiscreteOrdinatesProblem> Create(const ParameterBlock& params);
 
-protected:
+private:
+  /// Computes the number of moments for the given mesher types
+  void ValidateAndComputeScatteringMoments();
+
   /**
    * This routine groups angle-indices to groups sharing the same sweep ordering. It also takes
    * geometry into account.
    */
-  static std::pair<UniqueSOGroupings, DirIDToSOMap>
+  std::pair<UniqueSOGroupings, DirIDToSOMap>
   AssociateSOsAndDirections(std::shared_ptr<MeshContinuum> grid,
                             const AngularQuadrature& quadrature,
                             AngleAggregationType agg_type,

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
@@ -26,8 +26,8 @@ LBSGroupset::GetInputParameters()
                                    "The first and last group id this groupset operates on, e.g. A "
                                    "4 group problem <TT>groups_from_to= {0, 3}</TT>");
   // Anglesets
-  params.AddRequiredParameter<std::shared_ptr<AngularQuadrature>>(
-    "angular_quadrature", "A handle to an angular quadrature");
+  params.AddOptionalParameter<std::shared_ptr<AngularQuadrature>>(
+    "angular_quadrature", nullptr, "A handle to an angular quadrature");
   params.AddOptionalParameter(
     "angle_aggregation_type", "polar", "The angle aggregation method to use during sweeping");
   params.AddOptionalParameter("angle_aggregation_num_subsets",
@@ -157,7 +157,7 @@ LBSGroupset::LBSGroupset( // NOLINT(cppcoreguidelines-pro-type-member-init)
   }
 
   // Add quadrature
-  quadrature = params.GetSharedPtrParam<AngularQuadrature>("angular_quadrature");
+  quadrature = params.GetSharedPtrParam<AngularQuadrature>("angular_quadrature", false);
 
   // Angle aggregation
   const auto angle_agg_typestr = params.GetParamValue<std::string>("angle_aggregation_type");

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -48,12 +48,6 @@ public:
   /// Returns a constant reference to the solver options.
   const LBSOptions& GetOptions() const;
 
-  static InputParameters GetOptionsBlock();
-
-  static InputParameters GetBoundaryOptionsBlock();
-
-  static InputParameters GetXSMapEntryBlock();
-
   void SetOptions(const InputParameters& input);
 
   void SetBoundaryOptions(const InputParameters& params);
@@ -81,19 +75,7 @@ public:
    */
   size_t GetMaxPrecursorsPerMaterial() const;
 
-  /**
-   * Adds a group to the list of groups. If group id < 0, the id will be logically derived from the
-   * list size. If >= 0 the id will be set to the id specified.
-   */
-  void AddGroup(int id);
-
   const std::vector<LBSGroup>& GetGroups() const;
-
-  /**
-   * Adds a groupset to the list of groupsets. The groupset id will be logically derived from the
-   * list size.
-   */
-  void AddGroupset();
 
   std::vector<LBSGroupset>& GetGroupsets();
 
@@ -216,9 +198,6 @@ public:
 
   void Initialize() override;
 
-  /// Initializes default materials and physics materials.
-  void InitializeMaterials();
-
   bool TriggerRestartDump() const
   {
     if (options_.write_restart_time_interval <= std::chrono::seconds(0))
@@ -251,32 +230,36 @@ public:
    */
   virtual void ReorientAdjointSolution() {};
 
+private:
+  /// Initialize groupsets
+  void InitializeGroupsets(const InputParameters& params);
+
+  /// Initializes materials
+  void InitializeXSmapAndDensities(const InputParameters& params);
+  void InitializeMaterials();
+
+  /// Initialize sources
+  void InitializeSources(const InputParameters& params);
+
+  /// Initialize boundary conditions
+  void InitializeBoundaryConditions(const InputParameters& params);
+
 protected:
-  /// Performs general input checks before initialization continues.
-  virtual void PerformInputChecks();
-
-  /// Prints header information of simulation.
-  void PrintSimHeader();
-
-  virtual void InitializeSpatialDiscretization();
+  virtual void PrintSimHeader();
 
   void ComputeUnitIntegrals();
 
-  /// Initializes common groupset items.
-  void InitializeGroupsets();
-
-  /// Computes the number of moments for the given mesher types
-  void ValidateAndComputeScatteringMoments();
+  virtual void InitializeSpatialDiscretization();
 
   /// Initializes parallel arrays.
-  virtual void InitializeParrays();
+  void InitializeParrays();
 
   void InitializeFieldFunctions();
 
   /// Initializes boundaries.
   virtual void InitializeBoundaries() {}
 
-  virtual void InitializeSolverSchemes();
+  void InitializeSolverSchemes();
 
   virtual void InitializeWGSSolvers() {};
 
@@ -362,6 +345,12 @@ public:
 
   /// Returns the input parameters for this object.
   static InputParameters GetInputParameters();
+
+  static InputParameters GetOptionsBlock();
+
+  static InputParameters GetBoundaryOptionsBlock();
+
+  static InputParameters GetXSMapEntryBlock();
 };
 
 } // namespace opensn


### PR DESCRIPTION
This PR refactors problem classes in preparation for a new uncollided problem type. The following changes are included in this PR:

1. Refactors initialization of `LBSProblem`, moving as much of the initialization as possible into the constructor. This will be expanded in the future to make problem initialization as straightforward as possible.
2. The scattering order parameter has been moved from `LBSProblem` to `DiscreteOrdinatesProblem` as has the computation of num moments and the scattering order validation checks. The `scattering_order` and `num_moments` member variables still live in `LBSProblem` since it is responsible for managing parrays.
3. The angular quadrature parameter for groupsets is now optional.
4. Initialization of per-groupset angular unknown manager is now performed in the constructor for `DiscreteOrdinatesSolver`.
5. Updating class names and error messages