### PR TITLE
Spill sweep matrix to shared memory and global memory

### DIFF
--- a/external/caribou/device.hpp
+++ b/external/caribou/device.hpp
@@ -51,4 +51,15 @@ inline std::uint32_t get_warp_size(std::uint32_t device_id = get_current_device(
         impl::get_device_attribute(device_id, ::CUDA_OR_HIP(DevAttrWarpSize, DeviceAttributeWarpSize)));
 }
 
+inline std::uint32_t get_max_shared_memory_per_block(std::uint32_t device_id = get_current_device()) {
+    return static_cast<std::uint32_t>(impl::get_device_attribute(
+        device_id, ::CUDA_OR_HIP(DevAttrMaxSharedMemoryPerBlock, DeviceAttributeMaxSharedMemoryPerBlock)));
+}
+
+#if defined(__NVCC__) || defined(__HIP_PLATFORM_NVIDIA__)
+inline constexpr std::uint32_t num_cores_per_sm = 128;    // lazy evaluation, assuming compiled for Ampere or later.
+#elif defined(__HIP_PLATFORM_AMD__)
+inline constexpr std::uint32_t num_cores_per_sm = 64;
+#endif
+
 }  // namespace caribou

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
@@ -18,7 +18,7 @@ AAHD_FLUDSCommonData::AAHD_FLUDSCommonData(
   const SPDS& spds,
   const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,
   const SpatialDiscretization& sdm)
