### PR TITLE
Revert "Modified CBC FLUDS to have its own vector that stores local cell angular fluxes"

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -1022,10 +1022,14 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
       }
       else if (sweep_type_ == "CBC")
       {
+        OpenSnLogicalErrorIf(not options_.save_angular_flux,
+                             "When using sweep_type \"CBC\" then "
+                             "\"save_angular_flux\" must be true.");
         std::shared_ptr<FLUDS> fluds =
           std::make_shared<CBC_FLUDS>(gs_num_grps,
                                       angle_indices.size(),
                                       dynamic_cast<const CBC_FLUDSCommonData&>(fluds_common_data),
+                                      psi_new_local_[groupset.id],
                                       groupset.psi_uk_man_,
                                       *discretization_);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
@@ -5,7 +5,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -13,18 +12,14 @@ namespace opensn
 CBC_FLUDS::CBC_FLUDS(size_t num_groups,
                      size_t num_angles,
                      const CBC_FLUDSCommonData& common_data,
+                     std::vector<double>& local_psi_data,
                      const UnknownManager& psi_uk_man,
                      const SpatialDiscretization& sdm)
   : FLUDS(num_groups, num_angles, common_data.GetSPDS()),
     common_data_(common_data),
+    local_psi_data_(local_psi_data),
     psi_uk_man_(psi_uk_man),
-    sdm_(sdm),
-    num_angles_in_gs_quadrature_(psi_uk_man_.GetNumberOfUnknowns()),
-    num_quadrature_local_dofs_(sdm_.GetNumLocalDOFs(psi_uk_man_)),
-    num_local_spatial_dofs_(num_quadrature_local_dofs_ / num_angles_in_gs_quadrature_ /
-                            num_groups_),
-    local_psi_data_size_(num_local_spatial_dofs_ * num_groups_and_angles_),
-    local_psi_data_(local_psi_data_size_)
+    sdm_(sdm)
 {
 }
 
@@ -34,66 +29,32 @@ CBC_FLUDS::GetCommonData() const
   return common_data_;
 }
 
-double*
-CBC_FLUDS::UpwindPsi(const Cell& face_neighbor, unsigned int adj_cell_node, size_t as_ss_idx)
+const std::vector<double>&
+CBC_FLUDS::GetLocalUpwindDataBlock() const
 {
-  // Map to face neighbor cell's first spatial DOF index
-  // (0 to (num_local_spatial_dofs_ - 1))
-  const size_t face_nbr_spatial_dof_0_index =
-    (sdm_.MapDOFLocal(face_neighbor, 0, psi_uk_man_, 0, 0) / num_angles_in_gs_quadrature_ /
-     num_groups_);
-
-  // Index to start of neighbor cell's data block in local_psi_data_
-  const size_t face_nbr_data_start_index = face_nbr_spatial_dof_0_index * num_groups_and_angles_;
-  const size_t addr_offset = adj_cell_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
-  const size_t face_nbr_data_index = face_nbr_data_start_index + addr_offset;
-
-  assert((face_nbr_data_index >= 0) and (face_nbr_data_index < local_psi_data_.size()));
-
-  return &local_psi_data_[face_nbr_data_index];
+  return local_psi_data_;
 }
 
-double*
-CBC_FLUDS::OutgoingPsi(const Cell& cell, unsigned int cell_node, size_t as_ss_idx)
+const double*
+CBC_FLUDS::GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell)
 {
-  // Map to current cell's first spatial DOF index
-  // (0 to (num_local_spatial_dofs_ - 1))
-  const size_t cur_cell_spatial_dof_0_index =
-    (sdm_.MapDOFLocal(cell, 0, psi_uk_man_, 0, 0) / num_angles_in_gs_quadrature_ / num_groups_);
-
-  // Index to start of current cell's data block in local_psi_data_
-  const size_t cur_cell_data_start_index = cur_cell_spatial_dof_0_index * num_groups_and_angles_;
-  const size_t addr_offset = cell_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
-  const size_t cur_cell_data_index = cur_cell_data_start_index + addr_offset;
-
-  assert((cur_cell_data_index >= 0) and (cur_cell_data_index < local_psi_data_.size()));
-
-  return &local_psi_data_[cur_cell_data_index];
+  const auto dof_map = sdm_.MapDOFLocal(cell, 0, psi_uk_man_, 0, 0);
+  return &psi_data_block[dof_map];
 }
 
