### PR TITLE
Fixing minor bugs in sweep chunk routines

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
@@ -197,22 +197,14 @@ AAHSweepChunkRZ::Sweep(AngleSet& angle_set)
                 (cell_face.normal.Dot(normal_vector_boundary_) < -0.999999);
               if (!incident_on_symmetric_boundary)
               {
-                for (size_t fi = 0; fi < num_face_nodes; ++fi)
-                {
-                  for (size_t fj = 0; fj < num_face_nodes; ++fj)
-                  {
-                    psi = angle_set.PsiBoundary(cell_face.neighbor_id,
-                                                direction_num,
-                                                cell_local_id,
-                                                f,
-                                                fj,
-                                                gs_gi,
-                                                IsSurfaceSourceActive());
-                  }
-                }
+                psi = angle_set.PsiBoundary(cell_face.neighbor_id,
+                                            direction_num,
+                                            cell_local_id,
+                                            f,
+                                            fj,
+                                            gs_gi,
+                                            IsSurfaceSourceActive());
               }
-              else
-                psi = nullptr;
             }
 
             if (not psi)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_message_struct.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_message_struct.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "framework/mpi/mpi_comm_set.h"
+#include "framework/utils/error.h"
 #include <concepts>
 #include <cstddef>
 #include <limits>