-  : FLUDSCommonData(spds, grid_nodal_mappings)
+  : FLUDSCommonData(spds, grid_nodal_mappings), sdm_(sdm)
 {
   ComputeNodeIndexForNonDelayedLocalFaces(sdm);
   ComputeNodeIndexForDelayedLocalFaces(sdm);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
@@ -92,6 +92,8 @@ public:
 
   /// Get pointer to indexes on device.
   const std::uint64_t* GetDeviceIndex() const { return device_node_indexes_; }
+  /// Get reference to the spatial discretization.
+  const SpatialDiscretization& GetSDM() const { return sdm_; }
 
   /// Destructor.
   ~AAHD_FLUDSCommonData() override;
@@ -99,6 +101,8 @@ public:
 protected:
   /// Map face node to its associated index in the corresponding bank.
   std::map<AAHD_FaceNode, AAHD_NodeIndex> node_tracker_;
+
+  const SpatialDiscretization& sdm_;
 
   /// \name Allocation sizes
   /// \{

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aahd_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aahd_sweep_chunk.h
@@ -28,6 +28,7 @@ public:
 
 protected:
   DiscreteOrdinatesProblem& problem_;
+  std::size_t shared_mem_size_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/buffer.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/buffer.h
@@ -3,41 +3,156 @@
 
 #pragma once
 
+#include "modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h"
+#include "caribou/main.hpp"
 #include <array>
 #include <cstddef>
 
 namespace opensn::gpu_kernel
 {
 
+template <std::size_t ndofs>
+class MatBuffer;
+
 /// Solver buffer for the sweep.
 template <std::size_t ndofs>
-class Buffer
+  requires(ndofs <= max_dof_gpu_register)
+class MatBuffer<ndofs>
 {
 public:
-  /// Construct and zero-fill the buffer.
-  constexpr Buffer()
+  constexpr MatBuffer(double* un_used) { A_.fill(0.0); }
+
+  struct row_pointer
   {
-    A_.fill(0.0);
-    b_.fill(0.0);
-    s_.fill(0.0);
+  public:
+    constexpr row_pointer(double* data) : data_(data) {}
+    constexpr double& operator[](std::uint32_t idx) { return data_[idx]; }
+    constexpr const double& operator[](std::uint32_t idx) const { return data_[idx]; }
+    constexpr row_pointer operator+(std::uint32_t offset) const
+    {
+      return row_pointer(data_ + ndofs * offset);
+    }
+    constexpr row_pointer operator++()
+    {
+      data_ += ndofs;
+      return *this;
+    }
+    constexpr row_pointer operator++(int)
+    {
+      row_pointer temp = *this;
+      data_ += ndofs;
+      return temp;
+    }
+
+  private:
+    double* data_;
+  };
+  /// Get row pointer for the linear system matrix.
+  constexpr row_pointer row(std::uint32_t idx) { return row_pointer(A_.data() + idx * ndofs); }
+
+  struct element_pointer
+  {
+  public:
+    constexpr element_pointer(double* data) : data_(data) {}
+    constexpr double& operator*() { return *data_; }
+    constexpr const double& operator*() const { return *data_; }
+    constexpr element_pointer operator++()
+    {
+      ++data_;
+      return *this;
+    }
+    constexpr element_pointer operator++(int)
+    {
+      element_pointer temp = *this;
+      ++data_;
+      return temp;
+    }
+
+  private:
+    double* data_;
+  };
+  /// Get element pointer for the linear system matrix.
+  constexpr element_pointer element(std::uint32_t row_idx = 0, std::uint32_t col_idx = 0)
+  {
+    return element_pointer(A_.data() + row_idx * ndofs + col_idx);
   }
-
-  /// Get pointer to the linear system matrix.
-  constexpr double* A() { return A_.data(); }
-
-  /// Get poitner to the vector containing the angular flux.
-  constexpr double* b() { return b_.data(); }
-
-  /// Get pointer to the source vector.
-  constexpr double* s() { return s_.data(); }
 
 private:
   /// Linear system matrix.
   std::array<double, ndofs * ndofs> A_;
-  /// Vector containing the angular flux.
-  std::array<double, ndofs> b_;
-  /// Source.
-  std::array<double, ndofs> s_;
+};
+
+template <std::size_t ndofs>
+  requires(ndofs > max_dof_gpu_register)
+class MatBuffer<ndofs>
+{
+public:
+  __device__ MatBuffer(double* data) : A_(data)
+  {
+    _Pragma("unroll") for (std::uint32_t i = 0; i < ndofs * ndofs; ++i)
+    {
+      *data = 0.0;
+      data += warpSize;
+    }
+  }
+
+  struct row_pointer
+  {
+  public:
+    constexpr row_pointer(double* data) : data_(data) {}
+    constexpr double& operator[](std::uint32_t idx) { return data_[idx * warpSize]; }
+    constexpr const double& operator[](std::uint32_t idx) const { return data_[idx * warpSize]; }
+    constexpr row_pointer operator+(std::uint32_t offset) const
+    {
+      return row_pointer(data_ + ndofs * warpSize * offset);
+    }
+    constexpr row_pointer operator++()
+    {
+      data_ += ndofs * warpSize;
+      return *this;
+    }
+    constexpr row_pointer operator++(int)
+    {
+      row_pointer temp = *this;
+      data_ += ndofs * warpSize;
+      return temp;
+    }
+
+  private:
+    double* data_;
+  };
+  /// Get row pointer for the linear system matrix.
+  constexpr row_pointer row(std::uint32_t idx) { return row_pointer(A_ + idx * ndofs * warpSize); }
+
+  struct element_pointer
+  {
+  public:
+    constexpr element_pointer(double* data) : data_(data) {}
+    constexpr double& operator*() { return *data_; }
+    constexpr const double& operator*() const { return *data_; }
+    constexpr element_pointer operator++()
+    {
+      data_ += warpSize;
+      return *this;
+    }
+    constexpr element_pointer operator++(int)
+    {
+      element_pointer temp = *this;
+      data_ += warpSize;
+      return temp;
+    }
+
+  private:
+    double* data_;
+  };
+  /// Get element pointer for the linear system matrix.
+  constexpr element_pointer element(std::uint32_t row_idx = 0, std::uint32_t col_idx = 0)
+  {
+    return element_pointer(A_ + (row_idx * ndofs + col_idx) * warpSize);
+  }
+
+private:
+  double* A_ = nullptr;
 };
 
 } // namespace opensn::gpu_kernel

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/main.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/main.h
@@ -6,7 +6,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/arguments.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/buffer.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/solver.h"
-#include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h"
 
 namespace opensn::gpu_kernel
 {
@@ -29,6 +29,7 @@ using SweepFunc = std::add_pointer_t<void(const gpu_kernel::Arguments&,
                                           const unsigned int&,
                                           const unsigned int&,
                                           const std::uint32_t&,
+                                          double*,
                                           double*)>;
 template <std::size_t... IntSequence>
 __device__ constexpr std::array<SweepFunc, sizeof...(IntSequence)>
@@ -36,7 +37,7 @@ MakeSweepKernelSpecificationMap(std::index_sequence<IntSequence...>)
 {
   return std::array<SweepFunc, sizeof...(IntSequence)>{&gpu_kernel::Sweep<IntSequence>...};
 }
-__device__ std::array<SweepFunc, LBSProblem::max_dofs_gpu> sweep_spec_map =
-  MakeSweepKernelSpecificationMap(MakeIndexSequenceFromRange<1, LBSProblem::max_dofs_gpu + 1>{});
+__device__ std::array<SweepFunc, max_dof_gpu> sweep_spec_map =
+  MakeSweepKernelSpecificationMap(MakeIndexSequenceFromRange<1, max_dof_gpu + 1>{});
 
 } // namespace opensn::gpu_kernel

--- a/modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h"
 #include <format>
 
 namespace opensn
@@ -97,14 +98,14 @@ MeshCarrier::Assemble(LBSProblem& lbs_problem, TotalXSCarrier& xs, OutflowCarrie
     const CellMapping& cell_mapping = discretization.GetCellMapping(cell);
     std::size_t cell_num_nodes = cell_mapping.GetNumNodes();
     // check for cell num nodes compatibility with sweep kernel
-    if (cell_num_nodes > LBSProblem::max_dofs_gpu)
+    if (cell_num_nodes > max_dof_gpu)
     {
       throw std::runtime_error(
         std::format("GPU acceleration error: Cell local ID {} has {} DOFs which exceeds the "
                     "maximum supported DOFs per cell on GPU: {}.",
                     cell.local_id,
                     cell_num_nodes,
-                    LBSProblem::max_dofs_gpu));
+                    max_dof_gpu));
     }
     // record current pointer offset
     *(offset_cell_data++) = cell_data - data;

