### PR TITLE
Modified CBC FLUDS to have its own vector that stores local cell angular fluxes

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -1022,14 +1022,10 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
       }
       else if (sweep_type_ == "CBC")
       {
-        OpenSnLogicalErrorIf(not options_.save_angular_flux,
-                             "When using sweep_type \"CBC\" then "
-                             "\"save_angular_flux\" must be true.");
         std::shared_ptr<FLUDS> fluds =
           std::make_shared<CBC_FLUDS>(gs_num_grps,
                                       angle_indices.size(),
                                       dynamic_cast<const CBC_FLUDSCommonData&>(fluds_common_data),
-                                      psi_new_local_[groupset.id],
                                       groupset.psi_uk_man_,
                                       *discretization_);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -12,14 +13,18 @@ namespace opensn
 CBC_FLUDS::CBC_FLUDS(size_t num_groups,
                      size_t num_angles,
                      const CBC_FLUDSCommonData& common_data,
-                     std::vector<double>& local_psi_data,
                      const UnknownManager& psi_uk_man,
                      const SpatialDiscretization& sdm)
   : FLUDS(num_groups, num_angles, common_data.GetSPDS()),
     common_data_(common_data),
-    local_psi_data_(local_psi_data),
     psi_uk_man_(psi_uk_man),
-    sdm_(sdm)
+    sdm_(sdm),
+    num_angles_in_gs_quadrature_(psi_uk_man_.GetNumberOfUnknowns()),
+    num_quadrature_local_dofs_(sdm_.GetNumLocalDOFs(psi_uk_man_)),
+    num_local_spatial_dofs_(num_quadrature_local_dofs_ / num_angles_in_gs_quadrature_ /
+                            num_groups_),
+    local_psi_data_size_(num_local_spatial_dofs_ * num_groups_and_angles_),
+    local_psi_data_(local_psi_data_size_)
 {
 }
 
@@ -29,32 +34,66 @@ CBC_FLUDS::GetCommonData() const
   return common_data_;
 }
 
-const std::vector<double>&
-CBC_FLUDS::GetLocalUpwindDataBlock() const
+double*
+CBC_FLUDS::UpwindPsi(const Cell& face_neighbor, unsigned int adj_cell_node, size_t as_ss_idx)
 {
-  return local_psi_data_;
+  // Map to face neighbor cell's first spatial DOF index
+  // (0 to (num_local_spatial_dofs_ - 1))
+  const size_t face_nbr_spatial_dof_0_index =
+    (sdm_.MapDOFLocal(face_neighbor, 0, psi_uk_man_, 0, 0) / num_angles_in_gs_quadrature_ /
+     num_groups_);
+
+  // Index to start of neighbor cell's data block in local_psi_data_
+  const size_t face_nbr_data_start_index = face_nbr_spatial_dof_0_index * num_groups_and_angles_;
+  const size_t addr_offset = adj_cell_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
+  const size_t face_nbr_data_index = face_nbr_data_start_index + addr_offset;
+
+  assert((face_nbr_data_index >= 0) and (face_nbr_data_index < local_psi_data_.size()));
+
+  return &local_psi_data_[face_nbr_data_index];
 }
 
-const double*
-CBC_FLUDS::GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell)
+double*
+CBC_FLUDS::OutgoingPsi(const Cell& cell, unsigned int cell_node, size_t as_ss_idx)
 {
-  const auto dof_map = sdm_.MapDOFLocal(cell, 0, psi_uk_man_, 0, 0);
-  return &psi_data_block[dof_map];
+  // Map to current cell's first spatial DOF index
+  // (0 to (num_local_spatial_dofs_ - 1))
+  const size_t cur_cell_spatial_dof_0_index =
+    (sdm_.MapDOFLocal(cell, 0, psi_uk_man_, 0, 0) / num_angles_in_gs_quadrature_ / num_groups_);
+
+  // Index to start of current cell's data block in local_psi_data_
+  const size_t cur_cell_data_start_index = cur_cell_spatial_dof_0_index * num_groups_and_angles_;
+  const size_t addr_offset = cell_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
+  const size_t cur_cell_data_index = cur_cell_data_start_index + addr_offset;
+
+  assert((cur_cell_data_index >= 0) and (cur_cell_data_index < local_psi_data_.size()));
+
+  return &local_psi_data_[cur_cell_data_index];
 }
 
