### PR TITLE
Refactor LBSProblem for const-correct API, reduced visibility, and unified error reporting

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.cc
@@ -48,14 +48,14 @@ DiscreteOrdinatesKEigenAcceleration::DiscreteOrdinatesKEigenAcceleration(
     pi_max_its_(params.GetParamValue<int>("pi_max_its")),
     pi_k_tol_(params.GetParamValue<double>("pi_k_tol")),
     groupsets_(do_problem_.GetGroupsets()),
-    front_gs_(groupsets_.front()),
+    front_gs_(do_problem_.GetGroupset(0)),
     q_moments_local_(do_problem_.GetQMomentsLocal()),
     phi_old_local_(do_problem_.GetPhiOldLocal()),
     phi_new_local_(do_problem_.GetPhiNewLocal()),
     solver_(nullptr),
     name_(params.GetParamValue<std::string>("name"))
 {
-  if (do_problem_.GetGroupsets().size() != 1)
+  if (do_problem_.GetNumGroupsets() != 1)
     throw std::logic_error(
       "LBS acceleration schemes are only implemented for problems with a single groupset.");
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h
@@ -104,7 +104,7 @@ protected:
   const double pi_k_tol_;
 
   /// Groupsets from the LBSProblem
-  std::vector<LBSGroupset>& groupsets_;
+  const std::vector<LBSGroupset>& groupsets_;
   /// Front groupset from the LBSProblem
   LBSGroupset& front_gs_;
   /// Source moments vector from the LBSProblem

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
@@ -44,7 +44,7 @@ SCDSAAcceleration::SCDSAAcceleration(const InputParameters& params)
 void
 SCDSAAcceleration::Initialize()
 {
-  front_wgs_solver_ = do_problem_.GetWGSSolvers().at(front_gs_.id);
+  front_wgs_solver_ = do_problem_.GetWGSSolver(front_gs_.id);
   front_wgs_context_ = std::dynamic_pointer_cast<WGSContext>(front_wgs_solver_->GetContext());
   OpenSnLogicalErrorIf(not front_wgs_context_, ": Casting failed");
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_compute.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_compute.cc
@@ -24,7 +24,7 @@ ComputeBalance(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
   const auto& grid_ = do_problem.GetGrid();
   const auto& discretization_ = do_problem.GetSpatialDiscretization();
   auto& phi_new_local_ = do_problem.GetPhiNewLocal();
-  auto& groupsets_ = do_problem.GetGroupsets();
+  const auto& groupsets_ = do_problem.GetGroupsets();
   auto& q_moments_local_ = do_problem.GetQMomentsLocal();
   auto active_set_source_fn = do_problem.GetActiveSetSourceFunction();
   const auto& cell_transport_views_ = do_problem.GetCellTransportViews();
@@ -40,7 +40,7 @@ ComputeBalance(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
   // This is done using the SetSource routine because it allows a lot of flexibility.
   auto mat_src = phi_new_local_;
   mat_src.assign(mat_src.size(), 0.0);
-  for (auto& groupset : groupsets_)
+  for (const auto& groupset : groupsets_)
   {
     q_moments_local_.assign(q_moments_local_.size(), 0.0);
     active_set_source_fn(groupset,
@@ -299,11 +299,11 @@ ComputeLeakage(DiscreteOrdinatesProblem& do_problem,
 {
   CALI_CXX_MARK_SCOPE("ComputeLeakage");
 
-  OpenSnInvalidArgumentIf(groupset_id >= do_problem.GetGroupsets().size(), "Invalid groupset id.");
+  OpenSnInvalidArgumentIf(groupset_id >= do_problem.GetNumGroupsets(), "Invalid groupset id.");
 
   const auto& grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
-  const auto& groupset = do_problem.GetGroupsets().at(groupset_id);
+  const auto& groupset = do_problem.GetGroupset(groupset_id);
   const auto& cell_transport_views = do_problem.GetCellTransportViews();
   const auto& unit_cell_matrices = do_problem.GetUnitCellMatrices();
   const auto& sweep_boundaries = do_problem.GetSweepBoundaries();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -670,8 +670,9 @@ DiscreteOrdinatesProblem::ResetMode(SweepChunkMode target_mode)
   }
 
   if (switching_to_transient)
-    for (auto& wgs_solver : GetWGSSolvers())
+    for (size_t gsid = 0; gsid < GetNumWGSSolvers(); ++gsid)
     {
+      auto wgs_solver = GetWGSSolver(gsid);
       auto wgs_context = std::dynamic_pointer_cast<WGSContext>(wgs_solver->GetContext());
       OpenSnLogicalErrorIf(not wgs_context, GetName() + ": Cast to WGSContext failed.");
       wgs_context->lhs_src_scope.Unset(APPLY_WGS_FISSION_SOURCES);

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_residual_func.cc
@@ -22,9 +22,9 @@ NLKEigenAccResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   auto& diff_solver = nl_context_ptr->diff_solver;
 
   auto& do_problem = nl_context_ptr->do_problem;
-  auto& groupsets = do_problem.GetGroupsets();
+  const auto& groupsets = do_problem.GetGroupsets();
   auto active_set_source_function = do_problem.GetActiveSetSourceFunction();
-  auto& front_gs = groupsets.front();
+  const auto& front_gs = groupsets.front();
 
   auto& q_moments_local = do_problem.GetQMomentsLocal();
   auto& phi_old_local = do_problem.GetPhiOldLocal();

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/nl_keigen_acc_solver.cc
@@ -96,8 +96,8 @@ NLKEigenDiffSolver::PostSolveCallback()
   auto nl_context_ptr = GetNLKDiffContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& do_problem = nl_context_ptr->do_problem;
-  auto& groupsets = do_problem.GetGroupsets();
-  auto& front_gs = groupsets.front();
+  const auto& groupsets = do_problem.GetGroupsets();
+  const auto& front_gs = groupsets.front();
 
   auto& phi_old_local = do_problem.GetPhiOldLocal();
   auto& phi_new_local = do_problem.GetPhiNewLocal();

--- a/modules/linear_boltzmann_solvers/lbs_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/acceleration/smm_acceleration.cc
@@ -292,7 +292,7 @@ SMMAcceleration::ComputeBoundaryFactors()
 {
   const auto& grid = do_problem_.GetGrid();
   const auto& pwld = do_problem_.GetSpatialDiscretization();
-  const auto num_groupsets = do_problem_.GetGroupsets().size();
+  const auto num_groupsets = do_problem_.GetNumGroupsets();
 
   // Loop over groupsets
   int gs = 0;

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/convergence.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/convergence.cc
@@ -35,7 +35,7 @@ ComputePointwisePhiChange(
 {
   if (groupset_ids.empty())
   {
-    groupset_ids.resize(lbs_problem.GetGroupsets().size());
+    groupset_ids.resize(lbs_problem.GetNumGroupsets());
     std::iota(groupset_ids.begin(), groupset_ids.end(), 0);
   }
 
@@ -55,7 +55,7 @@ ComputePointwisePhiChange(
     {
       for (auto id : groupset_ids)
       {
-        auto& groupset = lbs_problem.GetGroupsets()[id];
+        const auto& groupset = lbs_problem.GetGroupset(id);
         auto gsi = groupset.first_group;
         for (unsigned int g = 0; g < groupset.GetNumGroups(); ++g)
         {

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
@@ -40,7 +40,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
 
   // Compute 1/k F phi
   Set(q_moments_local, 0.0);
-  for (auto& groupset : lbs_problem->GetGroupsets())
+  for (const auto& groupset : lbs_problem->GetGroupsets())
     active_set_source_function(groupset,
                                q_moments_local,
                                phi_old_local,
@@ -50,7 +50,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   Scale(q_moments_local, 1.0 / k_eff);
 
   // Now add MS phi
-  for (auto& groupset : lbs_problem->GetGroupsets())
+  for (const auto& groupset : lbs_problem->GetGroupsets())
   {
     auto& wgs_context = lbs_problem->GetWGSContext(groupset.id);
     const bool supress_wgs = wgs_context.lhs_src_scope & SUPPRESS_WG_SCATTER;
@@ -62,7 +62,7 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
 
   // Sweep all the groupsets
   // After this phi_new = DLinv(MSD phi + 1/k FD phi)
-  for (auto& groupset : lbs_problem->GetGroupsets())
+  for (const auto& groupset : lbs_problem->GetGroupsets())
   {
     auto& wgs_context = lbs_problem->GetWGSContext(groupset.id);
     wgs_context.ApplyInverseTransportOperator(SourceFlags());
@@ -78,9 +78,9 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   if (ierr != PETSC_SUCCESS)
     return ierr;
 
-  for (auto& groupset : lbs_problem->GetGroupsets())
+  for (const auto& groupset : lbs_problem->GetGroupsets())
   {
-    if ((groupset.apply_wgdsa or groupset.apply_tgdsa) and lbs_problem->GetGroupsets().size() > 1)
+    if ((groupset.apply_wgdsa or groupset.apply_tgdsa) and lbs_problem->GetNumGroupsets() > 1)
       throw std::logic_error(fname + ": Preconditioning currently only supports"
                                      "single groupset simulations.");
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
@@ -36,7 +36,7 @@ NLKEigenvalueAGSSolver::PreSetupCallback()
   auto nl_context_ptr = GetNLKAGSContextPtr(context_ptr_, __PRETTY_FUNCTION__);
 
   auto& lbs_problem = nl_context_ptr->lbs_problem;
-  for (auto& groupset : lbs_problem->GetGroupsets())
+  for (const auto& groupset : lbs_problem->GetGroupsets())
     nl_context_ptr->groupset_ids.push_back(groupset.id);
 }
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/power_iteration_keigen.cc
@@ -22,8 +22,9 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
 {
   const std::string fname = "PowerIterationKEigenSolver";
 
-  for (auto& wgs_solver : lbs_problem.GetWGSSolvers())
+  for (size_t gsid = 0; gsid < lbs_problem.GetNumWGSSolvers(); ++gsid)
   {
+    auto wgs_solver = lbs_problem.GetWGSSolver(gsid);
     auto context = wgs_solver->GetContext();
     auto wgs_context = std::dynamic_pointer_cast<WGSContext>(context);
 
@@ -38,11 +39,11 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
   auto& phi_old_local = lbs_problem.GetPhiOldLocal();
   auto& phi_new_local = lbs_problem.GetPhiNewLocal();
   auto ags_solver = lbs_problem.GetAGSSolver();
-  auto& groupsets = lbs_problem.GetGroupsets();
+  const auto& groupsets = lbs_problem.GetGroupsets();
   auto active_set_source_function = lbs_problem.GetActiveSetSourceFunction();
 
-  auto& front_gs = groupsets.front();
-  auto& front_wgs_solver = lbs_problem.GetWGSSolvers()[front_gs.id];
+  const auto& front_gs = groupsets.front();
+  auto front_wgs_solver = lbs_problem.GetWGSSolver(front_gs.id);
   auto frons_wgs_context = std::dynamic_pointer_cast<WGSContext>(front_wgs_solver->GetContext());
 
   k_eff = 1.0;
@@ -60,7 +61,7 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
   while (nit < max_iterations)
   {
     Set(q_moments_local, 0.0);
-    for (auto& groupset : groupsets)
+    for (const auto& groupset : groupsets)
       active_set_source_function(groupset,
                                  q_moments_local,
                                  phi_old_local,

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -15,6 +15,7 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/data_types/allowable_range.h"
+#include "framework/utils/error.h"
 #include "caliper/cali.h"
 #include <algorithm>
 #include <iomanip>
@@ -75,7 +76,7 @@ LBSProblem::LBSProblem(const InputParameters& params)
 #ifdef __OPENSN_WITH_GPU__
     CheckCapableDevices();
 #else
-    throw std::invalid_argument(
+    OpenSnInvalidArgument(
       GetName() + ": GPU support was requested, but OpenSn was built without CUDA enabled.");
 #endif // __OPENSN_WITH_GPU__
   }
@@ -92,19 +93,13 @@ LBSProblem::LBSProblem(const InputParameters& params)
 
   // Set geometry type
   geometry_type_ = grid_->GetGeometryType();
-  if (geometry_type_ == GeometryType::INVALID)
-    throw std::runtime_error(GetName() + ": Invalid geometry type.");
+  OpenSnInvalidArgumentIf(geometry_type_ == GeometryType::INVALID,
+                          GetName() + ": Invalid geometry type.");
 
   InitializeGroupsets(params);
   InitializeSources(params);
   InitializeXSmapAndDensities(params);
   InitializeMaterials();
-}
-
-LBSOptions&
-LBSProblem::GetOptions()
-{
-  return options_;
 }
 
 const LBSOptions&
@@ -128,8 +123,7 @@ LBSProblem::SetTime(double time)
 void
 LBSProblem::SetTimeStep(double dt)
 {
-  if (dt <= 0.0)
-    throw std::runtime_error(GetName() + " dt must be greater than zero.");
+  OpenSnInvalidArgumentIf(dt <= 0.0, GetName() + ": dt must be greater than zero.");
   dt_ = dt;
 }
 
@@ -142,8 +136,8 @@ LBSProblem::GetTimeStep() const
 void
 LBSProblem::SetTheta(double theta)
 {
-  if (theta <= 0.0 or theta > 1.0)
-    throw std::runtime_error(GetName() + " theta must be in (0.0, 1.0].");
+  OpenSnInvalidArgumentIf(theta <= 0.0 or theta > 1.0,
+                          GetName() + ": theta must be in (0.0, 1.0].");
   theta_ = theta;
 }
 
@@ -162,8 +156,7 @@ LBSProblem::IsTimeDependent() const
 void
 LBSProblem::SetTimeDependentMode()
 {
-  throw std::logic_error(GetName() +
-                         ": Time-dependent mode is not supported for this problem type.");
+  OpenSnLogicalError(GetName() + ": Time-dependent mode is not supported for this problem type.");
 }
 
 void
@@ -226,16 +219,28 @@ LBSProblem::GetMaxPrecursorsPerMaterial() const
   return max_precursors_per_material_;
 }
 
-std::vector<LBSGroupset>&
-LBSProblem::GetGroupsets()
-{
-  return groupsets_;
-}
-
 const std::vector<LBSGroupset>&
 LBSProblem::GetGroupsets() const
 {
   return groupsets_;
+}
+
+LBSGroupset&
+LBSProblem::GetGroupset(size_t groupset_id)
+{
+  return groupsets_.at(groupset_id);
+}
+
+const LBSGroupset&
+LBSProblem::GetGroupset(size_t groupset_id) const
+{
+  return groupsets_.at(groupset_id);
+}
+
+size_t
+LBSProblem::GetNumGroupsets() const
+{
+  return groupsets_.size();
 }
 
 void
@@ -432,15 +437,21 @@ LBSProblem::SetActiveSetSourceFunction(SetSourceFunction source_function)
 }
 
 std::shared_ptr<AGSLinearSolver>
-LBSProblem::GetAGSSolver()
+LBSProblem::GetAGSSolver() const
 {
   return ags_solver_;
 }
 
-std::vector<std::shared_ptr<LinearSolver>>&
-LBSProblem::GetWGSSolvers()
+std::shared_ptr<LinearSolver>
+LBSProblem::GetWGSSolver(size_t groupset_id) const
 {
-  return wgs_solvers_;
+  return wgs_solvers_.at(groupset_id);
+}
+
+size_t
+LBSProblem::GetNumWGSSolvers() const
+{
+  return wgs_solvers_.size();
 }
 
 WGSContext&
@@ -449,7 +460,8 @@ LBSProblem::GetWGSContext(int groupset_id)
   auto& wgs_solver = wgs_solvers_[groupset_id];
   auto raw_context = wgs_solver->GetContext();
   auto wgs_context_ptr = std::dynamic_pointer_cast<WGSContext>(raw_context);
-  OpenSnLogicalErrorIf(not wgs_context_ptr, "Failed to cast WGSContext");
+  OpenSnLogicalErrorIf(not wgs_context_ptr,
+                       GetName() + ": Failed to cast solver context to WGSContext.");
   return *wgs_context_ptr;
 }
 
@@ -466,13 +478,13 @@ LBSProblem::GetNumPhiIterativeUnknowns()
 std::shared_ptr<FieldFunctionGridBased>
 LBSProblem::GetScalarFluxFieldFunction(unsigned int g, unsigned int m) const
 {
-  OpenSnLogicalErrorIf(g >= num_groups_, "Group index out of range.");
-  OpenSnLogicalErrorIf(m >= num_moments_, "Moment index out of range.");
+  OpenSnLogicalErrorIf(g >= num_groups_, GetName() + ": Group index out of range.");
+  OpenSnLogicalErrorIf(m >= num_moments_, GetName() + ": Moment index out of range.");
 
   const auto map_it = phi_field_functions_local_map_.find({g, m});
   OpenSnLogicalErrorIf(map_it == phi_field_functions_local_map_.end(),
-                       std::string("Failure to map phi field function g") + std::to_string(g) +
-                         " m" + std::to_string(m));
+                       GetName() + ": Failed to map phi field function for g=" + std::to_string(g) +
+                         ", m=" + std::to_string(m) + ".");
 
   return field_functions_.at(map_it->second);
 }
@@ -481,7 +493,8 @@ std::shared_ptr<FieldFunctionGridBased>
 LBSProblem::GetPowerFieldFunction() const
 {
   OpenSnLogicalErrorIf(not options_.power_field_function_on,
-                       "Called when options_.power_field_function_on == false");
+                       GetName() + ": GetPowerFieldFunction called with "
+                                   "options_.power_field_function_on=false.");
 
   return field_functions_[power_gen_fieldfunc_local_handle_];
 }
@@ -709,13 +722,13 @@ LBSProblem::ParseOptions(const InputParameters& input)
     {
       if (not std::filesystem::exists(dir))
       {
-        if (not std::filesystem::create_directories(dir))
-          throw std::runtime_error(GetName() + ": Failed to create restart directory " +
-                                   dir.string());
+        OpenSnLogicalErrorIf(not std::filesystem::create_directories(dir),
+                             GetName() + ": Failed to create restart directory " + dir.string());
       }
-      else if (not std::filesystem::is_directory(dir))
-        throw std::runtime_error(GetName() + ": Restart path exists but is not a directory " +
-                                 dir.string());
+      else
+        OpenSnLogicalErrorIf(not std::filesystem::is_directory(dir),
+                             GetName() + ": Restart path exists but is not a directory " +
+                               dir.string());
     }
     opensn::mpi_comm.barrier();
     UpdateRestartWriteTime();
@@ -745,15 +758,34 @@ LBSProblem::BuildRuntime()
   PrintSimHeader();
   mpi_comm.barrier();
 
+  InitializeRuntimeCore();
+  ValidateRuntimeModeConfiguration();
+  InitializeSources();
+
+  initialized_ = true;
+}
+
+void
+LBSProblem::InitializeRuntimeCore()
+{
   InitializeSpatialDiscretization();
   InitializeParrays();
   InitializeBoundaries();
   InitializeGPUExtras();
+}
+
+void
+LBSProblem::ValidateRuntimeModeConfiguration() const
+{
   if (options_.adjoint)
     if (const auto* do_problem = dynamic_cast<const DiscreteOrdinatesProblem*>(this);
         do_problem and do_problem->IsTimeDependent())
-      throw std::runtime_error(GetName() + ": Time-dependent adjoint problems are not supported.");
+      OpenSnInvalidArgument(GetName() + ": Time-dependent adjoint problems are not supported.");
+}
 
+void
+LBSProblem::InitializeSources()
+{
   // Initialize point sources
   for (auto& point_source : point_sources_)
     point_source->Initialize(*this);
@@ -761,8 +793,6 @@ LBSProblem::BuildRuntime()
   // Initialize volumetric sources
   for (auto& volumetric_source : volumetric_sources_)
     volumetric_source->Initialize(*this);
-
-  initialized_ = true;
 }
 
 void
@@ -822,14 +852,12 @@ void
 LBSProblem::InitializeGroupsets(const InputParameters& params)
 {
   // Initialize groups
-  if (num_groups_ == 0)
-    throw std::invalid_argument(GetName() + ": Number of groups must be > 0");
+  OpenSnInvalidArgumentIf(num_groups_ == 0, GetName() + ": Number of groups must be > 0.");
 
   // Initialize groupsets
   const auto& groupsets_array = params.GetParam("groupsets");
   const size_t num_gs = groupsets_array.GetNumParameters();
-  if (num_gs == 0)
-    throw std::invalid_argument(GetName() + ": At least one groupset must be specified");
+  OpenSnInvalidArgumentIf(num_gs == 0, GetName() + ": At least one groupset must be specified.");
   for (size_t gs = 0; gs < num_gs; ++gs)
   {
     const auto& groupset_params = groupsets_array.GetParam(gs);
@@ -841,7 +869,7 @@ LBSProblem::InitializeGroupsets(const InputParameters& params)
     {
       std::stringstream oss;
       oss << GetName() << ": No groups added to groupset " << groupsets_.back().id;
-      throw std::runtime_error(oss.str());
+      OpenSnInvalidArgument(oss.str());
     }
   }
 }
@@ -1445,7 +1473,7 @@ LBSProblem::SetAdjoint(bool adjoint)
   if (adjoint)
     if (const auto* do_problem = dynamic_cast<const DiscreteOrdinatesProblem*>(this);
         do_problem and do_problem->IsTimeDependent())
-      throw std::runtime_error(GetName() + ": Time-dependent adjoint problems are not supported.");
+      OpenSnInvalidArgument(GetName() + ": Time-dependent adjoint problems are not supported.");
 
   options_.adjoint = adjoint;
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
@@ -6,6 +6,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/outflow_carrier.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/total_xs_carrier.h"
+#include "framework/utils/error.h"
 
 namespace opensn
 {
@@ -78,10 +79,7 @@ void
 LBSProblem::CheckCapableDevices()
 {
   std::uint32_t num_gpus = crb::get_num_gpus();
-  if (num_gpus == 0)
-  {
-    throw std::runtime_error("No GPU detected.\n");
-  }
+  OpenSnLogicalErrorIf(num_gpus == 0, "LBSProblem::CheckCapableDevices: No GPU detected.");
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -37,9 +37,6 @@ public:
 
   ~LBSProblem() override;
 
-  /// Returns a reference to the solver options.
-  LBSOptions& GetOptions();
-
   /// Returns a constant reference to the solver options.
   const LBSOptions& GetOptions() const;
 
@@ -115,9 +112,10 @@ public:
   /// Returns the maximum number of precursors defined on any material.
   unsigned int GetMaxPrecursorsPerMaterial() const;
 
-  std::vector<LBSGroupset>& GetGroupsets();
-
   const std::vector<LBSGroupset>& GetGroupsets() const;
+  LBSGroupset& GetGroupset(size_t groupset_id);
+  const LBSGroupset& GetGroupset(size_t groupset_id) const;
+  size_t GetNumGroupsets() const;
 
   /// Adds a point source to the solver.
   void AddPointSource(std::shared_ptr<PointSource> point_source);
@@ -139,8 +137,6 @@ public:
 
   /// Clears all the boundary conditions from the solver.
   virtual void ClearBoundaries() = 0;
-
-  size_t& GetLastRestartTime();
 
   /// Returns a reference to the map of material ids to XSs.
   const BlockID2XSMap& GetBlockID2XSMap() const;
@@ -218,11 +214,11 @@ public:
   const std::vector<double>& GetDensitiesLocal() const;
 
   SetSourceFunction GetActiveSetSourceFunction() const;
-  void SetActiveSetSourceFunction(SetSourceFunction source_function);
 
-  std::shared_ptr<AGSLinearSolver> GetAGSSolver();
+  std::shared_ptr<AGSLinearSolver> GetAGSSolver() const;
 
-  std::vector<std::shared_ptr<LinearSolver>>& GetWGSSolvers();
+  std::shared_ptr<LinearSolver> GetWGSSolver(size_t groupset_id) const;
+  size_t GetNumWGSSolvers() const;
 
   WGSContext& GetWGSContext(int groupset_id);
 
@@ -286,11 +282,6 @@ protected:
 
   virtual void InitializeSpatialDiscretization();
 
-  /// Initializes parallel arrays.
-  void InitializeParrays();
-
-  void InitializeFieldFunctions();
-
   /// Initializes boundaries.
   virtual void InitializeBoundaries() {}
 
@@ -301,11 +292,7 @@ protected:
 
   virtual void InitializeWGSSolvers() {};
 
-  /// Initializes data carriers to GPUs and memory pinner.
-  void InitializeGPUExtras();
-
-  /// Reset data carriers to null and unpin memory.
-  void ResetGPUCarriers();
+  void SetActiveSetSourceFunction(SetSourceFunction source_function);
 
   LBSOptions options_;
   double time_ = 0.0;
@@ -374,6 +361,17 @@ protected:
   bool applied_save_angular_flux_ = false;
 
 private:
+  void InitializeRuntimeCore();
+  void ValidateRuntimeModeConfiguration() const;
+  void InitializeSources();
+  /// Initializes parallel arrays.
+  void InitializeParrays();
+  void InitializeFieldFunctions();
+  /// Initializes data carriers to GPUs and memory pinner.
+  void InitializeGPUExtras();
+  /// Reset data carriers to null and unpin memory.
+  void ResetGPUCarriers();
+
   /// Initialize groupsets
   void InitializeGroupsets(const InputParameters& params);
 
@@ -386,6 +384,8 @@ private:
 
   /// Parse and validate options without applying runtime side-effects.
   void ParseOptions(const InputParameters& input);
+  /// Checks if the current CPU is associated with any GPU.
+  static void CheckCapableDevices();
 
 public:
   /// Max number of DOFs per cell that the sweep kernel on GPU can handle.
@@ -397,10 +397,6 @@ public:
   static InputParameters GetOptionsBlock();
 
   static InputParameters GetXSMapEntryBlock();
-
-protected:
-  /// Checks if the current CPU is associated with any GPU.
-  static void CheckCapableDevices();
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
@@ -75,10 +75,10 @@ LBSVecOps::ScalePhiVector(LBSProblem& lbs_problem, PhiSTLOption phi_opt, double 
 
   auto& phi = (phi_opt == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal()
                                                  : lbs_problem.GetPhiOldLocal();
-  auto& groupsets = lbs_problem.GetGroupsets();
+  const auto& groupsets = lbs_problem.GetGroupsets();
 
   Scale(phi, value);
-  for (auto& groupset : groupsets)
+  for (const auto& groupset : groupsets)
   {
     if (groupset.angle_agg)
     {
@@ -227,7 +227,7 @@ LBSVecOps::SetMultiGSPETScVecFromPrimarySTLvector(LBSProblem& lbs_problem,
 {
   auto& y = (which_phi == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal()
                                                  : lbs_problem.GetPhiOldLocal();
-  auto& groupsets = lbs_problem.GetGroupsets();
+  const auto& groupsets = lbs_problem.GetGroupsets();
   double* x_ref = nullptr;
   OpenSnPETScCall(VecGetArray(x, &x_ref));
 
@@ -260,7 +260,7 @@ LBSVecOps::SetPrimarySTLvectorFromMultiGSPETScVec(LBSProblem& lbs_problem,
 {
   auto& y = (which_phi == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal()
                                                  : lbs_problem.GetPhiOldLocal();
-  auto& groupsets = lbs_problem.GetGroupsets();
+  const auto& groupsets = lbs_problem.GetGroupsets();
   const double* x_ref = nullptr;
   OpenSnPETScCall(VecGetArrayRead(x, &x_ref));
 

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
@@ -46,11 +46,11 @@ protected:
   std::vector<double>& phi_old_local_;
   std::vector<double>& phi_new_local_;
 
-  std::vector<LBSGroupset>& groupsets_;
+  const std::vector<LBSGroupset>& groupsets_;
   std::shared_ptr<AGSLinearSolver> ags_solver_;
   SetSourceFunction active_set_source_function_;
 
-  LBSGroupset& front_gs_;
+  const LBSGroupset& front_gs_;
   std::shared_ptr<LinearSolver> front_wgs_solver_;
   std::shared_ptr<WGSContext> front_wgs_context_;
   bool initialized_ = false;

--- a/modules/linear_boltzmann_solvers/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/steady_state_solver.cc
@@ -67,7 +67,7 @@ SteadyStateSourceSolver::Execute()
   if (not initialized_)
     throw std::runtime_error(GetName() + ": Initialize must be called before Execute.");
 
-  auto& options = lbs_problem_->GetOptions();
+  const auto& options = lbs_problem_->GetOptions();
 
   auto& ags_solver = *lbs_problem_->GetAGSSolver();
   ags_solver.Solve();
@@ -90,9 +90,9 @@ SteadyStateSourceSolver::Execute()
 bool
 SteadyStateSourceSolver::ReadRestartData()
 {
-  auto& fname = lbs_problem_->GetOptions().read_restart_path;
+  const auto& fname = lbs_problem_->GetOptions().read_restart_path;
   auto& phi_old_local = lbs_problem_->GetPhiOldLocal();
-  auto& groupsets = lbs_problem_->GetGroupsets();
+  const auto& groupsets = lbs_problem_->GetGroupsets();
 
   auto file = H5Fopen(fname.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   bool success = (file >= 0);
@@ -132,10 +132,10 @@ SteadyStateSourceSolver::ReadRestartData()
 bool
 SteadyStateSourceSolver::WriteRestartData()
 {
-  auto& options = lbs_problem_->GetOptions();
+  const auto& options = lbs_problem_->GetOptions();
   auto fname = options.write_restart_path;
   auto& phi_old_local = lbs_problem_->GetPhiOldLocal();
-  auto& groupsets = lbs_problem_->GetGroupsets();
+  const auto& groupsets = lbs_problem_->GetGroupsets();
 
   auto file = H5Fcreate(fname.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   bool success = (file >= 0);

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
@@ -94,7 +94,7 @@ TransientSolver::Initialize()
   enforce_stop_time_ = false;
 
   // Ensure angular fluxes are available from the initial condition.
-  auto& options = do_problem_->GetOptions();
+  const auto& options = do_problem_->GetOptions();
   do_problem_->SetTime(current_time_);
 
   const std::string& init_state = initial_state_;
@@ -210,7 +210,7 @@ TransientSolver::Execute()
 void
 TransientSolver::Advance()
 {
-  auto& options = do_problem_->GetOptions();
+  const auto& options = do_problem_->GetOptions();
   if (not initialized_)
     throw std::runtime_error(GetName() + ": Initialize must be called before Advance.");
   if (enforce_stop_time_ and stop_time_ <= current_time_)
@@ -223,8 +223,9 @@ TransientSolver::Advance()
   const double theta = do_problem_->GetTheta();
 
   // Ensure RHS time term is enabled for transient sweeps
-  for (auto& wgs_solver : do_problem_->GetWGSSolvers())
+  for (size_t gsid = 0; gsid < do_problem_->GetNumWGSSolvers(); ++gsid)
   {
+    auto wgs_solver = do_problem_->GetWGSSolver(gsid);
     auto context = wgs_solver->GetContext();
     auto sweep_context = std::dynamic_pointer_cast<SweepWGSContext>(context);
     if (sweep_context)


### PR DESCRIPTION
- Remove mutable accessors from LBSProblem where possible
- Update solver/acceleration/iterative call sites to use const groupset iteration and new const accessor APIs
- Standardize LBSProblem error reporting
- Reduce visibility of LBSProblem methods where possible