### PR TITLE
Bug fixes for Lebedev quadratures.

### DIFF
--- a/framework/math/quadratures/angular/lebedev_quadrature.cc
+++ b/framework/math/quadratures/angular/lebedev_quadrature.cc
@@ -15,24 +15,24 @@
 namespace opensn
 {
 
-LebedevQuadrature::LebedevQuadrature(int order, bool verbose)
-  : AngularQuadrature(AngularQuadratureType::LebedevQuadrature, 3, order)
+LebedevQuadrature::LebedevQuadrature(int quadrature_order, int scattering_order, bool verbose)
+  : AngularQuadrature(AngularQuadratureType::LebedevQuadrature, 3, scattering_order)
 {
-  LoadFromOrder(order, verbose);
+  LoadFromOrder(quadrature_order, verbose);
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
 }
 
 void
-LebedevQuadrature::LoadFromOrder(int order, bool verbose)
+LebedevQuadrature::LoadFromOrder(int quadrature_order, bool verbose)
 {
   abscissae.clear();
   weights.clear();
   omegas.clear();
 
   // Get points from LebedevOrders
-  const auto& points = LebedevOrders::GetOrderPoints(order);
+  const auto& points = LebedevOrders::GetOrderPoints(quadrature_order);
 
   std::stringstream ostr;
   double weight_sum = 0.0;
@@ -78,7 +78,8 @@ LebedevQuadrature::LoadFromOrder(int order, bool verbose)
 
   if (verbose)
   {
-    log.Log() << "Loaded " << points.size() << " Lebedev quadrature points from order " << order;
+    log.Log() << "Loaded " << points.size() << " Lebedev quadrature points from quadrature order "
+              << quadrature_order;
     log.Log() << ostr.str() << "\n"
               << "Weight sum=" << weight_sum;
   }

--- a/framework/math/quadratures/angular/lebedev_quadrature.h
+++ b/framework/math/quadratures/angular/lebedev_quadrature.h
@@ -27,15 +27,16 @@ public:
    * @param order The order of the Lebedev quadrature set to load
    * @param verbose Flag to enable verbose output
    */
-  LebedevQuadrature(int order, bool verbose = false);
+  LebedevQuadrature(int quadrature_order, int scattering_order, bool verbose = false);
 
+private:
   /**
    * @brief Loads quadrature points for the specified order from predefined data.
    *
    * @param order The order to load
    * @param verbose Flag to enable verbose output
    */
-  void LoadFromOrder(int order, bool verbose = false);
+  void LoadFromOrder(int quadrature_order, bool verbose = false);
 };
 
 } // namespace opensn

--- a/python/lib/aquad.cc
+++ b/python/lib/aquad.cc
@@ -366,9 +366,9 @@ WrapLebedevQuadrature(py::module& aquad)
     py::init(
       [](py::kwargs& params)
       {
-        static const std::vector<std::string> required_keys = {"order"};
+        static const std::vector<std::string> required_keys = {"quadrature_order", "scattering_order"};
         static const std::vector<std::pair<std::string, py::object>> optional_keys = {{"verbose", py::bool_(false)}};
-        return construct_from_kwargs<LebedevQuadrature, int, bool>(params, required_keys, optional_keys);
+        return construct_from_kwargs<LebedevQuadrature, int, int, bool>(params, required_keys, optional_keys);
       }
     ),
     R"(
@@ -376,28 +376,13 @@ WrapLebedevQuadrature(py::module& aquad)
 
     Parameters
     ----------
-    order: int
+    quadrature_order: int
         The order of the quadrature.
+    scattering_order: int
+        Maximum scattering order supported by the angular quadrature.
     verbose: bool, default=False
         Whether to print verbose output during initialization.
     )"
-  );
-  
-  lebedev_quadrature.def(
-    "LoadFromOrder",
-    &LebedevQuadrature::LoadFromOrder,
-    R"(
-    Loads quadrature points from an Order.
-
-    Parameters
-    ----------
-    order: int
-        The order of the quadrature.
-    verbose: bool, default=False
-        Whether to print verbose output during loading.
-    )",
-    py::arg("order"),
-    py::arg("verbose") = false
   );
   // clang-format on
 }

--- a/test/python/framework/math/quadrature/lebedev_test.py
+++ b/test/python/framework/math/quadrature/lebedev_test.py
@@ -4,11 +4,11 @@
 # --- Lebedev Quadrature Test 1 ---
 # Create a Lebedev quadrature of order 7
 print("\n--- Testing Lebedev Quadrature, Order 7 ---")
-quad1_sum = sum(LebedevQuadrature(order=7).weights)
+quad1_sum = sum(LebedevQuadrature(quadrature_order=7, scattering_order=0).weights)
 print(f"Weight-Sum-1={quad1_sum:.3e}\n\n")
 
 # --- Lebedev Quadrature Test 2 ---
 # Create a higher order Lebedev quadrature
 print("\n--- Testing Lebedev Quadrature, Order 15 ---")
-quad2_sum = sum(LebedevQuadrature(order=15).weights)
+quad2_sum = sum(LebedevQuadrature(quadrature_order=15, scattering_order=0).weights)
 print(f"Weight-Sum-2={quad2_sum:.3e}\n\n")

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_7a_leb_quad.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_7a_leb_quad.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         strength.append(1.0)
     mg_src = VolumetricSource(block_ids=[0], group_strength=strength)
 
-    pquad = LebedevQuadrature(order=3)
+    pquad = LebedevQuadrature(quadrature_order=3, scattering_order=0)
 
     phys = DiscreteOrdinatesProblem(
         mesh=grid,

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_7b_leb_quad.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_7b_leb_quad.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         strength.append(1.0)
     mg_src = VolumetricSource(block_ids=[0], group_strength=strength)
 
-    pquad = LebedevQuadrature(order=21)
+    pquad = LebedevQuadrature(quadrature_order=21, scattering_order=0)
 
     phys = DiscreteOrdinatesProblem(
         mesh=grid,


### PR DESCRIPTION
This PR fixes a couple of bugs in the Lebedev quadrature:

1. `scattering_order` was missing as a user-supplied parameter
2. The quadrature order was being passed to `AngularQuadrature` as the scattering order instead of the user-supplied value.
3. `LoadFromOrder` was declared public and was user-facing in the Python API.