-const std::vector<double>&
-CBC_FLUDS::GetNonLocalUpwindData(uint64_t cell_global_id, unsigned int face_id) const
+double*
+CBC_FLUDS::NLUpwindPsi(uint64_t cell_global_id,
+                       unsigned int face_id,
+                       unsigned int face_node_mapped,
+                       size_t as_ss_idx)
 {
-  return deplocs_outgoing_messages_.at({cell_global_id, face_id});
+  std::vector<double>& psi = deplocs_outgoing_messages_.at({cell_global_id, face_id});
+  const size_t dof_map =
+    face_node_mapped * num_groups_and_angles_ + //  Offset to start of data for face_node_mapped
+    as_ss_idx * num_groups_;                    // Offset to start of data for angle_set_index
+
+  assert((dof_map >= 0) and (dof_map < psi.size()));
+  return &psi[dof_map];
 }
 
-const double*
-CBC_FLUDS::GetNonLocalUpwindPsi(const std::vector<double>& psi_data,
-                                unsigned int face_node_mapped,
-                                unsigned int angle_set_index)
+double*
+CBC_FLUDS::NLOutgoingPsi(std::vector<double>* psi_nonlocal_outgoing,
+                         size_t face_node,
+                         size_t as_ss_idx)
 {
-  const size_t dof_map = face_node_mapped * num_groups_and_angles_ + angle_set_index * num_groups_;
-  return &psi_data[dof_map];
+  assert(psi_nonlocal_outgoing != nullptr);
+  const size_t addr_offset = face_node * num_groups_and_angles_ + as_ss_idx * num_groups_;
+  return &(*psi_nonlocal_outgoing)[addr_offset];
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.h
@@ -5,6 +5,7 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds.h"
+#include <cstddef>
 #include <map>
 #include <functional>
 
@@ -15,28 +16,60 @@ class UnknownManager;
 class SpatialDiscretization;
 class Cell;
 
+/**
+ * Flux data structures (FLUDS) specific to the cell-by-cell (CBC) sweep algorithm
+ *
+ * This class manages the storage and access of angular flux data during a CBC sweep
+ *
+ * It provides methods to access:
+ * - Upwind angular flux data from local neighbor cells
+ * - Storage locations for downwind angular flux data for the current cell
+ * - Upwind angular flux data received from remote MPI ranks
+ */
 class CBC_FLUDS : public FLUDS
 {
 public:
   CBC_FLUDS(size_t num_groups,
             size_t num_angles,
             const CBC_FLUDSCommonData& common_data,
-            std::vector<double>& local_psi_data,
             const UnknownManager& psi_uk_man,
             const SpatialDiscretization& sdm);
 
   const FLUDSCommonData& GetCommonData() const;
 
-  const std::vector<double>& GetLocalUpwindDataBlock() const;
+  /**
+   * Given a local upwind neighbor cell, a node index on this cell, and an
+   * angleset subset index, this function returns a pointer to
+   * the start of the group data for the specified node and angle.
+   */
+  double* UpwindPsi(const Cell& face_neighbor, unsigned int adj_cell_node, size_t as_ss_idx);
 
-  const double* GetLocalCellUpwindPsi(const std::vector<double>& psi_data_block, const Cell& cell);
+  /**
+   * Given a local cell, a node index on this cell, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * node and angle for writing its just solved angular fluxes.
+   */
+  double* OutgoingPsi(const Cell& cell, unsigned int cell_node, size_t as_ss_idx);
 
-  const std::vector<double>& GetNonLocalUpwindData(uint64_t cell_global_id,
-                                                   unsigned int face_id) const;
+  /**
+   * Given a remote upwind cell's global ID, a face ID on this cell,
+   * a node index on this face, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * face node and angle.
+   */
+  double* NLUpwindPsi(uint64_t cell_global_id,
+                      unsigned int face_id,
+                      unsigned int face_node_mapped,
+                      size_t as_ss_idx);
 
-  const double* GetNonLocalUpwindPsi(const std::vector<double>& psi_data,
-                                     unsigned int face_node_mapped,
-                                     unsigned int angle_set_index);
+  /**
+   * Given a pointer to a vector holding the non-local outgoing psi data for a face,
+   * a node index on this face, and an angleset subset index,
+   * this function returns a pointer to the start of the group data for the specified
+   * face node and angle.
+   */
+  double*
+  NLOutgoingPsi(std::vector<double>* psi_nonlocal_outgoing, size_t face_node, size_t as_ss_idx);
 
   void ClearLocalAndReceivePsi() override { deplocs_outgoing_messages_.clear(); }
   void ClearSendPsi() override {}
@@ -57,9 +90,17 @@ public:
 
 private:
   const CBC_FLUDSCommonData& common_data_;
-  std::reference_wrapper<std::vector<double>> local_psi_data_;
   const UnknownManager& psi_uk_man_;
   const SpatialDiscretization& sdm_;
+  size_t num_angles_in_gs_quadrature_;
+  size_t num_quadrature_local_dofs_;
+  size_t num_local_spatial_dofs_;
+  size_t local_psi_data_size_;
+  /**
+   * Layout for storage for local angular fluxes:
+   * spatial DOF major -> angle in angleset major -> group in groupset major
+   */
+  std::vector<double> local_psi_data_;
 
   std::vector<std::vector<double>> boundryI_incoming_psi_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
@@ -75,7 +75,7 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
   {
     const size_t num_faces = cell.faces.size();
     unsigned int num_dependencies = 0;
-    std::vector<uint64_t> succesors;
+    std::vector<uint64_t> successors;
 
     for (size_t f = 0; f < num_faces; ++f)
     {
@@ -88,11 +88,11 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
       {
         const auto& face = cell.faces[f];
         if (face.has_neighbor and grid->IsCellLocal(face.neighbor_id))
-          succesors.push_back(grid->cells[face.neighbor_id].local_id);
+          successors.push_back(grid->cells[face.neighbor_id].local_id);
       }
     }
 
-    task_list_.push_back({num_dependencies, succesors, cell.local_id, &cell, false});
+    task_list_.push_back({num_dependencies, successors, cell.local_id, &cell, false});
   }
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
@@ -41,6 +41,7 @@ CBCSweepChunk::CBCSweepChunk(std::vector<double>& destination_phi,
     fluds_(nullptr),
     gs_size_(0),
     gs_gi_(0),
+    num_angles_in_as_(0),
     group_stride_(0),
     group_angle_stride_(0),
     surface_source_active_(false),
@@ -64,8 +65,9 @@ CBCSweepChunk::SetAngleSet(AngleSet& angle_set)
   gs_gi_ = groupset_.groups.front().id;
 
   surface_source_active_ = IsSurfaceSourceActive();
+  num_angles_in_as_ = angle_set.GetNumAngles();
   group_stride_ = angle_set.GetNumGroups();
-  group_angle_stride_ = angle_set.GetNumGroups() * angle_set.GetNumAngles();
+  group_angle_stride_ = group_stride_ * num_angles_in_as_;
 }
 
 void
@@ -93,7 +95,7 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
 
   DenseMatrix<double> Amat(max_num_cell_dofs_, max_num_cell_dofs_);
   DenseMatrix<double> Atemp(max_num_cell_dofs_, max_num_cell_dofs_);
-  std::vector<Vector<double>> b(groupset_.groups.size(), Vector<double>(max_num_cell_dofs_));
+  std::vector<Vector<double>> b(gs_size_, Vector<double>(max_num_cell_dofs_));
   std::vector<double> source(max_num_cell_dofs_);
 
   const auto& face_orientations = angle_set.GetSPDS().GetCellFaceOrientations()[cell_local_id_];
@@ -105,7 +107,8 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
   // as = angle set
   // ss = subset
   const std::vector<std::uint32_t>& as_angle_indices = angle_set.GetAngleIndices();
-  for (size_t as_ss_idx = 0; as_ss_idx < as_angle_indices.size(); ++as_ss_idx)
+
+  for (size_t as_ss_idx = 0; as_ss_idx < num_angles_in_as_; ++as_ss_idx)
   {
     auto direction_num = as_angle_indices[as_ss_idx];
     auto omega = groupset_.quadrature->omegas[direction_num];
@@ -136,19 +139,6 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       const auto* face_nodal_mapping =
         &fluds_->GetCommonData().GetFaceNodalMapping(cell_local_id_, f);
 
-      const std::vector<double>* psi_upwnd_data_block = nullptr;
-      const double* psi_local_face_upwnd_data = nullptr;
-      if (is_local_face)
-      {
-        psi_upwnd_data_block = &fluds_->GetLocalUpwindDataBlock();
-        psi_local_face_upwnd_data = fluds_->GetLocalCellUpwindPsi(
-          *psi_upwnd_data_block, *cell_transport_view_->FaceNeighbor(f));
-      }
-      else if (not is_boundary_face)
-      {
-        psi_upwnd_data_block = &fluds_->GetNonLocalUpwindData(cell_->global_id, f);
-      }
-
       // IntSf_mu_psi_Mij_dA
       const size_t num_face_nodes = cell_mapping_->GetNumFaceNodes(f);
       for (size_t fi = 0; fi < num_face_nodes; ++fi)
@@ -163,19 +153,14 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
           Amat(i, j) += mu_Nij;
 
           const double* psi = nullptr;
+
           if (is_local_face)
-          {
-            assert(psi_local_face_upwnd_data);
-            const unsigned int adj_cell_node = face_nodal_mapping->cell_node_mapping_[fj];
-            psi = &psi_local_face_upwnd_data[adj_cell_node * groupset_angle_group_stride_ +
-                                             direction_num * groupset_group_stride_];
-          }
+            psi = fluds_->UpwindPsi(*cell_transport_view_->FaceNeighbor(f),
+                                    face_nodal_mapping->cell_node_mapping_[fj],
+                                    as_ss_idx);
           else if (not is_boundary_face)
-          {
-            assert(psi_upwnd_data_block);
-            const unsigned int adj_face_node = face_nodal_mapping->face_node_mapping_[fj];
-            psi = fluds_->GetNonLocalUpwindPsi(*psi_upwnd_data_block, adj_face_node, as_ss_idx);
-          }
+            psi = fluds_->NLUpwindPsi(
+              cell_->global_id, f, face_nodal_mapping->face_node_mapping_[fj], as_ss_idx);
           else
             psi = angle_set.PsiBoundary(face.neighbor_id,
                                         direction_num,
@@ -185,11 +170,9 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
                                         gs_gi_,
                                         surface_source_active_);
 
-          if (not psi)
-            continue;
-
-          for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-            b[gsg](i) += psi[gsg] * mu_Nij;
+          if (psi != nullptr)
+            for (size_t gsg = 0; gsg < gs_size_; ++gsg)
+              b[gsg](i) += psi[gsg] * mu_Nij;
         } // for face node j
       } // for face node i
     } // for f
