### PR TITLE
Correctly find LAPACK and link against it

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -15,23 +15,36 @@ jobs:
         include:
           - compiler: gcc/13
             tag: gcc-13
+            dir: gcc/13.3.0
           - compiler: gcc/14
             tag: gcc-14
+            dir: gcc/14.2.0
           - compiler: clang/17
             tag: clang-17
+            dir: clang/17.0.6
           - compiler: clang/18
             tag: clang-18
+            dir: clang/18.1.8
           - compiler: clang/19
             tag: clang-19
+            dir: clang/19.1.5
           - compiler: intel/oneapi
             tag: intel-oneapi
+            dir: intel/2025.0.0
     steps:
       - uses: actions/checkout@v7
       - name: build
         shell: bash
         run: |
           module load python3/3.12.3 opensn/${{ matrix.compiler }}
-          mkdir build && cd build && cmake -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            ..
+          make -j
       - name: test
         shell: bash
         run: |
@@ -70,15 +83,25 @@ jobs:
         include:
           - compiler: gcc/14
             tag: gcc-14
+            dir: gcc/14.2.0
           - compiler: clang/19
             tag: clang-19
+            dir: clang/19.1.5
     steps:
       - uses: actions/checkout@v7
       - name: build
         shell: bash
         run: |
           module load python3/3.12.3 opensn/${{ matrix.compiler }}
-          mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Native -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DCMAKE_BUILD_TYPE=Native \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            ..
+          make -j
       - name: test
         shell: bash
         run: |
@@ -104,15 +127,26 @@ jobs:
         include:
           - compiler: gcc/14
             tag: gcc-14
+            dir: gcc/14.2.0
           - compiler: clang/19
             tag: clang-19
+            dir: clang/19.1.5
     steps:
       - uses: actions/checkout@v7
       - name: build
         shell: bash
         run: |
           module load cuda/13.0 python3/3.12.3 opensn/${{ matrix.compiler }}
-          mkdir build && cd build && cmake -DOPENSN_WITH_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=89 -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/${{ matrix.dir }}/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_CUDA=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=89 \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            ..
+          make -j
       - name: test
         shell: bash
         run: |
@@ -137,7 +171,11 @@ jobs:
         shell: bash
         run: |
           module load python3/3.12.3 opensn/clang/17
-          cmake -DOPENSN_WITH_PYTHON_MODULE=ON --preset clang+debug+sanitizer
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/clang/17.0.6/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/clang/17.0.6/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            --preset clang+debug+sanitizer
           cmake --build --preset clang+debug+sanitizer -j64
       - name: test
         shell: bash

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,7 +14,13 @@ jobs:
         shell: bash
         run: |
           module load cuda/13.0 python3/3.12.3 opensn/gcc/14
-          cmake -DOPENSN_WITH_PYTHON_MODULE=ON -DOPENSN_WITH_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=89 --preset coverage
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            -DOPENSN_WITH_CUDA=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=89 \
+            --preset coverage
           cmake --build --preset coverage -j64
       - name: test
         shell: bash

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -20,7 +20,13 @@ jobs:
         shell: bash
         run: |
           module load python3/3.12.3 opensn/gcc/14
-          mkdir build && cd build && cmake -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_PYTHON_MODULE=ON ..
+          make -j
       - name: test
         shell: bash
         run: |
@@ -68,7 +74,16 @@ jobs:
         shell: bash
         run: |
           module load cuda/12.9 python3/3.12.3 opensn/gcc/14
-          mkdir build && cd build && cmake -DOPENSN_WITH_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=89 -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_CUDA=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=89 \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            ..
+          make -j
       - name: test
         shell: bash
         run: |
@@ -95,7 +110,16 @@ jobs:
           module load cuda/12.9 python3/3.12.3 rocm/7.1.1 opensn/clang/19
           export HIP_PLATFORM=nvidia
           export HIP_COMPILER=nvcc
-          mkdir build && cd build && cmake -DOPENSN_WITH_HIP=ON -DCMAKE_HIP_ARCHITECTURES=89 -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/clang/19.1.5/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/clang/19.1.5/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_HIP=ON \
+            -DCMAKE_HIP_ARCHITECTURES=89 \
+            -DOPENSN_WITH_PYTHON_MODULE=ON \
+            ..
+          make -j
       - name: test
         shell: bash
         run: |

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -20,7 +20,13 @@ jobs:
         shell: bash
         run: |
           module load python3/3.12.3 opensn/clang/22
