### PR TITLE
Use correct return type on functions used by PETSc

### DIFF
--- a/framework/math/linear_solver/petsc_linear_system_solver.cc
+++ b/framework/math/linear_solver/petsc_linear_system_solver.cc
@@ -144,7 +144,7 @@ PETScLinearSolver::PETScIterativeMethodName()
   }
 }
 
-int
+PetscErrorCode
 PETScLinearSolver::LinearSolverMatrixAction(Mat matrix, Vec vector, Vec action)
 {
   LinearSystemContext* context = nullptr;

--- a/framework/math/linear_solver/petsc_linear_system_solver.h
+++ b/framework/math/linear_solver/petsc_linear_system_solver.h
@@ -5,6 +5,7 @@
 
 #include "framework/math/linear_solver/linear_system_solver.h"
 #include "framework/math/linear_solver/linear_solver_context.h"
+#include <petscsystypes.h>
 #include <string>
 #include <utility>
 #include <memory>
@@ -74,7 +75,7 @@ private:
   std::string PETScIterativeMethodName();
 
 protected:
-  static int LinearSolverMatrixAction(Mat matrix, Vec vector, Vec action);
+  static PetscErrorCode LinearSolverMatrixAction(Mat matrix, Vec vector, Vec action);
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_dsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_dsa_preconditioner.cc
@@ -13,7 +13,7 @@
 namespace opensn
 {
 
-int
+PetscErrorCode
 WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
 {
   void* context = nullptr;
@@ -60,7 +60,7 @@ WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   return 0;
 }
 
-int
+PetscErrorCode
 WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec pc_output)
 {
   // Shorten some names

--- a/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_shell_operations.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_shell_operations.h
@@ -10,10 +10,11 @@ namespace opensn
 {
 
 /// Applies WGDSA or TGDSA to the given input vector.
-int WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output);
+PetscErrorCode WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output);
 /// Applies WGDSA or TGDSA to the given input vector.
-int WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec pc_output);
+PetscErrorCode
+WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec pc_output);
 /// Applies TGDSA to the given input vector.
-int MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output);
+PetscErrorCode MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output);
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
@@ -11,7 +11,7 @@
 namespace opensn
 {
 
-int
+PetscErrorCode
 MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
 {
   void* context = nullptr;


### PR DESCRIPTION
PETSc assumes `PetscErrorCode` as a return type.

Refs #90