### PR TITLE
Refactor PETSc error handling

### DIFF
--- a/framework/data_types/parallel_vector/parallel_stl_vector.cc
+++ b/framework/data_types/parallel_vector/parallel_stl_vector.cc
@@ -3,7 +3,8 @@
 
 #include "framework/data_types/parallel_vector/parallel_stl_vector.h"
 #include "framework/data_types/byte_array.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
+#include "framework/utils/error.h"
 #include "framework/logging/log.h"
 #include "framework/mpi/mpi_utils.h"
 #include <petsc.h>
@@ -151,15 +152,15 @@ void
 ParallelSTLVector::CopyLocalValues(Vec y)
 {
   PetscInt n = 0;
-  VecGetLocalSize(y, &n);
+  OpenSnPETScCall(VecGetLocalSize(y, &n));
 
   OpenSnInvalidArgumentIf(std::cmp_less(n, local_size_),
                           "Attempted update with a vector of insufficient size.");
 
   const double* x = nullptr;
-  VecGetArrayRead(y, &x);
+  OpenSnPETScCall(VecGetArrayRead(y, &x));
   std::copy(x, x + n, values_.begin());
-  VecRestoreArrayRead(y, &x);
+  OpenSnPETScCall(VecRestoreArrayRead(y, &x));
 }
 
 void
