### PR TITLE
Minor bug fixes across the various solver classes

### DIFF
--- a/modules/linear_boltzmann_solvers/solvers/nl_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/nl_keigen_solver.cc
@@ -8,8 +8,8 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.h"
 #include "framework/object_factory.h"
 #include "framework/logging/log.h"
+#include "framework/utils/error.h"
 #include "framework/runtime.h"
-#include <stdexcept>
 
 namespace opensn
 {
@@ -22,7 +22,7 @@ NonLinearKEigenSolver::GetInputParameters()
   InputParameters params = Solver::GetInputParameters();
 
   params.SetGeneralDescription("Implementation of a non-linear k-Eigenvalue solver");
-  params.ChangeExistingParamToOptional("name", "PowerIterationKEigenSolver");
+  params.ChangeExistingParamToOptional("name", "NonLinearKEigenSolver");
   params.AddRequiredParameter<std::shared_ptr<Problem>>("problem", "An existing lbs problem");
 
   // Non-linear solver parameters
@@ -43,6 +43,7 @@ NonLinearKEigenSolver::GetInputParameters()
                               0,
                               "The number of initial power iterations to execute before entering "
                               "the non-linear algorithm");
+  params.ConstrainParameterRange("num_initial_power_iterations", AllowableRangeLowLimit::New(0));
 
   return params;
 }
@@ -60,7 +61,7 @@ NonLinearKEigenSolver::NonLinearKEigenSolver(const InputParameters& params)
     nl_context_(std::make_shared<NLKEigenAGSContext>(do_problem_)),
     nl_solver_(nl_context_),
     reset_phi0_(params.GetParamValue<bool>("reset_phi0")),
-    num_initial_power_its_(params.GetParamValue<int>("num_initial_power_iterations"))
+    num_initial_power_its_(params.GetParamValue<unsigned int>("num_initial_power_iterations"))
 {
   auto& tolerances = nl_solver_.GetToleranceOptions();
 
@@ -80,17 +81,16 @@ NonLinearKEigenSolver::NonLinearKEigenSolver(const InputParameters& params)
 void
 NonLinearKEigenSolver::Initialize()
 {
-  if (do_problem_->IsTimeDependent())
-    throw std::runtime_error(GetName() + ": Problem is in time-dependent mode. Call problem."
-                                         "SetSteadyStateMode() before initializing this solver.");
+  OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
+                          GetName() + ": Problem is in time-dependent mode. Call problem."
+                                      "SetSteadyStateMode() before initializing this solver.");
   initialized_ = true;
 }
 
 void
 NonLinearKEigenSolver::Execute()
 {
-  if (not initialized_)
-    throw std::runtime_error(GetName() + ": Initialize must be called before Execute.");
+  OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   if (reset_phi0_)
     LBSVecOps::SetPhiVectorScalarValues(*do_problem_, PhiSTLOption::PHI_OLD, 1.0);

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.cc
@@ -9,13 +9,13 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/utils/hdf_utils.h"
+#include "framework/utils/error.h"
 #include "framework/object_factory.h"
 #include "framework/runtime.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/ags_linear_solver.h"
+#include <cmath>
 #include <iomanip>
-#include <stdexcept>
-#include "sys/stat.h"
 
 namespace opensn
 {
@@ -35,8 +35,6 @@ PowerIterationKEigenSolver::GetInputParameters()
     "acceleration", {}, "The acceleration method");
   params.AddOptionalParameter("max_iters", 1000, "Maximum power iterations allowed");
   params.AddOptionalParameter("k_tol", 1.0e-10, "Tolerance on the k-eigenvalue");
-  params.AddOptionalParameter(
-    "reset_solution", true, "If set to true will initialize the flux moments to 1.0");
   params.AddOptionalParameter("reset_phi0", true, "If true, reinitializes scalar fluxes to 1.0");
   return params;
 }
