### PR TITLE
Add support for CEPXS cross sections

### DIFF
--- a/framework/materials/multi_group_xs/cepxs_import.cc
+++ b/framework/materials/multi_group_xs/cepxs_import.cc
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include "framework/runtime.h"
+#include "framework/logging/log.h"
+#include "framework/utils/utils.h"
+
+#include <fstream>
+#include <array>
+#include <algorithm>
+#include <cmath>
+
+namespace opensn
+{
+
+MultiGroupXS
+MultiGroupXS::LoadFromCEPXS(const std::string& filename)
+{
+  std::ifstream fin(filename);
+  OpenSnLogicalErrorIf(not fin.is_open(), "Unable to open CEPXS file \"" + filename + "\".");
+  log.Log() << "Reading CEPXS cross-section file \"" << filename << "\"\n";
+
+  MultiGroupXS mgxs;
+
+  int n_materials = 0;
+  std::array<int, 3> n_groups_particle{0, 0, 0}; // gamma, electron, positron
+  fin >> n_groups_particle[0] >> n_groups_particle[1] >> n_groups_particle[2] >> n_materials;
+  OpenSnLogicalErrorIf(not fin.good(),
+                       "Failed to parse CEPXS header in file \"" + filename + "\".");
+
+  OpenSnLogicalErrorIf(n_materials != 1,
+                       "CEPXS reader currently supports exactly one material per file.");
+  OpenSnLogicalErrorIf(std::any_of(n_groups_particle.begin(),
+                                   n_groups_particle.end(),
+                                   [](int n) { return n < 0; }),
+                       "CEPXS group counts must be non-negative.");
+
+  const int num_groups = n_groups_particle[0] + n_groups_particle[1] + n_groups_particle[2];
+  OpenSnLogicalErrorIf(num_groups <= 0, "CEPXS file has zero total groups.");
+  mgxs.num_groups_ = static_cast<unsigned int>(num_groups);
+
+  int L_max = 0;
+  fin >> L_max;
+  OpenSnLogicalErrorIf(not fin.good(), "Failed parsing CEPXS scattering order.");
+  OpenSnLogicalErrorIf(L_max < 0, "CEPXS scattering order must be non-negative.");
+  mgxs.scattering_order_ = static_cast<unsigned int>(L_max);
+
+  mgxs.is_fissionable_ = false;
+  mgxs.num_precursors_ = 0;
+
+  // CEPXS does not provide native group boundaries in this form. We maintain a monotonic
+  // descending pseudo-boundary set for introspection consistency.
+  mgxs.e_bounds_.resize(mgxs.num_groups_ + 1, 0.0);
+  for (unsigned int b = 0; b <= mgxs.num_groups_; ++b)
+    mgxs.e_bounds_[b] = static_cast<double>(mgxs.num_groups_ - b);
+
+  mgxs.sigma_t_.assign(mgxs.num_groups_, 0.0);
+  mgxs.energy_deposition_.assign(mgxs.num_groups_, 0.0);
+  mgxs.transfer_matrices_.assign(mgxs.scattering_order_ + 1,
+                                 SparseMatrix(mgxs.num_groups_, mgxs.num_groups_));
+
+  auto read_particle_block = [&](std::vector<double>& destination)
+  {
+    unsigned int offset = 0;
+    for (const int n_groups_for_particle : n_groups_particle)
+    {
+      for (int g = 0; g < n_groups_for_particle; ++g)
+      {
+        fin >> destination.at(offset + static_cast<unsigned int>(g));
+        OpenSnLogicalErrorIf(not fin.good(),
+                             "Unexpected end-of-file reading CEPXS block in \"" + filename + "\".");
+      }
+      offset += static_cast<unsigned int>(n_groups_for_particle);
+    }
+  };
+
+  read_particle_block(mgxs.sigma_t_);
+  read_particle_block(mgxs.energy_deposition_);
+
+  const auto is_finite_vec = [](const std::vector<double>& vec)
+  {
+    return std::all_of(vec.begin(), vec.end(), [](const double v) { return std::isfinite(v); });
+  };
+
+  OpenSnLogicalErrorIf(not IsNonNegative(mgxs.sigma_t_),
+                       "CEPXS total cross section contains negative values.");
+  OpenSnLogicalErrorIf(not is_finite_vec(mgxs.sigma_t_),
+                       "CEPXS total cross section contains non-finite values.");
+  OpenSnLogicalErrorIf(not is_finite_vec(mgxs.energy_deposition_),
+                       "CEPXS energy deposition contains non-finite values.");
+
+  for (unsigned int ell = 0; ell <= mgxs.scattering_order_; ++ell)
+  {
+    auto& Sm = mgxs.transfer_matrices_[ell];
+    for (unsigned int g = 0; g < mgxs.num_groups_; ++g)
+      for (unsigned int gp = 0; gp < mgxs.num_groups_; ++gp)
+      {
+        double val = 0.0;
+        fin >> val;
+        OpenSnLogicalErrorIf(not fin.good(),
+                             "Unexpected end-of-file reading CEPXS transfer matrices in \"" +
+                               filename + "\".");
+        OpenSnLogicalErrorIf(not std::isfinite(val),
+                             "CEPXS transfer matrix contains non-finite values.");
+        if (val != 0.0)
+          Sm.Insert(g, gp, val);
+      }
+  }
+
+  mgxs.ComputeAbsorption();
+  mgxs.ComputeDiffusionParameters();
+
+  return mgxs;
+}
+
+} // namespace opensn

