### PR TITLE
Bug fixes and improvements to MultiGroupXS

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.cc
+++ b/framework/materials/multi_group_xs/multi_group_xs.cc
@@ -49,14 +49,11 @@ MultiGroupXS::Combine(
     auto xs = combo.first;
     xsecs.push_back(xs);
 
-    // Set the scaling factor
-    xs->SetScalingFactor(combo.second);
-
     // Increment densities
     if (xs->IsFissionable())
     {
       mgxs.is_fissionable_ = true;
-      Nf_total += xs->GetScalingFactor();
+      Nf_total += combo.second;
     }
 
     // Define and check number of groups
@@ -123,39 +120,42 @@ MultiGroupXS::Combine(
   unsigned int precursor_count = 0;
   for (size_t x = 0; x < xsecs.size(); ++x)
   {
+    const auto& xs = xsecs[x];
+    const double density = combinations[x].second;
+
     // Fraction of fissile density
-    const auto N_i = xsecs[x]->GetScalingFactor();
-    const auto ff_i = xsecs[x]->IsFissionable() ? N_i / Nf_total : 0.0;
+    const auto ff_i = xs->IsFissionable() ? density / Nf_total : 0.0;
 
     // Combine cross sections
-    const auto& sig_t = xsecs[x]->GetSigmaTotal();
-    const auto& sig_a = xsecs[x]->GetSigmaAbsorption();
-    const auto& chi = xsecs[x]->GetChi();
-    const auto& sig_f = xsecs[x]->GetSigmaFission();
-    const auto& nu_p_sig_f = xsecs[x]->GetNuPromptSigmaF();
-    const auto& nu_d_sig_f = xsecs[x]->GetNuDelayedSigmaF();
-    const auto& F = xsecs[x]->GetProductionMatrix();
+    const auto& sig_t = xs->GetSigmaTotal();
+    const auto& sig_a = xs->GetSigmaAbsorption();
+    const auto& chi = xs->GetChi();
+    const auto& sig_f = xs->GetSigmaFission();
+    const auto& nu_sig_f = xs->GetNuSigmaF();
+    const auto& nu_p_sig_f = xs->GetNuPromptSigmaF();
+    const auto& nu_d_sig_f = xs->GetNuDelayedSigmaF();
+    const auto& F = xs->GetProductionMatrix();
 
     // Here, raw cross sections are scaled by densities and spectra by
     // fractional densities. The latter is done to preserve a unit spectra.
     for (unsigned int g = 0; g < n_grps; ++g)
     {
-      mgxs.sigma_t_[g] += sig_t[g];
-      mgxs.sigma_a_[g] += sig_a[g];
+      mgxs.sigma_t_[g] += density * sig_t[g];
+      mgxs.sigma_a_[g] += density * sig_a[g];
 
-      if (xsecs[x]->IsFissionable())
+      if (xs->IsFissionable())
       {
-        mgxs.sigma_f_[g] += sig_f[g];
+        mgxs.sigma_f_[g] += density * sig_f[g];
         if (not chi.empty())
           mgxs.chi_[g] += ff_i * chi[g];
-        mgxs.nu_sigma_f_[g] += sig_f[g];
+        mgxs.nu_sigma_f_[g] += density * nu_sig_f[g];
         for (unsigned int gp = 0; gp < mgxs.num_groups_; ++gp)
-          mgxs.production_matrix_[g][gp] += F[g][gp];
+          mgxs.production_matrix_[g][gp] += density * F[g][gp];
 
         if (n_precs > 0)
         {
-          mgxs.nu_prompt_sigma_f_[g] += nu_p_sig_f[g];
-          mgxs.nu_delayed_sigma_f_[g] += nu_d_sig_f[g];
+          mgxs.nu_prompt_sigma_f_[g] += density * nu_p_sig_f[g];
+          mgxs.nu_delayed_sigma_f_[g] += density * nu_d_sig_f[g];
         }
       }
     } // for g
@@ -168,10 +168,10 @@ MultiGroupXS::Combine(
     // precursor yields must be scaled based on the fraction of the total density of materials
     // with precursors they make up.
 
-    if (xsecs[x]->GetNumPrecursors() > 0)
+    if (xs->GetNumPrecursors() > 0)
     {
-      const auto& precursors = xsecs[x]->GetPrecursors();
-      for (unsigned int j = 0; j < xsecs[x]->GetNumPrecursors(); ++j)
+      const auto& precursors = xs->GetPrecursors();
+      for (unsigned int j = 0; j < xs->GetNumPrecursors(); ++j)
       {
         auto count = precursor_count + j;
         const auto& precursor = precursors[j];
@@ -180,15 +180,15 @@ MultiGroupXS::Combine(
         mgxs.precursors_[count].emission_spectrum = precursor.emission_spectrum;
       } // for j
 
-      precursor_count += xsecs[x]->GetNumPrecursors();
+      precursor_count += xs->GetNumPrecursors();
     }
 
     // Set inverse velocity data
-    if (x == 0 and not xsecs[x]->GetInverseVelocity().empty())
-      mgxs.inv_velocity_ = xsecs[x]->GetInverseVelocity();
+    if (x == 0 and not xs->GetInverseVelocity().empty())
+      mgxs.inv_velocity_ = xs->GetInverseVelocity();
     if (not mgxs.inv_velocity_.empty())
       OpenSnLogicalErrorIf(
-        xsecs[x]->GetInverseVelocity() != mgxs.inv_velocity_,
+        xs->GetInverseVelocity() != mgxs.inv_velocity_,
         "All cross sections being combined must have the same group-wise velocities.");
 
     // Combine transfer matrices
@@ -198,18 +198,18 @@ MultiGroupXS::Combine(
     // together has to take the sparse matrix's protection mechanisms into
     // account.
 
-    if (not xsecs[x]->GetTransferMatrices().empty())
+    if (not xs->GetTransferMatrices().empty())
     {
-      for (unsigned int m = 0; m < xsecs[x]->GetScatteringOrder() + 1; ++m)
+      for (unsigned int m = 0; m < xs->GetScatteringOrder() + 1; ++m)
       {
         auto& Sm = mgxs.transfer_matrices_[m];
-        const auto& Sm_other = xsecs[x]->GetTransferMatrix(m);
+        const auto& Sm_other = xs->GetTransferMatrix(m);
         for (unsigned int g = 0; g < mgxs.num_groups_; ++g)
         {
           const auto& cols = Sm_other.rowI_indices[g];
           const auto& vals = Sm_other.rowI_values[g];
           for (size_t t = 0; t < cols.size(); ++t)
-            Sm.InsertAdd(g, t, vals[t]);
+            Sm.InsertAdd(g, cols[t], density * vals[t]);
         }
       }
     }
@@ -231,6 +231,7 @@ MultiGroupXS::Reset()
   sigma_t_.clear();
   sigma_a_.clear();
   transfer_matrices_.clear();
+  transposed_transfer_matrices_.clear();
 
   sigma_f_.clear();
   chi_.clear();
@@ -238,6 +239,7 @@ MultiGroupXS::Reset()
   nu_prompt_sigma_f_.clear();
   nu_delayed_sigma_f_.clear();
   production_matrix_.clear();
+  transposed_production_matrix_.clear();
   precursors_.clear();
 
   inv_velocity_.clear();
@@ -394,47 +396,59 @@ MultiGroupXS::ComputeDiffusionParameters()
   diffusion_initialized_ = true;
 }
 
-void
-MultiGroupXS::SetScalingFactor(const double factor)
+MultiGroupXS
+MultiGroupXS::Scale(const double factor) const
 {
-  const double m = factor / scaling_factor_;
-  scaling_factor_ = factor;
+  MultiGroupXS scaled = *this;
 
   // Apply to STL vector-based data
-  for (unsigned int g = 0; g < num_groups_; ++g)
+  for (unsigned int g = 0; g < scaled.num_groups_; ++g)
   {
-    sigma_t_[g] *= m;
-    sigma_a_[g] *= m;
+    scaled.sigma_t_[g] *= factor;
+    scaled.sigma_a_[g] *= factor;
 
-    if (is_fissionable_)
+    if (scaled.is_fissionable_)
     {
-      sigma_f_[g] *= m;
-      nu_sigma_f_[g] *= m;
-      if (num_precursors_ > 0)
+      scaled.sigma_f_[g] *= factor;
+      scaled.nu_sigma_f_[g] *= factor;
+      if (scaled.num_precursors_ > 0)
       {
-        nu_prompt_sigma_f_[g] *= m;
-        nu_delayed_sigma_f_[g] *= m;
+        scaled.nu_prompt_sigma_f_[g] *= factor;
+        scaled.nu_delayed_sigma_f_[g] *= factor;
       }
 
-      for (auto& x : production_matrix_[g])
-        x *= m;
+      for (auto& x : scaled.production_matrix_[g])
+        x *= factor;
     }
   }
 
   // Apply to transfer matrices
-  for (auto& S_ell : transfer_matrices_)
-    for (unsigned int g = 0; g < num_groups_; ++g)
+  for (auto& S_ell : scaled.transfer_matrices_)
+    for (unsigned int g = 0; g < scaled.num_groups_; ++g)
       for (const auto& [_, gp, sig_ell] : S_ell.Row(g))
-        sig_ell *= m;
+        sig_ell *= factor;
 
-  // Reinitialize diffusion
-  diffusion_initialized_ = false;
-  ComputeDiffusionParameters();
+  for (auto& S_ell : scaled.transposed_transfer_matrices_)
+    for (unsigned int g = 0; g < scaled.num_groups_; ++g)
+      for (const auto& [_, gp, sig_ell] : S_ell.Row(g))
+        sig_ell *= factor;
+
+  for (auto& row : scaled.transposed_production_matrix_)
+    for (auto& x : row)
+      x *= factor;
+
+  scaled.diffusion_initialized_ = false;
+  scaled.ComputeDiffusionParameters();
+
+  return scaled;
 }
 
 void
 MultiGroupXS::TransposeTransferAndProduction()
 {
+  transposed_transfer_matrices_.clear();
+  transposed_production_matrix_.clear();
+
   // Transpose transfer matrices
   for (unsigned int ell = 0; ell <= scattering_order_; ++ell)
   {
@@ -455,7 +469,6 @@ MultiGroupXS::TransposeTransferAndProduction()
   // Transpose production matrices
   if (is_fissionable_)
   {
-    transposed_production_matrix_.clear();
     transposed_production_matrix_.resize(num_groups_);
     const auto& F = production_matrix_;
     for (unsigned int g = 0; g < num_groups_; ++g)

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -18,7 +18,6 @@ public:
       num_precursors_(0),
       is_fissionable_(false),
       adjoint_(false),
-      scaling_factor_(1.0),
       diffusion_initialized_(false)
   {
   }
@@ -31,13 +30,8 @@ public:
     std::vector<double> emission_spectrum;
   };
 
-  /**
-   * Scale the cross sections by the specified factor.
-   *
-   * @note Scaling factors do not compound. Each time this routine is called, the cross sections
-   *       are scaled by the ratio of the argument and the existing scaling factor.
-   */
-  void SetScalingFactor(double factor);
+  /// Return a scaled copy of the cross sections.
+  MultiGroupXS Scale(double factor) const;
 
   /**
    * Exports the cross-section information to OpenSn format.
@@ -65,8 +59,6 @@ public:
   }
 
   bool GetAdjointMode() const { return adjoint_; }
-
-  double GetScalingFactor() const { return scaling_factor_; }
 
   const std::vector<double>& GetSigmaTotal() const { return sigma_t_; }
 
@@ -132,8 +124,6 @@ private:
   bool is_fissionable_;
   /// Can be used for adjoint calculations
   bool adjoint_;
-  /// An arbitrary scaling factor
-  double scaling_factor_ = 1.0;
   /// Evaluation temperature
   double temperature_ = 294.0;
   /// Energy bin boundaries in MeV

--- a/framework/materials/multi_group_xs/opensn_export.cc
+++ b/framework/materials/multi_group_xs/opensn_export.cc
@@ -128,18 +128,18 @@ MultiGroupXS::ExportToOpenSnXSFile(const std::string& file_name, const double fi
     Print1DXS(ofile, "INV_VELOCITY", GetInverseVelocity(), 1.0e-20);
 
   // Transfer matrices
-  if (not GetTransferMatrices().empty())
+  if (not transfer_matrices_.empty())
   {
     ofile << "\n";
     ofile << "TRANSFER_MOMENTS_BEGIN\n";
-    for (size_t ell = 0; ell < GetTransferMatrices().size(); ++ell)
+    for (size_t ell = 0; ell < transfer_matrices_.size(); ++ell)
     {
       if (ell == 0)
         ofile << "#Zeroth moment (l=0)\n";
       else
         ofile << "#(l=" << ell << ")\n";
 
-      const auto& matrix = GetTransferMatrix(ell);
+      const auto& matrix = transfer_matrices_[ell];
 
       for (size_t g = 0; g < matrix.rowI_values.size(); ++g)
       {
@@ -156,14 +156,15 @@ MultiGroupXS::ExportToOpenSnXSFile(const std::string& file_name, const double fi
   } // if has transfer matrices
 
   // Write production matrix
-  if (not GetProductionMatrix().empty())
+  if (not production_matrix_.empty())
   {
     ofile << "\n";
     ofile << "PRODUCTION_MATRIX_BEGIN\n";
     for (unsigned int g = 0; g < GetNumGroups(); ++g)
       for (unsigned int gp = 0; gp < GetNumGroups(); ++gp)
-        ofile << "G_GPRIME_VAL " << g << " " << gp << " "
-              << fission_scaling * GetProductionMatrix()[g][gp] << "\n";
+        ofile << "GPRIME_G_VAL " << g << " " << gp << " "
+              << fission_scaling * production_matrix_[g][gp] << "\n";
+    ofile << "PRODUCTION_MATRIX_END\n";
   }
   ofile.close();
 

--- a/framework/materials/multi_group_xs/opensn_import.cc
+++ b/framework/materials/multi_group_xs/opensn_import.cc
@@ -170,6 +170,9 @@ MultiGroupXS::LoadFromOpenSn(const std::string& filename)
                            "When a production matrix is specified, it must "
                            "be accompanied with a fission cross section.");
 
+      mgxs.sigma_f_ = xsf.sigma_f_;
+      mgxs.production_matrix_ = xsf.production_matrix_;
+
       // Compute production cross section
       mgxs.nu_sigma_f_.assign(xsf.num_groups_, 0.0);
       for (unsigned int g = 0; g < xsf.num_groups_; ++g)
@@ -177,7 +180,7 @@ MultiGroupXS::LoadFromOpenSn(const std::string& filename)
           mgxs.nu_sigma_f_[gp] += xsf.production_matrix_[g][gp];
 
       // Check for reasonable fission neutron yield
-      auto nu = xsf.nu_sigma_f_;
+      auto nu = mgxs.nu_sigma_f_;
       for (unsigned int g = 0; g < xsf.num_groups_; ++g)
         if (xsf.sigma_f_[g] > 0.0)
           nu[g] /= xsf.sigma_f_[g];

--- a/framework/materials/multi_group_xs/xsfile.cc
+++ b/framework/materials/multi_group_xs/xsfile.cc
@@ -278,7 +278,7 @@ XSFile::Read()
         {
           log.Log0Warning() << "The delayed fission neutron yield specified in "
                             << "\"" << file_name_ << "\" is uniformly zero... Clearing it.";
-          nu_prompt_.clear();
+          nu_delayed_.clear();
         }
       } // if nu_delayed
 

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -28,6 +28,13 @@ WrapMultiGroupXS(py::module& xs)
     Multi-group cross section.
 
     Wrapper of :cpp:class:`opensn::MultiGroupXS`.
+
+    The Python API currently has two types of methods:
+
+    - Creation/loading methods such as ``CreateSimpleOneGroup``,
+      ``LoadFromOpenSn``, and ``LoadFromOpenMC`` populate an existing object.
+    - Transformation methods such as ``Scale`` and ``Combine`` return new
+      cross-section objects and do not mutate their inputs.
     )"
   );
   multigroup_xs.def(
@@ -46,7 +53,7 @@ WrapMultiGroupXS(py::module& xs)
       self = MultiGroupXS::CreateSimpleOneGroup(sigma_t, c, velocity);
     },
     R"(
-    Create a one-group cross section.
+    Populate this object with a one-group cross section.
 
     Parameters
     ----------
@@ -57,6 +64,10 @@ WrapMultiGroupXS(py::module& xs)
     velocity: float, optional
         Group velocity. If provided and positive, inverse velocity
         is populated with 1.0/velocity.
+
+    Notes
+    -----
+    This method mutates ``self`` by replacing its current contents.
     )",
     py::arg("sigma_t"),
     py::arg("c"),
@@ -70,7 +81,8 @@ WrapMultiGroupXS(py::module& xs)
     },
     py::arg("file_name"),
     R"(
-    Load multi-group cross sections from an OpenSn cross section input file.
+    Load multi-group cross sections from an OpenSn cross section input file
+    into this object.
 
     Format is as follows (for transfers, gprime denotes the departing group and g is the arrival
     group).
@@ -102,22 +114,42 @@ WrapMultiGroupXS(py::module& xs)
        .
        M_GFROM_GTO_VAL nmom-1 ng-1 ng-1 value
        TRANSFER_MOMENTS_END
+
+    Notes
+    -----
+    This method mutates ``self`` by replacing its current contents.
     )"
   );
-  multigroup_xs.def(
+  multigroup_xs.def_static(
     "Combine",
-    [](MultiGroupXS& self, const std::vector<std::pair<std::shared_ptr<MultiGroupXS>, double>>& combinations)
-    {
-      self = MultiGroupXS::Combine(combinations);
-    },
+    &MultiGroupXS::Combine,
     R"(
-    Combine cross-section
+    Return a new combined cross-section.
 
     Parameters
     ----------
 
     combinations: List[Tuple[pyopensn.xs.MultiGroupXS, float]]
-        List of combinations (cross section, factor)
+        List of ``(cross_section, density)`` pairs.
+        The density values are linear weights used to combine raw cross sections.
+
+    Returns
+    -------
+    pyopensn.xs.MultiGroupXS
+        A new combined cross-section object. The input cross sections are not
+        modified.
+
+    Notes
+    -----
+    Let :math:`d_i` be the supplied density for cross section :math:`i`.
+
+    - Raw XS terms are density-weighted sums:
+      :math:`\sigma = \sum_i d_i \sigma_i`
+      (e.g. total, absorption, fission, transfer, production).
+    - Fission spectra and precursor yields are weighted by fissile density
+      fraction so their sums remain normalized.
+    - All inputs must have the same number of groups.
+    - If inverse velocity is present, all inputs must have identical values.
 
     Examples
     --------
@@ -126,12 +158,11 @@ WrapMultiGroupXS(py::module& xs)
     >>> xs_1.CreateSimpleOneGroup(sigma_t=1, c=0.5)
     >>> xs_2 = MultiGroupXS()
     >>> xs_2.CreateSimpleOneGroup(sigma_t=2, c=1./3.)
-    >>> xs_combined = MultiGroupXS()
     >>> combo = [
     ...     ( xs_1, 0.5 ),
     ...     ( xs_2, 3.0 )
     ... ]
-    >>> xs_combined.Combine(combo)
+    >>> xs_combined = MultiGroupXS.Combine(combo)
     )",
     py::arg("combinations")
   );
@@ -145,16 +176,35 @@ WrapMultiGroupXS(py::module& xs)
     {
       self = MultiGroupXS::LoadFromOpenMC(file_name, dataset_name, temperature, extra_xs_names);
     },
-    "Load multi-group cross sections from an OpenMC cross-section file.",
+    R"(
+    Load multi-group cross sections from an OpenMC cross-section file into this
+    object.
+
+    Notes
+    -----
+    This method mutates ``self`` by replacing its current contents.
+    )",
     py::arg("file_name"),
     py::arg("dataset_name"),
     py::arg("temperature"),
     py::arg("extra_xs_names") = std::vector<std::string>()
   );
   multigroup_xs.def(
-    "SetScalingFactor",
-    &MultiGroupXS::SetScalingFactor,
-    "Scale the cross sections by the specified factor.",
+    "Scale",
+    &MultiGroupXS::Scale,
+    R"(
+    Return a scaled copy of the cross sections.
+
+    Parameters
+    ----------
+    factor: float
+        Multiplicative factor applied to scalable cross-section data.
+
+    Returns
+    -------
+    pyopensn.xs.MultiGroupXS
+        A new scaled cross-section object. ``self`` is not modified.
+    )",
     py::arg("factor")
   );
   multigroup_xs.def_property_readonly(
@@ -176,11 +226,6 @@ WrapMultiGroupXS(py::module& xs)
     "is_fissionable",
     &MultiGroupXS::IsFissionable,
     "Check if the material is fissile."
-  );
-  multigroup_xs.def_property_readonly(
-    "scaling_factor",
-    &MultiGroupXS::GetScalingFactor,
-    "Get the arbitrary scaling factor."
   );
   multigroup_xs.def_property_readonly(
     "sigma_t",

--- a/test/python/framework/materials/xs_combined.py
+++ b/test/python/framework/materials/xs_combined.py
@@ -15,12 +15,11 @@ if __name__ == "__main__":
     xs_2 = MultiGroupXS()
     xs_2.CreateSimpleOneGroup(sigma_t=2, c=1. / 3.)
 
-    xs_combined = MultiGroupXS()
     combo = [
         (xs_1, 0.5),
         (xs_2, 3.0)
     ]
-    xs_combined.Combine(combo)
+    xs_combined = MultiGroupXS.Combine(combo)
 
     print(f"Combined sigma_t: {xs_combined.sigma_t[0]}")
     print(f"Combined sigma_a: {xs_combined.sigma_a[0]}")

--- a/test/python/framework/materials/xs_printout.py
+++ b/test/python/framework/materials/xs_printout.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Read a cross section file, apply a scaling factor, and print out some components to the console.
+Read a cross section file, create a scaled copy, and print out some components to the console.
 """
 
 import pprint
@@ -30,8 +30,8 @@ my_xs["fuel"] = fuel_xs
 chi_before = my_xs["fuel"].chi[0]
 sigt_before = my_xs["fuel"].sigma_t[0]
 
-# Apply the scaling factor
-my_xs["fuel"].SetScalingFactor(2.0)
+# Create a scaled copy
+my_xs["fuel"] = my_xs["fuel"].Scale(2.0)
 
 # After scaling
 chi_after = my_xs["fuel"].chi[0]

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
@@ -8,8 +8,11 @@
 inputs.
 
 FP_RATIO_ACTUAL = 2.2
-sigma_f_mix = sigma_f_crit + sigma_f_super, so ratio = (1.0 + 1.2) = 2.2
-relative to the critical xs. FP_RATIO_ACTUAL checks Combine behavior with
+Combine uses density weights, so with (1.0, 1.0):
+sigma_f_mix = 1.0 * sigma_f_crit + 1.0 * sigma_f_super.
+Given sigma_f_super = 1.2 * sigma_f_crit, the ratio is
+sigma_f_mix / sigma_f_crit = 1.0 + 1.2 = 2.2.
+FP_RATIO_ACTUAL checks Combine behavior with
 mixed group velocities. TRANSIENT_OK ensures the first transient step is
 finite and positive.
 """
@@ -44,8 +47,7 @@ if __name__ == "__main__":
     xs_super = MultiGroupXS()
     xs_super.LoadFromOpenSn(os.path.join(os.path.dirname(__file__), "xs2g_prompt_super.cxs"))
 
-    xs_mix = MultiGroupXS()
-    xs_mix.Combine([(xs_crit, 0.5), (xs_super, 0.5)])
+    xs_mix = MultiGroupXS.Combine([(xs_crit, 1.0), (xs_super, 1.0)])
 
     pquad = GLCProductQuadrature2DXY(n_polar=2, n_azimuthal=4, scattering_order=0)
 


### PR DESCRIPTION
This PR includes the following fixes and improvements:

1. MultiGroupXS::Scale replaces MultiGroupXS::SetScalingFactor. Scale is value-based and returns a new object instead of mutating the existing object.
2. MultiGroupXS::Combine is value-based and density-driven. It returns a new object and does not mutate inputs.
3. Fixed Combine transfer-matrix accumulation to use actual sparse column indices.
4. Fixed Combine fission production accumulation to use nu_sigma_f rather than sigma_f.
5. Fixed OpenSn production-matrix export format to always write forward data.
6. Fixed OpenSn production-matrix import to populate sigma_f_ and production_matrix_.
7. Fixed the production-matrix import consistency check to derive nu from the computed production cross section.
8. Fixed NU_DELAYED_BEGIN parsing.
9. Other minor fixes.