-          mkdir build && cd build && cmake -DOPENSN_WITH_PYTHON_MODULE=ON .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/clang/22.1.0/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/clang/22.1.0/dependencies/lib/libf2cblas.a" \
+            -DOPENSN_WITH_PYTHON_MODULE=ON ..
+          make -j
       - name: clang-tidy
         shell: bash
         run: |

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -14,7 +14,14 @@ jobs:
         shell: bash
         run: |
           module load python3/3.12.3 opensn/gcc/14
-          mkdir build && cd build && cmake .. && make -j && cd ..
+          mkdir build
+          cd build
+          cmake \
+            -DBLAS_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            -DLAPACK_LIBRARIES="/opt/local/opensn/gcc/14.2.0/dependencies/lib/libf2cblas.a" \
+            ..
+          make -j
+
       - name: test
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.29)
 
 project(opensn
     VERSION 1.0.1
-    LANGUAGES C CXX
+    LANGUAGES C CXX Fortran
 )
 
 set(CMAKE_CXX_STANDARD 20)
@@ -14,6 +14,8 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(CheckTypeSize)
 include(CheckSymbolExists)
+include(CheckFortranFunctionExists)
+include(CMakePushCheckState)
 include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 include(FetchContent)
@@ -138,7 +140,17 @@ if(OPENSN_WITH_PYTHON_MODULE)
 endif()
 
 # dependencies
-find_package(MPI REQUIRED)
+find_package(LAPACK REQUIRED)
+if(TARGET LAPACK::LAPACK)
+  cmake_push_check_state(RESET)
+
+  set(CMAKE_REQUIRED_LIBRARIES LAPACK::LAPACK)
+  check_fortran_function_exists(dgesv OPENSN_HAVE_DGESV)
+
+  cmake_pop_check_state()
+endif()
+
+find_package(MPI REQUIRED COMPONENTS C)
 find_package(mpicpp-lite 2.7.1 REQUIRED)
 
 find_package(HDF5 REQUIRED COMPONENTS C HL)
@@ -367,7 +379,7 @@ if (OPENSN_WITH_GPU)
       $<BUILD_INTERFACE:${PETSC_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
   )
-  target_link_libraries(libopensngpu PRIVATE MPI::MPI_CXX)
+  target_link_libraries(libopensngpu PRIVATE MPI::MPI_C)
 endif()
 
 target_link_libraries(libopensn
@@ -377,7 +389,9 @@ target_link_libraries(libopensn
     caliper
     ${HDF5_LIBRARIES}
     mpicpp-lite::mpicpp-lite
-    MPI::MPI_CXX
+    MPI::MPI_C
+    PRIVATE
+    LAPACK::LAPACK
 )
 if (OPENSN_WITH_GPU)
   target_link_libraries(libopensn INTERFACE libopensngpu)

--- a/pyopensn/CMakeLists.txt
+++ b/pyopensn/CMakeLists.txt
@@ -39,6 +39,6 @@ target_link_libraries(__init__
     libopensn
     libopensnpy
     ${PETSC_LIBRARY}
-    MPI::MPI_CXX
+    MPI::MPI_C
     caliper
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(libopensnpy
     PUBLIC
     libopensn
     ${PETSC_LIBRARY}
-    MPI::MPI_CXX
+    MPI::MPI_C
     caliper
     pybind11::embed
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(opensn-unit
     ${PETSC_LIBRARY}
     ${HDF5_LIBRARIES}
     caliper
-    MPI::MPI_CXX
+    MPI::MPI_C
     GTest::gmock_main
     GTest::gtest_main
 )


### PR DESCRIPTION
PETSc is built with BLAS/LAPACK support, but it treats it as a private library. That means the libraries used when building PETSc are not exposed to the PETSc client code. Suprisingly there is no issue on linux. However, on a Mac and in a conda environment there might be multiple installations of BLAS/LAPACK (Apple supplies one and conda can install additional ones).

Then, it can happen that OpenSn tries to link against the wrong version which may have different name mangling.  This patch adds support at the cmake level to find LAPACK (this shows now in the configure output). However, this by itself may not be enough to get a successful build. A cmake variable `BLA_VENDOR` can be set on the command line to hint cmake with BLAS/LAPACK to use. Typically, users should point to the BLAS/LAPACK used by PETSc if multiple libraries are installed.