--- a/framework/materials/multi_group_xs/cepxs_import.cc
+++ b/framework/materials/multi_group_xs/cepxs_import.cc
@@ -1,6 +1,24 @@
 // SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 
+/*
+ * CEPXS uses the BXSLIB binary cross-section file format. A description of the
+ * BXSLIB format can be found in:
+ *
+ *   Shapiro, A., and Huria, H.
+ *   "Standard Interface File Format"
+ *   University of Cincinnati Nuclear Engineering Program, 1992
+ *   https://www.osti.gov/servlets/purl/10115350
+ *
+ * CEPXS format blocks for various materials can be found in:
+ *
+ *   McConn, R. J., Gesh, C. J., Pagh, R. T., et al.
+ *   "Compendium of Material Composition Data for Radiation Transport Modeling"
+ *   Pacific Northwest National Laboratory, PNNL-15870 Rev. 1, 2006
+ *   https://www.pnnl.gov/main/publications/external/technical_reports/
+ *   pnnl-15870rev1.pdf
+ */
+
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
@@ -10,107 +28,341 @@
 #include <array>
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 namespace opensn
 {
-
-MultiGroupXS
-MultiGroupXS::LoadFromCEPXS(const std::string& filename)
+namespace
 {
-  std::ifstream fin(filename);
-  OpenSnLogicalErrorIf(not fin.is_open(), "Unable to open CEPXS file \"" + filename + "\".");
-  log.Log() << "Reading CEPXS cross-section file \"" << filename << "\"\n";
 
-  MultiGroupXS mgxs;
+class FortranRecordReader
+{
+public:
+  explicit FortranRecordReader(const std::string& filename) : in_(filename, std::ios::binary) {}
 
-  int n_materials = 0;
-  std::array<int, 3> n_groups_particle{0, 0, 0}; // gamma, electron, positron
-  fin >> n_groups_particle[0] >> n_groups_particle[1] >> n_groups_particle[2] >> n_materials;
-  OpenSnLogicalErrorIf(not fin.good(),
-                       "Failed to parse CEPXS header in file \"" + filename + "\".");
+  bool IsOpen() const { return in_.is_open(); }
 
-  OpenSnLogicalErrorIf(n_materials != 1,
-                       "CEPXS reader currently supports exactly one material per file.");
-  OpenSnLogicalErrorIf(std::any_of(n_groups_particle.begin(),
-                                   n_groups_particle.end(),
-                                   [](int n) { return n < 0; }),
-                       "CEPXS group counts must be non-negative.");
-
-  const int num_groups = n_groups_particle[0] + n_groups_particle[1] + n_groups_particle[2];
-  OpenSnLogicalErrorIf(num_groups <= 0, "CEPXS file has zero total groups.");
-  mgxs.num_groups_ = static_cast<unsigned int>(num_groups);
-
-  int L_max = 0;
-  fin >> L_max;
-  OpenSnLogicalErrorIf(not fin.good(), "Failed parsing CEPXS scattering order.");
-  OpenSnLogicalErrorIf(L_max < 0, "CEPXS scattering order must be non-negative.");
-  mgxs.scattering_order_ = static_cast<unsigned int>(L_max);
-
-  mgxs.is_fissionable_ = false;
-  mgxs.num_precursors_ = 0;
-
-  // CEPXS does not provide native group boundaries in this form. We maintain a monotonic
-  // descending pseudo-boundary set for introspection consistency.
-  mgxs.e_bounds_.resize(mgxs.num_groups_ + 1, 0.0);
-  for (unsigned int b = 0; b <= mgxs.num_groups_; ++b)
-    mgxs.e_bounds_[b] = static_cast<double>(mgxs.num_groups_ - b);
-
-  mgxs.sigma_t_.assign(mgxs.num_groups_, 0.0);
-  mgxs.energy_deposition_.assign(mgxs.num_groups_, 0.0);
-  mgxs.transfer_matrices_.assign(mgxs.scattering_order_ + 1,
-                                 SparseMatrix(mgxs.num_groups_, mgxs.num_groups_));
-
-  auto read_particle_block = [&](std::vector<double>& destination)
+  bool ReadRecord(std::vector<char>& payload)
   {
-    unsigned int offset = 0;
-    for (const int n_groups_for_particle : n_groups_particle)
+    std::uint32_t len = 0;
+    if (not ReadU32(in_, len))
+      return false;
+
+    payload.resize(len);
+    if (len > 0 and not in_.read(payload.data(), static_cast<std::streamsize>(len)))
+      throw std::runtime_error("Failed reading Fortran record payload.");
+
+    std::uint32_t tail = 0;
+    if (not ReadU32(in_, tail))
+      throw std::runtime_error("Failed reading Fortran record trailer.");
+    if (tail != len)
+      throw std::runtime_error("Fortran record marker mismatch.");
+
+    return true;
+  }
+
+private:
+  static bool ReadU32(std::istream& in, std::uint32_t& value)
+  {
+    std::array<char, sizeof(std::uint32_t)> bytes{};
+    if (not in.read(bytes.data(), static_cast<std::streamsize>(bytes.size())))
+      return false;
+    std::memcpy(&value, bytes.data(), sizeof(value));
+    return true;
+  }
+
+  std::ifstream in_;
+};
+
+struct ParsedCEPXSData
+{
+  unsigned int num_groups = 0;
+  unsigned int scattering_order = 0;
+  bool is_fissionable = false;
+  unsigned int num_precursors = 0;
+
+  std::vector<double> e_bounds;
+  std::vector<double> sigma_t;
+  std::vector<double> charge_deposition;
+  std::vector<double> secondary_production;
+  std::vector<double> energy_deposition;
+  std::vector<SparseMatrix> transfer_matrices;
+};
+
+std::vector<std::int32_t>
+BytesToInt32(const std::vector<char>& bytes)
+{
+  OpenSnLogicalErrorIf(bytes.size() % sizeof(std::int32_t) != 0,
+                       "Invalid record size for int32 conversion.");
+  std::vector<std::int32_t> vals(bytes.size() / sizeof(std::int32_t), 0);
+  std::memcpy(vals.data(), bytes.data(), bytes.size());
+  return vals;
+}
+
+std::vector<double>
+BytesToDouble(const std::vector<char>& bytes)
+{
+  OpenSnLogicalErrorIf(bytes.size() % sizeof(double) != 0,
+                       "Invalid record size for double conversion.");
+  std::vector<double> vals(bytes.size() / sizeof(double), 0.0);
+  std::memcpy(vals.data(), bytes.data(), bytes.size());
+  return vals;
+}
+
+std::vector<double>
+ExtractEnergyBoundsFromAncillary(const std::vector<char>& ancillary, const int n_groups)
+{
+  OpenSnLogicalErrorIf(n_groups <= 0, "Invalid group count for CEPXS ancillary parsing.");
+  OpenSnLogicalErrorIf(ancillary.size() % sizeof(double) != 0,
+                       "CEPXS ancillary record is not an integer multiple of 8 bytes.");
+
+  const auto vals = BytesToDouble(ancillary);
+  const auto n_bounds = static_cast<size_t>(n_groups) + 1U;
+  OpenSnLogicalErrorIf(vals.size() < n_bounds,
+                       "CEPXS ancillary record is too short to contain group boundaries.");
+
+  const auto is_valid_bounds = [&](const size_t start_idx)
+  {
+    const double e0 = vals[start_idx];
+    const double eN = vals[start_idx + n_bounds - 1];
+    if (not std::isfinite(e0) or not std::isfinite(eN) or e0 <= 0.0 or eN <= 0.0 or e0 <= eN)
+      return false;
+
+    for (size_t i = 1; i < n_bounds; ++i)
     {
-      for (int g = 0; g < n_groups_for_particle; ++g)
-      {
-        fin >> destination.at(offset + static_cast<unsigned int>(g));
-        OpenSnLogicalErrorIf(not fin.good(),
-                             "Unexpected end-of-file reading CEPXS block in \"" + filename + "\".");
-      }
-      offset += static_cast<unsigned int>(n_groups_for_particle);
+      const double e_prev = vals[start_idx + i - 1];
+      const double e_curr = vals[start_idx + i];
+      if (not std::isfinite(e_curr) or e_curr <= 0.0 or e_prev <= e_curr)
+        return false;
     }
+    return true;
   };
 
-  read_particle_block(mgxs.sigma_t_);
-  read_particle_block(mgxs.energy_deposition_);
-
-  const auto is_finite_vec = [](const std::vector<double>& vec)
+  const auto is_finite_positive_window = [&](const size_t start_idx)
   {
-    return std::all_of(vec.begin(), vec.end(), [](const double v) { return std::isfinite(v); });
+    bool any_change = false;
+    for (size_t i = 0; i < n_bounds; ++i)
+    {
+      const double e = vals[start_idx + i];
+      if (not std::isfinite(e) or e <= 0.0)
+        return false;
+      if (i > 0 and vals[start_idx + i - 1] != e)
+        any_change = true;
+    }
+    return any_change;
   };
 
-  OpenSnLogicalErrorIf(not IsNonNegative(mgxs.sigma_t_),
-                       "CEPXS total cross section contains negative values.");
-  OpenSnLogicalErrorIf(not is_finite_vec(mgxs.sigma_t_),
-                       "CEPXS total cross section contains non-finite values.");
-  OpenSnLogicalErrorIf(not is_finite_vec(mgxs.energy_deposition_),
-                       "CEPXS energy deposition contains non-finite values.");
+  // CEPXS BFP ancillary records commonly place group boundaries near index 96.
+  const size_t canonical_start = 96;
+  if (canonical_start + n_bounds <= vals.size() and is_valid_bounds(canonical_start))
+    return {vals.begin() + static_cast<std::ptrdiff_t>(canonical_start),
+            vals.begin() + static_cast<std::ptrdiff_t>(canonical_start + n_bounds)};
 
-  for (unsigned int ell = 0; ell <= mgxs.scattering_order_; ++ell)
+  // Fallback: search the entire ancillary vector for a strictly decreasing positive window.
+  for (size_t start = 0; start + n_bounds <= vals.size(); ++start)
+    if (is_valid_bounds(start))
+      return {vals.begin() + static_cast<std::ptrdiff_t>(start),
+              vals.begin() + static_cast<std::ptrdiff_t>(start + n_bounds)};
+
+  // Coupled electron-photon libraries can carry group windows. Use a looser window
+  // search before giving up.
+  if (canonical_start + n_bounds <= vals.size() and is_finite_positive_window(canonical_start))
+    return {vals.begin() + static_cast<std::ptrdiff_t>(canonical_start),
+            vals.begin() + static_cast<std::ptrdiff_t>(canonical_start + n_bounds)};
+
+  for (size_t start = 0; start + n_bounds <= vals.size(); ++start)
+    if (is_finite_positive_window(start))
+      return {vals.begin() + static_cast<std::ptrdiff_t>(start),
+              vals.begin() + static_cast<std::ptrdiff_t>(start + n_bounds)};
+
+  // Last resort
+  std::vector<double> synthetic(n_bounds, 0.0);
+  for (size_t i = 0; i < n_bounds; ++i)
+    synthetic[i] = static_cast<double>(n_groups - static_cast<int>(i));
+  log.Log()
+    << "Warning: CEPXS ancillary group-boundary window not found; using synthetic bounds.\n";
+  return synthetic;
+}
+
+bool
+LooksLikeFortranBinary(const std::string& filename)
+{
+  std::ifstream in(filename, std::ios::binary);
+  if (not in.is_open())
+    return false;
+
+  std::uint32_t marker = 0;
   {
-    auto& Sm = mgxs.transfer_matrices_[ell];
-    for (unsigned int g = 0; g < mgxs.num_groups_; ++g)
-      for (unsigned int gp = 0; gp < mgxs.num_groups_; ++gp)
+    std::array<char, sizeof(std::uint32_t)> bytes{};
+    if (not in.read(bytes.data(), static_cast<std::streamsize>(bytes.size())))
+      return false;
+    std::memcpy(&marker, bytes.data(), sizeof(marker));
+  }
+
+  return marker > 0 and marker < (1U << 20);
+}
+
+ParsedCEPXSData
+ParseCEPXSBFPBinary(const std::string& filename, int material_id)
+{
+  FortranRecordReader rdr(filename);
+  OpenSnLogicalErrorIf(not rdr.IsOpen(), "Unable to open CEPXS binary file \"" + filename + "\".");
+  log.Log() << "Reading CEPXS-BFP binary cross-section file \"" << filename << "\"\n";
+
+  ParsedCEPXSData xs;
+
+  std::vector<char> rec;
+  OpenSnLogicalErrorIf(not rdr.ReadRecord(rec), "Failed reading CEPXS binary title record.");
+
+  OpenSnLogicalErrorIf(not rdr.ReadRecord(rec), "Failed reading CEPXS binary metadata record.");
+  const auto meta = BytesToInt32(rec);
+  OpenSnLogicalErrorIf(meta.size() < 8, "CEPXS binary metadata record is too short.");
+
+  const int n_groups = meta[0];
+  const int n_materials = meta[1];
+  const int n_entries = meta[2];
+  const int total_xs_row = meta[3] - 1;     // Convert to 0-based indexing.
+  const int self_scatter_row = meta[4] - 1; // Convert to 0-based indexing.
+  const int n_moments = meta[5];
+  const int n_tables_from_header = meta[7];
+
+  OpenSnLogicalErrorIf(n_materials <= 0, "CEPXS binary has invalid number of materials.");
+  OpenSnLogicalErrorIf(n_groups <= 0, "CEPXS binary has invalid number of groups.");
+  OpenSnLogicalErrorIf(n_entries <= 8, "CEPXS binary has invalid number of entries.");
+  OpenSnLogicalErrorIf(total_xs_row < 0 || total_xs_row >= n_entries,
+                       "CEPXS binary has invalid total-xs row index.");
+  OpenSnLogicalErrorIf(self_scatter_row < 0 || self_scatter_row >= n_entries,
+                       "CEPXS binary has invalid self-scatter row index.");
+  OpenSnLogicalErrorIf(n_moments <= 0, "CEPXS binary has invalid number of moments.");
+  OpenSnLogicalErrorIf(material_id < 0 || material_id >= n_materials,
+                       "CEPXS binary material_id out of range.");
+
+  OpenSnLogicalErrorIf(not rdr.ReadRecord(rec), "Failed reading CEPXS binary ancillary record.");
+
+  xs.num_groups = static_cast<unsigned int>(n_groups);
+  xs.e_bounds = ExtractEnergyBoundsFromAncillary(rec, n_groups);
+
+  xs.sigma_t.assign(xs.num_groups, 0.0);
+  xs.charge_deposition.assign(xs.num_groups, 0.0);
+  xs.secondary_production.assign(xs.num_groups, 0.0);
+  xs.energy_deposition.assign(xs.num_groups, 0.0);
+
+  std::vector<std::vector<double>> moment_tables;
+  while (rdr.ReadRecord(rec))
+  {
+    const auto expected_record_size =
+      static_cast<size_t>(n_groups) * static_cast<size_t>(n_entries) * sizeof(double);
+    OpenSnLogicalErrorIf(rec.size() != expected_record_size,
+                         "Unexpected CEPXS binary moment-record size.");
+    moment_tables.push_back(BytesToDouble(rec));
+  }
+
+  OpenSnLogicalErrorIf(moment_tables.empty(), "CEPXS binary contains no moment records.");
+  if (n_tables_from_header > 0)
+    OpenSnLogicalErrorIf(moment_tables.size() != static_cast<size_t>(n_tables_from_header),
+                         "CEPXS binary table count mismatch with header.");
+
+  OpenSnLogicalErrorIf(static_cast<int>(moment_tables.size()) != n_materials * n_moments,
+                       "CEPXS binary table count does not match materials*moments.");
+
+  xs.scattering_order = static_cast<unsigned int>(n_moments - 1);
+  xs.transfer_matrices.assign(xs.scattering_order + 1, SparseMatrix(xs.num_groups, xs.num_groups));
+  constexpr int charge_deposition_row = 0;    // 1-based row 1
+  constexpr int secondary_production_row = 1; // 1-based row 2
+  constexpr int energy_deposition_row = 2;    // 1-based row 3
+  const int first_transfer_row = std::min(self_scatter_row, total_xs_row + 1);
+
+  for (int mom = 0; mom < n_moments; ++mom)
+  {
+    const int table_idx = material_id * n_moments + mom;
+    OpenSnLogicalErrorIf(table_idx < 0 || static_cast<size_t>(table_idx) >= moment_tables.size(),
+                         "Computed CEPXS binary table index out of range.");
+
+    const auto& table = moment_tables[table_idx];
+    auto& Sm = xs.transfer_matrices[static_cast<size_t>(mom)];
+
+    for (int g_to = 0; g_to < n_groups; ++g_to)
+      for (int row = 0; row < n_entries; ++row)
       {
-        double val = 0.0;
-        fin >> val;
-        OpenSnLogicalErrorIf(not fin.good(),
-                             "Unexpected end-of-file reading CEPXS transfer matrices in \"" +
-                               filename + "\".");
-        OpenSnLogicalErrorIf(not std::isfinite(val),
-                             "CEPXS transfer matrix contains non-finite values.");
-        if (val != 0.0)
-          Sm.Insert(g, gp, val);
+        const auto table_index =
+          static_cast<size_t>(row) + static_cast<size_t>(n_entries) * static_cast<size_t>(g_to);
+        const double value = table[table_index];
+
+        if (mom == 0)
+        {
+          if (row == charge_deposition_row)
+            xs.charge_deposition[g_to] = value;
+          else if (row == secondary_production_row)
+            xs.secondary_production[g_to] = value;
+          else if (row == energy_deposition_row)
+            xs.energy_deposition[g_to] = value;
+          else if (row == total_xs_row)
+            xs.sigma_t[g_to] = value;
+        }
+
+        if (row < first_transfer_row || value == 0.0)
+          continue;
+
+        int g_from = -1;
+        if (row < self_scatter_row)
+          g_from = self_scatter_row - row + g_to;
+        else if (row == self_scatter_row)
+          g_from = g_to;
+        else
+          g_from = g_to - (row - self_scatter_row);
+
+        if (g_from < 0 or g_from >= n_groups)
+          continue;
+
+        Sm.Insert(g_to, g_from, value);
       }
   }
 
+  const auto is_finite_vec = [](const std::vector<double>& vec)
+  { return std::all_of(vec.begin(), vec.end(), [](const double v) { return std::isfinite(v); }); };
+
+  OpenSnLogicalErrorIf(not IsNonNegative(xs.sigma_t),
+                       "CEPXS binary total cross section contains negative values.");
+  OpenSnLogicalErrorIf(not is_finite_vec(xs.sigma_t),
+                       "CEPXS binary total cross section contains non-finite values.");
+  OpenSnLogicalErrorIf(not is_finite_vec(xs.energy_deposition),
+                       "CEPXS binary energy deposition contains non-finite values.");
+
+  return xs;
+}
+
+} // namespace
+
+MultiGroupXS
+MultiGroupXS::LoadFromCEPXS(const std::string& filename, int material_id)
+{
+  MultiGroupXS mgxs;
+  OpenSnLogicalErrorIf(not LooksLikeFortranBinary(filename),
+                       "LoadFromCEPXS supports Fortran-record binary CEPXS only. File: \"" +
+                         filename + "\".");
+  const auto parsed = ParseCEPXSBFPBinary(filename, material_id);
+
+  mgxs.num_groups_ = parsed.num_groups;
+  mgxs.scattering_order_ = parsed.scattering_order;
+  mgxs.is_fissionable_ = parsed.is_fissionable;
+  mgxs.num_precursors_ = parsed.num_precursors;
+
+  mgxs.e_bounds_ = parsed.e_bounds;
+  mgxs.sigma_t_ = parsed.sigma_t;
+  // Derive absorption from total and transfer matrices
+  mgxs.sigma_a_.clear();
+  mgxs.energy_deposition_ = parsed.energy_deposition;
+  mgxs.transfer_matrices_ = parsed.transfer_matrices;
+  if (not parsed.charge_deposition.empty())
+    mgxs.custom_xs_["cepxs_charge_deposition"] = parsed.charge_deposition;
+  if (not parsed.secondary_production.empty())
+    mgxs.custom_xs_["cepxs_secondary_production"] = parsed.secondary_production;
+
   mgxs.ComputeAbsorption();
   mgxs.ComputeDiffusionParameters();
-
   return mgxs;
 }
 

--- a/framework/materials/multi_group_xs/multi_group_xs.cc
+++ b/framework/materials/multi_group_xs/multi_group_xs.cc
@@ -91,6 +91,8 @@ MultiGroupXS::Combine(
   mgxs.sigma_t_.assign(n_grps, 0.0);
   mgxs.sigma_a_.assign(n_grps, 0.0);
   std::map<std::string, std::vector<double>> combined_custom_xs;
+  mgxs.energy_deposition_.assign(n_grps, 0.0);
+  bool has_energy_deposition = false;
 
   // Init transfer matrices only if at least one exists
   if (std::any_of(xsecs.begin(),
@@ -150,6 +152,11 @@ MultiGroupXS::Combine(
         if (combined_xs.empty())
           combined_xs.assign(n_grps, 0.0);
         combined_xs[g] += density * xs->GetCustomXS(xs_name)[g];
+      }
+      if (not xsecs[x]->GetEnergyDeposition().empty())
+      {
+        has_energy_deposition = true;
+        mgxs.energy_deposition_[g] += density * xsecs[x]->GetEnergyDeposition()[g];
       }
 
       if (xs->IsFissionable())
@@ -225,6 +232,8 @@ MultiGroupXS::Combine(
   } // for cross sections
 
   mgxs.custom_xs_ = std::move(combined_custom_xs);
+  if (not has_energy_deposition)
+    mgxs.energy_deposition_.clear();
   mgxs.ComputeDiffusionParameters();
 
   return mgxs;
@@ -242,6 +251,7 @@ MultiGroupXS::Reset()
 
   sigma_t_.clear();
   sigma_a_.clear();
+  energy_deposition_.clear();
   transfer_matrices_.clear();
   transposed_transfer_matrices_.clear();
 
@@ -431,6 +441,8 @@ MultiGroupXS::Scale(const double factor)
   {
     sigma_t_[g] *= scaling_factor_;
     sigma_a_[g] *= scaling_factor_;
+    if (not energy_deposition_.empty())
+      energy_deposition_[g] *= scaling_factor_;
 
     if (is_fissionable_)
     {

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -72,6 +72,8 @@ public:
 
   const std::vector<double>& GetSigmaAbsorption() const { return sigma_a_; }
 
+  const std::vector<double>& GetEnergyDeposition() const { return energy_deposition_; }
+
   const std::vector<SparseMatrix>& GetTransferMatrices() const
   {
     return adjoint_ ? transposed_transfer_matrices_ : transfer_matrices_;
@@ -142,6 +144,8 @@ private:
   std::vector<double> sigma_t_;
   /// Absorption cross section
   std::vector<double> sigma_a_;
+  /// Energy deposition cross section
+  std::vector<double> energy_deposition_;
   /// Fission cross section
   std::vector<double> sigma_f_;
   /// Neutron production due to fission
@@ -203,6 +207,7 @@ public:
   /// Makes a simple material with a 1-group cross-section set.
   static MultiGroupXS CreateSimpleOneGroup(double sigma_t, double c, double velocity = 0.0);
   static MultiGroupXS LoadFromOpenSn(const std::string& filename);
+  static MultiGroupXS LoadFromCEPXS(const std::string& filename);
   /// This method populates transport cross sections from an OpenMC cross-section file.
   static MultiGroupXS LoadFromOpenMC(const std::string& file_name,
                                      const std::string& dataset_name,

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -207,7 +207,7 @@ public:
   /// Makes a simple material with a 1-group cross-section set.
   static MultiGroupXS CreateSimpleOneGroup(double sigma_t, double c, double velocity = 0.0);
   static MultiGroupXS LoadFromOpenSn(const std::string& filename);
-  static MultiGroupXS LoadFromCEPXS(const std::string& filename);
+  static MultiGroupXS LoadFromCEPXS(const std::string& filename, int material_id = 0);
   /// This method populates transport cross sections from an OpenMC cross-section file.
   static MultiGroupXS LoadFromOpenMC(const std::string& file_name,
                                      const std::string& dataset_name,

--- a/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
+++ b/framework/math/spatial_discretization/cell_mappings/finite_element/piecewise_linear/piecewise_linear_slab_mapping.cc
@@ -243,8 +243,8 @@ PieceWiseLinearSlabMapping::MakeSurfaceFiniteElementData(size_t face_index) cons
   for (size_t qp = 0; qp < num_srf_qpoints; ++qp)
   {
     F_JxW.push_back(JxW);
-
-    F_qpoints_xyz.emplace_back(0.0, 0.0, f);
+    const auto face_xyz = (f == 0) ? grid_->vertices[v0i_] : grid_->vertices[v1i_];
+    F_qpoints_xyz.push_back(face_xyz);
   }
 
   F_num_nodes = 1;

--- a/modules/linear_boltzmann_solvers/lbs_problem/fieldfunc/lbs_fieldfunc.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/fieldfunc/lbs_fieldfunc.cc
@@ -185,6 +185,8 @@ LBSProblem::GetFieldFunctionCoefficients(const MultiGroupXS& xs, const std::stri
     return xs.GetSigmaFission().empty() ? nullptr : &xs.GetSigmaFission();
   if (xs_name == "nu_sigma_f")
     return xs.GetNuSigmaF().empty() ? nullptr : &xs.GetNuSigmaF();
+  if (xs_name == "energy_deposition")
+    return xs.GetEnergyDeposition().empty() ? nullptr : &xs.GetEnergyDeposition();
   if (xs_name == "chi")
     return xs.GetChi().empty() ? nullptr : &xs.GetChi();
   if (xs_name == "inv_velocity")

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -188,6 +188,15 @@ WrapMultiGroupXS(py::module& xs)
     py::arg("extra_xs_names") = std::vector<std::string>()
   );
   multigroup_xs.def(
+    "LoadFromCEPXS",
+    [](MultiGroupXS& self, const std::string& file_name)
+    {
+      self = MultiGroupXS::LoadFromCEPXS(file_name);
+    },
+    "Load multi-group cross sections from a CEPXS cross-section file.",
+    py::arg("file_name")
+  );
+  multigroup_xs.def(
     "Scale",
     &MultiGroupXS::Scale,
     R"(
@@ -235,6 +244,12 @@ WrapMultiGroupXS(py::module& xs)
     "sigma_a",
     XS_GETTER(GetSigmaAbsorption),
     "Get absorption cross section.",
+    py::keep_alive<0, 1>()
+  );
+  multigroup_xs.def_property_readonly(
+    "energy_deposition",
+    XS_GETTER(GetEnergyDeposition),
+    "Get energy deposition cross section.",
     py::keep_alive<0, 1>()
   );
   multigroup_xs.def_property_readonly(

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -189,12 +189,13 @@ WrapMultiGroupXS(py::module& xs)
   );
   multigroup_xs.def(
     "LoadFromCEPXS",
-    [](MultiGroupXS& self, const std::string& file_name)
+    [](MultiGroupXS& self, const std::string& file_name, int material_id)
     {
-      self = MultiGroupXS::LoadFromCEPXS(file_name);
+      self = MultiGroupXS::LoadFromCEPXS(file_name, material_id);
     },
     "Load multi-group cross sections from a CEPXS cross-section file.",
-    py::arg("file_name")
+    py::arg("file_name"),
+    py::arg("material_id") = 0
   );
   multigroup_xs.def(
     "Scale",


### PR DESCRIPTION
This PR adds support for CEPXS cross sections in `bxslib` format. This gives us the ability to do coupled electron-photon transport. Note that this PR also includes a new field function for reporting energy deposition. This is just a reaction rate field function and can be removed when the post-processing code is merged.  I've added two regression tests from SAND-89-2211 (https://www.osti.gov/servlets/purl/6758232):

**1. II.3.C2 - 1.0 MeV electrons normally incident on an Al slab (no coupling):**
<img width="648" height="432" alt="image" src="https://github.com/user-attachments/assets/bc819524-9959-4587-9143-e777d8f806f1" />


**2. II.3.D - 1.0 MeV electrons normally incident on a Cu slab (full coupling):** 
<img width="648" height="648" alt="image" src="https://github.com/user-attachments/assets/e0ec68ed-3dc8-465f-9342-b81743ea4424" />
