### PR TITLE
Fixing wrong_parameter test

### DIFF
--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/wrong_parameter.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/wrong_parameter.py
@@ -59,10 +59,10 @@ if __name__ == "__main__":
                 "xs": xs_3_170
             }
         ],
+        boundary_conditions=[
+        ],
         options={
             "wrong-parameter": True,
-            "boundary_conditions": [
-            ],
         }
     )
     ss_solver = SteadyStateSolver(problem=phys)


### PR DESCRIPTION
Test is checking that if we supply "wrong-parameter" an error is thrown. "boundary_conditions" parameter must be supplied as a correct parameter, otherwise we see the test to report a false error.

```
Warnings during test execution:
<class 'UserWarning'>  Check failed : type="StrCompare", key="Invalid param ", wordnum=6, gold="wrong-parameter" 
[0]  **** ERROR ****  Invalid param "boundary_conditions" supplied.

['[0]', '****', 'ERROR', '****', 'Invalid', 'param', '"boundary_conditions"', 'supplied.']
```