### PR TITLE
Adding ability to load user-specifed OpenMC cross sections

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.cc
+++ b/framework/materials/multi_group_xs/multi_group_xs.cc
@@ -248,6 +248,32 @@ MultiGroupXS::Reset()
   diffusion_coeff_.clear();
   sigma_r_.clear();
   sigma_s_gtog_.clear();
+  custom_xs_.clear();
+}
+
+bool
+MultiGroupXS::HasCustomXS(const std::string& name) const
+{
+  return custom_xs_.find(name) != custom_xs_.end();
+}
+
+const std::vector<double>&
+MultiGroupXS::GetCustomXS(const std::string& name) const
+{
+  const auto it = custom_xs_.find(name);
+  if (it == custom_xs_.end())
+    throw std::runtime_error("MultiGroupXS: Custom XS not found: " + name);
+  return it->second;
+}
+
+std::vector<std::string>
+MultiGroupXS::GetCustomXSNames() const
+{
+  std::vector<std::string> names;
+  names.reserve(custom_xs_.size());
+  for (const auto& entry : custom_xs_)
+    names.push_back(entry.first);
+  return names;
 }
 
 void

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "framework/data_types/sparse_matrix/sparse_matrix.h"
+#include <map>
 
 namespace opensn
 {
@@ -110,6 +111,10 @@ public:
 
   const std::vector<double>& GetSigmaSGtoG() const { return sigma_s_gtog_; }
 
+  bool HasCustomXS(const std::string& name) const;
+  const std::vector<double>& GetCustomXS(const std::string& name) const;
+  std::vector<std::string> GetCustomXSNames() const;
+
 private:
   /// Total number of groups
   unsigned int num_groups_;
@@ -162,6 +167,8 @@ private:
   /// Within-group scattering cross section
   std::vector<double> sigma_s_gtog_;
 
+  std::map<std::string, std::vector<double>> custom_xs_;
+
   void Reset();
 
   void ComputeAbsorption();
@@ -175,8 +182,10 @@ public:
   static MultiGroupXS CreateSimpleOneGroup(double sigma_t, double c, double velocity = 0.0);
   static MultiGroupXS LoadFromOpenSn(const std::string& filename);
   /// This method populates transport cross sections from an OpenMC cross-section file.
-  static MultiGroupXS
-  LoadFromOpenMC(const std::string& file_name, const std::string& dataset_name, double temperature);
+  static MultiGroupXS LoadFromOpenMC(const std::string& file_name,
+                                     const std::string& dataset_name,
+                                     double temperature,
+                                     const std::vector<std::string>& extra_xs_names = {});
   /// Populates the cross section from a combination of others.
   static MultiGroupXS
   Combine(const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations);

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -137,15 +137,19 @@ WrapMultiGroupXS(py::module& xs)
   );
   multigroup_xs.def(
     "LoadFromOpenMC",
-    [](MultiGroupXS& self, const std::string& file_name, const std::string& dataset_name,
-       double temperature)
+    [](MultiGroupXS& self,
+       const std::string& file_name,
+       const std::string& dataset_name,
+       double temperature,
+       const std::vector<std::string>& extra_xs_names)
     {
-      self = MultiGroupXS::LoadFromOpenMC(file_name, dataset_name, temperature);
+      self = MultiGroupXS::LoadFromOpenMC(file_name, dataset_name, temperature, extra_xs_names);
     },
     "Load multi-group cross sections from an OpenMC cross-section file.",
     py::arg("file_name"),
     py::arg("dataset_name"),
-    py::arg("temperature")
+    py::arg("temperature"),
+    py::arg("extra_xs_names") = std::vector<std::string>()
   );
   multigroup_xs.def(
     "SetScalingFactor",
@@ -219,6 +223,24 @@ WrapMultiGroupXS(py::module& xs)
     XS_GETTER(GetNuDelayedSigmaF),
     "Get delayed neutron production due to fission.",
     py::keep_alive<0, 1>()
+  );
+  multigroup_xs.def(
+    "has_custom_xs",
+    &MultiGroupXS::HasCustomXS,
+    "Check if a custom XS is available.",
+    py::arg("name")
+  );
+  multigroup_xs.def(
+    "get_custom_xs",
+    [](MultiGroupXS& self, const std::string& name)
+    { return convert_vector(self.GetCustomXS(name)); },
+    "Get a custom XS vector.",
+    py::arg("name")
+  );
+  multigroup_xs.def(
+    "custom_xs_names",
+    &MultiGroupXS::GetCustomXSNames,
+    "Get a list of custom XS entries."
   );
   multigroup_xs.def_property_readonly(
     "inv_velocity",

--- a/test/python/framework/materials/tests.json
+++ b/test/python/framework/materials/tests.json
@@ -49,5 +49,18 @@
         "abs_tol": 1e-05
       }
     ]
