### PR TITLE
Refactoring SweepBoundary to expose an improved boundary condition interface

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -956,7 +956,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
 
   // Passing the sweep boundaries to the angle aggregation
   groupset.angle_agg =
-    std::make_shared<AngleAggregation>(sweep_boundaries_, num_groups_, groupset.quadrature, grid_);
+    std::make_shared<AngleAggregation>(sweep_boundaries_, groupset.quadrature, grid_);
 
   AngleSetGroup angle_set_group;
   size_t angle_set_id = 0;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set_group.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h"
 #include "framework/math/quadratures/angular/angular_quadrature.h"
@@ -29,7 +30,6 @@ namespace opensn
 class AngleAggregation
 {
 private:
-  size_t num_groups_;
   bool num_ang_unknowns_avail_;
   std::pair<size_t, size_t> number_angular_unknowns_;
   std::shared_ptr<MeshContinuum> grid_;
@@ -38,7 +38,6 @@ private:
 
 public:
   AngleAggregation(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
-                   size_t num_groups,
                    std::shared_ptr<AngularQuadrature>& quadrature,
                    std::shared_ptr<MeshContinuum>& grid);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.cc
@@ -2,11 +2,328 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h"
-#include "framework/logging/log.h"
-#include "caliper/cali.h"
+#include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace opensn
 {
+
+template <typename Fn>
+void
+ReflectingBoundary::ForEachDelayedAngularFlux(bool use_old_store, Fn&& fn)
+{
+  auto&& apply = std::forward<Fn>(fn);
+  auto& flux = use_old_store ? boundary_flux_old_ : boundary_flux_;
+  for (auto& angle : flux)
+    for (auto& cellvec : angle)
+      for (auto& facevec : cellvec)
+        for (auto& dofvec : facevec)
+          for (auto& val : dofvec)
+            apply(val);
+}
+
+template <typename Fn>
+void
+ReflectingBoundary::ForEachDelayedAngularFluxConst(bool use_old_store, Fn&& fn) const
+{
+  auto&& apply = std::forward<Fn>(fn);
+  const auto& flux = use_old_store ? boundary_flux_old_ : boundary_flux_;
+  for (const auto& angle : flux)
+    for (const auto& cellvec : angle)
+      for (const auto& facevec : cellvec)
+        for (const auto& dofvec : facevec)
+          for (const auto& val : dofvec)
+            apply(val);
+}
+
+void
+ReflectingBoundary::InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
+                                                 const AngularQuadrature& quadrature)
+{
+  if (not grid)
+    throw std::logic_error("ReflectingBoundary: mesh continuum is null.");
+
+  const auto tot_num_angles = static_cast<int>(quadrature.abscissae.size());
+  reflected_anglenum_.assign(tot_num_angles, -1);
+  angle_readyflags_.assign(tot_num_angles, false);
+
+  const Vector3 ihat(1.0, 0.0, 0.0);
+  const Vector3 jhat(0.0, 1.0, 0.0);
+
+  for (int n = 0; n < tot_num_angles; ++n)
+  {
+    const Vector3& omega_n = quadrature.omegas[n];
+    Vector3 omega_reflected;
+
+    switch (GetCoordType())
+    {
+      case CoordinateSystemType::SPHERICAL:
+        omega_reflected = -1.0 * omega_n;
+        break;
+      case CoordinateSystemType::CYLINDRICAL:
+      {
+        // left, top and bottom are regular reflecting
+        if (std::fabs(normal_.Dot(jhat)) > 0.999999 or normal_.Dot(ihat) < -0.999999)
+          omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
+        // right derives normal from omega_n
+        else if (normal_.Dot(ihat) > 0.999999)
+        {
+          Vector3 normal_star;
+          if (omega_n.Dot(normal_) > 0.0)
+            normal_star = Vector3(omega_n.x, 0.0, omega_n.z).Normalized();
+          else
+            normal_star = Vector3(-omega_n.x, 0.0, -omega_n.y).Normalized();
+          omega_reflected = omega_n - 2.0 * normal_star * omega_n.Dot(normal_star);
+        }
+        break;
+      }
+      case CoordinateSystemType::CARTESIAN:
+      default:
+        omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
+        break;
+    }
+
+    bool found = false;
+    for (int nstar = 0; nstar < tot_num_angles; ++nstar)
+    {
+      if (omega_reflected.Dot(quadrature.omegas[nstar]) > (1.0 - epsilon_))
+      {
+        reflected_anglenum_[n] = nstar;
+        found = true;
+        break;
+      }
+    }
+
+    if (not found)
+    {
+      throw std::logic_error("ReflectingBoundary: Reflected angle not found for angle " +
+                             std::to_string(n) + " with direction " +
+                             quadrature.omegas[n].PrintStr() +
+                             ".\nThis can happen for two reasons:\n1) A quadrature is used "
+                             "that is not symmetric about the axis associated with the "
+                             "reflected boundary.\n2) The reflecting boundary is not "
+                             "aligned with a reflecting axis of the quadrature.");
+    }
+  }
+
+  boundary_flux_.clear();
+  boundary_flux_old_.clear();
+  boundary_flux_.resize(tot_num_angles);
+
+  const size_t num_local_cells = grid->local_cells.size();
+  for (int n = 0; n < tot_num_angles; ++n)
+  {
+    if (quadrature.omegas[n].Dot(normal_) < 0.0)
+      continue;
+
+    auto& cell_vec = boundary_flux_[n];
+    cell_vec.resize(num_local_cells);
+
+    for (const auto& cell : grid->local_cells)
+    {
+      const uint64_t c = cell.local_id;
+      bool on_ref_bndry = false;
+
+      for (const auto& face : cell.faces)
+      {
+        if ((not face.has_neighbor) and (face.normal.Dot(normal_) > 0.999999))
+        {
+          on_ref_bndry = true;
+          break;
+        }
+      }
+
+      if (not on_ref_bndry)
+        continue;
+
+      cell_vec[c].resize(cell.faces.size());
+      int f = 0;
+      for (const auto& face : cell.faces)
+      {
+        if ((not face.has_neighbor) and (face.normal.Dot(normal_) > 0.999999))
+        {
+          cell_vec[c][f].clear();
+          cell_vec[c][f].resize(face.vertex_ids.size(), std::vector<double>(num_groups_, 0.0));
+        }
+        ++f;
+      }
+    }
+  }
+}
+
+void
+ReflectingBoundary::FinalizeDelayedAngularFluxSetup(
+  uint64_t boundary_id, const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+{
+  for (const auto& [otherbid, otherbndry] : boundaries)
+  {
+    if (boundary_id == otherbid)
+      continue;
+
+    const Vector3* other_normal = otherbndry->GetNormalForReflection();
+    if (other_normal == nullptr)
+      continue;
+
+    if (normal_.Dot(*other_normal) < (0.0 - epsilon_))
+    {
+      if (boundary_id < otherbid)
+      {
+        opposing_reflected_ = true;
+        break;
+      }
+    }
+  }
+
+  if (opposing_reflected_)
+    boundary_flux_old_ = boundary_flux_;
+}
+
+void
+ReflectingBoundary::ZeroOpposingDelayedAngularFluxOld()
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFlux(true, [](double& val) { val = 0.0; });
+}
+
+size_t
+ReflectingBoundary::CountDelayedAngularDOFsNew() const
+{
+  if (not opposing_reflected_)
+    return 0;
+
+  size_t counter = 0;
+  ForEachDelayedAngularFluxConst(false, [&](const double&) { ++counter; });
+  return counter;
+}
+
+size_t
+ReflectingBoundary::CountDelayedAngularDOFsOld() const
+{
+  if (not opposing_reflected_)
+    return 0;
+
+  size_t counter = 0;
+  ForEachDelayedAngularFluxConst(true, [&](const double&) { ++counter; });
+  return counter;
+}
+
+void
+ReflectingBoundary::AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFluxConst(false, [&](const double& val) { output.push_back(val); });
+}
+
+void
+ReflectingBoundary::AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFluxConst(true, [&](const double& val) { output.push_back(val); });
+}
+
+void
+ReflectingBoundary::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFluxConst(false,
+                                 [&](const double& val)
+                                 {
+                                   ++index;
+                                   buffer[index] = val;
+                                 });
+}
+
+void
+ReflectingBoundary::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFluxConst(true,
+                                 [&](const double& val)
+                                 {
+                                   ++index;
+                                   buffer[index] = val;
+                                 });
+}
+
+void
+ReflectingBoundary::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer)
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFlux(false,
+                            [&](double& val)
+                            {
+                              ++index;
+                              val = buffer[index];
+                            });
+}
+
+void
+ReflectingBoundary::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer)
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFlux(true,
+                            [&](double& val)
+                            {
+                              ++index;
+                              val = buffer[index];
+                            });
+}
+
+void
+ReflectingBoundary::SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values,
+                                                       size_t& index)
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFlux(false, [&](double& val) { val = values[index++]; });
+}
+
+void
+ReflectingBoundary::SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values,
+                                                       size_t& index)
+{
+  if (not opposing_reflected_)
+    return;
+
+  ForEachDelayedAngularFlux(true, [&](double& val) { val = values[index++]; });
+}
+
+void
+ReflectingBoundary::CopyDelayedAngularFluxOldToNew()
+{
+  if (not opposing_reflected_)
+    return;
+
+  boundary_flux_ = boundary_flux_old_;
+}
+
+void
+ReflectingBoundary::CopyDelayedAngularFluxNewToOld()
+{
+  if (not opposing_reflected_)
+    return;
+
+  boundary_flux_old_ = boundary_flux_;
+}
 
 double*
 ReflectingBoundary::PsiIncoming(uint64_t cell_local_id,
@@ -15,15 +332,12 @@ ReflectingBoundary::PsiIncoming(uint64_t cell_local_id,
                                 unsigned int angle_num,
                                 int group_num)
 {
-  double* psi = nullptr;
   int reflected_angle_num = reflected_anglenum_[angle_num];
 
   if (opposing_reflected_)
-    psi = &boundary_flux_old_[reflected_angle_num][cell_local_id][face_num][fi].front();
-  else
-    psi = &boundary_flux_[reflected_angle_num][cell_local_id][face_num][fi].front();
+    return &boundary_flux_old_[reflected_angle_num][cell_local_id][face_num][fi].front();
 
-  return psi;
+  return &boundary_flux_[reflected_angle_num][cell_local_id][face_num][fi].front();
 }
 
 double*
@@ -47,13 +361,13 @@ ReflectingBoundary::CheckAnglesReadyStatus(const std::vector<std::uint32_t>& ang
 {
   if (opposing_reflected_)
     return true;
-  bool ready_flag = true;
+
   for (const auto& n : angles)
     if (not boundary_flux_[reflected_anglenum_[n]].empty())
       if (not angle_readyflags_[n])
         return false;
 
-  return ready_flag;
+  return true;
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h
@@ -37,17 +37,44 @@ public:
 
   const Vector3& GetNormal() const { return normal_; }
 
-  bool IsOpposingReflected() const { return opposing_reflected_; }
+  const Vector3* GetNormalForReflection() const override { return &normal_; }
 
-  void SetOpposingReflected(bool value) { opposing_reflected_ = value; }
+  bool HasDelayedAngularFlux() const override { return true; }
 
-  AngularFluxData& GetBoundaryFluxNew() { return boundary_flux_; }
+  void InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
+                                    const AngularQuadrature& quadrature) override;
 
-  AngularFluxData& GetBoundaryFluxOld() { return boundary_flux_old_; }
+  void FinalizeDelayedAngularFluxSetup(
+    uint64_t boundary_id,
+    const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries) override;
 
-  std::vector<int>& GetReflectedAngleIndexMap() { return reflected_anglenum_; }
+  void ZeroOpposingDelayedAngularFluxOld() override;
 
-  std::vector<bool>& GetAngleReadyFlags() { return angle_readyflags_; }
+  size_t CountDelayedAngularDOFsNew() const override;
+
+  size_t CountDelayedAngularDOFsOld() const override;
+
+  void AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const override;
+
+  void AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const override;
+
+  void AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const override;
+
+  void AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const override;
+
+  void SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) override;
+
+  void SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) override;
+
+  void SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values,
+                                          size_t& index) override;
+
+  void SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values,
+                                          size_t& index) override;
+
+  void CopyDelayedAngularFluxOldToNew() override;
+
+  void CopyDelayedAngularFluxNewToOld() override;
 
   double* PsiIncoming(uint64_t cell_local_id,
                       unsigned int face_num,
@@ -64,8 +91,17 @@ public:
 
   bool CheckAnglesReadyStatus(const std::vector<std::uint32_t>& angles) override;
 
-  /// Resets angle ready flags to false.
-  void ResetAnglesReadyStatus();
+  void ResetAnglesReadyStatus() override;
+
+private:
+  static constexpr double epsilon_ = 1.0e-8;
+
+private:
+  template <typename Fn>
+  void ForEachDelayedAngularFlux(bool use_old_store, Fn&& fn);
+
+  template <typename Fn>
+  void ForEachDelayedAngularFluxConst(bool use_old_store, Fn&& fn) const;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"
+#include <map>
+#include <memory>
 #include <vector>
 
 namespace opensn
@@ -44,6 +46,52 @@ public:
   double GetEvaluationTime() const { return evaluation_time_; }
 
   void SetEvaluationTime(double time) { evaluation_time_ = time; }
+
+  virtual bool HasDelayedAngularFlux() const { return false; }
+
+  virtual void InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
+                                            const AngularQuadrature& quadrature)
+  {
+  }
+
+  virtual void FinalizeDelayedAngularFluxSetup(
+    uint64_t boundary_id, const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+  {
+  }
+
+  virtual void ZeroOpposingDelayedAngularFluxOld() {}
+
+  virtual size_t CountDelayedAngularDOFsNew() const { return 0; }
+
+  virtual size_t CountDelayedAngularDOFsOld() const { return 0; }
+
+  virtual void AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const {}
+
+  virtual void AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const {}
+
+  virtual void AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const {}
+
+  virtual void AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const {}
+
+  virtual void SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) {}
+
+  virtual void SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) {}
+
+  virtual void SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values, size_t& index)
+  {
+  }
+
+  virtual void SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values, size_t& index)
+  {
+  }
+
+  virtual void CopyDelayedAngularFluxOldToNew() {}
+
+  virtual void CopyDelayedAngularFluxNewToOld() {}
+
+  virtual void ResetAnglesReadyStatus() {}
+
+  virtual const Vector3* GetNormalForReflection() const { return nullptr; }
 
   /// Returns a pointer to the location of the incoming flux.
   virtual double* PsiIncoming(uint64_t cell_local_id,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
@@ -3,7 +3,6 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.h"
-#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
@@ -166,13 +165,7 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
       angle_set->ResetSweepBuffers();
 
   for (const auto& [bid, bndry] : angle_agg_.GetSimBoundaries())
-  {
-    if (bndry->GetType() == LBSBoundaryType::REFLECTING)
-    {
-      auto rbndry = std::static_pointer_cast<ReflectingBoundary>(bndry);
-      rbndry->ResetAnglesReadyStatus();
-    }
-  }
+    bndry->ResetAnglesReadyStatus();
 }
 
 void
@@ -219,13 +212,7 @@ SweepScheduler::ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
       angle_set->ResetSweepBuffers();
 
   for (const auto& [bid, bndry] : angle_agg_.GetSimBoundaries())
-  {
-    if (bndry->GetType() == LBSBoundaryType::REFLECTING)
-    {
-      auto rbndry = std::static_pointer_cast<ReflectingBoundary>(bndry);
-      rbndry->ResetAnglesReadyStatus();
-    }
-  }
+    bndry->ResetAnglesReadyStatus();
 }
 
 void


### PR DESCRIPTION
This PR implements an improved `SweepBoundary` API that provides better support for complex boundary conditions (like reflecting bcs) without RTTI.

1. `SweepBoundary` now exposes a number of methods for dealing with delayed angular flux storage
2. `ReflectingBoundary` overrides the base methods and is more self-contained
3. `AngleAggregation` and `SweepScheduler` now use the base interface instead of casting

Closes #853 