### PR TITLE
Minor sweep context fixes

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -115,6 +115,12 @@ SweepWGSContext::GetSystemSize()
 }
 
 void
+SweepWGSContext::PreSolveCallback()
+{
+  sweep_times.clear();
+}
+
+void
 SweepWGSContext::ApplyInverseTransportOperator(SourceFlags scope)
 {
   CALI_CXX_MARK_SCOPE("SweepWGSContext::ApplyInverseTransportOperator");
@@ -155,21 +161,26 @@ SweepWGSContext::PostSolveCallback()
 
   if (log_info)
   {
-    double tot_sweep_time = 0.0;
-    auto num_sweeps = static_cast<double>(sweep_times.size());
-    for (auto time : sweep_times)
-      tot_sweep_time += time;
-    double avg_sweep_time = tot_sweep_time / num_sweeps;
-    size_t num_angles = groupset.quadrature->abscissae.size();
-    size_t num_unknowns = do_problem.GetGlobalNodeCount() * num_angles * groupset.GetNumGroups();
-    double max_avg_sweep_time = 0.0;
-    opensn::mpi_comm.all_reduce(&avg_sweep_time, 1, &max_avg_sweep_time, mpi::op::max<double>());
+    if (not sweep_times.empty())
+    {
+      double tot_sweep_time = 0.0;
+      auto num_sweeps = static_cast<double>(sweep_times.size());
+      for (auto time : sweep_times)
+        tot_sweep_time += time;
+      double avg_sweep_time = tot_sweep_time / num_sweeps;
+      size_t num_angles = groupset.quadrature->abscissae.size();
+      size_t num_unknowns = do_problem.GetGlobalNodeCount() * num_angles * groupset.GetNumGroups();
+      double max_avg_sweep_time = 0.0;
+      opensn::mpi_comm.all_reduce(&avg_sweep_time, 1, &max_avg_sweep_time, mpi::op::max<double>());
 
-    log.Log() << "\n       Average sweep time (s):        " << max_avg_sweep_time
-              << "\n       Sweep Time/Unknown (ns):       "
-              << max_avg_sweep_time * 1.0e9 / static_cast<double>(num_unknowns)
-              << "\n       Number of unknowns per sweep:  " << num_unknowns << "\n\n";
+      log.Log() << "\n       Average sweep time (s):        " << max_avg_sweep_time
+                << "\n       Sweep Time/Unknown (ns):       "
+                << max_avg_sweep_time * 1.0e9 / static_cast<double>(num_unknowns)
+                << "\n       Number of unknowns per sweep:  " << num_unknowns << "\n\n";
+    }
   }
+
+  sweep_times.clear();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
@@ -25,6 +25,8 @@ struct SweepWGSContext : public WGSContext
 
   std::pair<int64_t, int64_t> GetSystemSize() override;
 
+  void PreSolveCallback() override;
+
   void ApplyInverseTransportOperator(SourceFlags scope) override;
 
   void PostSolveCallback() override;

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/classic_richardson.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/classic_richardson.cc
@@ -30,6 +30,7 @@ ClassicRichardson::Solve()
 {
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   gs_context_ptr->PreSetupCallback();
+  gs_context_ptr->PreSolveCallback();
 
   auto& groupset = gs_context_ptr->groupset;
   auto& do_problem = gs_context_ptr->do_problem;


### PR DESCRIPTION
1. Reset grind time calculations on every groupset solve
2. Correctly handle sweep times in the case where no sweeps were executed