@@ -242,18 +225,19 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       }
     }
 
-    // Save angular flux during sweep
+    // If requested, save angular fluxes during sweep
     if (save_angular_flux_)
     {
-      double* cell_psi_data =
+      double* cell_psi =
         &destination_psi_[discretization_.MapDOFLocal(*cell_, 0, groupset_.psi_uk_man_, 0, 0)];
 
       for (size_t i = 0; i < cell_num_nodes_; ++i)
       {
-        const size_t imap =
+        const size_t addr_offset =
           i * groupset_angle_group_stride_ + direction_num * groupset_group_stride_;
+
         for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-          cell_psi_data[imap + gsg] = b[gsg](i);
+          cell_psi[addr_offset + gsg] = b[gsg](i);
       }
     }
 
@@ -274,22 +258,25 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
       const size_t num_face_nodes = cell_mapping_->GetNumFaceNodes(f);
       const auto& face_nodal_mapping =
         fluds_->GetCommonData().GetFaceNodalMapping(cell_local_id_, f);
-      std::vector<double>* psi_dnwnd_data = nullptr;
+      std::vector<double>* psi_nonlocal_outgoing = nullptr;
+
       if (not is_boundary_face and not is_local_face)
       {
         auto& async_comm = *angle_set.GetCommunicator();
-        size_t data_size = num_face_nodes * group_angle_stride_;
-        psi_dnwnd_data = &async_comm.InitGetDownwindMessageData(locality,
-                                                                face.neighbor_id,
-                                                                face_nodal_mapping.associated_face_,
-                                                                angle_set.GetID(),
-                                                                data_size);
+        const size_t data_size_for_msg = num_face_nodes * group_angle_stride_;
+        psi_nonlocal_outgoing =
+          &async_comm.InitGetDownwindMessageData(locality,
+                                                 face.neighbor_id,
+                                                 face_nodal_mapping.associated_face_,
+                                                 angle_set.GetID(),
+                                                 data_size_for_msg);
       }
 
       for (size_t fi = 0; fi < num_face_nodes; ++fi)
       {
         const int i = cell_mapping_->MapFaceNode(f, fi);
 
+        // Tally outflow for particle balance
         if (is_boundary_face)
         {
           for (size_t gsg = 0; gsg < gs_size_; ++gsg)
@@ -298,24 +285,18 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
         }
 
         double* psi = nullptr;
+
         if (is_local_face)
-          psi = nullptr;
+          psi = fluds_->OutgoingPsi(*cell_, i, as_ss_idx);
         else if (not is_boundary_face)
-        {
-          assert(psi_dnwnd_data);
-          const size_t addr_offset = fi * group_angle_stride_ + as_ss_idx * group_stride_;
-          psi = &(*psi_dnwnd_data)[addr_offset];
-        }
+          psi = fluds_->NLOutgoingPsi(psi_nonlocal_outgoing, fi, as_ss_idx);
         else if (is_reflecting_boundary_face)
           psi = angle_set.PsiReflected(face.neighbor_id, direction_num, cell_local_id_, f, fi);
-        if (psi)
-        {
-          if (not is_boundary_face or is_reflecting_boundary_face)
-          {
-            for (size_t gsg = 0; gsg < gs_size_; ++gsg)
-              psi[gsg] = b[gsg](i);
-          }
-        }
+
+        // Write the solved angular flux to the determined location
+        if (psi != nullptr)
+          for (size_t gsg = 0; gsg < gs_size_; ++gsg)
+            psi[gsg] = b[gsg](i);
       } // for fi
     } // for face
   } // for angleset/subset

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h
@@ -10,6 +10,17 @@ namespace opensn
 {
 class CellMapping;
 
+/**
+ * Implements the core sweep operation for a single cell within the
+ *        cell-by-cell (CBC) sweep algorithm
+ *
+ * This class is responsible for performing the discrete ordinates transport
+ * calculation on a given cell for all angles and groups managed by its
+ * current AngleSet
+ * It interacts with a CBC_FLUDS object to obtain upwind angular flux data
+ * (from local neighbors, MPI remote buffers, or boundaries) and to store
+ * outgoing angular flux data (to local neighbors or MPI send buffers)
+ */
 class CBCSweepChunk : public SweepChunk
 {
 public:
@@ -31,14 +42,30 @@ public:
 
   void SetCell(Cell const* cell_ptr, AngleSet& angle_set) override;
 
+  /**
+   * Performs the discrete ordinates sweep calculation for the currently
+   *        set cell, for all angles and groups within the provided AngleSet
+   *
+   * It:
+   * - Assembles the local transport equation system for each angle and group
+   * - Retrieves upwind angular fluxes from local neighbors, remote locations
+   *   (via MPI data managed by CBC_FLUDS), or boundaries
+   * - Solves the local system for the outgoing angular fluxes at the cell nodes
+   * - Updates the global scalar flux moments
+   * - If save_angular_flux_ is true, stores the computed angular fluxes into
+   *   the global angular flux vector
+   * - Propagates outgoing angular fluxes to local downwind neighbors or stages
+   *   them for MPI transmission to remote downwind neighbors
+   */
   void Sweep(AngleSet& angle_set) override;
 
 private:
   CBC_FLUDS* fluds_;
   size_t gs_size_;
   int gs_gi_;
-  size_t group_stride_;
-  size_t group_angle_stride_;
+  size_t num_angles_in_as_;
+  size_t group_stride_;       // Stride for consecutive angles
+  size_t group_angle_stride_; // Stride for consecutive spatial DOFs
   bool surface_source_active_;
 
   const Cell* cell_;

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/c5g7_restart.py
@@ -74,7 +74,6 @@ if __name__ == "__main__":
             "power_field_function_on": True,
             "power_default_kappa": 1.0,
             "power_normalization": 1.0,
-            "save_angular_flux": True,
             "read_restart_path": "c5g7_restart/c5g7",
             # "restart_writes_enabled": True,
             # "write_delayed_psi_to_restart": True,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
@@ -80,8 +80,7 @@ if __name__ == "__main__":
         options={
             "use_precursors": use_precursors,
             "verbose_inner_iterations": False,
-            "verbose_outer_iterations": True,
-            "save_angular_flux": True,
+            "verbose_outer_iterations": True
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1a_qblock_cbc.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
 
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,
-            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
 
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": True,
-            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1c_qblock_cbc.py
@@ -52,7 +52,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": True,
             "verbose_outer_iterations": True,
-            "save_angular_flux": True,
         },
         sweep_type="CBC",
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/hdpe_balance.py
@@ -74,9 +74,6 @@ if __name__ == "__main__":
             {"name": "zmin", "type": "reflecting"},
             {"name": "zmax", "type": "reflecting"},
         ],
-        options={
-            "save_angular_flux": True,
-        },
         sweep_type="CBC"
     )
     ss_solver = SteadyStateSourceSolver(problem=phys)

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_1d_1.py
@@ -99,8 +99,7 @@ if __name__ == "__main__":
         scattering_order=5,
         volumetric_sources=[mg_src],
         options={
-            "max_ags_iterations": 1,
-            "save_angular_flux": True
+            "max_ags_iterations": 1
         },
         sweep_type="CBC"
     )

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cbc/transport_2d_1_poly.py
@@ -102,8 +102,7 @@ if __name__ == "__main__":
             {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
         ],
         options={
-            "max_ags_iterations": 1,
-            "save_angular_flux": True
+            "max_ags_iterations": 1
         },
         sweep_type="CBC"
     )


