### PR TITLE
Adds lazy flux-moment field-function allocation to LBSProblem

### DIFF
--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -484,17 +484,13 @@ LBSProblem::GetNumPhiIterativeUnknowns()
 }
 
 std::shared_ptr<FieldFunctionGridBased>
-LBSProblem::GetScalarFluxFieldFunction(unsigned int g, unsigned int m) const
+LBSProblem::GetScalarFluxFieldFunction(unsigned int g, unsigned int m)
 {
   OpenSnLogicalErrorIf(g >= num_groups_, GetName() + ": Group index out of range.");
   OpenSnLogicalErrorIf(m >= num_moments_, GetName() + ": Moment index out of range.");
 
-  const auto map_it = phi_field_functions_local_map_.find({g, m});
-  OpenSnLogicalErrorIf(map_it == phi_field_functions_local_map_.end(),
-                       GetName() + ": Failed to map phi field function for g=" + std::to_string(g) +
-                         ", m=" + std::to_string(m) + ".");
-
-  return field_functions_.at(map_it->second);
+  const size_t ff_index = AllocatePhiFieldFunction(g, m);
+  return field_functions_.at(ff_index);
 }
 
 std::shared_ptr<FieldFunctionGridBased>
@@ -1166,35 +1162,11 @@ LBSProblem::InitializeFieldFunctions()
 
   // Initialize Field Functions for flux moments
   phi_field_functions_local_map_.clear();
+  field_functions_.reserve(num_groups_ + (options_.power_field_function_on ? 1 : 0));
 
+  // Create only scalar-flux field functions eagerly. Higher moments are created on demand.
   for (unsigned int g = 0; g < num_groups_; ++g)
-  {
-    for (unsigned int m = 0; m < num_moments_; ++m)
-    {
-      std::string prefix;
-      if (options_.field_function_prefix_option == "prefix")
-      {
-        prefix = options_.field_function_prefix;
-        if (not prefix.empty())
-          prefix += "_";
-      }
-      if (options_.field_function_prefix_option == "solver_name")
-        prefix = GetName() + "_";
-
-      std::ostringstream oss;
-      oss << prefix << "phi_g" << std::setw(3) << std::setfill('0') << static_cast<int>(g) << "_m"
-          << std::setw(2) << std::setfill('0') << static_cast<int>(m);
-      const std::string name = oss.str();
-
-      auto group_ff = std::make_shared<FieldFunctionGridBased>(
-        name, discretization_, Unknown(UnknownType::SCALAR));
-
-      field_function_stack.push_back(group_ff);
-      field_functions_.push_back(group_ff);
-
-      phi_field_functions_local_map_[{g, m}] = field_functions_.size() - 1;
-    } // for m
-  } // for g
+    AllocatePhiFieldFunction(g, 0);
 
   // Initialize power generation field function
   if (options_.power_field_function_on)
@@ -1217,6 +1189,62 @@ LBSProblem::InitializeFieldFunctions()
 
     power_gen_fieldfunc_local_handle_ = field_functions_.size() - 1;
   }
+}
+
+size_t
+LBSProblem::AllocatePhiFieldFunction(unsigned int g, unsigned int m)
+{
+  const auto key = std::make_pair(g, m);
+  const auto map_it = phi_field_functions_local_map_.find(key);
+  if (map_it != phi_field_functions_local_map_.end())
+    return map_it->second;
+
+  std::string prefix;
+  if (options_.field_function_prefix_option == "prefix")
+  {
+    prefix = options_.field_function_prefix;
+    if (not prefix.empty())
+      prefix += "_";
+  }
+  if (options_.field_function_prefix_option == "solver_name")
+    prefix = GetName() + "_";
+
+  std::ostringstream oss;
+  oss << prefix << "phi_g" << std::setw(3) << std::setfill('0') << static_cast<int>(g) << "_m"
+      << std::setw(2) << std::setfill('0') << static_cast<int>(m);
+
+  auto group_ff = std::make_shared<FieldFunctionGridBased>(
+    oss.str(), discretization_, Unknown(UnknownType::SCALAR));
+
+  // Initialize newly-created field functions from the current phi solution so on-demand
+  // allocation after a solve returns up-to-date data immediately.
+  {
+    const auto& sdm = *discretization_;
+    const auto& phi_uk_man = flux_moments_uk_man_;
+    std::vector<double> data_vector_local(local_node_count_, 0.0);
+
+    for (const auto& cell : grid_->local_cells)
+    {
+      const auto& cell_mapping = sdm.GetCellMapping(cell);
+      const size_t num_nodes = cell_mapping.GetNumNodes();
+
+      for (size_t i = 0; i < num_nodes; ++i)
+      {
+        const auto imapA = sdm.MapDOFLocal(cell, i, phi_uk_man, m, g);
+        const auto imapB = sdm.MapDOFLocal(cell, i);
+        data_vector_local[imapB] = phi_new_local_[imapA];
+      }
+    }
+
+    group_ff->UpdateFieldVector(data_vector_local);
+  }
+
+  field_function_stack.push_back(group_ff);
+  field_functions_.push_back(group_ff);
+
+  const size_t ff_index = field_functions_.size() - 1;
+  phi_field_functions_local_map_[key] = ff_index;
+  return ff_index;
 }
 
 void
