### PR TITLE
Separating WGSContext and WGSSolver handling and initialization

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -1067,11 +1067,14 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
 }
 
 void
-DiscreteOrdinatesProblem::InitializeWGSSolvers()
+DiscreteOrdinatesProblem::InitializeWGSContexts()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeWGSSolvers");
+  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeWGSContexts");
 
   // Determine max size and number of matrices along sweep front
+  max_groupset_size_ = 0;
+  max_level_size_ = 0;
+  max_angleset_size_ = 0;
   for (auto& groupset : groupsets_)
   {
     // Max groupset size
@@ -1090,7 +1093,7 @@ DiscreteOrdinatesProblem::InitializeWGSSolvers()
     }
   }
 
-  wgs_solvers_.clear(); // this is required
+  wgs_contexts_.clear();
   for (auto& groupset : groupsets_)
   {
     std::shared_ptr<SweepChunk> sweep_chunk = SetSweepChunk(groupset);
@@ -1102,7 +1105,27 @@ DiscreteOrdinatesProblem::InitializeWGSSolvers()
       APPLY_FIXED_SOURCES | APPLY_AGS_SCATTER_SOURCES | APPLY_AGS_FISSION_SOURCES,
       options_.verbose_inner_iterations,
       sweep_chunk);
+    wgs_contexts_.push_back(sweep_wgs_context_ptr);
+  }
+}
 
