### PR TITLE
Initializing `LightWeightFace::neighbor` with uint64::max

### DIFF
--- a/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
+++ b/framework/mesh/unpartitioned_mesh/unpartitioned_mesh.h
@@ -20,7 +20,7 @@ public:
   {
     std::vector<uint64_t> vertex_ids;
     bool has_neighbor = false;
-    uint64_t neighbor = 0;
+    uint64_t neighbor = std::numeric_limits<uint64_t>::max();
 
     LightWeightFace() = default;
     explicit LightWeightFace(std::vector<uint64_t> vertex_ids) : vertex_ids(std::move(vertex_ids))


### PR DESCRIPTION
This matches the initialization of `CellFace::neighbor` with `uint64::max`. Without this the light-weight faces were constructed with `neighbor == 0`, which could collide with the boundary ID assignment in the mesh. For example initially, all mesh faces had boundary ID set to 0 and if the mesh defined a boundary with ID 0, all those faces were lumped together with all the faces rendering the boundary look like "all around" the mesh, which is wrong.

In `CellFace`, we set the boundary ID to `uint64::max` to avoid the above-described problem. So `LightWeightFace` now does the same thing, because `CellFace`s are constructed from `LightWeightFace`s. wihtout this, they would override the boundary ID with 0, since that was their default value.

Closes #964