### PR TITLE
Update steady-state <--> time-dependent mode transitions

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -38,11 +38,14 @@ public:
   {
     return sweep_chunk_mode_.value_or(SweepChunkMode::Default) == SweepChunkMode::TimeDependent;
   }
+  void SetTimeDependentMode();
+  void SetSteadyStateMode();
   std::shared_ptr<SweepChunk> CreateSweepChunk(LBSGroupset& groupset)
   {
     return SetSweepChunk(groupset);
   }
   void EnableTimeDependentMode();
+  void ResetMode(SweepChunkMode target_mode);
   /// Rebuild WGS/AGS solver schemes (e.g., after changing sweep chunk mode).
   void ReinitializeSolverSchemes();
 
@@ -144,7 +147,7 @@ protected:
   /// Sets up the sweek chunk for the given discretization method.
   virtual std::shared_ptr<SweepChunk> SetSweepChunk(LBSGroupset& groupset);
 
-  void ZeroSolutions() override;
+  void ZeroPsi() override;
 
   BoundaryDefinition CreateBoundaryFromParams(const InputParameters& params) const;
   std::shared_ptr<SweepBoundary> CreateSweepBoundary(uint64_t boundary_id) const;
@@ -174,6 +177,8 @@ protected:
   std::vector<std::vector<double>> psi_new_local_;
   std::vector<std::vector<double>> psi_old_local_;
   std::optional<SweepChunkMode> sweep_chunk_mode_;
+  bool forced_save_angular_flux_for_transient_ = false;
+  bool save_angular_flux_before_transient_ = false;
 
   std::map<std::tuple<size_t, size_t, size_t>, size_t> angular_flux_field_functions_local_map_;
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -81,6 +81,8 @@ public:
   bool IsAdjoint() const;
   virtual void SetSaveAngularFlux(bool save);
   void ApplyOptions();
+  void ZeroPhi();
+  virtual void ZeroPsi() = 0;
 
   GeometryType GetGeometryType() const;
 
@@ -297,8 +299,6 @@ protected:
 
   /// Reset data carriers to null and unpin memory.
   void ResetGPUCarriers();
-
-  virtual void ZeroSolutions() = 0;
 
   LBSOptions options_;
   double time_ = 0.0;

--- a/modules/linear_boltzmann_solvers/solvers/nl_keigen_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/nl_keigen_solver.h
@@ -25,6 +25,7 @@ private:
   std::shared_ptr<DiscreteOrdinatesProblem> do_problem_;
   std::shared_ptr<NLKEigenAGSContext> nl_context_;
   NLKEigenvalueAGSSolver nl_solver_;
+  bool initialized_ = false;
 
   bool reset_phi0_;
   unsigned int num_initial_power_its_;

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
@@ -53,6 +53,7 @@ protected:
   LBSGroupset& front_gs_;
   std::shared_ptr<LinearSolver> front_wgs_solver_;
   std::shared_ptr<WGSContext> front_wgs_context_;
+  bool initialized_ = false;
 
 private:
   bool WriteRestartData();

--- a/modules/linear_boltzmann_solvers/solvers/steady_state_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/steady_state_solver.h
@@ -21,6 +21,7 @@ public:
 
 protected:
   std::shared_ptr<LBSProblem> lbs_problem_;
+  bool initialized_ = false;
 
 private:
   bool ReadRestartData();

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_leakage_pulse_decay.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_leakage_pulse_decay.py
@@ -90,6 +90,8 @@ if __name__ == "__main__":
 
     phys.SetVolumetricSources(clear_volumetric_sources=True)
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, dt=dt, theta=1.0, stop_time=dt, initial_state="existing")
     solver.Initialize()
     solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_decay.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_decay.py
@@ -115,6 +115,8 @@ if __name__ == "__main__":
 
     phys.SetVolumetricSources(clear_volumetric_sources=True)
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, dt=dt, theta=1.0, stop_time=dt, initial_state="existing")
     solver.Initialize()
     solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_steady_state_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_steady_state_source.py