### PR DESCRIPTION
_**Note**: This is a re-submission of [PR 623](https://github.com/Open-Sn/opensn/pull/623). This re-submission includes some minor revisions to `cbc_sweep_chunk.cc` that allows for all the sanitizer build regression tests to pass. This re-submission also includes strong-scaling results for a 128-node run on LLNL Dane, with 64 ranks per node._

This PR refactors the cell-by-cell (CBC) sweep algorithm's handling of local angular flux data, primarily by reducing the memory footprint of the `local_psi_data_` vector within the `CBC_FLUDS` class. 

**Motivation:**

Previously, the `CBC_FLUDS::local_psi_data_` (which, earlier, was effectively an alias of the `LBSSolver`'s `psi_new_local_[groupset.id]` vector) was sized based on the `LBSGroupset`'s `psi_uk_man_`. This meant it allocated memory to store angular fluxes for all angles in the parent `LBSGroupset`'s quadrature, even if the specific `CBC_AngleSet` (and its associated `CBC_FLUDS` instance) processed only a subset of those angles. This led to unnecessarily large memory consumption, especially when an `LBSGroupset` was divided into multiple `AngleSet`s.

**Changes:**

1.  **Optimized `CBC_FLUDS::local_psi_data_` sizing and management:**
    *   `CBC_FLUDS` now manages its own `local_psi_data_` vector.
    *   This vector is now sized based on the number of local spatial DOFs, the number of angles specific to its associated `AngleSet`, and the number of energy groups. This is the primary memory optimization. 
    *   New accessors (`UpwindPsi`, `OutgoingPsi`) in `CBC_FLUDS` provide base pointers into this compact vector, facilitating local data transfer during the sweep.

2.  **`CbcSweepChunk` Adaptation to Compact Storage:**
    *   The `Sweep` method now uses the local angle index within the AngleSet (`as_ss_idx`) for all intra-rank (local cell-to-cell) angular flux propagation (reading upwind and writing downwind values).
    
Below is a strong-scaling plot for the CBC algorithm run with the reduced storage `CBC_FLUDS` class on LLNL Dane, whose node specs are given below. 
- 112 Intel Sapphire Rapids cores/node
- 105MB cache/CPU
- 2.28GB DDR5 per core

The scaling study was run on 2, 4, 8, 16, 32, 64, and 128 nodes, with 64 ranks per node (rpn). 

The study cannot be run on 1 rank due to node memory limitations, so the average sweep time for 1 rank was extrapolated from the 2 rank run by doubling the 2 rank run's average sweep time.

_**Note**: The study cannot be run on 1 rank due to node memory limitations, so the average sweep time for 1 rank was extrapolated from the 2 rank run by doubling the 2 rank run's average sweep time._

<img width="1002" height="485" alt="opensn-strong-scaling-cbc-reduced-storage-fluds-also-with-128-nodes" src="https://github.com/user-attachments/assets/cc962305-ccdb-4883-a7e8-37160d84dc49" />
