### PR TITLE
Add surface angular flux I/O support

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/angular_flux_io.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/angular_flux_io.cc
@@ -7,6 +7,9 @@
 #include "framework/runtime.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/utils/hdf_utils.h"
+#include <algorithm>
+#include <cmath>
+#include <unordered_set>
 
 namespace opensn
 {
@@ -241,6 +244,428 @@ DiscreteOrdinatesProblemIO::ReadAngularFluxes(
           }
     }
   }
+}
+void
+DiscreteOrdinatesProblemIO::WriteSurfaceAngularFluxes(
+  DiscreteOrdinatesProblem& do_problem,
+  const std::string& file_base,
+  const std::vector<std::string>& bndry_surfs,
+  const std::vector<std::pair<std::string, std::pair<std::string, double>>>& int_surfs)
+{
+  OpenSnLogicalErrorIf(bndry_surfs.empty() and int_surfs.empty(),
+                       "No surface provided. Provide either boundary names or internal surface "
+                       "definitions.");
+
+  // Open the HDF5 file
+  const std::string file_name = file_base + std::to_string(opensn::mpi_comm.rank()) + ".h5";
+  const H5FileHandle file(H5Fcreate(file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT));
+  OpenSnLogicalErrorIf(file.Id() < 0,
+                       "WriteSurfaceAngularFluxes: Failed to open " + file_name + ".");
+
+  const auto CreateGroupError = [&file_name](const std::string& group)
+  {
+    std::string message = "Failed to create ";
+    message.append(group).append(" in ").append(file_name).append(".");
+    return message;
+  };
+
+  // Get angular fluxes
+  const auto& psi = do_problem.GetPsiNewLocal();
+
+  // Get problem information
+  const auto& grid = do_problem.GetGrid();
+  const auto& allowed_bd_ids = grid->GetBoundaryIDMap();
+  const auto& allowed_bd_names = grid->GetBoundaryNameMap();
+  const auto& discretization = do_problem.GetSpatialDiscretization();
+  const auto& groupsets = do_problem.GetGroupsets();
+  const auto num_groupsets = static_cast<uint64_t>(groupsets.size());
+
+  // Check the boundary IDs
+  std::vector<uint64_t> bndry_ids;
+  if (not bndry_surfs.empty())
+  {
+    const auto unique_bids = grid->GetUniqueBoundaryIDs();
+    for (const auto& bndry : bndry_surfs)
+    {
+      const auto bndry_name_it = allowed_bd_names.find(bndry);
+      OpenSnInvalidArgumentIf(bndry_name_it == allowed_bd_names.end(),
+                              "Boundary " + bndry + " not found in the boundary-name map.");
+
+      const auto bndry_id = bndry_name_it->second;
+      const auto id = std::find(unique_bids.begin(), unique_bids.end(), bndry_id);
+      OpenSnInvalidArgumentIf(id == unique_bids.end(), "Boundary " + bndry + " not found on grid.");
+      bndry_ids.push_back(bndry_id);
+    }
+  }
+
+  log.Log() << "Writing surface angular flux data to " << file_base;
+
+  OpenSnLogicalErrorIf(not H5CreateAttribute(file.Id(), "num_groupsets", num_groupsets),
+                       "Failed to write the number of groupsets to " + file_name + ".");
+  OpenSnLogicalErrorIf(not H5CreateGroup(file.Id(), "mesh"),
+                       "Failed to create the mesh group in " + file_name + ".");
+
+  // Mesh information is shared by all groupsets.
+  std::map<std::string, std::vector<uint64_t>> cell_map, node_map;
+  std::map<std::string, std::vector<double>> x_map, y_map, z_map;
+
+  constexpr double surface_tolerance = 1.0e-10;
+
+  for (size_t groupset_index = 0; groupset_index < groupsets.size(); ++groupset_index)
+  {
+    const auto& groupset = groupsets[groupset_index];
+    std::unordered_set<std::string> surface_tags;
+    std::map<std::string, SurfaceData> data_map;
+
+    const auto groupset_id = groupset.id;
+    const auto& uk_man = groupset.psi_uk_man_;
+    const auto& quadrature = groupset.quadrature;
+    const auto num_gs_dirs = quadrature->GetNumAngles();
+    const auto num_gs_groups = groupset.GetNumGroups();
+
+    for (const auto& cell : grid->local_cells)
+    {
+      const auto cell_id = cell.global_id;
+      const auto& cell_mapping = discretization.GetCellMapping(cell);
+      const auto& node_locations = cell_mapping.GetNodeLocations();
+      const auto& unit_cell_matrices = do_problem.GetUnitCellMatrices();
+      const auto& fe_values = unit_cell_matrices.at(cell.local_id);
+
+      for (size_t f = 0; f < cell.faces.size(); ++f)
+      {
+        const auto& face = cell.faces[f];
+        bool is_surface = false;
+        std::string surf_name;
+
+        // Internal surface mapping
+        if (not int_surfs.empty())
+        {
+          for (const auto& surface : int_surfs)
+          {
+            const auto& surf_id = surface.first;
+            const auto& axis = surface.second.first;
+            const auto slice = surface.second.second;
+
+            OpenSnInvalidArgumentIf(axis != "x" and axis != "y" and axis != "z",
+                                    "Invalid internal-surface axis '" + axis + "'.");
+
+            const auto num_face_nodes = cell_mapping.GetNumFaceNodes(f);
+            size_t nodes_on_face = 0;
+            for (size_t fi = 0; fi < num_face_nodes; ++fi)
+            {
+              const auto i = cell_mapping.MapFaceNode(f, fi);
+              const auto& node_vec = node_locations[i];
+              const auto coordinate =
+                axis == "x" ? node_vec.x : (axis == "y" ? node_vec.y : node_vec.z);
+              if (std::abs(coordinate - slice) <= surface_tolerance)
+                ++nodes_on_face;
+            }
+
+            if (nodes_on_face == num_face_nodes)
+            {
+              const Vector3 global_norm = axis == "x"   ? Vector3{1.0, 0.0, 0.0}
+                                          : axis == "y" ? Vector3{0.0, 1.0, 0.0}
+                                                        : Vector3{0.0, 0.0, 1.0};
+              const auto alignment = face.normal.Dot(global_norm);
+              surf_name = surf_id + (alignment > 0 ? "_u" : "_d");
+              is_surface = true;
+            }
+          }
+        }
+
+        // Boundary surface mapping
+        if (not bndry_surfs.empty() and not face.has_neighbor)
+        {
+          const auto id = std::find(bndry_ids.begin(), bndry_ids.end(), face.neighbor_id);
+          if (id != bndry_ids.end())
+          {
+            surf_name = allowed_bd_ids.at(*id);
+            is_surface = true;
+          }
+        }
+
+        if (is_surface)
+        {
+          surface_tags.insert(surf_name);
+          const auto& int_f_shape_i = fe_values.intS_shapeI[f];
+          const auto& mass_matrix = fe_values.intS_shapeI_shapeJ[f];
+          const auto num_face_nodes = cell_mapping.GetNumFaceNodes(f);
+          auto& surface_data = data_map[surf_name];
+
+          if (groupset_index == 0)
+          {
+            cell_map[surf_name].push_back(cell_id);
+            node_map[surf_name].push_back(num_face_nodes);
+          }
+
+          for (size_t fi = 0; fi < num_face_nodes; ++fi)
+          {
+            const auto i = cell_mapping.MapFaceNode(f, fi);
+            const auto& node_vec = node_locations[i];
+            if (groupset_index == 0)
+            {
+              x_map[surf_name].push_back(node_vec.x);
+              y_map[surf_name].push_back(node_vec.y);
+              z_map[surf_name].push_back(node_vec.z);
+            }
+
+            for (size_t d = 0; d < num_gs_dirs; ++d)
+            {
+              const auto& omega_d = quadrature->GetOmega(d);
+              const auto weight_d = quadrature->GetWeight(d);
+              const auto mu_d = omega_d.Dot(face.normal);
+
+              surface_data.omega.insert(surface_data.omega.end(),
+                                        {omega_d.x, omega_d.y, omega_d.z});
+              surface_data.mu.push_back(mu_d);
+              surface_data.wt_d.push_back(weight_d);
+              surface_data.fe_shape.push_back(int_f_shape_i(i));
+              for (unsigned int g = 0; g < num_gs_groups; ++g)
+              {
+                const auto dof_map = discretization.MapDOFLocal(cell, i, uk_man, d, g);
+                surface_data.psi.push_back(psi[groupset_id][dof_map]);
+              }
+            }
+
+            for (size_t fj = 0; fj < num_face_nodes; ++fj)
+            {
+              const auto j = cell_mapping.MapFaceNode(f, fj);
+              surface_data.mass_matrix.push_back(mass_matrix(i, j));
+            }
+          }
+        }
+      }
+    }
+
+    // Export data to HDF5
+    const std::string group_name = "groupset_" + std::to_string(groupset_id);
+    OpenSnLogicalErrorIf(not H5CreateGroup(file.Id(), group_name), CreateGroupError(group_name));
+    OpenSnLogicalErrorIf(
+      not H5CreateAttribute(file.Id(), group_name + "/num_directions", num_gs_dirs),
+      "Failed to write the direction count for " + group_name + ".");
+    OpenSnLogicalErrorIf(
+      not H5CreateAttribute(file.Id(), group_name + "/num_groups", num_gs_groups),
+      "Failed to write the group count for " + group_name + ".");
+
+    for (const auto& surf_id : surface_tags)
+    {
+      if (groupset_index == 0)
+      {
+        const auto& cell_ids = cell_map.at(surf_id);
+        const auto& num_face_nodes = node_map.at(surf_id);
+        const auto& x_surf = x_map.at(surf_id);
+        const auto& y_surf = y_map.at(surf_id);
+        const auto& z_surf = z_map.at(surf_id);
+
+        const std::string surf_mesh = "mesh/" + surf_id;
+        OpenSnLogicalErrorIf(not H5CreateGroup(file.Id(), surf_mesh), CreateGroupError(surf_mesh));
+        OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_mesh + "/cell_ids", cell_ids),
+                             "Failed to write cell IDs for " + surf_id + ".");
+        OpenSnLogicalErrorIf(
+          not H5WriteDataset1D(file.Id(), surf_mesh + "/num_face_nodes", num_face_nodes),
+          "Failed to write face-node counts for " + surf_id + ".");
+        OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_mesh + "/nodes_x", x_surf),
+                             "Failed to write x-coordinates for " + surf_id + ".");
+        OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_mesh + "/nodes_y", y_surf),
+                             "Failed to write y-coordinates for " + surf_id + ".");
+        OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_mesh + "/nodes_z", z_surf),
+                             "Failed to write z-coordinates for " + surf_id + ".");
+      }
+
+      std::string surf_group = group_name;
+      surf_group.append("/").append(surf_id);
+      OpenSnLogicalErrorIf(not H5CreateGroup(file.Id(), surf_group), CreateGroupError(surf_group));
+
+      const auto& data = data_map.at(surf_id);
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/omega", data.omega),
+                           "Failed to write omega for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/wt_d", data.wt_d),
+                           "Failed to write weights for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/mu", data.mu),
+                           "Failed to write direction cosines for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/fe_shape", data.fe_shape),
+                           "Failed to write finite-element shape data for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/surf_flux", data.psi),
+                           "Failed to write surface angular flux for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5WriteDataset1D(file.Id(), surf_group + "/M_ij", data.mass_matrix),
+                           "Failed to write the mass matrix for " + surf_group + ".");
+    }
+  }
+}
+
+std::vector<DiscreteOrdinatesProblemIO::SurfaceAngularFlux>
+DiscreteOrdinatesProblemIO::ReadSurfaceAngularFluxes(DiscreteOrdinatesProblem& do_problem,
+                                                     const std::string& file_base,
+                                                     const std::vector<std::string>& surfaces)
+{
+  std::vector<SurfaceAngularFlux> surf_fluxes;
+
+  // Open HDF5 file
+  const std::string file_name = file_base + std::to_string(opensn::mpi_comm.rank()) + ".h5";
+  const H5FileHandle file(H5Fopen(file_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT));
+  OpenSnLogicalErrorIf(file.Id() < 0, "Failed to open " + file_name + ".");
+
+  log.Log() << "Reading surface angular flux file from " << file_base;
+
+  // Read macro data and check for compatibility
+  uint64_t file_num_groupsets = 0;
+  OpenSnLogicalErrorIf(not H5ReadAttribute(file.Id(), "num_groupsets", file_num_groupsets),
+                       "Failed to read the number of groupsets from " + file_name + ".");
+
+  const auto& groupsets = do_problem.GetGroupsets();
+  const auto num_groupsets = groupsets.size();
+
+  OpenSnLogicalErrorIf(file_num_groupsets != num_groupsets,
+                       "Incompatible number of groupsets found in file " + file_name + ".");
+
+  surf_fluxes.reserve(groupsets.size() * surfaces.size());
+  constexpr double coordinate_epsilon = 1.0e-6;
+  const auto Quantize = [](const double coordinate)
+  { return static_cast<int64_t>(std::llround(coordinate / coordinate_epsilon)); };
+
+  for (const auto& groupset : groupsets)
+  {
+    const auto& quadrature = groupset.quadrature;
+    const auto groupset_id = groupset.id;
+    const auto num_gs_dirs = quadrature->GetNumAngles();
+    const auto num_gs_groups = groupset.GetNumGroups();
+
+    uint64_t file_num_gs_dirs = 0;
+    uint64_t file_num_gs_groups = 0;
+    const std::string group_name = "groupset_" + std::to_string(groupset_id);
+    OpenSnLogicalErrorIf(
+      not H5ReadAttribute(file.Id(), group_name + "/num_directions", file_num_gs_dirs),
+      "Failed to read the direction count for " + group_name + ".");
+    OpenSnLogicalErrorIf(
+      not H5ReadAttribute(file.Id(), group_name + "/num_groups", file_num_gs_groups),
+      "Failed to read the group count for " + group_name + ".");
+    OpenSnLogicalErrorIf(file_num_gs_dirs != num_gs_dirs,
+                         "Incompatible number of directions in " + group_name + ".");
+    OpenSnLogicalErrorIf(file_num_gs_groups != num_gs_groups,
+                         "Incompatible number of groups in " + group_name + ".");
+
+    for (const auto& surface : surfaces)
+    {
+      SurfaceMap surf_map;
+      SurfaceData surf_data;
+      std::map<QuantizedCoordinate, uint64_t> cell_map;
+      std::vector<FaceMap> faces;
+
+      const std::string mesh_tag = "mesh/" + surface;
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<uint64_t>(file.Id(), mesh_tag + "/cell_ids", surf_map.cell_ids),
+        "Failed to read cell IDs for " + surface + ".");
+      OpenSnLogicalErrorIf(not H5ReadDataset1D<uint64_t>(
+                             file.Id(), mesh_tag + "/num_face_nodes", surf_map.num_face_nodes),
+                           "Failed to read face-node counts for " + surface + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), mesh_tag + "/nodes_x", surf_map.nodes_x),
+        "Failed to read x-coordinates for " + surface + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), mesh_tag + "/nodes_y", surf_map.nodes_y),
+        "Failed to read y-coordinates for " + surface + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), mesh_tag + "/nodes_z", surf_map.nodes_z),
+        "Failed to read z-coordinates for " + surface + ".");
+
+      std::string surf_group = group_name;
+      surf_group.append("/").append(surface);
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), surf_group + "/omega", surf_data.omega),
+        "Failed to read omega for " + surf_group + ".");
+      OpenSnLogicalErrorIf(not H5ReadDataset1D<double>(file.Id(), surf_group + "/mu", surf_data.mu),
+                           "Failed to read direction cosines for " + surf_group + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), surf_group + "/wt_d", surf_data.wt_d),
+        "Failed to read weights for " + surf_group + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), surf_group + "/M_ij", surf_data.mass_matrix),
+        "Failed to read the mass matrix for " + surf_group + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), surf_group + "/fe_shape", surf_data.fe_shape),
+        "Failed to read finite-element shape data for " + surf_group + ".");
+      OpenSnLogicalErrorIf(
+        not H5ReadDataset1D<double>(file.Id(), surf_group + "/surf_flux", surf_data.psi),
+        "Failed to read surface angular flux for " + surf_group + ".");
+
+      OpenSnLogicalErrorIf(surf_map.cell_ids.size() != surf_map.num_face_nodes.size(),
+                           "Incompatible surface mesh metadata for " + surface + ".");
+      OpenSnLogicalErrorIf(surf_map.nodes_x.size() != surf_map.nodes_y.size() or
+                             surf_map.nodes_x.size() != surf_map.nodes_z.size(),
+                           "Incompatible surface node coordinates for " + surface + ".");
+
+      std::vector<uint64_t> cell_stride;
+      std::vector<uint64_t> node_index = {0};
+      std::vector<uint64_t> dir_index = {0};
+
+      size_t node_stride = 0;
+      size_t stride = 0;
+      size_t expected_mass_matrix_size = 0;
+      const auto num_cells = surf_map.cell_ids.size();
+      for (size_t ci = 0; ci < num_cells; ++ci)
+      {
+        cell_stride.push_back(stride);
+        const auto num_face_nodes = surf_map.num_face_nodes[ci];
+        expected_mass_matrix_size += num_face_nodes * num_face_nodes;
+        Vector3 centroid;
+        FaceMap face_map;
+        for (size_t ni = 0; ni < num_face_nodes; ++ni)
+        {
+          OpenSnLogicalErrorIf(node_stride >= surf_map.nodes_x.size(),
+                               "Face-node counts exceed coordinate data for " + surface + ".");
+
+          centroid += Vector3{surf_map.nodes_x[node_stride],
+                              surf_map.nodes_y[node_stride],
+                              surf_map.nodes_z[node_stride]};
+          const QuantizedCoordinate vertex = {Quantize(surf_map.nodes_x[node_stride]),
+                                              Quantize(surf_map.nodes_y[node_stride]),
+                                              Quantize(surf_map.nodes_z[node_stride])};
+          face_map[vertex] = stride;
+
+          for (size_t d = 0; d < file_num_gs_dirs; ++d)
+          {
+            stride += file_num_gs_groups;
+            if (d + 1 < file_num_gs_dirs or ni + 1 < num_face_nodes or ci + 1 < num_cells)
+              dir_index.push_back(stride);
+          }
+
+          if (ni + 1 < num_face_nodes or ci + 1 < num_cells)
+            node_index.push_back(stride);
+
+          ++node_stride;
+        }
+        faces.push_back(std::move(face_map));
+
+        OpenSnLogicalErrorIf(num_face_nodes == 0,
+                             "Encountered a surface face without nodes for " + surface + ".");
+        centroid *= 1.0 / static_cast<double>(num_face_nodes);
+        const QuantizedCoordinate key = {
+          Quantize(centroid.x), Quantize(centroid.y), Quantize(centroid.z)};
+        cell_map[key] = ci;
+      }
+
+      OpenSnLogicalErrorIf(node_stride != surf_map.nodes_x.size(),
+                           "Coordinate data contains unused nodes for " + surface + ".");
+      OpenSnLogicalErrorIf(surf_data.omega.size() != 3 * node_stride * file_num_gs_dirs or
+                             surf_data.mu.size() != node_stride * file_num_gs_dirs or
+                             surf_data.wt_d.size() != node_stride * file_num_gs_dirs or
+                             surf_data.fe_shape.size() != node_stride * file_num_gs_dirs or
+                             surf_data.psi.size() != stride or
+                             surf_data.mass_matrix.size() != expected_mass_matrix_size,
+                           "Incompatible surface angular-flux data sizes for " + surf_group + ".");
+
+      surf_map.cell_map = std::move(cell_map);
+      surf_map.cell_stride = std::move(cell_stride);
+      surf_map.faces = std::move(faces);
+
+      surf_data.node_index = std::move(node_index);
+      surf_data.dir_index = std::move(dir_index);
+
+      surf_fluxes.push_back({groupset_id, surface, std::move(surf_map), std::move(surf_data)});
+    }
+  }
+
+  return surf_fluxes;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
@@ -6,8 +6,11 @@
 #include "hdf5.h"
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <optional>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace opensn
@@ -62,6 +65,70 @@ public:
     const std::string& file_base,
     std::optional<std::reference_wrapper<std::vector<std::vector<double>>>> opt_dest =
       std::nullopt);