@@ -86,6 +86,8 @@ if __name__ == "__main__":
     steady.Initialize()
     steady.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, dt=dt, theta=1.0, stop_time=dt, initial_state="existing")
     solver.Initialize()
     solver.Execute()

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_time_dependent_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_time_dependent_source.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=1,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": (0, 0),

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_zero_absorber_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_zero_absorber_source.py
@@ -59,6 +59,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=1,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": (0, 0),

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_prke_vs_stk.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_prke_vs_stk.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_prompt_step.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_prompt_step.py
@@ -73,6 +73,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_theta_precursor_scaling.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_theta_precursor_scaling.py
@@ -66,6 +66,8 @@ def run_case(theta, use_precursors, xs):
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
     solver.SetTheta(theta)

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_delayed_step.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_delayed_step.py
@@ -81,6 +81,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_delayed_prke_vs_stk_2p.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_delayed_prke_vs_stk_2p.py
@@ -155,6 +155,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_prompt_ramp_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_prompt_ramp_xs.py
@@ -76,6 +76,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_2g_prompt_step_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_2g_prompt_step_xs.py
@@ -78,6 +78,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_6g_delayed_step_nu_sigma_f.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_6g_delayed_step_nu_sigma_f.py
@@ -78,6 +78,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_analytic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_analytic.py
@@ -107,6 +107,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, verbose=False, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p.py
@@ -161,6 +161,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p_callbacks.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p_callbacks.py
@@ -162,6 +162,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(
         problem=phys,
         stop_time=t_end,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_ramp_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_ramp_xs.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, verbose=False, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_stiff_dt_sensitivity.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_stiff_dt_sensitivity.py
@@ -79,6 +79,8 @@ def run_transient(dt, t_end, xs_crit, xs_super):
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_analytic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_analytic.py
@@ -85,6 +85,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, verbose=False, initial_state="existing")
     solver.Initialize()
     phi_old = phys.GetPhiOldLocal()

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_bc_leakage.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_bc_leakage.py
@@ -76,6 +76,8 @@ def run_case(bc_type, xs_crit, xs_super):
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_mid_step_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_mid_step_swap.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
     keigen.Initialize()
     keigen.Execute()
 
+    phys.SetTimeDependentMode()
+
     solver = TransientSolver(problem=phys, initial_state="existing")
     solver.Initialize()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_pulse_inf_med.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_pulse_inf_med.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_ramp_source_analytic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_ramp_source_analytic.py
@@ -79,6 +79,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=1,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": (0, 0),

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v0.5_inf_med.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v0.5_inf_med.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v1_inf_med.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v1_inf_med.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v1_inf_med_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v1_inf_med_swap.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v2_inf_med.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_1g_v2_inf_med.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_downscatter.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_downscatter.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_downscatter_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_downscatter_swap.py
@@ -62,6 +62,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr_ramp_dt.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr_ramp_dt.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": gs0,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_openmc_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_openmc_xs.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
         num_groups=num_groups,
+        time_dependent=True,
         groupsets=[
             {
                 "groups_from_to": [0, num_groups - 1],


### PR DESCRIPTION
This PR updates steady-state <--> time-dependent mode transitions with the following changes:

1.  Adds user-facing solver transition calls to problem: `SetSteadyStateMode`, `SetTimeDependentMode`
2. Adds user-facing calls for clearing solution vectors (phi and psi). 
3. Adds a time-dependent parameter to the problem constructor.
4. Solvers now check that initialization is complete and the problem is in the required mode before executing (includes methods like `Execute` and `Advance`).

This PR makes the state transition between steady-state and time-dependent mode obvious with no hidden side effects. It allows a single problem instance to support mixing and chaining of any number of different solver types with clearly understood state transitions.

This PR changes problem API and will require minor changes to existing transient inputs.