-double*
-CBC_FLUDS::NLUpwindPsi(uint64_t cell_global_id,
-                       unsigned int face_id,
-                       unsigned int face_node_mapped,
-                       size_t as_ss_idx)
+const std::vector<double>&
+CBC_FLUDS::GetNonLocalUpwindData(uint64_t cell_global_id, unsigned int face_id) const
 {
-  std::vector<double>& psi = deplocs_outgoing_messages_.at({cell_global_id, face_id});
-  const size_t dof_map =
-    face_node_mapped * num_groups_and_angles_ + //  Offset to start of data for face_node_mapped
-    as_ss_idx * num_groups_;                    // Offset to start of data for angle_set_index
-
-  assert((dof_map >= 0) and (dof_map < psi.size()));
-  return &psi[dof_map];
+  return deplocs_outgoing_messages_.at({cell_global_id, face_id});
 }
 
-double*
-CBC_FLUDS::NLOutgoingPsi(std::vector<double>* psi_nonlocal_outgoing,
-                         size_t face_node,
-                         size_t as_ss_idx)
+const double*
+CBC_FLUDS::GetNonLocalUpwindPsi(const std::vector<double>& psi_data,
+                                unsigned int face_node_mapped,
+                                unsigned int angle_set_index)
 {
-  assert(psi_nonlocal_outgoing != nullptr);
-  const size_t addr_offset = face_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
-  return &(*psi_nonlocal_outgoing)[addr_offset];
+  const size_t dof_map = face_node_mapped * num_groups_and_angles_ + angle_set_index * num_groups_;
+  return &psi_data[dof_map];
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
@@ -5,7 +5,6 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h"
-#include <cstddef>
 #include <map>
 #include <functional>
 
@@ -16,60 +15,28 @@ class UnknownManager;
 class SpatialDiscretization;
 class Cell;
 
-/**
- * Flux data structures (FLUDS) specific to the cell-by-cell (CBC) sweep algorithm
- *
- * This class manages the storage and access of angular flux data during a CBC sweep
- *
- * It provides methods to access:
- * - Upwind angular flux data from local neighbor cells
- * - Storage locations for downwind angular flux data for the current cell
- * - Upwind angular flux data received from remote MPI ranks
- */
 class CBC_FLUDS : public FLUDS
 {
 public:
   CBC_FLUDS(size_t num_groups,
             size_t num_angles,
             const CBC_FLUDSCommonData& common_data,
+            std::vector<double>& local_psi_data,
             const UnknownManager& psi_uk_man,
             const SpatialDiscretization& sdm);
 
   const FLUDSCommonData& GetCommonData() const;
 
-  /**
-   * Given a local upwind neighbor cell, a node index on this cell, and an
-   * angleset subset index, this function returns a pointer to
-   * the start of the group data for the specified node and angle.
-   */
-  double* UpwindPsi(const Cell& face_neighbor, unsigned int adj_cell_node, size_t as_ss_idx);
+  const std::vector<double>& GetLocalUpwindDataBlock() const;
 
-  /**
-   * Given a local cell, a node index on this cell, and an angleset subset index,
-   * this function returns a pointer to the start of the group data for the specified
-   * node and angle for writing its just solved angular fluxes.
-   */
-  double* OutgoingPsi(const Cell& cell, unsigned int cell_node, size_t as_ss_idx);
+  const double* GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell);
 
-  /**
-   * Given a remote upwind cell's global ID, a face ID on this cell,
-   * a node index on this face, and an angleset subset index,
-   * this function returns a pointer to the start of the group data for the specified
-   * face node and angle.
-   */
-  double* NLUpwindPsi(uint64_t cell_global_id,
-                      unsigned int face_id,
-                      unsigned int face_node_mapped,
-                      size_t as_ss_idx);
+  const std::vector<double>& GetNonLocalUpwindData(uint64_t cell_global_id,
+                                                   unsigned int face_id) const;
 
-  /**
-   * Given a pointer to a vector holding the non-local outgoing psi data for a face,
-   * a node index on this face, and an angleset subset index,
-   * this function returns a pointer to the start of the group data for the specified
-   * face node and angle.
-   */
-  double*
-  NLOutgoingPsi(std::vector<double>* psi_nonlocal_outgoing, size_t face_node, size_t as_ss_idx);
+  const double* GetNonLocalUpwindPsi(const std::vector<double>& psi_data,
+                                     unsigned int face_node_mapped,
+                                     unsigned int angle_set_index);
 
   void ClearLocalAndReceivePsi() override { deplocs_outgoing_messages_.clear(); }
   void ClearSendPsi() override {}
@@ -90,17 +57,9 @@ public:
 
 private:
   const CBC_FLUDSCommonData& common_data_;
+  std::reference_wrapper<std::vector<double>> local_psi_data_;
   const UnknownManager& psi_uk_man_;
   const SpatialDiscretization& sdm_;
-  size_t num_angles_in_gs_quadrature_;
-  size_t num_quadrature_local_dofs_;
-  size_t num_local_spatial_dofs_;
-  size_t local_psi_data_size_;
-  /**
-   * Layout for storage for local angular fluxes:
-   * spatial DOF major -> angle in angleset major -> group in groupset major
-   */
-  std::vector<double> local_psi_data_;
 
   std::vector<std::vector<double>> boundryI_incoming_psi_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
@@ -75,7 +75,7 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
   {
     const size_t num_faces = cell.faces.size();
     unsigned int num_dependencies = 0;
-    std::vector<uint64_t> successors;
+    std::vector<uint64_t> succesors;
 
     for (size_t f = 0; f < num_faces; ++f)
     {
@@ -88,11 +88,11 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
       {
         const auto& face = cell.faces[f];
         if (face.has_neighbor and grid->IsCellLocal(face.neighbor_id))
-          successors.push_back(grid->cells[face.neighbor_id].local_id);
+          succesors.push_back(grid->cells[face.neighbor_id].local_id);
       }
     }
 
-    task_list_.push_back({num_dependencies, successors, cell.local_id, &cell, false});
+    task_list_.push_back({num_dependencies, succesors, cell.local_id, &cell, false});
   }
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
@@ -10,17 +10,6 @@ namespace opensn
 {
 class CellMapping;
 
-/**
- * Implements the core sweep operation for a single cell within the
- *        cell-by-cell (CBC) sweep algorithm
- *
- * This class is responsible for performing the discrete ordinates transport
- * calculation on a given cell for all angles and groups managed by its
- * current AngleSet
- * It interacts with a CBC_FLUDS object to obtain upwind angular flux data
- * (from local neighbors, MPI remote buffers, or boundaries) and to store
- * outgoing angular flux data (to local neighbors or MPI send buffers)
- */
 class CBCSweepChunk : public SweepChunk
 {
 public:
@@ -42,30 +31,14 @@ public:
 
   void SetCell(Cell const* cell_ptr, AngleSet& angle_set) override;
 
-  /**
-   * Performs the discrete ordinates sweep calculation for the currently
-   *        set cell, for all angles and groups within the provided AngleSet
-   *
-   * It:
-   * - Assembles the local transport equation system for each angle and group
-   * - Retrieves upwind angular fluxes from local neighbors, remote locations
-   *   (via MPI data managed by CBC_FLUDS), or boundaries
-   * - Solves the local system for the outgoing angular fluxes at the cell nodes
-   * - Updates the global scalar flux moments
-   * - If save_angular_flux_ is true, stores the computed angular fluxes into
-   *   the global angular flux vector
-   * - Propagates outgoing angular fluxes to local downwind neighbors or stages
-   *   them for MPI transmission to remote downwind neighbors
-   */
   void Sweep(AngleSet& angle_set) override;
 
 private:
   CBC_FLUDS* fluds_;
   size_t gs_size_;
   int gs_gi_;
-  size_t num_angles_in_as_;
-  size_t group_stride_;       // Stride for consecutive angles
-  size_t group_angle_stride_; // Stride for consecutive spatial DOFs
+  size_t group_stride_;
+  size_t group_angle_stride_;
   bool surface_source_active_;
 
   const Cell* cell_;

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
             "power_field_function_on": True,
             "power_default_kappa": 1.0,
             "power_normalization": 1.0,
+            "save_angular_flux": True,
             "read_restart_path": "c5g7_restart/c5g7",
             # "restart_writes_enabled": True,
             # "write_delayed_psi_to_restart": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
@@ -80,7 +80,8 @@ if __name__ == "__main__":
         options={
             "use_precursors": use_precursors,
             "verbose_inner_iterations": False,
-            "verbose_outer_iterations": True
+            "verbose_outer_iterations": True,
+            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
 
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,
+            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
 
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,
+            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": True,
             "verbose_outer_iterations": True,
+            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
@@ -74,6 +74,9 @@ if __name__ == "__main__":
             {"name": "zmin", "type": "reflecting"},
             {"name": "zmax", "type": "reflecting"},
         ],
+        options={
+            "save_angular_flux": True,
+        },
         sweep_type="CBC"
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
@@ -99,7 +99,8 @@ if __name__ == "__main__":
         scattering_order=5,
         volumetric_sources=[mg_src],
         options={
-            "max_ags_iterations": 1
+            "max_ags_iterations": 1,
+            "save_angular_flux": True
         },
         sweep_type="CBC"
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
             {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
         ],
         options={
-            "max_ags_iterations": 1
+            "max_ags_iterations": 1,
+            "save_angular_flux": True
         },
         sweep_type="CBC"
     )


### PR DESCRIPTION
Reverts Open-Sn/opensn#623. It looks like 623 wasn't ready to merge after all. All problems that use CBC now fail sanitizer tests. This PR reverts the changes in 623 and Eappen will need to re-open his PR and fix the sanitizer issues.