@@ -59,18 +60,21 @@ SetupMessageData(const std::vector<int>& locations,
   for (std::size_t i = 0; i < num_locations; ++i)
   {
     auto num_unknowns_64 = get_unknown_count(i);
-    if (num_unknowns_64 > static_cast<std::size_t>(std::numeric_limits<int>::max()))
-      throw std::overflow_error("Number of unknowns is too large for int");
+    OpenSnLogicalErrorIf(num_unknowns_64 >
+                           static_cast<std::size_t>(std::numeric_limits<int>::max()),
+                         "Number of unknowns is too large for int");
     auto num_unknowns = static_cast<int>(num_unknowns_64);
     // compute message count and size
     int message_count = 0, message_size = 0;
     if (num_unknowns != 0)
     {
-      int total_bytes = num_unknowns * static_cast<int>(sizeof(double));
+      const std::size_t total_bytes =
+        static_cast<std::size_t>(num_unknowns) * static_cast<std::size_t>(sizeof(double));
+      const auto max_message_bytes = static_cast<std::size_t>(max_mpi_message_size);
       message_count = 1;
-      if (total_bytes > max_mpi_message_size)
+      if (total_bytes > max_message_bytes)
       {
-        message_count = (total_bytes + (max_mpi_message_size - 1)) / max_mpi_message_size;
+        message_count = static_cast<int>((total_bytes + max_message_bytes - 1) / max_message_bytes);
       }
       message_count = std::min(message_count, num_unknowns);
       message_size = ((num_unknowns + (message_count - 1)) / message_count);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
@@ -6,6 +6,7 @@
 #include "framework/math/math.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
+#include <utility>
 
 namespace opensn
 {
@@ -67,7 +68,9 @@ AAH_FLUDS::OutgoingPsi(std::size_t cell_so_index,
 double*
 AAH_FLUDS::NLOutgoingPsi(int outb_face_counter, std::size_t face_dof, std::size_t n)
 {
-  if (outb_face_counter > common_data_.nonlocal_outb_face_deplocI_slot_.size())
+  if (outb_face_counter < 0 ||
+      std::cmp_greater_equal(outb_face_counter,
+                             common_data_.nonlocal_outb_face_deplocI_slot_.size()))
   {
     std::ostringstream oss;
     oss << "AAH_FLUDS: Invalid value for outb_face_counter " << outb_face_counter << " (max "
@@ -82,7 +85,7 @@ AAH_FLUDS::NLOutgoingPsi(int outb_face_counter, std::size_t face_dof, std::size_
   std::size_t index = nonlocal_psi_Gn_blockstride * num_groups_ * n +
                       static_cast<std::size_t>(slot) * num_groups_ + face_dof * num_groups_;
 
-  if ((index < 0) or (index > deplocI_outgoing_psi_[depLocI].size()))
+  if (index >= deplocI_outgoing_psi_[depLocI].size())
   {
     std::stringstream oss;
     oss << "AAH_FLUDS: Invalid index " << index

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
@@ -154,8 +154,6 @@ SweepScheduler::SortRuleValuesDOGRZ()
                        return a.sign_of_omegax > b.sign_of_omegax;
                      if (a.depth_of_graph != b.depth_of_graph)
                        return a.depth_of_graph > b.depth_of_graph;
-                     if (a.sign_of_omegax != b.sign_of_omegax)
-                       return a.sign_of_omegax > b.sign_of_omegax;
                      if (a.sign_of_omegay != b.sign_of_omegay)
                        return a.sign_of_omegay > b.sign_of_omegay;
                      if (a.sign_of_omegaz != b.sign_of_omegaz)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
@@ -84,8 +84,14 @@ struct AVX2Ops
     return _mm256_fnmadd_pd(a, b, c);
   }
 #else
-  static inline Vec Fmadd(const Vec& a, const Vec& b, const Vec& c) { return Add(a, Mul(b, c)); }
-  static inline Vec Fnmadd(const Vec& a, const Vec& b, const Vec& c) { return Sub(c, Mul(a, b)); }
+  static inline avx_vec Fmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
+  {
+    return Add(a, Mul(b, c));
+  }
+  static inline avx_vec Fnmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
+  {
+    return Sub(c, Mul(a, b));
+  }
 #endif
 
   static inline avx_vec Reciprocal(const avx_vec& v) { return Div(Set1(1.0), v); }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cc
@@ -29,7 +29,6 @@ AAHSweepChunk::AAHSweepChunk(DiscreteOrdinatesProblem& problem, LBSGroupset& gro
                problem.GetMaxCellDOFCount(),
                problem.GetMinCellDOFCount()),
     problem_(problem),
-    max_level_size_(problem.GetMaxLevelSize()),
     sweep_impl_(&AAHSweepChunk::Sweep_Generic)
 {
   if (min_num_cell_dofs_ == max_num_cell_dofs_ and min_num_cell_dofs_ >= 2 and

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.h
@@ -34,7 +34,6 @@ public:
 
 protected:
   DiscreteOrdinatesProblem& problem_;
-  size_t max_level_size_;
   unsigned int group_block_size_;
 
 private:

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
@@ -27,11 +27,9 @@ AAHSweepChunkTD::AAHSweepChunkTD(DiscreteOrdinatesProblem& problem, LBSGroupset&
                problem.GetMaxCellDOFCount(),
                problem.GetMinCellDOFCount()),
     problem_(problem),
-    max_level_size_(problem.GetMaxLevelSize()),
-    psi_old_(problem.GetPsiOldLocal()[groupset.id]),
-    use_gpus_(problem.UseGPUs())
+    psi_old_(problem.GetPsiOldLocal()[groupset.id])
 {
-  if (use_gpus_)
+  if (problem.UseGPUs())
     throw std::runtime_error("Time-dependent calculations do not yet support GPUs.\n");
 
   if (min_num_cell_dofs_ == max_num_cell_dofs_ and min_num_cell_dofs_ >= 2 and

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.h
@@ -33,10 +33,7 @@ protected:
   void Sweep_FixedN(AngleSet& angle_set);
 
   DiscreteOrdinatesProblem& problem_;
-  size_t max_level_size_;
-  void* level_vector_ = nullptr;
   const std::vector<double>& psi_old_;
-  bool use_gpus_;
   unsigned int group_block_size_ = 0;
   bool use_fixed_n_ = false;
   unsigned int fixed_num_nodes_ = 0;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.cc
@@ -3,9 +3,28 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
+#include "framework/utils/error.h"
 
 namespace opensn
 {
+void
+SweepChunk::Sweep(AngleSet& angle_set)
+{
+  OpenSnLogicalError("SweepChunk::Sweep must be overridden by derived sweep chunk.");
+}
+
+void
+SweepChunk::SetAngleSet(AngleSet& angle_set)
+{
+  OpenSnLogicalError("SweepChunk::SetAngleSet is not implemented for this sweep chunk.");
+}
+
+void
+SweepChunk::SetCell(Cell const* cell_ptr, AngleSet& angle_set)
+{
+  OpenSnLogicalError("SweepChunk::SetCell is not implemented for this sweep chunk.");
+}
+
 void
 SweepChunk::ZeroDestinationPhi()
 {
@@ -15,15 +34,15 @@ SweepChunk::ZeroDestinationPhi()
   for (const auto& cell : grid_->local_cells)
   {
     const auto& transport_view = cell_transport_views_[cell.local_id];
-
-    for (int i = 0; i < cell.vertex_ids.size(); ++i)
+    const auto num_nodes = static_cast<size_t>(transport_view.GetNumNodes());
+    for (size_t i = 0; i < num_nodes; ++i)
     {
       for (unsigned int m = 0; m < num_moments_; ++m)
       {
         const auto mapping = transport_view.MapDOF(i, m, gsi);
         for (unsigned int g = 0; g < gss; ++g)
         {
-          (destination_phi_)[mapping + g] = 0.0;
+          destination_phi_[mapping + g] = 0.0;
         } // for g
       } // for moment
     } // for dof

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h
@@ -54,13 +54,13 @@ public:
   }
 
   /// Sweep chunks should override this.
-  virtual void Sweep(AngleSet& angle_set) {}
+  virtual void Sweep(AngleSet& angle_set);
 
   /// Sets the currently active angleset.
-  virtual void SetAngleSet(AngleSet& angle_set) {}
+  virtual void SetAngleSet(AngleSet& angle_set);
 
   /// For cell-by-cell methods or computing the residual on a single cell.
-  virtual void SetCell(Cell const* cell_ptr, AngleSet& angle_set) {}
+  virtual void SetCell(Cell const* cell_ptr, AngleSet& angle_set);
 
   /**
    * Zero the portion of the output flux moments vector corresponding to the groupset for this

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady_cyl/tests.json
@@ -130,31 +130,31 @@
         "type": "KeyValuePair",
         "key": "Top leakage=",
         "goldvalue": 36.173790857624596,
-        "abs_tol": 1e-09
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Bottom leakage=",
         "goldvalue": 36.17379086382096,
-        "abs_tol": 1e-09
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Side leakage=",
         "goldvalue": 39.74878117223803,
-        "abs_tol": 1e-09
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Total leakage=",
         "goldvalue": 112.0963628936836,
-        "abs_tol": 1e-09
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Leakage/Source=",
         "goldvalue": 0.9144851226179025,
-        "abs_tol": 1e-09
+        "abs_tol": 1e-06
       }
     ]
   },
@@ -178,20 +178,20 @@
       {
         "type": "KeyValuePair",
         "key": "Side leakage=",
-        "goldvalue": 97.24938933424164,
-        "abs_tol": 1e-09
+        "goldvalue": 97.24863271745009,
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Total leakage=",
-        "goldvalue": 97.24938933424164,
-        "abs_tol": 1e-09
+        "goldvalue": 97.24863271745009,
+        "abs_tol": 1e-06
       },
       {
         "type": "KeyValuePair",
         "key": "Leakage/Source=",
-        "goldvalue": 0.7933631157523604,
-        "abs_tol": 1e-09
+        "goldvalue": 0.7933569432523587,
+        "abs_tol": 1e-06
       }
     ]
   },


### PR DESCRIPTION
This PR fixes the following bugs in the sweep chunk routines:

1. Fix incorrect incoming boundary flux pointer handling for RZ
2. Fix potential overflows in size/message count calculations for AAH
3. Fix out-of-range checks for AAH nonlocal outgoing psi indexing
4. Fix ordering bug in DOG RZ scheduling
5. Fix type bug in AVX2 AAH sweepchunk
6. Remove unused member variables in AAH TD sweep chunk
7. SweepChunk virtual methods now throw an error instead of silently failing
8. Fix ZeroDestinationPhi in SweepChunk to loop over DOFs instead of vertices