### PR TITLE
Adding `min` field function operation

### DIFF
--- a/framework/field_functions/interpolation/ffinter_volume.cc
+++ b/framework/field_functions/interpolation/ffinter_volume.cc
@@ -92,7 +92,7 @@ FieldFunctionInterpolationVolume::Execute()
 
       double function_value = ff_value;
       if (op_type_ >= FieldFunctionInterpolationOperation::OP_SUM_FUNC and
-          op_type_ <= FieldFunctionInterpolationOperation::OP_MAX_FUNC)
+          op_type_ <= FieldFunctionInterpolationOperation::OP_MIN_FUNC)
         function_value = oper_function_(ff_value, cell.block_id);
 
       local_volume += fe_vol_data.JxW(qp);
@@ -122,6 +122,11 @@ FieldFunctionInterpolationVolume::Execute()
            op_type_ == FieldFunctionInterpolationOperation::OP_MAX_FUNC)
   {
     mpi_comm.all_reduce(local_max, op_value_, mpi::op::max<double>());
+  }
+  else if (op_type_ == FieldFunctionInterpolationOperation::OP_MIN or
+           op_type_ == FieldFunctionInterpolationOperation::OP_MIN_FUNC)
+  {
+    mpi_comm.all_reduce(local_min, op_value_, mpi::op::min<double>());
   }
 }
 

--- a/framework/field_functions/interpolation/ffinterpolation.h
+++ b/framework/field_functions/interpolation/ffinterpolation.h
@@ -26,9 +26,11 @@ enum class FieldFunctionInterpolationOperation : int
   OP_SUM = 10,
   OP_AVG = 11,
   OP_MAX = 12,
-  OP_SUM_FUNC = 13,
-  OP_AVG_FUNC = 14,
-  OP_MAX_FUNC = 15,
+  OP_MIN = 13,
+  OP_SUM_FUNC = 14,
+  OP_AVG_FUNC = 15,
+  OP_MAX_FUNC = 16,
+  OP_MIN_FUNC = 17,
 };
 
 enum class FieldFunctionInterpolationProperty : int


### PR DESCRIPTION
A `min` field function op can be useful for easily determining things like a constant solution. Also adds better error reporting so we don't get the dreaded `at()` error if the user supplies an unsupported operation.