@@ -206,7 +207,7 @@ ParallelSTLVector::BlockCopyLocalValues(Vec y,
   const auto local_end = local_offset + num_values;
 
   PetscInt y_local_size = 0;
-  VecGetLocalSize(y, &y_local_size);
+  OpenSnPETScCall(VecGetLocalSize(y, &y_local_size));
 
   OpenSnInvalidArgumentIf(y_end > y_local_size,
                           "y_offset + num_values=" + std::to_string(y_end) +
@@ -219,13 +220,13 @@ ParallelSTLVector::BlockCopyLocalValues(Vec y,
                             std::to_string(local_size_));
 
   const double* y_data = nullptr;
-  VecGetArrayRead(y, &y_data);
+  OpenSnPETScCall(VecGetArrayRead(y, &y_data));
 
   std::copy(y_data + y_offset,
             y_data + y_offset + num_values,
             values_.begin() + static_cast<long>(local_offset));
 
-  VecRestoreArrayRead(y, &y_data);
+  OpenSnPETScCall(VecRestoreArrayRead(y, &y_data));
 }
 
 void

--- a/framework/data_types/varying.cc
+++ b/framework/data_types/varying.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/data_types/varying.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include <algorithm>
 #include <sstream>
 

--- a/framework/data_types/varying.h
+++ b/framework/data_types/varying.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "framework/data_types/vector3.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include <cstddef>
 #include <iostream>
 #include <type_traits>

--- a/framework/data_types/vector_ghost_communicator/vector_ghost_communicator.cc
+++ b/framework/data_types/vector_ghost_communicator/vector_ghost_communicator.cc
@@ -3,7 +3,7 @@
 
 #include "framework/data_types/vector_ghost_communicator/vector_ghost_communicator.h"
 #include "framework/mpi/mpi_utils.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include <map>
 #include <optional>
 #include <string>

--- a/framework/field_functions/field_function.cc
+++ b/framework/field_functions/field_function.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/field_functions/field_function.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "framework/runtime.h"
 
 namespace opensn

--- a/framework/logging/log.h
+++ b/framework/logging/log.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "framework/logging/log_stream.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include <utility>
 #include <vector>
 #include <memory>

--- a/framework/math/petsc_utils/petsc_utils.h
+++ b/framework/math/petsc_utils/petsc_utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "framework/utils/error.h"
 #include <petscksp.h>
 #include <vector>
 

--- a/framework/math/quadratures/gauss_quadrature.cc
+++ b/framework/math/quadratures/gauss_quadrature.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/math/quadratures/gauss_quadrature.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 
 namespace opensn
 {

--- a/framework/math/quadratures/spatial/line_quadrature.cc
+++ b/framework/math/quadratures/spatial/line_quadrature.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/math/quadratures/spatial/line_quadrature.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 
 namespace opensn
 {

--- a/framework/math/spatial_discretization/finite_volume/finite_volume.cc
+++ b/framework/math/spatial_discretization/finite_volume/finite_volume.cc
@@ -5,7 +5,7 @@
 #include "framework/math/spatial_discretization/cell_mappings/finite_volume/finite_volume_mapping.h"
 #include "framework/math/unknown_manager/unknown_manager.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "framework/logging/log.h"
 #include "framework/mpi/mpi_utils.h"
 #include "framework/runtime.h"

--- a/framework/object_factory.h
+++ b/framework/object_factory.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "framework/parameters/input_parameters.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "framework/utils/utils.h"
 #include <memory>
 

--- a/framework/utils/error.h
+++ b/framework/utils/error.h
@@ -6,6 +6,24 @@
 #include <string>
 #include <stdexcept>
 
+namespace opensn
+{
+[[noreturn]] void ThrowPETScError(int ierr, const char* expr, const char* file, int line);
+
+inline void
+CheckPETScCall(int ierr, const char* expr, const char* file, int line)
+{
+  const bool failed =
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_expect(ierr != 0, 0);
+#else
+    ierr != 0;
+#endif
+  if (failed)
+    ThrowPETScError(ierr, expr, file, line);
+}
+} // namespace opensn
+
 #define OpenSnInvalidArgumentIf(condition, message)                                                \
   if (condition)                                                                                   \
   throw std::invalid_argument(std::string(__PRETTY_FUNCTION__) + ": " + (message))
@@ -34,3 +52,5 @@
                                         std::string(__PRETTY_FUNCTION__) +                         \
                                       ": " + #message);                                            \
   }
+
+#define OpenSnPETScCall(expr) ::opensn::CheckPETScCall((expr), #expr, __FILE__, __LINE__)

--- a/framework/utils/utils.cc
+++ b/framework/utils/utils.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/utils/utils.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include <fstream>
 #include <cmath>
 #include <iomanip>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -31,7 +31,7 @@
 #include "framework/field_functions/field_function_grid_based.h"
 #include "framework/math/quadratures/angular/product_quadrature.h"
 #include "framework/logging/log.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "framework/utils/timer.h"
 #include "framework/utils/utils.h"
 #include "framework/object_factory.h"

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_shell_operations.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
@@ -68,17 +69,17 @@ SweepWGSContext::SetPreconditioner(KSP& solver)
   auto& ksp = solver;
 
   PC pc = nullptr;
-  KSPGetPC(ksp, &pc);
+  OpenSnPETScCall(KSPGetPC(ksp, &pc));
 
   if (groupset.apply_wgdsa or groupset.apply_tgdsa)
   {
-    PCSetType(pc, PCSHELL);
-    PCShellSetApply(pc, (PCShellPtr)WGDSA_TGDSA_PreConditionerMult);
-    PCShellSetContext(pc, &(*this));
+    OpenSnPETScCall(PCSetType(pc, PCSHELL));
+    OpenSnPETScCall(PCShellSetApply(pc, (PCShellPtr)WGDSA_TGDSA_PreConditionerMult));
+    OpenSnPETScCall(PCShellSetContext(pc, &(*this)));
   }
 
-  KSPSetPCSide(ksp, PC_LEFT);
-  KSPSetUp(ksp);
+  OpenSnPETScCall(KSPSetPCSide(ksp, PC_LEFT));
+  OpenSnPETScCall(KSPSetUp(ksp));
 }
 
 std::pair<int64_t, int64_t>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
@@ -5,7 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_kernels.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "caliper/cali.h"
 #include <algorithm>
 #include <array>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_kernels.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/acceleration.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/acceleration.cc
@@ -4,7 +4,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/acceleration/acceleration.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
-#include "framework/logging/log_exceptions.h"
+#include "framework/utils/error.h"
 #include "framework/runtime.h"
 
 namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_residual_func.cc
@@ -15,7 +15,9 @@ PetscErrorCode
 NLKEigenAccResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
 {
   NLKEigenDiffContext* nl_context_ptr = nullptr;
-  SNESGetApplicationContext(snes, static_cast<void*>(&nl_context_ptr));
+  PetscErrorCode ierr = SNESGetApplicationContext(snes, static_cast<void*>(&nl_context_ptr));
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   auto& diff_solver = nl_context_ptr->diff_solver;
 
@@ -115,7 +117,7 @@ NLKEigenAccResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
 
   nl_context_ptr->kresid_func_context.k_eff = lambda;
 
-  return 0;
+  return PETSC_SUCCESS;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_solver.cc
@@ -36,13 +36,15 @@ NLKEigenDiffSolver::SetMonitor()
   auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   if (nl_context_ptr->verbosity_level >= 1)
-    SNESMonitorSet(nl_solver_, &KEigenSNESMonitor, &nl_context_ptr->kresid_func_context, nullptr);
+    OpenSnPETScCall(SNESMonitorSet(
+      nl_solver_, &KEigenSNESMonitor, &nl_context_ptr->kresid_func_context, nullptr));
 
   if (nl_context_ptr->verbosity_level >= 2)
   {
     KSP ksp = nullptr;
-    SNESGetKSP(nl_solver_, &ksp);
-    KSPMonitorSet(ksp, &KEigenKSPMonitor, &nl_context_ptr->kresid_func_context, nullptr);
+    OpenSnPETScCall(SNESGetKSP(nl_solver_, &ksp));
+    OpenSnPETScCall(
+      KSPMonitorSet(ksp, &KEigenKSPMonitor, &nl_context_ptr->kresid_func_context, nullptr));
   }
 }
 
@@ -63,7 +65,7 @@ NLKEigenDiffSolver::SetSystem()
 {
   // Create the vectors
   x_ = CreateVector(num_local_dofs_, num_global_dofs_);
-  VecDuplicate(x_, &r_);
+  OpenSnPETScCall(VecDuplicate(x_, &r_));
 }
 
 void
@@ -71,21 +73,21 @@ NLKEigenDiffSolver::SetFunction()
 {
   auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
-  SNESSetFunction(
-    nl_solver_, r_, NLKEigenAccResidualFunction, &nl_context_ptr->kresid_func_context);
+  OpenSnPETScCall(SNESSetFunction(
+    nl_solver_, r_, NLKEigenAccResidualFunction, &nl_context_ptr->kresid_func_context));
 }
 
 void
 NLKEigenDiffSolver::SetJacobian()
 {
-  MatCreateSNESMF(nl_solver_, &J_);
-  SNESSetJacobian(nl_solver_, J_, J_, MatMFFDComputeJacobian, nullptr);
+  OpenSnPETScCall(MatCreateSNESMF(nl_solver_, &J_));
+  OpenSnPETScCall(SNESSetJacobian(nl_solver_, J_, J_, MatMFFDComputeJacobian, nullptr));
 }
 
 void
 NLKEigenDiffSolver::SetInitialGuess()
 {
-  VecSet(x_, 0.0);
+  OpenSnPETScCall(VecSet(x_, 0.0));
 }
 
 void
@@ -114,7 +116,7 @@ NLKEigenDiffSolver::PostSolveCallback()
   LBSVecOps::ScalePhiVector(do_problem, PhiSTLOption::PHI_OLD, k_eff / production);
 
   PetscInt number_of_func_evals = 0;
-  SNESGetNumberFunctionEvals(nl_solver_, &number_of_func_evals);
+  OpenSnPETScCall(SNESGetNumberFunctionEvals(nl_solver_, &number_of_func_evals));
 
   // Print summary
   if (nl_context_ptr->verbosity_level >= 1)

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
@@ -20,7 +20,9 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   auto& function_context = *static_cast<KResidualFunctionContext*>(ctx);
 
   NLKEigenAGSContext* nl_context_ptr = nullptr;
-  SNESGetApplicationContext(snes, static_cast<void*>(&nl_context_ptr));
+  PetscErrorCode ierr = SNESGetApplicationContext(snes, static_cast<void*>(&nl_context_ptr));
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   auto& lbs_problem = nl_context_ptr->lbs_problem;
   const auto& phi_old_local = lbs_problem->GetPhiOldLocal();
@@ -72,7 +74,9 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   LBSVecOps::SetMultiGSPETScVecFromPrimarySTLvector(
     *lbs_problem, groupset_ids, r, PhiSTLOption::PHI_NEW);
 
-  VecAXPY(r, -1.0, phi);
+  ierr = VecAXPY(r, -1.0, phi);
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   for (auto& groupset : lbs_problem->GetGroupsets())
   {
@@ -87,7 +91,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   // Assign k to the context so monitors can work
   function_context.k_eff = k_eff;
 
-  return 0;
+  return PETSC_SUCCESS;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/wgs_context.cc
@@ -4,6 +4,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/wgs_context.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "caliper/cali.h"
 
@@ -33,7 +34,7 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
   CALI_CXX_MARK_SCOPE("WGSContext::MatrixAction");
 
   WGSContext* gs_context_ptr = nullptr;
-  MatShellGetContext(matrix, static_cast<void*>(&gs_context_ptr));
+  OpenSnPETScCall(MatShellGetContext(matrix, static_cast<void*>(&gs_context_ptr)));
 
   // Copy krylov action_vector into local
   LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(
@@ -64,7 +65,7 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
   // A  = [I - DLinvMS]
   // Av = [I - DLinvMS]v
   //    = v - DLinvMSv
-  VecAYPX(action, -1.0, action_vector);
+  OpenSnPETScCall(VecAYPX(action, -1.0, action_vector));
 
   return 0;
 }

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/wgs_convergence_test.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/wgs_convergence_test.cc
@@ -22,7 +22,9 @@ GSConvergenceTest(
 
   // Get data context
   WGSContext* context = nullptr;
-  KSPGetApplicationContext(ksp, static_cast<void*>(&context));
+  PetscErrorCode ierr = KSPGetApplicationContext(ksp, static_cast<void*>(&context));
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   // Set rhs norm
   double residual_scale = 1.0;
@@ -48,7 +50,9 @@ GSConvergenceTest(
   // Compute test criterion
   double tol = 0.0;
   int64_t maxIts = 0;
-  KSPGetTolerances(ksp, nullptr, &tol, nullptr, &maxIts);
+  ierr = KSPGetTolerances(ksp, nullptr, &tol, nullptr, &maxIts);
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   double scaled_residual = rnorm * residual_scale;
 
@@ -72,7 +76,7 @@ GSConvergenceTest(
   if (context->log_info)
     log.Log() << iter_info.str() << std::endl;
 
-  return KSP_CONVERGED_ITERATING;
+  return PETSC_SUCCESS;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
@@ -3,6 +3,7 @@
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
 
 namespace opensn
 {
@@ -106,7 +107,7 @@ LBSVecOps::SetGSPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
   const auto& src_phi =
     (src == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal() : lbs_problem.GetPhiOldLocal();
   double* petsc_dest = nullptr;
-  VecGetArray(dest, &petsc_dest);
+  OpenSnPETScCall(VecGetArray(dest, &petsc_dest));
   int64_t index = GroupsetScopedCopy(lbs_problem,
                                      groupset.first_group,
                                      groupset.GetNumGroups(),
@@ -119,7 +120,7 @@ LBSVecOps::SetGSPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
     else if (src == PhiSTLOption::PHI_OLD)
       groupset.angle_agg->AppendOldDelayedAngularDOFsToArray(index, petsc_dest);
   }
-  VecRestoreArray(dest, &petsc_dest);
+  OpenSnPETScCall(VecRestoreArray(dest, &petsc_dest));
 }
 
 void
@@ -131,7 +132,7 @@ LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(LBSProblem& lbs_problem,
   auto& dest_phi =
     (dest == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal() : lbs_problem.GetPhiOldLocal();
   const double* petsc_src = nullptr;
-  VecGetArrayRead(src, &petsc_src);
+  OpenSnPETScCall(VecGetArrayRead(src, &petsc_src));
   int64_t index = GroupsetScopedCopy(lbs_problem,
                                      groupset.first_group,
                                      groupset.GetNumGroups(),
@@ -144,7 +145,7 @@ LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(LBSProblem& lbs_problem,
     else if (dest == PhiSTLOption::PHI_OLD)
       groupset.angle_agg->SetOldDelayedAngularDOFsFromArray(index, petsc_src);
   }
-  VecRestoreArrayRead(src, &petsc_src);
+  OpenSnPETScCall(VecRestoreArrayRead(src, &petsc_src));
 }
 
 void
@@ -155,12 +156,12 @@ LBSVecOps::SetGroupScopedPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
                                                       const std::vector<double>& src)
 {
   double* petsc_dest = nullptr;
-  VecGetArray(dest, &petsc_dest);
+  OpenSnPETScCall(VecGetArray(dest, &petsc_dest));
   GroupsetScopedCopy(lbs_problem,
                      first_group_id,
                      last_group_id - first_group_id + 1,
                      [&](int64_t idx, size_t mapped_idx) { petsc_dest[idx] = src[mapped_idx]; });
-  VecRestoreArray(dest, &petsc_dest);
+  OpenSnPETScCall(VecRestoreArray(dest, &petsc_dest));
 }
 
 void
@@ -173,13 +174,13 @@ LBSVecOps::SetPrimarySTLvectorFromGroupScopedPETScVec(LBSProblem& lbs_problem,
   auto& dest_phi =
     (dest == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal() : lbs_problem.GetPhiOldLocal();
   const double* petsc_src = nullptr;
-  VecGetArrayRead(src, &petsc_src);
+  OpenSnPETScCall(VecGetArrayRead(src, &petsc_src));
   GroupsetScopedCopy(lbs_problem,
                      first_group_id,
                      last_group_id - first_group_id + 1,
                      [&](int64_t idx, size_t mapped_idx)
                      { dest_phi[mapped_idx] = petsc_src[idx]; });
-  VecRestoreArrayRead(src, &petsc_src);
+  OpenSnPETScCall(VecRestoreArrayRead(src, &petsc_src));
 }
 
 void
@@ -228,7 +229,7 @@ LBSVecOps::SetMultiGSPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
                                                  : lbs_problem.GetPhiOldLocal();
   auto& groupsets = lbs_problem.GetGroupsets();
   double* x_ref = nullptr;
-  VecGetArray(x, &x_ref);
+  OpenSnPETScCall(VecGetArray(x, &x_ref));
 
   for (auto gs_id : groupset_ids)
   {
@@ -248,7 +249,7 @@ LBSVecOps::SetMultiGSPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
     }
   }
 
-  VecRestoreArray(x, &x_ref);
+  OpenSnPETScCall(VecRestoreArray(x, &x_ref));
 }
 
 void
@@ -261,7 +262,7 @@ LBSVecOps::SetPrimarySTLvectorFromMultiGSPETScVec(LBSProblem& lbs_problem,
                                                  : lbs_problem.GetPhiOldLocal();
   auto& groupsets = lbs_problem.GetGroupsets();
   const double* x_ref = nullptr;
-  VecGetArrayRead(x, &x_ref);
+  OpenSnPETScCall(VecGetArrayRead(x, &x_ref));
 
   for (auto gs_id : groupset_ids)
   {
@@ -281,7 +282,7 @@ LBSVecOps::SetPrimarySTLvectorFromMultiGSPETScVec(LBSProblem& lbs_problem,
     }
   }
 
-  VecRestoreArrayRead(x, &x_ref);
+  OpenSnPETScCall(VecRestoreArrayRead(x, &x_ref));
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_dsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbs_dsa_preconditioner.cc
@@ -17,7 +17,9 @@ PetscErrorCode
 WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
 {
   void* context = nullptr;
-  PCShellGetContext(pc, static_cast<void*>(&context));
+  PetscErrorCode ierr = PCShellGetContext(pc, static_cast<void*>(&context));
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   auto* gs_context_ptr = static_cast<WGSContext*>(context);
 
@@ -57,7 +59,7 @@ WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   LBSVecOps::SetGSPETScVecFromPrimarySTLvector(
     do_problem, groupset, pc_output, PhiSTLOption::PHI_NEW);
 
-  return 0;
+  return PETSC_SUCCESS;
 }
 
 PetscErrorCode
@@ -99,7 +101,7 @@ WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec p
   LBSVecOps::SetGSPETScVecFromPrimarySTLvector(
     do_problem, groupset, pc_output, PhiSTLOption::PHI_NEW);
 
-  return 0;
+  return PETSC_SUCCESS;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
@@ -15,7 +15,9 @@ PetscErrorCode
 MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
 {
   void* context = nullptr;
-  PCShellGetContext(pc, static_cast<void*>(&context));
+  PetscErrorCode ierr = PCShellGetContext(pc, static_cast<void*>(&context));
+  if (ierr != PETSC_SUCCESS)
+    return ierr;
 
   auto* gs_context_ptr = static_cast<WGSContext*>(context);
 
@@ -41,7 +43,7 @@ MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   // Copy STL vector to PETSc Vec
   LBSVecOps::SetGSPETScVecFromPrimarySTLvector(solver, groupset, pc_output, PhiSTLOption::PHI_NEW);
 
-  return 0;
+  return PETSC_SUCCESS;
 }
 
 } // namespace opensn


### PR DESCRIPTION
This PR refactors PETSc error handling. It touches a lot of files, but the modifications are minimal - just wrapping of PETSc calls with the `OpenSnPETScCall` macro. Although we typically don't encourage the use of macros, it seems like the proper tool for this job.

In addition, I've deprecated the `framework/logging/log_exceptions.h` header and moved all of the OpenSn error checking macros to `framework/utils/error.h`.