--- a/modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.cu
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h"
+#include "caribou/main.hpp"
+
+namespace crb = caribou;
+
+namespace opensn
+{
+
+std::uint32_t
+ComputeMaxDofSharedMem()
+{
+  std::uint32_t shared_mem_size = crb::get_max_shared_memory_per_block();
+  std::uint32_t max_dof = max_dof_gpu_register;
+  std::uint32_t required_shared_mem = crb::num_cores_per_sm * max_dof * max_dof * sizeof(double);
+  while (required_shared_mem <= shared_mem_size)
+  {
+    ++max_dof;
+    required_shared_mem = crb::num_cores_per_sm * max_dof * max_dof * sizeof(double);
+  }
+  return max_dof;
+}
+
+std::uint32_t max_dof_gpu_shared_mem = max_dof_gpu_register;
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <cstdint>
+
+namespace opensn
+{
+
+constexpr std::uint32_t max_dof_gpu_register = 4;
+
+extern std::uint32_t max_dof_gpu_shared_mem;
+
+std::uint32_t ComputeMaxDofSharedMem();
+
+constexpr std::uint32_t max_dof_gpu = 10;
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/device/dof_limits.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/memory_pinner.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/outflow_carrier.h"
@@ -30,6 +31,8 @@ LBSProblem::InitializeGPUExtras()
   MemoryPinner<double>* phi = new MemoryPinner<double>(phi_new_local_);
   pinners_[0] = src;
   pinners_[1] = phi;
+  // compute shared emmory DOF limits
+  max_dof_gpu_shared_mem = ComputeMaxDofSharedMem();
 }
 
 void

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -380,9 +380,6 @@ private:
   void ParseOptions(const InputParameters& input);
 
 public:
-  /// Max number of DOFs per cell that the sweep kernel on GPU can handle.
-  static constexpr std::uint32_t max_dofs_gpu = 10;
-
   /// Returns the input parameters for this object.
   static InputParameters GetInputParameters();
 


### PR DESCRIPTION
In this PR, the sweep matrix is manually spilled to either the shared memory or the global memory.

- For DOF <= 4, no performance gain/loose.
- For DOF = 8 (3D structured), performance is reduced by ~15% comapred to NVIDIA automatic register spill, measured for 64 groups, 32 angles, 64 iterations on a 25x25x25 mesh.

(more profiling results to come)
(not yet run on AMD GPU)