+  },
+  {
+    "file": "xs_custom.py",
+    "comment": "load custom absorption XS from OpenMC and compare to reference values",
+    "num_procs": 1,
+    "checks": [
+      {
+        "type": "KeyValuePair",
+        "key": "PASS ",
+        "goldvalue": 1,
+        "abs_tol": 0
+      }
+    ]
   }
 ]

--- a/test/python/framework/materials/xs_custom.py
+++ b/test/python/framework/materials/xs_custom.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+xs_custom.py: Regression test for user-provided custom XS loading.
+
+Loads OpenMC HDPE cross sections, requests the "absorption" dataset by name
+and compares the named xs values to the raw HDF5 dataset for a few indices.
+"""
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.xs import MultiGroupXS
+
+
+def main():
+    xs_file = "../../modules/linear_boltzmann_solvers/transport_steady/HDPE.h5"
+    dataset = "set1"
+    temperature = 294.0
+    custom_xs = "absorption"
+    tol = 1.0e-6
+    expected = {
+        0: 0.00434302,
+        5: 0.00635482,
+        9: 5.6538e-06,
+        13: 5.05473e-06,
+        17: 4.51771e-06,
+        21: 4.1906e-06,
+        25: 4.1563e-06,
+        29: 5.00753e-06,
+        33: 9.54322e-06,
+        37: 1.80119e-05,
+        41: 2.72368e-05,
+        45: 4.56202e-05,
+        49: 7.27354e-05,
+        53: 0.000112619,
+        57: 0.000150834,
+        61: 0.000237293,
+        65: 0.000412622,
+        69: 0.000595737,
+        73: 0.000700987,
+        77: 0.000850868,
+        81: 0.00113468,
+        86: 0.00155062,
+        91: 0.00216394,
+        96: 0.00267416,
+        101: 0.00303944,
+        106: 0.00341594,
+        110: 0.00367713,
+        114: 0.00397723,
+        118: 0.00415121,
+        123: 0.00434302,
+        128: 0.00454675,
+        132: 0.00492324,
+        136: 0.00604985,
+        140: 0.00693216,
+        144: 0.00786618,
+        149: 0.0101541,
+        154: 0.0133354,
+        159: 0.0174687,
+        164: 0.0263177,
+        169: 0.0565075,
+        171: 0.106801,
+    }
+
+    mgxs = MultiGroupXS()
+    mgxs.LoadFromOpenMC(xs_file, dataset, temperature, [custom_xs])
+    named_vals = mgxs.get_custom_xs(custom_xs)
+
+    ok = True
+    for idx, ref_val in expected.items():
+        if idx >= len(named_vals):
+            raise RuntimeError(f"Index {idx} out of range for {custom_xs}")
+        diff = abs(float(named_vals[idx]) - ref_val)
+        if diff > tol:
+            ok = False
+            break
+
+    print(f"PASS {int(ok)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Extend LoadFromOpenMC to accept user‑specified 1D dataset names
- Add Python accessors to query and retrieve custom cross sections:

> - `has_custom_xs(name)`
> - `get_custom_xs(name)`
> - `custom_xs_names()`