+void
+DiscreteOrdinatesProblem::InitializeWGSSolvers()
+{
+  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeWGSSolvers");
+
+  if (not wgs_solvers_.empty())
+    return;
+
+  CheckWGSContextsInitialized();
+  OpenSnLogicalErrorIf(wgs_contexts_.size() != groupsets_.size(),
+                       GetName() + ": WGS context count does not match groupset count.");
+
+  for (size_t gsid = 0; gsid < groupsets_.size(); ++gsid)
+  {
+    auto& groupset = groupsets_[gsid];
+    const auto& sweep_wgs_context_ptr = wgs_contexts_[gsid];
+    OpenSnLogicalErrorIf(not sweep_wgs_context_ptr, GetName() + ": Null WGS context.");
     if (groupset.iterative_method == LinearSystemSolver::IterativeMethod::CLASSIC_RICHARDSON)
     {
       wgs_solvers_.push_back(std::make_shared<ClassicRichardson>(

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -125,6 +125,8 @@ protected:
 
   void InitializeBoundaries() override;
 
+  void InitializeWGSContexts() override;
+
   /// Initializes Within-GroupSet solvers.
   void InitializeWGSSolvers() override;
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -445,32 +445,69 @@ LBSProblem::SetActiveSetSourceFunction(SetSourceFunction source_function)
 }
 
 std::shared_ptr<AGSLinearSolver>
-LBSProblem::GetAGSSolver() const
+LBSProblem::GetAGSSolver()
 {
+  CheckAGSSolverInitialized();
   return ags_solver_;
 }
 
 std::shared_ptr<LinearSolver>
-LBSProblem::GetWGSSolver(size_t groupset_id) const
+LBSProblem::GetWGSSolver(size_t groupset_id)
 {
+  CheckWGSSolversInitialized();
   return wgs_solvers_.at(groupset_id);
 }
 
 size_t
-LBSProblem::GetNumWGSSolvers() const
+LBSProblem::GetNumWGSSolvers()
 {
+  CheckWGSSolversInitialized();
   return wgs_solvers_.size();
 }
 
 WGSContext&
 LBSProblem::GetWGSContext(int groupset_id)
 {
-  auto& wgs_solver = wgs_solvers_[groupset_id];
-  auto raw_context = wgs_solver->GetContext();
-  auto wgs_context_ptr = std::dynamic_pointer_cast<WGSContext>(raw_context);
-  OpenSnLogicalErrorIf(not wgs_context_ptr,
-                       GetName() + ": Failed to cast solver context to WGSContext.");
+  CheckWGSContextsInitialized();
+  auto& wgs_context_ptr = wgs_contexts_.at(groupset_id);
+  OpenSnLogicalErrorIf(not wgs_context_ptr, GetName() + ": Null WGS context.");
   return *wgs_context_ptr;
+}
+
+void
+LBSProblem::CheckWGSContextsInitialized()
+{
+  if (wgs_contexts_.empty())
+    InitializeWGSContexts();
+}
+
+void
+LBSProblem::CheckWGSSolversInitialized()
+{
+  CheckWGSContextsInitialized();
+  if (wgs_solvers_.empty())
+    InitializeWGSSolvers();
+}
+
+void
+LBSProblem::CheckAGSSolverInitialized()
+{
+  CheckWGSSolversInitialized();
+  if (ags_solver_)
+    return;
+
+  ags_solver_ = std::make_shared<AGSLinearSolver>(*this, wgs_solvers_);
+  if (groupsets_.size() == 1)
+  {
+    ags_solver_->SetMaxIterations(1);
+    ags_solver_->SetVerbosity(false);
+  }
+  else
+  {
+    ags_solver_->SetMaxIterations(options_.max_ags_iterations);
+    ags_solver_->SetVerbosity(options_.verbose_ags_iterations);
+  }
+  ags_solver_->SetTolerance(options_.ags_tolerance);
 }
 
 std::pair<size_t, size_t>
@@ -1251,20 +1288,10 @@ void
 LBSProblem::InitializeSolverSchemes()
 {
   CALI_CXX_MARK_SCOPE("LBSProblem::InitializeSolverSchemes");
-  InitializeWGSSolvers();
-
-  ags_solver_ = std::make_shared<AGSLinearSolver>(*this, wgs_solvers_);
-  if (groupsets_.size() == 1)
-  {
-    ags_solver_->SetMaxIterations(1);
-    ags_solver_->SetVerbosity(false);
-  }
-  else
-  {
-    ags_solver_->SetMaxIterations(options_.max_ags_iterations);
-    ags_solver_->SetVerbosity(options_.verbose_ags_iterations);
-  }
-  ags_solver_->SetTolerance(options_.ags_tolerance);
+  ags_solver_.reset();
+  wgs_solvers_.clear();
+  wgs_contexts_.clear();
+  InitializeWGSContexts();
 }
 
 #ifndef __OPENSN_WITH_GPU__

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -26,6 +26,7 @@ class MPICommunicatorSet;
 class GridFaceHistogram;
 class AGSLinearSolver;
 class WGSLinearSolver;
+class LinearSolver;
 struct WGSContext;
 class TotalXSCarrier;
 class OutflowCarrier;
@@ -237,10 +238,10 @@ public:
 
   SetSourceFunction GetActiveSetSourceFunction() const;
 
-  std::shared_ptr<AGSLinearSolver> GetAGSSolver() const;
+  std::shared_ptr<AGSLinearSolver> GetAGSSolver();
 
-  std::shared_ptr<LinearSolver> GetWGSSolver(size_t groupset_id) const;
-  size_t GetNumWGSSolvers() const;
+  std::shared_ptr<LinearSolver> GetWGSSolver(size_t groupset_id);
+  size_t GetNumWGSSolvers();
 
   WGSContext& GetWGSContext(int groupset_id);
 
@@ -322,7 +323,11 @@ protected:
 
   void InitializeSolverSchemes();
 
+  virtual void InitializeWGSContexts() {};
   virtual void InitializeWGSSolvers() {};
+  void CheckWGSContextsInitialized();
+  void CheckWGSSolversInitialized();
+  void CheckAGSSolverInitialized();
 
   void SetActiveSetSourceFunction(SetSourceFunction source_function);
 
@@ -368,6 +373,7 @@ protected:
   SetSourceFunction active_set_source_function_;
 
   std::shared_ptr<AGSLinearSolver> ags_solver_;
+  std::vector<std::shared_ptr<WGSContext>> wgs_contexts_;
   std::vector<std::shared_ptr<LinearSolver>> wgs_solvers_;
   bool initialized_ = false;
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g.py
@@ -43,10 +43,6 @@ if __name__ == "__main__":
     kes_max_iterations = 5000
     kes_tolerance = 1e-8
 
-    # Source iteration parameters
-    si_max_iterations = 500
-    si_tolerance = 1e-8
-
     # Create and configure the discrete ordinates solver
     phys = DiscreteOrdinatesProblem(
         mesh=grid,
@@ -58,9 +54,6 @@ if __name__ == "__main__":
                     n_polar=n_angles,
                     scattering_order=scat_order
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": si_max_iterations,
-                "l_abs_tol": si_tolerance,
             }
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_cbc.py
@@ -36,10 +36,6 @@ if __name__ == "__main__":
     kes_max_iterations = 5000
     kes_tolerance = 1e-8
 
-    # Source iteration parameters
-    si_max_iterations = 500
-    si_tolerance = 1e-8
-
     # Setup mesh
     dx = L / n_cells
     nodes = [i * dx for i in range(n_cells + 1)]
@@ -65,9 +61,6 @@ if __name__ == "__main__":
                     n_polar=n_angles,
                     scattering_order=scat_order
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": si_max_iterations,
-                "l_abs_tol": si_tolerance,
             },
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_scalar_power_ff.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_1d_1g_scalar_power_ff.py
@@ -43,9 +43,6 @@ if __name__ == "__main__":
             {
                 "groups_from_to": (0, 0),
                 "angular_quadrature": GLProductQuadrature1DSlab(n_polar=32, scattering_order=0),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-8,
             }
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock.py
@@ -35,10 +35,6 @@ if __name__ == "__main__":
             {
                 "groups_from_to": (0, num_groups - 1),
                 "angular_quadrature": pquad,
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 50,
-                "gmres_restart_interval": 50,
-                "l_abs_tol": 1.0e-10,
             },
         ],
         xs_map=xs_map,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_2d_1b_qblock_cbc.py
@@ -35,10 +35,6 @@ if __name__ == "__main__":
             {
                 "groups_from_to": (0, num_groups - 1),
                 "angular_quadrature": pquad,
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 50,
-                "gmres_restart_interval": 50,
-                "l_abs_tol": 1.0e-10,
             },
         ],
         xs_map=xs_map,

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235.py
@@ -65,9 +65,6 @@ if __name__ == "__main__":
                     n_azimuthal=4,
                     scattering_order=1
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-12,
             },
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_cbc_gpu.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_cbc_gpu.py
@@ -65,9 +65,6 @@ if __name__ == "__main__":
                     n_azimuthal=4,
                     scattering_order=1
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-12,
             },
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_gpu.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_U235_gpu.py
@@ -65,9 +65,6 @@ if __name__ == "__main__":
                     n_azimuthal=4,
                     scattering_order=1
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-12,
             },
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2.py
@@ -70,9 +70,6 @@ if __name__ == "__main__":
                     n_azimuthal=4,
                     scattering_order=1
                 ),
-                "inner_linear_method": "petsc_gmres",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-12,
             },
         ],
         xs_map=[

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2_crichardson.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/keigenvalue_transport_3d_openmcxs_UO2_crichardson.py
@@ -70,9 +70,6 @@ if __name__ == "__main__":
                     n_azimuthal=4,
                     scattering_order=1
                 ),
-                "inner_linear_method": "classic_richardson",
-                "l_max_its": 500,
-                "l_abs_tol": 1.0e-12,
             },
         ],
         xs_map=[


### PR DESCRIPTION
This PR separates WGSContext objects and WGSSolver objects. WGSContext is essentially the sweep, and WGSSolver is the WGS linear solver object that invokes the sweep. In some iterative methods (NonLinearKEigen for example) we don't use the linear solver and just need the sweep. This PR makes the line between context and solver less fuzzy.