### PR TITLE
Minor bug fixes for LBS utility routines

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -92,6 +92,12 @@ public:
 
   const std::vector<double>& GetNuDelayedSigmaF() const { return nu_delayed_sigma_f_; }
 
+  /**
+   * @note The LBS source and fission-production routines assume this matrix represents
+   * prompt production when delayed-neutrons are enabled, and add delayed production
+   * from nu_delayed_sigma_f separately. If production_matrix_ ever includes delayed
+   * contributions, those routines must be updated to avoid double counting.
+   */
   const std::vector<std::vector<double>>& GetProductionMatrix() const
   {
     return adjoint_ ? transposed_production_matrix_ : production_matrix_;
@@ -152,7 +158,10 @@ private:
   /// Sparse scattering matrix
   std::vector<SparseMatrix> transfer_matrices_;
   std::vector<SparseMatrix> transposed_transfer_matrices_;
-  /// Total neutron production matrix
+  /**
+   * Neutron production matrix used by transport source assembly.
+   * See GetProductionMatrix note regarding prompt-vs-delayed semantics.
+   */
   std::vector<std::vector<double>> production_matrix_;
   std::vector<std::vector<double>> transposed_production_matrix_;
 

--- a/framework/materials/multi_group_xs/openmc_import.cc
+++ b/framework/materials/multi_group_xs/openmc_import.cc
@@ -163,6 +163,9 @@ MultiGroupXS::LoadFromOpenMC(const std::string& file_name,
         nu[g] /= mgxs.sigma_f_[g];
 
     // Production matrix (computed)
+    // TODO: This path uses chi * nu_sigma_f (total production). If delayed-neutron data is
+    // introduced here in the future, ensure LBS source/fission-production routines remain
+    // consistent with prompt-vs-total production to avoid double counting.
     if (mgxs.production_matrix_.empty())
     {
       mgxs.production_matrix_.resize(mgxs.num_groups_, std::vector<double>(mgxs.num_groups_));

--- a/framework/materials/multi_group_xs/opensn_import.cc
+++ b/framework/materials/multi_group_xs/opensn_import.cc
@@ -140,6 +140,11 @@ MultiGroupXS::LoadFromOpenSn(const std::string& filename)
       }
 
       // Compute production matrix
+      // NOTE: When prompt data exists, this intentionally uses prompt-only production
+      // (chi_prompt * nu_prompt_sigma_f). Downstream LBS source/fission routines add
+      // delayed production separately from nu_delayed_sigma_f. If this changes and
+      // delayed contributions are folded into the production_matrix_, these downstream
+      // routines must be updated to prevent double counting.
       const auto fis_spec = not xsf.chi_prompt_.empty() ? xsf.chi_prompt_ : xsf.chi_;
       const auto nu_sigma_f =
         not xsf.nu_prompt_.empty() ? mgxs.nu_prompt_sigma_f_ : xsf.nu_sigma_f_;

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.cc
@@ -5,12 +5,13 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
+#include <cassert>
 
 namespace opensn
 {
 
 double
-ComputeFissionProduction(LBSProblem& lbs_problem, const std::vector<double>& phi)
+ComputeFissionProduction(const LBSProblem& lbs_problem, const std::vector<double>& phi)
 {
   CALI_CXX_MARK_SCOPE("ComputeFissionProduction");
 
@@ -18,6 +19,8 @@ ComputeFissionProduction(LBSProblem& lbs_problem, const std::vector<double>& phi
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
   const auto& unit_cell_matrices = lbs_problem.GetUnitCellMatrices();
   const auto& options = lbs_problem.GetOptions();
+  assert(phi.size() == lbs_problem.GetPhiNewLocal().size() &&
+         "ComputeFissionProduction size mismatch.");
 
   const auto first_grp = 0;
   const auto last_grp = lbs_problem.GetNumGroups() - 1;
@@ -51,6 +54,10 @@ ComputeFissionProduction(LBSProblem& lbs_problem, const std::vector<double>& phi
         for (unsigned int gp = 0; gp <= last_grp; ++gp)
           local_production += prod[gp] * phi[uk_map + gp] * IntV_ShapeI;
 
+        // When delayed-neutrons are enabled, this utility assumes production matrix
+        // contributions are prompt-only and adds delayed production separately via
+        // nu_delayed_sigma_f. If the production matrix changes to include delayed
+        // production, adjust this sum to prevent double counting.
         if (options.use_precursors)
           local_production += nu_delayed_sigma_f[g] * phi[uk_map + g] * IntV_ShapeI;
       }
@@ -65,13 +72,14 @@ ComputeFissionProduction(LBSProblem& lbs_problem, const std::vector<double>& phi
 }
 
 double
-ComputeFissionRate(LBSProblem& lbs_problem, const std::vector<double>& phi)
+ComputeFissionRate(const LBSProblem& lbs_problem, const std::vector<double>& phi)
 {
   CALI_CXX_MARK_SCOPE("ComputeFissionRate");
 
   const auto& grid = lbs_problem.GetGrid();
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
   const auto& unit_cell_matrices = lbs_problem.GetUnitCellMatrices();
+  assert(phi.size() == lbs_problem.GetPhiNewLocal().size() && "ComputeFissionRate size mismatch.");
 
   const auto first_grp = 0;
   const auto last_grp = lbs_problem.GetNumGroups() - 1;
@@ -124,7 +132,7 @@ ComputePrecursors(LBSProblem& lbs_problem)
   const auto& grid = lbs_problem.GetGrid();
   const auto& unit_cell_matrices = lbs_problem.GetUnitCellMatrices();
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
-  auto& phi_new_local = lbs_problem.GetPhiNewLocal();
+  const auto& phi_new_local = lbs_problem.GetPhiNewLocal();
 
   // Loop over cells
   for (const auto& cell : grid->local_cells)
@@ -132,6 +140,7 @@ ComputePrecursors(LBSProblem& lbs_problem)
     const auto& fe_values = unit_cell_matrices[cell.local_id];
     const auto& transport_view = cell_transport_views[cell.local_id];
     const double cell_volume = transport_view.GetVolume();
+    assert(cell_volume > 0.0 && "ComputePrecursors encountered non-positive cell volume.");
 
     // Obtain xs
     const auto& xs = transport_view.GetXS();
@@ -143,6 +152,8 @@ ComputePrecursors(LBSProblem& lbs_problem)
     {
       size_t dof = cell.local_id * J + j;
       const auto& precursor = precursors[j];
+      assert(precursor.decay_constant > 0.0 &&
+             "ComputePrecursors encountered non-positive precursor decay constant.");
       const double coeff = precursor.fractional_yield / precursor.decay_constant;
 
       // Loop over nodes

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <vector>
-#include <map>
-#include <cstdint>
 
 namespace opensn
 {
@@ -15,12 +13,12 @@ class LBSProblem;
 /**
  * Compute the total fission production in the problem.
  */
-double ComputeFissionProduction(LBSProblem& lbs_problem, const std::vector<double>& phi);
+double ComputeFissionProduction(const LBSProblem& lbs_problem, const std::vector<double>& phi);
 
 /**
  * Computes the total fission rate in the problem.
  */
-double ComputeFissionRate(LBSProblem& lbs_problem, const std::vector<double>& phi);
+double ComputeFissionRate(const LBSProblem& lbs_problem, const std::vector<double>& phi);
 
 /// Compute the steady state delayed neutron precursor concentrations.
 void ComputePrecursors(LBSProblem& lbs_problem);

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.cc
@@ -25,7 +25,8 @@ LBSVecOps::GroupsetScopedCopy(LBSProblem& lbs_problem,
   for (const auto& cell : grid->local_cells)
   {
     const auto& transport_view = cell_transport_views[cell.local_id];
-    for (std::size_t i = 0; i < cell.vertex_ids.size(); ++i)
+    const auto num_nodes = static_cast<std::size_t>(transport_view.GetNumNodes());
+    for (std::size_t i = 0; i < num_nodes; ++i)
     {
       for (unsigned int m = 0; m < num_moments; ++m)
       {

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_vecops.h
@@ -30,7 +30,7 @@ public:
                                                 Vec dest,
                                                 PhiSTLOption src);
 
-  /// Assembles a vector for a given groupset from a source vector.
+  /// Disassembles a groupset-scoped PETSc vector back into a primary STL vector.
   static void SetPrimarySTLvectorFromGSPETScVec(LBSProblem& lbs_problem,
                                                 const LBSGroupset& groupset,
                                                 Vec src,
@@ -43,20 +43,20 @@ public:
                                                          Vec dest,
                                                          const std::vector<double>& src);
 
-  /// Assembles a vector for a given groupset from a source vector.
+  /// Disassembles a group-span PETSc vector back into a primary STL vector.
   static void SetPrimarySTLvectorFromGroupScopedPETScVec(LBSProblem& lbs_problem,
                                                          unsigned int first_group_id,
                                                          unsigned int last_group_id,
                                                          Vec src,
                                                          PhiSTLOption dest);
 
-  /// Assembles a vector for a given groupset from a source vector.
+  /// Copies one groupset scope from source STL vector to destination STL vector.
   static void GSScopedCopyPrimarySTLvectors(LBSProblem& lbs_problem,
                                             const LBSGroupset& groupset,
                                             const std::vector<double>& src,
                                             std::vector<double>& dest);
 
-  /// Assembles a vector for a given groupset from a source vector.
+  /// Copies one groupset scope between primary STL vectors selected by phi options.
   static void GSScopedCopyPrimarySTLvectors(LBSProblem& lbs_problem,
                                             const LBSGroupset& groupset,
                                             PhiSTLOption src,
@@ -68,7 +68,7 @@ public:
                                                      Vec x,
                                                      PhiSTLOption which_phi);
 
-  /// Disassembles a multiple Groupset PETSc vector STL vectors.
+  /// Disassembles a multi-groupset PETSc vector back into the primary STL vector.
   static void SetPrimarySTLvectorFromMultiGSPETScVec(LBSProblem& lbs_problem,
                                                      const std::vector<unsigned int>& groupset_ids,
                                                      Vec x,

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_view.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_view.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "framework/materials/multi_group_xs/multi_group_xs.h"
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -38,7 +39,12 @@ public:
       neighbor_cell_ptrs_(neighbor_cell_ptrs)
   {
     if (cell_on_boundary)
+    {
       outflow_.resize(num_faces);
+      for (int f = 0; f < num_faces; ++f)
+        if (face_locality_[f] < 0)
+          outflow_[f].assign(num_groups_, 0.0);
+    }
   }
 
   size_t MapDOF(uint64_t node, uint64_t moment, unsigned int grp) const
@@ -48,11 +54,23 @@ public:
 
   const MultiGroupXS& GetXS() const { return *xs_; }
 
-  bool IsFaceLocal(std::size_t f) const { return face_local_flags_[f]; }
+  bool IsFaceLocal(std::size_t f) const
+  {
+    assert(f < face_local_flags_.size() && "CellLBSView::IsFaceLocal face index out of range.");
+    return face_local_flags_[f];
+  }
 
-  int FaceLocality(std::size_t f) const { return face_locality_[f]; }
+  int FaceLocality(std::size_t f) const
+  {
+    assert(f < face_locality_.size() && "CellLBSView::FaceLocality face index out of range.");
+    return face_locality_[f];
+  }
 
-  const Cell* FaceNeighbor(std::size_t f) const { return neighbor_cell_ptrs_[f]; }
+  const Cell* FaceNeighbor(std::size_t f) const
+  {
+    assert(f < neighbor_cell_ptrs_.size() && "CellLBSView::FaceNeighbor face index out of range.");
+    return neighbor_cell_ptrs_[f];
+  }
 
   int GetNumNodes() const { return num_nodes_; }
 
@@ -60,16 +78,18 @@ public:
 
   void ZeroOutflow(std::size_t f, unsigned int g)
   {
+    assert(f < face_local_flags_.size() && "CellLBSView::ZeroOutflow face index out of range.");
+    assert(g < num_groups_ && "CellLBSView::ZeroOutflow group index out of range.");
     if (f < outflow_.size() and g < outflow_[f].size())
       outflow_[f][g] = 0.0;
   }
 
   void AddOutflow(std::size_t f, unsigned int g, double intS_mu_psi)
   {
+    assert(f < face_local_flags_.size() && "CellLBSView::AddOutflow face index out of range.");
+    assert(g < num_groups_ && "CellLBSView::AddOutflow group index out of range.");
     if (f < outflow_.size())
     {
-      if (outflow_[f].empty())
-        outflow_[f].resize(num_groups_, 0.0);
       if (g < outflow_[f].size())
         outflow_[f][g] += intS_mu_psi;
     }
@@ -77,6 +97,8 @@ public:
 
   double GetOutflow(std::size_t f, unsigned int g) const
   {
+    assert(f < face_local_flags_.size() && "CellLBSView::GetOutflow face index out of range.");
+    assert(g < num_groups_ && "CellLBSView::GetOutflow group index out of range.");
     if (f < outflow_.size() and g < outflow_[f].size())
       return outflow_[f][g];
     return 0.0;


### PR DESCRIPTION
This PR fixes the following issues in the LBS utility routines:

1. const correctness
2. Add comments about delayed neutron handling
3. Replace loops over cell vertices with loops over cell nodes