@@ -1404,7 +1432,15 @@ LBSProblem::SetPhiFromFieldFunctions(PhiSTLOption which_phi,
   {
     for (const auto g : g_ids_to_copy)
     {
-      const size_t ff_index = phi_field_functions_local_map_.at({g, m});
+      const auto key = std::make_pair(g, m);
+      const auto ff_it = phi_field_functions_local_map_.find(key);
+      OpenSnLogicalErrorIf(ff_it == phi_field_functions_local_map_.end(),
+                           GetName() +
+                             ": SetPhiFromFieldFunctions requested field function "
+                             "for group=" +
+                             std::to_string(g) + " moment=" + std::to_string(m) +
+                             " but it has not been allocated.");
+      const size_t ff_index = ff_it->second;
       const auto& ff_ptr = field_functions_.at(ff_index);
       const auto& ff_data = ff_ptr->GetLocalFieldVector();
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -250,9 +250,14 @@ public:
    */
   virtual std::pair<size_t, size_t> GetNumPhiIterativeUnknowns();
 
-  /// Returns a flux-moment field function for a given group and moment.
+  /**
+   * Returns a flux-moment field function for a given group and moment.
+   *
+   * Scalar-flux field functions are created eagerly during initialization. Higher moments are
+   * allocated lazily on first request and initialized from the current \c phi_new state.
+   */
   std::shared_ptr<FieldFunctionGridBased> GetScalarFluxFieldFunction(unsigned int g,
-                                                                     unsigned int m = 0) const;
+                                                                     unsigned int m = 0);
 
   /// Returns the power generation field function, if enabled.
   std::shared_ptr<FieldFunctionGridBased> GetPowerFieldFunction() const;
@@ -277,7 +282,12 @@ public:
   /// Copy relevant section of phi_old to the field functions.
   void UpdateFieldFunctions();
 
-  /// Sets the internal phi vector to the value in the associated field function.
+  /**
+   * Sets the internal phi vector to the value in previously allocated field functions.
+   *
+   * With lazy field-function allocation, higher-moment field functions must already exist before
+   * this method is called.
+   */
   void SetPhiFromFieldFunctions(PhiSTLOption which_phi,
                                 const std::vector<unsigned int>& m_indices,
                                 const std::vector<unsigned int>& g_indices);
@@ -383,6 +393,7 @@ private:
   /// Initializes parallel arrays.
   void InitializeParrays();
   void InitializeFieldFunctions();
+  size_t AllocatePhiFieldFunction(unsigned int g, unsigned int m);
   /// Initializes data carriers to GPUs and memory pinner.
   void InitializeGPUExtras();
   /// Reset data carriers to null and unpin memory.

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -141,6 +141,18 @@ WrapLBS(py::module& slv)
 
     Notes
     -----
+    Flux-moment field functions are allocated lazily.
+
+    The zeroth-moment field function for each group is created eagerly during solver
+    initialization, so scalar-flux output is always available.
+
+    Higher-moment field functions are created on demand. Calling
+    ``GetScalarFluxFieldFunction(only_scalar_flux=False)`` allocates all higher moments
+    and initializes them from the current solver state.
+
+    This is a substantial memory saver for typical problems, because most workflows only
+    need scalar-flux output and do not need to store field functions for every moment.
+
     In the nested form (``only_scalar_flux=False``), the moment index varies fastest
     within each group (inner index = moment, outer index = group).
     )",


### PR DESCRIPTION
1. scalar-flux field functions are still created eagerly at initialization
2. higher-moment field functions are now allocated on demand when requested
3. newly allocated higher-moment field functions are initialized from the current phi_new state immediately
4. `SetPhiFromFieldFunctions()` now requires the requested field functions to already exist instead of silently allocating them