### PR TITLE
Fixing test output

### DIFF
--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
@@ -110,6 +110,8 @@ if __name__ == "__main__":
     fflist = phys.GetScalarFluxFieldFunction()
     monitor_volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
 
+    phi0 = []
+    phi1 = []
     while current_time < stop_time:
         target_time = min(current_time + dt, stop_time)
         step_dt = target_time - current_time
@@ -138,6 +140,7 @@ if __name__ == "__main__":
         ff_interp_g0.Initialize()
         ff_interp_g0.Execute()
         flux_max_g0 = ff_interp_g0.GetValue()
+        phi0.append(flux_max_g0)
 
         # Group 1
         ff_interp_g1 = FieldFunctionInterpolationVolume()
@@ -147,10 +150,11 @@ if __name__ == "__main__":
         ff_interp_g1.Initialize()
         ff_interp_g1.Execute()
         flux_max_g1 = ff_interp_g1.GetValue()
-
-        if rank == 0:
-            print("Max phi0 = {:.6f}".format(flux_max_g0))
-            print("Max phi1 = {:.6f}".format(flux_max_g1))
+        phi1.append(flux_max_g1)
 
         current_time = target_time
         step += 1
+
+    if rank == 0:
+        print("Max phi0 = {:.6f}".format(max(phi0)))
+        print("Max phi1 = {:.6f}".format(max(phi1)))


### PR DESCRIPTION
This changes the output of the test, so that it print the max phi values only once at the end of the run.

Without this, the CI pipeline would report:
```
Check failed : type="KeyValuePair", key="Max phi0 = ", goldvalue=3.663371, rel_tol=0.0, abs_tol=1e-06
Max phi0 = 0.037038

Check failed : type="KeyValuePair", key="Max phi0 = ", goldvalue=3.663371, rel_tol=0.0, abs_tol=1e-06
Max phi0 = 0.184711

Check failed : type="KeyValuePair", key="Max phi0 = ", goldvalue=3.663371, rel_tol=0.0, abs_tol=1e-06
Max phi0 = 0.466348

Check failed : type="KeyValuePair", key="Max phi0 = ", goldvalue=3.663371, rel_tol=0.0, abs_tol=1e-06
Max phi0 = 0.849389
...
```
But surprisingly it would report success at the end. This could confuse users and mislead them that they introduced a bug.

Now, we just collect `max_flux` into an array and we report maximum at the end.