@@ -61,17 +59,16 @@ PowerIterationKEigenSolver::PowerIterationKEigenSolver(const InputParameters& pa
     q_moments_local_(do_problem_->GetQMomentsLocal()),
     phi_old_local_(do_problem_->GetPhiOldLocal()),
     phi_new_local_(do_problem_->GetPhiNewLocal()),
-    groupsets_(do_problem_->GetGroupsets()),
-    front_gs_(groupsets_.front())
+    groupsets_(do_problem_->GetGroupsets())
 {
 }
 
 void
 PowerIterationKEigenSolver::Initialize()
 {
-  if (do_problem_->IsTimeDependent())
-    throw std::runtime_error(GetName() + ": Problem is in time-dependent mode. Call problem."
-                                         "SetSteadyStateMode() before initializing this solver.");
+  OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
+                          GetName() + ": Problem is in time-dependent mode. Call problem."
+                                      "SetSteadyStateMode() before initializing this solver.");
 
   const auto& options = do_problem_->GetOptions();
   active_set_source_function_ = do_problem_->GetActiveSetSourceFunction();
@@ -94,11 +91,6 @@ PowerIterationKEigenSolver::Initialize()
                                options.max_ags_iterations > 1;
   ags_solver_->SetVerbosity(print_ags_iters);
 
-  front_wgs_solver_ = do_problem_->GetWGSSolver(front_gs_.id);
-  front_wgs_context_ = std::dynamic_pointer_cast<WGSContext>(front_wgs_solver_->GetContext());
-
-  OpenSnLogicalErrorIf(not front_wgs_context_, ": Casting failed");
-
   bool restart_successful = false;
   if (not options.read_restart_path.empty())
     restart_successful = ReadRestartData();
@@ -116,8 +108,7 @@ PowerIterationKEigenSolver::Initialize()
 void
 PowerIterationKEigenSolver::Execute()
 {
-  if (not initialized_)
-    throw std::runtime_error(GetName() + ": Initialize must be called before Execute.");
+  OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   if (acceleration_)
     acceleration_->PreExecute();
@@ -131,6 +122,9 @@ PowerIterationKEigenSolver::Execute()
   bool converged = false;
   while (nit < max_iters_)
   {
+    OpenSnLogicalErrorIf(k_eff_ <= 0.0 or not std::isfinite(k_eff_),
+                         GetName() + ": invalid k_eff encountered: " + std::to_string(k_eff_));
+
     // Set the fission source
     SetLBSFissionSource(phi_old_local_, false);
     do_problem_->ScaleQMoments(1.0 / k_eff_);
@@ -150,14 +144,19 @@ PowerIterationKEigenSolver::Execute()
     else
     {
       const auto F_new = ComputeFissionProduction(*do_problem_, phi_new_local_);
+      OpenSnLogicalErrorIf(
+        F_prev_ == 0.0, GetName() + ": previous fission production is zero. Cannot update k_eff.");
       k_eff_ = F_new / F_prev_ * k_eff_;
       F_prev_ = F_new;
     }
 
+    OpenSnLogicalErrorIf(k_eff_ <= 0.0 or not std::isfinite(k_eff_),
+                         GetName() + ": invalid k_eff computed: " + std::to_string(k_eff_));
+
     const double reactivity = (k_eff_ - 1.0) / k_eff_;
 
     // Check convergence, bookkeeping
-    k_eff_change = fabs(k_eff_ - k_eff_prev) / k_eff_;
+    k_eff_change = std::fabs(k_eff_ - k_eff_prev) / k_eff_;
     k_eff_prev = k_eff_;
     nit += 1;
 
@@ -196,6 +195,7 @@ PowerIterationKEigenSolver::Execute()
     auto wgs_solver = do_problem_->GetWGSSolver(gsid);
     auto context = wgs_solver->GetContext();
     auto wgs_context = std::dynamic_pointer_cast<WGSContext>(context);
+    OpenSnLogicalErrorIf(not wgs_context, GetName() + ": Cast to WGSContext failed.");
     total_num_sweeps += wgs_context->counter_applications_of_inv_op;
   }
 

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
@@ -12,7 +12,6 @@ namespace opensn
 class DiscreteOrdinatesProblem;
 class DiscreteOrdinatesKEigenAcceleration;
 class AGSLinearSolver;
-class LinearSolver;
 
 class PowerIterationKEigenSolver : public Solver
 {
@@ -50,9 +49,6 @@ protected:
   std::shared_ptr<AGSLinearSolver> ags_solver_;
   SetSourceFunction active_set_source_function_;
 
-  const LBSGroupset& front_gs_;
-  std::shared_ptr<LinearSolver> front_wgs_solver_;
-  std::shared_ptr<WGSContext> front_wgs_context_;
   bool initialized_ = false;
 
 private:

--- a/modules/linear_boltzmann_solvers/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/steady_state_solver.cc
@@ -9,9 +9,9 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "framework/object_factory.h"
 #include "framework/utils/hdf_utils.h"
+#include "framework/utils/error.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
-#include <stdexcept>
 #include <memory>
 
 namespace opensn
@@ -50,9 +50,9 @@ SteadyStateSourceSolver::Initialize()
   CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Initialize");
 
   if (auto do_problem = std::dynamic_pointer_cast<DiscreteOrdinatesProblem>(lbs_problem_))
-    if (do_problem->IsTimeDependent())
-      throw std::runtime_error(GetName() + ": Problem is in time-dependent mode. Call problem."
-                                           "SetSteadyStateMode() before initializing this solver.");
+    OpenSnInvalidArgumentIf(do_problem->IsTimeDependent(),
+                            GetName() + ": Problem is in time-dependent mode. Call problem."
+                                        "SetSteadyStateMode() before initializing this solver.");
   initialized_ = true;
 
   if (not lbs_problem_->GetOptions().read_restart_path.empty())
@@ -64,8 +64,7 @@ SteadyStateSourceSolver::Execute()
 {
   CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Execute");
 
-  if (not initialized_)
-    throw std::runtime_error(GetName() + ": Initialize must be called before Execute.");
+  OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   const auto& options = lbs_problem_->GetOptions();
 

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
@@ -7,6 +7,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.h"
 #include "framework/logging/log.h"
+#include "framework/utils/error.h"
 #include "framework/runtime.h"
 #include <iomanip>
 #include <limits>
@@ -72,8 +73,6 @@ TransientSolver::TransientSolver(const InputParameters& params)
 void
 TransientSolver::RefreshLocalViews()
 {
-  q_moments_local_ = &do_problem_->GetQMomentsLocal();
-  phi_old_local_ = &do_problem_->GetPhiOldLocal();
   phi_new_local_ = &do_problem_->GetPhiNewLocal();
   precursor_new_local_ = &do_problem_->GetPrecursorsNewLocal();
   psi_new_local_ = &do_problem_->GetPsiNewLocal();
@@ -99,9 +98,9 @@ TransientSolver::Initialize()
 
   const std::string& init_state = initial_state_;
   RefreshLocalViews();
-  if (not phi_new_local_ or phi_new_local_->empty())
-    throw std::runtime_error(GetName() + ": Problem must be fully constructed before "
-                                         "TransientSolver initialization.");
+  OpenSnLogicalErrorIf(not phi_new_local_ or phi_new_local_->empty(),
+                       GetName() + ": Problem must be fully constructed before "
+                                   "TransientSolver initialization.");
 
   if (init_state == "zero")
   {
@@ -111,9 +110,9 @@ TransientSolver::Initialize()
       std::fill(psi.begin(), psi.end(), 0.0);
   }
 
-  if (not do_problem_->IsTimeDependent())
-    throw std::runtime_error(GetName() + ": Problem is in steady-state mode. Call problem."
-                                         "SetTimeDependentMode() before initializing this solver.");
+  OpenSnInvalidArgumentIf(not do_problem_->IsTimeDependent(),
+                          GetName() + ": Problem is in steady-state mode. Call problem."
+                                      "SetTimeDependentMode() before initializing this solver.");
   do_problem_->SetTime(current_time_);
   RefreshLocalViews();
   ags_solver_ = do_problem_->GetAGSSolver();
@@ -136,7 +135,6 @@ TransientSolver::Initialize()
   // Sync with the current solution
   phi_prev_local_ = *phi_new_local_;
   precursor_prev_local_ = *precursor_new_local_;
-  psi_prev_local_ = *psi_new_local_;
 
   initialized_ = true;
 }
@@ -145,15 +143,13 @@ void
 TransientSolver::Execute()
 {
   log.Log() << "Executing " << GetName() << ".";
-  if (not initialized_)
-    throw std::runtime_error(GetName() + ": Initialize must be called before Execute.");
+  OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   const double t0 = current_time_;
   const double tf = stop_time_;
   const double dt_nominal = do_problem_->GetTimeStep();
 
-  if (tf < t0)
-    throw std::runtime_error(GetName() + ": stop_time must be >= current_time");
+  OpenSnInvalidArgumentIf(tf < t0, GetName() + ": stop_time must be >= current_time");
 
   const double tol =
     64.0 * std::numeric_limits<double>::epsilon() * std::max({1.0, std::abs(tf), std::abs(t0)});
@@ -176,8 +172,7 @@ TransientSolver::Execute()
         pre_advance_callback_();
 
       const double dt = do_problem_->GetTimeStep();
-      if (dt <= 0.0)
-        throw std::runtime_error(GetName() + ": dt must be positive");
+      OpenSnLogicalErrorIf(dt <= 0.0, GetName() + ": dt must be positive");
       const double step_dt = (remaining < dt) ? remaining : dt;
       do_problem_->SetTimeStep(step_dt);
       do_problem_->SetTime(current_time_);
@@ -210,8 +205,7 @@ void
 TransientSolver::Advance()
 {
   const auto& options = do_problem_->GetOptions();
-  if (not initialized_)
-    throw std::runtime_error(GetName() + ": Initialize must be called before Advance.");
+  OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Advance.");
   if (enforce_stop_time_ and stop_time_ <= current_time_)
   {
     if (verbose_)
@@ -222,13 +216,18 @@ TransientSolver::Advance()
   const double theta = do_problem_->GetTheta();
 
   // Ensure RHS time term is enabled for transient sweeps
+  std::vector<std::shared_ptr<SweepWGSContext>> transient_sweep_contexts;
+  transient_sweep_contexts.reserve(do_problem_->GetNumWGSSolvers());
   for (size_t gsid = 0; gsid < do_problem_->GetNumWGSSolvers(); ++gsid)
   {
     auto wgs_solver = do_problem_->GetWGSSolver(gsid);
     auto context = wgs_solver->GetContext();
     auto sweep_context = std::dynamic_pointer_cast<SweepWGSContext>(context);
     if (sweep_context)
+    {
+      transient_sweep_contexts.push_back(sweep_context);
       sweep_context->sweep_chunk->IncludeRHSTimeTerm(true);
+    }
   }
 
   do_problem_->SetTime(current_time_);
@@ -241,7 +240,6 @@ TransientSolver::Advance()
 
   // Zero source moments before recomputing sources for this step
   do_problem_->ZeroQMoments();
-  UpdateHasFissionableMaterial();
 
   // Solve
   do_problem_->SetPhiOldFrom(phi_prev_local_);
@@ -250,9 +248,20 @@ TransientSolver::Advance()
     if (current_solver.get() != ags_solver_.get())
       ags_solver_ = std::move(current_solver);
   }
-  if (not ags_solver_)
-    throw std::runtime_error(GetName() + ": AGS solver not available.");
-  ags_solver_->Solve();
+  OpenSnLogicalErrorIf(not ags_solver_, GetName() + ": AGS solver not available.");
+  try
+  {
+    ags_solver_->Solve();
+  }
+  catch (...)
+  {
+    for (const auto& sweep_context : transient_sweep_contexts)
+      sweep_context->sweep_chunk->IncludeRHSTimeTerm(false);
+    throw;
+  }
+
+  for (const auto& sweep_context : transient_sweep_contexts)
+    sweep_context->sweep_chunk->IncludeRHSTimeTerm(false);
 
   // For non-fission source-only problems, match TimeDependentSourceSolver behavior.
   // For fissioning problems (and any precursor case), apply the transient
@@ -278,7 +287,6 @@ TransientSolver::Advance()
   current_time_ += dt;
   do_problem_->SetTime(current_time_);
   phi_prev_local_ = *phi_new_local_;
-  psi_prev_local_ = *psi_new_local_;
   do_problem_->UpdateFieldFunctions();
   do_problem_->UpdatePsiOld();
   if (options.use_precursors)

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.h
@@ -43,9 +43,6 @@ private:
   std::shared_ptr<DiscreteOrdinatesProblem> do_problem_;
   std::shared_ptr<AGSLinearSolver> ags_solver_;
 
-  std::vector<double>* q_moments_local_ = nullptr;
-  std::vector<double>* phi_old_local_ = nullptr;
-
   std::vector<double>* phi_new_local_ = nullptr;
   std::vector<double>* precursor_new_local_ = nullptr;
   std::vector<std::vector<double>>* psi_new_local_ = nullptr;
@@ -53,7 +50,6 @@ private:
   /// Previous time step vectors
   std::vector<double> phi_prev_local_;
   std::vector<double> precursor_prev_local_;
-  std::vector<std::vector<double>> psi_prev_local_;
 
   /// Time discretization values and methods
   double stop_time_ = 0.1;


### PR DESCRIPTION
This PR includes the following fixes:

1. Use OpenSn error macros consistently across solvers
2. Correct name in NonLinearKEigenSolver
3. Add range limits for number of initial power iterations in NonLinearKEigenSolver
4. Correct type for number of initial power iterations in NonLinearKEigenSolver
4. Remove dead parameters and variables across all solvers
5. Correctly reset all sweep contexts and disable RHS time term in TransientSolver
6. Protect against invalid values for k_eff in PowerIterationKEigenSolver