+
+  /**
+   * Surface Angular flux
+   */
+  using QuantizedCoordinate = std::tuple<int64_t, int64_t, int64_t>;
+  using FaceMap = std::map<QuantizedCoordinate, uint64_t>;
+
+  struct SurfaceMap
+  {
+    std::vector<uint64_t> cell_ids;
+    std::vector<uint64_t> num_face_nodes;
+    std::map<QuantizedCoordinate, uint64_t> cell_map;
+    std::vector<uint64_t> cell_stride;
+    std::vector<FaceMap> faces;
+    std::vector<double> nodes_x;
+    std::vector<double> nodes_y;
+    std::vector<double> nodes_z;
+  };
+
+  struct SurfaceData
+  {
+    std::vector<double> omega;
+    std::vector<double> mu;
+    std::vector<double> wt_d;
+    std::vector<double> mass_matrix;
+    std::vector<double> fe_shape;
+    std::vector<double> psi;
+    std::vector<uint64_t> node_index;
+    std::vector<uint64_t> dir_index;
+  };
+
+  struct SurfaceAngularFlux
+  {
+    int groupset_id = 0;
+    std::string surface_name;
+    SurfaceMap mapping;
+    SurfaceData data;
+  };
+
+  /**
+   * Write surface angular flux vector(s) to a file.
+   *
+   * \param do_problem Discrete ordinates problem
+   * \param file_base File name base
+   * \param bndry_surfs Boundary surface names
+   * \param int_surfs Internal surface definitions
+   */
+  static void WriteSurfaceAngularFluxes(
+    DiscreteOrdinatesProblem& do_problem,
+    const std::string& file_base,
+    const std::vector<std::string>& bndry_surfs,
+    const std::vector<std::pair<std::string, std::pair<std::string, double>>>& int_surfs);
+
+  /**
+   * Read a surface angular flux vector from a file.
+   *
+   * \param do_problem Discrete ordinates problem
+   * \param file_base File name base
+   * \param surfaces Surface names to read
+   */
+  static std::vector<SurfaceAngularFlux>
+  ReadSurfaceAngularFluxes(DiscreteOrdinatesProblem& do_problem,
+                           const std::string& file_base,
+                           const std::vector<std::string>& surfaces);
 };
 
 } // namespace opensn

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -461,6 +461,119 @@ WrapLBS(py::module& slv)
     py::arg("file_base")
   );
   lbs_problem.def(
+    "WriteSurfaceAngularFluxes",
+    [](DiscreteOrdinatesProblem& self, const std::string& file_base, py::list surfaces)
+    {
+      std::vector<std::string> boundary_surfaces;
+      std::vector<std::pair<std::string, std::pair<std::string, double>>> internal_surfaces;
+      for (py::handle surface : surfaces)
+      {
+        // Group boundary and internal surfaces
+        if (py::isinstance<py::str>(surface))
+        {
+          boundary_surfaces.push_back(surface.cast<std::string>());
+        }
+        else if (py::isinstance<py::tuple>(surface))
+        {
+          const auto surface_tuple = surface.cast<py::tuple>();
+          if (surface_tuple.size() != 2)
+            throw std::invalid_argument("Surface tuple must have 2 elements (name, {axis: value})");
+
+          const auto surface_name = surface_tuple[0].cast<std::string>();
+          const auto surface_dict = surface_tuple[1].cast<py::dict>();
+          if (surface_dict.size() != 1)
+            throw std::invalid_argument("Surface dict must have exactly one key-value pair");
+
+          const auto& surface_slice = *surface_dict.begin();
+          const auto axis = surface_slice.first.cast<std::string>();
+          const auto value = surface_slice.second.cast<double>();
+          internal_surfaces.push_back({surface_name, {axis, value}});
+        }
+        else
+        {
+          throw std::invalid_argument(
+            "Each element in 'surfaces' must be either a string corresponding to a boundary ID "
+            "or a tuple defining an internal surface ('name', {'axis': value})");
+        }
+      }
+      DiscreteOrdinatesProblemIO::WriteSurfaceAngularFluxes(
+        self, file_base, boundary_surfaces, internal_surfaces);
+    },
+    R"(
+    Write surface angular flux data to file.
+
+    Parameters
+    ----------
+    file_base: str
+        File basename.
+    surfaces: List[str, Tuple], default=[]
+        List of strings corresponding to boundary IDs or tuples prescribing an internal surface.
+        Internal surfaces are along a fixed axis and defined by a tuple ('name', {'axis': value}).
+    )",
+    py::arg("file_base"),
+    py::arg("surfaces") = py::list{}
+  );
+  lbs_problem.def(
+    "ReadSurfaceAngularFluxes",
+    [](DiscreteOrdinatesProblem& self, const std::string& file_base, py::list surfaces)
+    {
+      std::vector<std::string> surface_ids;
+      for (py::handle surface : surfaces)
+        surface_ids.push_back(surface.cast<std::string>());
+
+      const auto surface_fluxes =
+        DiscreteOrdinatesProblemIO::ReadSurfaceAngularFluxes(self, file_base, surface_ids);
+      py::list result;
+      for (const auto& surface_flux : surface_fluxes)
+      {
+        py::dict mapping;
+        mapping["cell_ids"] = surface_flux.mapping.cell_ids;
+        mapping["num_face_nodes"] = surface_flux.mapping.num_face_nodes;
+        mapping["cell_map"] = surface_flux.mapping.cell_map;
+        mapping["cell_stride"] = surface_flux.mapping.cell_stride;
+        mapping["faces"] = surface_flux.mapping.faces;
+        mapping["nodes_x"] = surface_flux.mapping.nodes_x;
+        mapping["nodes_y"] = surface_flux.mapping.nodes_y;
+        mapping["nodes_z"] = surface_flux.mapping.nodes_z;
+
+        py::dict data;
+        data["omega"] = surface_flux.data.omega;
+        data["mu"] = surface_flux.data.mu;
+        data["wt_d"] = surface_flux.data.wt_d;
+        data["M_ij"] = surface_flux.data.mass_matrix;
+        data["fe_shape"] = surface_flux.data.fe_shape;
+        data["psi"] = surface_flux.data.psi;
+        data["node_index"] = surface_flux.data.node_index;
+        data["dir_index"] = surface_flux.data.dir_index;
+
+        py::dict entry;
+        entry["groupset_id"] = surface_flux.groupset_id;
+        entry["surface_name"] = surface_flux.surface_name;
+        entry["mapping"] = std::move(mapping);
+        entry["data"] = std::move(data);
+        result.append(std::move(entry));
+      }
+      return result;
+    },
+    R"(
+    Read surface angular fluxes from file.
+
+    Parameters
+    ----------
+    file_base: str
+        File basename.
+    surfaces: List[str]
+        Surface names to read.
+
+    Returns
+    -------
+    List[dict]
+        Surface mapping and angular-flux data for each groupset and requested surface.
+    )",
+    py::arg("file_base"),
+    py::arg("surfaces")
+  );
+  lbs_problem.def(
     "SetPointSources",
     [](LBSProblem& self, py::kwargs& params)
     {

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_surf.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_surf.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+2D transport response test exercising surface angular-flux I/O.
+"""
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+    barrier = MPI.COMM_WORLD.Barrier
+    global_sum = MPI.COMM_WORLD.allreduce
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.fieldfunc import FieldFunctionInterpolationVolume
+    from pyopensn.logvol import RPPLogicalVolume
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.response import ResponseEvaluator
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
+    from pyopensn.source import VolumetricSource
+    from pyopensn.xs import MultiGroupXS
+else:
+    barrier = MPIBarrier
+    global_sum = MPIAllReduce
+
+
+if __name__ == "__main__":
+    num_procs = 1
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} processors but got {size}.")
+
+    # Create mesh and assign material IDs.
+    num_cells = 20
+    length = 10.0
+    cell_size = length / num_cells
+    nodes = [i * cell_size for i in range(num_cells + 1)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes, nodes])
+    grid = meshgen.Execute()
+    grid.SetOrthogonalBoundaries()
+    grid.SetUniformBlockID(0)
+
+    source_volume = RPPLogicalVolume(
+        xmin=nodes[0], xmax=nodes[2], ymin=nodes[0], ymax=nodes[2], infz=True
+    )
+    grid.SetBlockIDFromLogicalVolume(source_volume, 1, True)
+
+    detector_volume = RPPLogicalVolume(
+        xmin=nodes[-2], xmax=nodes[-1], ymin=nodes[-2], ymax=nodes[-1], infz=True
+    )
+    grid.SetBlockIDFromLogicalVolume(detector_volume, 2, True)
+
+    # Define cross sections.
+    xs_background = MultiGroupXS()
+    xs_background.CreateSimpleOneGroup(0.1, 0.9)
+
+    xs_source = MultiGroupXS()
+    xs_source.CreateSimpleOneGroup(2.0, 1.0)
+
+    xs_detector = MultiGroupXS()
+    xs_detector.CreateSimpleOneGroup(0.8, 0.0)
+
+    xs_map = [
+        {"block_ids": [0], "xs": xs_background},
+        {"block_ids": [1], "xs": xs_source},
+        {"block_ids": [2], "xs": xs_detector},
+    ]
+    source_block_id = 1
+
+    # Set up the transport problem.
+    quadrature = GLCProductQuadrature2DXY(n_polar=2, n_azimuthal=32, scattering_order=0)
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quadrature,
+                "inner_linear_method": "petsc_gmres",
+                "l_abs_tol": 1.0e-12,
+                "l_max_its": 500,
+                "gmres_restart_interval": 100,
+            },
+        ],
+        xs_map=xs_map,
+        boundary_conditions=[
+            {"name": "xmin", "type": "vacuum"},
+            {"name": "xmax", "type": "vacuum"},
+            {"name": "ymin", "type": "vacuum"},
+            {"name": "ymax", "type": "vacuum"},
+        ],
+        options={"save_angular_flux": True},
+    )
+
+    source_strength = 1.0
+    source_area = (nodes[2] - nodes[0]) ** 2
+    forward_source = VolumetricSource(
+        block_ids=[source_block_id], group_strength=[source_strength / source_area]
+    )
+    problem.SetVolumetricSources(volumetric_sources=[forward_source])
+
+    # Forward solve and surface-flux export.
+    solver = SteadyStateSourceSolver(problem=problem)
+    solver.Initialize()
+    solver.Execute()
+
+    field_functions = problem.GetScalarFluxFieldFunction()
+    interpolator = FieldFunctionInterpolationVolume()
+    interpolator.SetOperationType("sum")
+    interpolator.SetLogicalVolume(detector_volume)
+    interpolator.AddFieldFunction(field_functions[0])
+    interpolator.Execute()
+    forward_qoi = 0.8 * interpolator.GetValue()
+
+    forward_surface_prefix = "InteriorSurf_FwdSrc_p"
+    problem.WriteSurfaceAngularFluxes(forward_surface_prefix, [("inter_x", {"x": 6.0})])
+
+    # Adjoint solve and response evaluation.
+    problem.SetAdjoint(True)
+    adjoint_source = VolumetricSource(logical_volume=detector_volume, group_strength=[0.8])
+    problem.SetVolumetricSources(volumetric_sources=[adjoint_source])
+    solver.Execute()
+
+    adjoint_flux_prefix = "AdjFluxMoments_p"
+    adjoint_surface_prefix = "InteriorSurf_AdjSrc_p"
+    problem.WriteFluxMoments(adjoint_flux_prefix)
+    problem.WriteSurfaceAngularFluxes(adjoint_surface_prefix, [("inter_x", {"x": 6.0})])
+
+    evaluator = ResponseEvaluator(problem=problem)
+    evaluator.SetOptions(
+        buffers=[
+            {"name": "detector", "file_prefixes": {"flux_moments": adjoint_flux_prefix}}
+        ],
+        sources={
+            "material": [
+                {"block_id": source_block_id, "strength": [source_strength / source_area]}
+            ]
+        },
+    )
+    adjoint_qoi = evaluator.EvaluateResponse("detector")
+
+    forward_surface_up = problem.ReadSurfaceAngularFluxes(
+        forward_surface_prefix, ["inter_x_u"]
+    )
+    forward_surface_down = problem.ReadSurfaceAngularFluxes(
+        forward_surface_prefix, ["inter_x_d"]
+    )
+    local_forward_flux = sum(forward_surface_up[0]["data"]["psi"]) + sum(
+        forward_surface_down[0]["data"]["psi"]
+    )
+    forward_boundary_flux = global_sum(local_forward_flux)
+
+    adjoint_surface_up = problem.ReadSurfaceAngularFluxes(
+        adjoint_surface_prefix, ["inter_x_u"]
+    )
+    adjoint_surface_down = problem.ReadSurfaceAngularFluxes(
+        adjoint_surface_prefix, ["inter_x_d"]
+    )
+    local_adjoint_importance = sum(adjoint_surface_up[0]["data"]["psi"]) + sum(
+        adjoint_surface_down[0]["data"]["psi"]
+    )
+    adjoint_boundary_importance = global_sum(local_adjoint_importance)
+
+    if rank == 0:
+        print(f"Forward QoI={forward_qoi:.5e}")
+        print(f"Adjoint QoI={adjoint_qoi:.5e}")
+        print(f"Forward Boundary Flux={forward_boundary_flux:.5e}")
+        print(f"Adjoint Boundary Importance={adjoint_boundary_importance:.5e}")
+
+    barrier()
+    for file_prefix in (forward_surface_prefix, adjoint_flux_prefix, adjoint_surface_prefix):
+        os.remove(f"{file_prefix}{rank}.h5")

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/tests.json
@@ -124,6 +124,37 @@
     ]
   },
   {
+    "file": "response_2d_surf.py",
+    "comment": "2D transport response evaluation test writing surface data",
+    "num_procs": 1,
+    "checks": [
+      {
+        "type": "KeyValuePair",
+        "key": "Forward QoI=",
+        "goldvalue": 4.94381e-04,
+        "abs_tol": 1e-8
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "Adjoint QoI=",
+        "goldvalue": 4.94381e-04,
+        "abs_tol": 1e-8
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "Forward Boundary Flux=",
+        "goldvalue": 6.02053e+01,
+        "abs_tol": 1e-8
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "Adjoint Boundary Importance=",
+        "goldvalue": 1.23155e+01,
+        "abs_tol": 1e-8
+      }
+    ]
+  },
+  {
     "file": "mode_switch_forward_adjoint_forward.py",
     "comment": "Forward -> adjoint -> forward mode switching with source and boundary reset",
     "num_procs": 4,


### PR DESCRIPTION
- Added functionality to export surface angular fluxes at a specified boundary id or user provided surface id. 
- Added functionality for computing the response function along a surface provided forward and adjoint surfaces.


 