### PR TITLE
Expand SetBlock2XSMap and remove cached problem members from solvers.

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -805,6 +805,25 @@ DiscreteOrdinatesProblem::ReinitializeSolverSchemes()
 }
 
 void
+DiscreteOrdinatesProblem::SetBlockID2XSMap(const BlockID2XSMap& xs_map)
+{
+  LBSProblem::SetBlockID2XSMap(xs_map);
+
+  if (not initialized_)
+    return;
+
+  for (auto& groupset : groupsets_)
+  {
+    WGDSA::CleanUp(groupset);
+    TGDSA::CleanUp(groupset);
+    WGDSA::Init(*this, groupset);
+    TGDSA::Init(*this, groupset);
+  }
+
+  ReinitializeSolverSchemes();
+}
+
+void
 DiscreteOrdinatesProblem::UpdateAngularFluxStorage()
 {
   psi_new_local_.resize(groupsets_.size());

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -109,6 +109,8 @@ public:
 
   void SetSaveAngularFlux(bool save) override;
 
+  void SetBlockID2XSMap(const BlockID2XSMap& xs_map) override;
+
   void SetBoundaryOptions(const InputParameters& params) override;
   void ClearBoundaries() override;
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_compute.cc
@@ -58,7 +58,7 @@ ComputeFissionProduction(const LBSProblem& lbs_problem, const std::vector<double
         // contributions are prompt-only and adds delayed production separately via
         // nu_delayed_sigma_f. If the production matrix changes to include delayed
         // production, adjust this sum to prevent double counting.
-        if (options.use_precursors)
+        if (options.use_precursors and xs.GetNumPrecursors() > 0)
           local_production += nu_delayed_sigma_f[g] * phi[uk_map + g] * IntV_ShapeI;
       }
     } // for node

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -995,12 +995,17 @@ LBSProblem::InitializeMaterials()
     max_precursors_per_material_ = std::max(xs->GetNumPrecursors(), max_precursors_per_material_);
   }
 
-  // if no precursors, turn off precursors
-  if (num_precursors_ == 0)
-    options_.use_precursors = false;
+  const bool has_fissionable_precursors =
+    std::any_of(block_id_to_xs_map_.begin(),
+                block_id_to_xs_map_.end(),
+                [](const auto& mat_id_xs)
+                {
+                  const auto& xs = mat_id_xs.second;
+                  return xs->IsFissionable() and xs->GetNumPrecursors() > 0;
+                });
 
-  // check compatibility when precursors are on
-  if (options_.use_precursors)
+  // check compatibility when at least one fissionable material has delayed-neutron data
+  if (options_.use_precursors and has_fissionable_precursors)
   {
     for (const auto& [mat_id, xs] : block_id_to_xs_map_)
     {

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -294,8 +294,48 @@ LBSProblem::GetBlockID2XSMap() const
 void
 LBSProblem::SetBlockID2XSMap(const BlockID2XSMap& xs_map)
 {
+  const BlockID2XSMap old_xs_map = block_id_to_xs_map_;
+  const size_t old_max_precursors_per_material = max_precursors_per_material_;
+  const auto old_precursor_state = precursor_new_local_;
+
   block_id_to_xs_map_ = xs_map;
   InitializeMaterials();
+
+  if (initialized_)
+  {
+    if (options_.use_precursors)
+    {
+      const size_t num_cells = grid_->local_cells.size();
+      const size_t new_max_precursors_per_material = max_precursors_per_material_;
+      const size_t num_precursor_dofs = num_cells * new_max_precursors_per_material;
+
+      std::vector<double> remapped_precursors(num_precursor_dofs, 0.0);
+      if (old_precursor_state.size() == num_cells * old_max_precursors_per_material)
+      {
+        for (const auto& cell : grid_->local_cells)
+        {
+          unsigned int old_num_precursors = 0;
+          if (const auto old_xs_it = old_xs_map.find(cell.block_id); old_xs_it != old_xs_map.end())
+            old_num_precursors = old_xs_it->second->GetNumPrecursors();
+
+          const unsigned int new_num_precursors =
+            block_id_to_xs_map_.at(cell.block_id)->GetNumPrecursors();
+          const unsigned int num_precursors_to_copy =
+            std::min(old_num_precursors, new_num_precursors);
+
+          const size_t old_base = cell.local_id * old_max_precursors_per_material;
+          const size_t new_base = cell.local_id * new_max_precursors_per_material;
+          for (unsigned int j = 0; j < num_precursors_to_copy; ++j)
+            remapped_precursors[new_base + j] = old_precursor_state[old_base + j];
+        }
+      }
+
+      precursor_new_local_ = std::move(remapped_precursors);
+    }
+    else
+      precursor_new_local_.clear();
+  }
+
   ResetGPUCarriers();
   InitializeGPUExtras();
 }

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -167,7 +167,7 @@ public:
   const BlockID2XSMap& GetBlockID2XSMap() const;
 
   /// Replaces the map of block ids to XSs and refreshes material data.
-  void SetBlockID2XSMap(const BlockID2XSMap& xs_map);
+  virtual void SetBlockID2XSMap(const BlockID2XSMap& xs_map);
 
   /// Obtains a reference to the grid.
   std::shared_ptr<MeshContinuum> GetGrid() const;

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.cc
@@ -72,7 +72,6 @@ PowerIterationKEigenSolver::Initialize()
 
   const auto& options = do_problem_->GetOptions();
   active_set_source_function_ = do_problem_->GetActiveSetSourceFunction();
-  ags_solver_ = do_problem_->GetAGSSolver();
 
   for (size_t gsid = 0; gsid < do_problem_->GetNumWGSSolvers(); ++gsid)
   {
@@ -89,7 +88,9 @@ PowerIterationKEigenSolver::Initialize()
   const bool print_ags_iters = options.verbose_ags_iterations and
                                do_problem_->GetNumGroupsets() > 1 and
                                options.max_ags_iterations > 1;
-  ags_solver_->SetVerbosity(print_ags_iters);
+  auto ags_solver = do_problem_->GetAGSSolver();
+  OpenSnLogicalErrorIf(not ags_solver, GetName() + ": AGS solver not available.");
+  ags_solver->SetVerbosity(print_ags_iters);
 
   bool restart_successful = false;
   if (not options.read_restart_path.empty())
@@ -133,7 +134,9 @@ PowerIterationKEigenSolver::Execute()
       acceleration_->PrePowerIteration();
 
     // This solves the inners for transport
-    ags_solver_->Solve();
+    auto ags_solver = do_problem_->GetAGSSolver();
+    OpenSnLogicalErrorIf(not ags_solver, GetName() + ": AGS solver not available.");
+    ags_solver->Solve();
 
     // Get k-eigenvalue from the acceleration method
     if (acceleration_)

--- a/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/pi_keigen_solver.h
@@ -12,7 +12,6 @@ namespace opensn
 
 class DiscreteOrdinatesProblem;
 class DiscreteOrdinatesKEigenAcceleration;
-class AGSLinearSolver;
 
 class PowerIterationKEigenSolver : public Solver
 {
@@ -49,7 +48,6 @@ protected:
   std::vector<double>& phi_new_local_;
 
   const std::vector<LBSGroupset>& groupsets_;
-  std::shared_ptr<AGSLinearSolver> ags_solver_;
   SetSourceFunction active_set_source_function_;
 
   bool initialized_ = false;

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
@@ -18,6 +18,21 @@ namespace opensn
 {
 OpenSnRegisterObjectInNamespace(lbs, TransientSolver);
 
+namespace
+{
+
+bool
+HasFissionableMaterial(const DiscreteOrdinatesProblem& do_problem)
+{
+  for (const auto& [_, xs] : do_problem.GetBlockID2XSMap())
+    if (xs->IsFissionable())
+      return true;
+
+  return false;
+}
+
+} // namespace
+
 InputParameters
 TransientSolver::GetInputParameters()
 {
@@ -78,22 +93,6 @@ TransientSolver::TransientSolver(const InputParameters& params)
 }
 
 void
-TransientSolver::RefreshLocalViews()
-{
-  phi_new_local_ = &do_problem_->GetPhiNewLocal();
-  precursor_new_local_ = &do_problem_->GetPrecursorsNewLocal();
-  psi_new_local_ = &do_problem_->GetPsiNewLocal();
-}
-
-void
-TransientSolver::UpdateHasFissionableMaterial()
-{
-  has_fissionable_material_ = false;
-  for (const auto& [_, xs] : do_problem_->GetBlockID2XSMap())
-    has_fissionable_material_ = has_fissionable_material_ or xs->IsFissionable();
-}
-
-void
 TransientSolver::Initialize()
 {
   log.Log() << "Initializing " << GetName() << ".";
@@ -101,8 +100,13 @@ TransientSolver::Initialize()
 
   const auto& options = do_problem_->GetOptions();
   bool restart_successful = false;
-  RefreshLocalViews();
-  OpenSnLogicalErrorIf(not phi_new_local_ or phi_new_local_->empty(),
+  do_problem_->SetTime(current_time_);
+
+  const std::string& init_state = initial_state_;
+  auto& phi_new_local = do_problem_->GetPhiNewLocal();
+  auto& precursor_new_local = do_problem_->GetPrecursorsNewLocal();
+  auto& psi_new_local = do_problem_->GetPsiNewLocal();
+  OpenSnLogicalErrorIf(phi_new_local.empty(),
                        GetName() + ": Problem must be fully constructed before "
                                    "TransientSolver initialization.");
 
@@ -116,22 +120,19 @@ TransientSolver::Initialize()
   if (not restart_successful)
     do_problem_->SetTime(current_time_);
 
-  RefreshLocalViews();
-
   if (initial_state_ == "zero" and not restart_successful)
   {
     do_problem_->ZeroPhi();
     do_problem_->ZeroPrecursors();
-    for (auto& psi : *psi_new_local_)
+    for (auto& psi : psi_new_local)
       std::fill(psi.begin(), psi.end(), 0.0);
   }
 
-  ags_solver_ = do_problem_->GetAGSSolver();
-  UpdateHasFissionableMaterial();
-  if (options.use_precursors and not has_fissionable_material_)
+  const bool has_fissionable_material = HasFissionableMaterial(*do_problem_);
+  if (options.use_precursors and not has_fissionable_material)
     log.Log0Warning() << GetName()
                       << ": use_precursors is enabled but no fissionable material is present.";
-  if ((not options.use_precursors) and has_fissionable_material_)
+  if ((not options.use_precursors) and has_fissionable_material)
     log.Log0Warning() << GetName()
                       << ": fissionable material is present but use_precursors is disabled. "
                          "Running prompt-only transient.";
@@ -148,8 +149,8 @@ TransientSolver::Initialize()
 
   // Sync with the current solution
   current_time_ = do_problem_->GetTime();
-  phi_prev_local_ = *phi_new_local_;
-  precursor_prev_local_ = *precursor_new_local_;
+  phi_prev_local_ = phi_new_local;
+  precursor_prev_local_ = precursor_new_local;
 
   initialized_ = true;
 }
@@ -237,6 +238,14 @@ TransientSolver::Advance()
   }
   const double dt = do_problem_->GetTimeStep();
   const double theta = do_problem_->GetTheta();
+  auto& phi_new_local = do_problem_->GetPhiNewLocal();
+  auto& precursor_new_local = do_problem_->GetPrecursorsNewLocal();
+  const bool has_fissionable_material = HasFissionableMaterial(*do_problem_);
+  phi_prev_local_ = phi_new_local;
+  if (options.use_precursors)
+    precursor_prev_local_ = precursor_new_local;
+  else
+    precursor_prev_local_.clear();
 
   // Ensure RHS time term is enabled for transient sweeps
   std::vector<std::shared_ptr<SweepWGSContext>> transient_sweep_contexts;
@@ -266,15 +275,11 @@ TransientSolver::Advance()
 
   // Solve
   do_problem_->SetPhiOldFrom(phi_prev_local_);
-  {
-    auto current_solver = do_problem_->GetAGSSolver();
-    if (current_solver.get() != ags_solver_.get())
-      ags_solver_ = std::move(current_solver);
-  }
-  OpenSnLogicalErrorIf(not ags_solver_, GetName() + ": AGS solver not available.");
+  auto ags_solver = do_problem_->GetAGSSolver();
+  OpenSnLogicalErrorIf(not ags_solver, GetName() + ": AGS solver not available.");
   try
   {
-    ags_solver_->Solve();
+    ags_solver->Solve();
   }
   catch (...)
   {
@@ -288,26 +293,22 @@ TransientSolver::Advance()
 
   // Compute t^{n+1}
   const double inv_theta = 1.0 / theta;
-  auto& phi = *phi_new_local_;
   const auto& phi_prev = phi_prev_local_;
-  for (size_t i = 0; i < phi.size(); ++i)
-    phi[i] = inv_theta * (phi[i] + (theta - 1.0) * phi_prev[i]);
+  for (size_t i = 0; i < phi_new_local.size(); ++i)
+    phi_new_local[i] = inv_theta * (phi_new_local[i] + (theta - 1.0) * phi_prev[i]);
 
   if (options.use_precursors)
     StepPrecursors();
 
-  if (verbose_ and (has_fissionable_material_ or options.use_precursors))
+  if (verbose_ and (has_fissionable_material or options.use_precursors))
   {
-    const double FP_new = ComputeFissionProduction(*do_problem_, *phi_new_local_);
+    const double FP_new = ComputeFissionProduction(*do_problem_, phi_new_local);
     log.Log() << GetName() << " FP = " << std::scientific << std::setprecision(6) << FP_new;
   }
 
   current_time_ += dt;
   do_problem_->SetTime(current_time_);
-  phi_prev_local_ = *phi_new_local_;
   do_problem_->UpdatePsiOld();
-  if (options.use_precursors)
-    precursor_prev_local_ = *precursor_new_local_;
   ++step_;
 }
 
@@ -317,6 +318,8 @@ TransientSolver::StepPrecursors()
   const double theta = do_problem_->GetTheta();
   const double eff_dt = theta * do_problem_->GetTimeStep();
   do_problem_->ZeroPrecursors();
+  auto& phi_new_local = do_problem_->GetPhiNewLocal();
+  auto& precursor_new_local = do_problem_->GetPrecursorsNewLocal();
 
   // Uses phi_new and precursor_prev_local to compute precursor_new_local (theta-flavor)
   auto& transport_views = do_problem_->GetCellTransportViews();
@@ -336,7 +339,7 @@ TransientSolver::StepPrecursors()
       const double node_V_fraction = fe_values.intV_shapeI(i) / cell_volume;
 
       for (int g = 0; g < do_problem_->GetNumGroups(); ++g)
-        delayed_fission += nu_delayed_sigma_f[g] * (*phi_new_local_)[uk_map + g] * node_V_fraction;
+        delayed_fission += nu_delayed_sigma_f[g] * phi_new_local[uk_map + g] * node_V_fraction;
     }
 
     // Loop over precursors
@@ -348,20 +351,18 @@ TransientSolver::StepPrecursors()
       const double coeff = 1.0 / (1.0 + eff_dt * precursor.decay_constant);
 
       // Contribute last time step precursors
-      (*precursor_new_local_)[dof_map] = coeff * precursor_prev_local_[dof_map];
+      precursor_new_local[dof_map] = coeff * precursor_prev_local_[dof_map];
 
       // Contribute delayed fission production
-      (*precursor_new_local_)[dof_map] +=
-        coeff * eff_dt * precursor.fractional_yield * delayed_fission;
+      precursor_new_local[dof_map] += coeff * eff_dt * precursor.fractional_yield * delayed_fission;
     }
   }
 
   // Compute t^{n+1} value
-  auto& Cj = *precursor_new_local_;
-  const auto& Cj_prev = precursor_prev_local_;
   const double inv_theta = 1.0 / theta;
-  for (size_t i = 0; i < Cj.size(); ++i)
-    Cj[i] = inv_theta * (Cj[i] + (theta - 1.0) * Cj_prev[i]);
+  for (size_t i = 0; i < precursor_new_local.size(); ++i)
+    precursor_new_local[i] =
+      inv_theta * (precursor_new_local[i] + (theta - 1.0) * precursor_prev_local_[i]);
 }
 
 bool

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.cc
@@ -329,6 +329,9 @@ TransientSolver::StepPrecursors()
     const double cell_volume = transport_views[cell.local_id].GetVolume();
     const auto& xs = do_problem_->GetBlockID2XSMap().at(cell.block_id);
     const auto& precursors = xs->GetPrecursors();
+    if (precursors.empty())
+      continue;
+
     const auto& nu_delayed_sigma_f = xs->GetNuDelayedSigmaF();
 
     // Compute delayed fission production

--- a/modules/linear_boltzmann_solvers/solvers/transient_solver.h
+++ b/modules/linear_boltzmann_solvers/solvers/transient_solver.h
@@ -15,7 +15,6 @@ namespace opensn
 {
 
 class DiscreteOrdinatesProblem;
-class AGSLinearSolver;
 
 class TransientSolver : public Solver
 {
@@ -39,17 +38,10 @@ public:
   BalanceTable ComputeBalanceTable() const;
 
 private:
-  void RefreshLocalViews();
-  void UpdateHasFissionableMaterial();
   bool ReadRestartData();
   bool WriteRestartData();
 
   std::shared_ptr<DiscreteOrdinatesProblem> do_problem_;
-  std::shared_ptr<AGSLinearSolver> ags_solver_;
-
-  std::vector<double>* phi_new_local_ = nullptr;
-  std::vector<double>* precursor_new_local_ = nullptr;
-  std::vector<std::vector<double>>* psi_new_local_ = nullptr;
 
   /// Previous time step vectors
   std::vector<double> phi_prev_local_;
@@ -62,7 +54,6 @@ private:
   bool verbose_ = true;
   bool initialized_ = false;
   bool enforce_stop_time_ = false;
-  bool has_fissionable_material_ = false;
   std::string initial_state_;
   std::function<void()> pre_advance_callback_;
   std::function<void()> post_advance_callback_;

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -561,6 +561,26 @@ WrapLBS(py::module& slv)
 
     Notes
     -----
+    The problem is refreshed immediately after replacing the map. Material metadata,
+    precursor storage, GPU carriers, and derived solver state owned by the concrete
+    problem are rebuilt for the new cross sections.
+
+    If ``options.use_precursors=True``, this flag remains active across XS-map
+    changes even when the current map has no precursor-bearing material. In that
+    case delayed-neutron source terms are simply inactive until a later map provides
+    precursor data again.
+
+    Existing precursor concentrations are remapped by local cell and precursor-family
+    index. When the new material for a cell has fewer precursor families, extra old
+    families are dropped. When it has more families, newly introduced families are
+    initialized to zero. If a cell changes through a material with zero precursors,
+    the precursor history for that cell is discarded and any later reintroduced
+    precursor families start from zero.
+
+    If any fissionable material in the new map contains delayed-neutron precursor
+    data and ``options.use_precursors=True``, all fissionable materials in the map
+    must contain precursor data. Non-fissionable materials may have zero precursors.
+
     Forward/adjoint mode toggles via :meth:`LBSProblem.SetAdjoint` do not change this map.
     The ``MultiGroupXS`` objects themselves are mutable and shared by pointer. If the same
     ``MultiGroupXS`` handle is shared across multiple problems, toggling adjoint mode in one
@@ -756,6 +776,13 @@ WrapLBS(py::module& slv)
           - write_restart_time_interval: int, default=0
             (must be 0 or >=30)
           - use_precursors: bool, default=False
+            Enable delayed-neutron precursor treatment. This is treated as user intent and remains
+            active across later ``SetXSMap`` calls, even if the current XS map temporarily contains
+            no precursor-bearing material. When XS maps are swapped, existing precursor
+            concentrations are remapped by cell and precursor-family index; new families start at
+            zero and removed families are discarded. If any fissionable material in the active map
+            has precursor data, all fissionable materials in that map must have precursor data.
+            Non-fissionable materials may have zero precursors.
           - use_source_moments: bool, default=False
           - save_angular_flux: bool, default=False
           - adjoint: bool, default=False

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
@@ -308,6 +308,34 @@
     ]
   },
   {
+    "file": "transient_keigen_1d_precursor_count_xs_swap.py",
+    "comment": "1D delayed transient XS swap across fissionability and precursor counts",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "PRECURSOR_SWAP_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_init_precursor_count_xs_swap.py",
+    "comment": "1D prompt-to-delayed transient XS swap from 0 to 2 precursor families",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "PRECURSOR_INTRO_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
     "file": "transient_keigen_2d_delayed_prke_vs_stk_2p.py",
     "comment": "2D delayed homogeneous step: PRKE vs space-time kinetics",
     "num_procs": 4,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_count_xs_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_count_xs_swap.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+1D fission transient with an XS swap from 0 to 2 precursor families.
+
+This regression starts from a homogeneous prompt-only fissionable critical
+k-eigen state with zero precursor families, then swaps to a delayed
+2-precursor fissionable material before advancing in time.
+
+The geometry is homogeneous with reflecting boundaries, so after the swap the
+space-time transport solution reduces to homogeneous point kinetics with two
+precursor families. The reference model uses the exact Backward Euler update
+for the same kinetics equations and initial condition C_j(0)=0.
+
+PRECURSOR_INTRO_PASS is 1 if the scalar-flux ratio matches the piecewise
+Backward Euler reference within 5.0e-6 relative error for all tested time steps.
+"""
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.aquad import GLProductQuadrature1DSlab
+    from pyopensn.fieldfunc import FieldFunctionInterpolationVolume
+    from pyopensn.logvol import RPPLogicalVolume
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.solver import (
+        DiscreteOrdinatesProblem,
+        PowerIterationKEigenSolver,
+        TransientSolver,
+    )
+    from pyopensn.xs import MultiGroupXS
+
+
+def read_precursor_values(path, block_name):
+    begin = f"{block_name}_BEGIN"
+    end = f"{block_name}_END"
+    in_block = False
+    values = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line == begin:
+                in_block = True
+                continue
+            if line == end:
+                break
+            if in_block:
+                parts = line.split()
+                if len(parts) >= 2:
+                    values.append(float(parts[1]))
+    if not values:
+        raise RuntimeError(f"Failed to find values for {block_name} in {path}")
+    return values
+
+
+def max_phi(problem):
+    fflist = problem.GetScalarFluxFieldFunction()
+    monitor_volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    field_interp = FieldFunctionInterpolationVolume()
+    field_interp.SetOperationType("max")
+    field_interp.SetLogicalVolume(monitor_volume)
+    field_interp.AddFieldFunction(fflist[0])
+    field_interp.Execute()
+    return field_interp.GetValue()
+
+
+def backward_euler_two_precursors(phi_n, c_n, dt, reactivity, betas, decay_consts, generation_time):
+    beta_total = sum(betas)
+    a_coeff = (reactivity - beta_total) / generation_time
+
+    denominator = 1.0 - dt * a_coeff
+    numerator = phi_n
+    new_precursors = []
+
+    for beta_j, lam_j, c_j_n in zip(betas, decay_consts, c_n):
+        source_coeff = beta_j / generation_time
+        denom_j = 1.0 + dt * lam_j
+        denominator -= (dt * dt * lam_j * source_coeff) / denom_j
+        numerator += (dt * lam_j * c_j_n) / denom_j
+
+    phi_np1 = numerator / denominator
+
+    for beta_j, lam_j, c_j_n in zip(betas, decay_consts, c_n):
+        source_coeff = beta_j / generation_time
+        c_np1 = (c_j_n + dt * source_coeff * phi_np1) / (1.0 + dt * lam_j)
+        new_precursors.append(c_np1)
+
+    return phi_np1, new_precursors
+
+
+if __name__ == "__main__":
+    n_cells = 40
+    length = 8.0
+    dx = length / n_cells
+    nodes = [i * dx for i in range(n_cells + 1)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    base_dir = os.path.dirname(__file__)
+    xs_prompt_crit_path = os.path.join(base_dir, "xs1g_prompt_crit.cxs")
+    xs_super_2p_path = os.path.join(base_dir, "xs1g_delayed_super_2p.cxs")
+
+    xs_prompt_crit = MultiGroupXS()
+    xs_prompt_crit.LoadFromOpenSn(xs_prompt_crit_path)
+
+    xs_super_2p = MultiGroupXS()
+    xs_super_2p.LoadFromOpenSn(xs_super_2p_path)
+
+    pquad = GLProductQuadrature1DSlab(n_polar=4, scattering_order=0)
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": pquad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 200,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs_prompt_crit}],
+        boundary_conditions=[
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": True,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+            "verbose_ags_iterations": False,
+        },
+    )
+
+    keigen = PowerIterationKEigenSolver(problem=problem, max_iters=200, k_tol=1.0e-10)
+    keigen.Initialize()
+    keigen.Execute()
+
+    phi_initial = max_phi(problem)
+    if phi_initial <= 0.0:
+        raise RuntimeError("Initial scalar flux must be positive.")
+
+    problem.SetTimeDependentMode()
+
+    solver = TransientSolver(problem=problem, verbose=False, initial_state="existing")
+    solver.Initialize()
+
+    problem.SetXSMap(xs_map=[{"block_ids": [0], "xs": xs_super_2p}])
+
+    betas = read_precursor_values(xs_super_2p_path, "PRECURSOR_FRACTIONAL_YIELDS")
+    decay_consts = read_precursor_values(xs_super_2p_path, "PRECURSOR_DECAY_CONSTANTS")
+    sigma_a = xs_super_2p.sigma_a[0]
+    nu_sigma_f = xs_super_2p.nu_sigma_f[0]
+    velocity = 1.0 / xs_super_2p.inv_velocity[0]
+    k_eff = nu_sigma_f / sigma_a
+    reactivity = (k_eff - 1.0) / k_eff
+    generation_time = 1.0 / (velocity * nu_sigma_f)
+
+    dt = 1.0e-2
+    n_steps = 20
+    rel_tol = 5.0e-6
+
+    solver.SetTimeStep(dt)
+    solver.SetTheta(1.0)
+
+    phi_ref = 1.0
+    c_ref = [0.0 for _ in betas]
+    ok = True
+
+    if rank == 0:
+        print("step time ratio_numeric ratio_reference")
+
+    for step in range(1, n_steps + 1):
+        solver.Advance()
+        phi_ref, c_ref = backward_euler_two_precursors(
+            phi_ref, c_ref, dt, reactivity, betas, decay_consts, generation_time
+        )
+        phi_num = max_phi(problem)
+        ratio_num = phi_num / phi_initial
+        time_now = problem.GetTime()
+        if rank == 0:
+            print(f"{step:4d} {time_now:10.4e} {ratio_num:12.6e} {phi_ref:12.6e}")
+        if abs(ratio_num - phi_ref) > rel_tol * max(phi_ref, 1.0e-12):
+            ok = False
+
+    if rank == 0:
+        print(f"PRECURSOR_INTRO_PASS {1 if ok else 0}")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_precursor_count_xs_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_precursor_count_xs_swap.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+1D delayed transient with XS swaps across fissionability and precursor counts.
+
+This regression exercises runtime XS-map swaps that:
+1. change from a delayed fissionable material with 2 precursor families
+2. to a non-fissionable pure absorber with 0 precursor families
+3. to a delayed fissionable material with 1 precursor family
+
+The geometry is homogeneous with reflecting boundaries, so the transport solution
+reduces to an infinite-medium kinetics problem. We compare the scalar-flux ratio
+against an exact Backward Euler update for the corresponding reduced model:
+
+- During the non-fissionable interval, phi_{n+1} = phi_n / (1 + v sigma_t dt)
+- During the 1-precursor interval, [phi, C]^T is advanced by the exact 2x2
+  Backward Euler kinetics solve with C initialized to zero after the 0-precursor swap
+
+PRECURSOR_SWAP_PASS is 1 if the numeric scalar-flux ratio matches the piecewise
+reference within 5.0e-6 relative error at every step.
+"""
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.aquad import GLProductQuadrature1DSlab
+    from pyopensn.fieldfunc import FieldFunctionInterpolationVolume
+    from pyopensn.logvol import RPPLogicalVolume
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.solver import (
+        DiscreteOrdinatesProblem,
+        PowerIterationKEigenSolver,
+        TransientSolver,
+    )
+    from pyopensn.xs import MultiGroupXS
+
+
+def read_precursor_values(path, block_name):
+    begin = f"{block_name}_BEGIN"
+    end = f"{block_name}_END"
+    in_block = False
+    values = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line == begin:
+                in_block = True
+                continue
+            if line == end:
+                break
+            if in_block:
+                parts = line.split()
+                if len(parts) >= 2:
+                    values.append(float(parts[1]))
+    if not values:
+        raise RuntimeError(f"Failed to find values for {block_name} in {path}")
+    return values
+
+
+def max_phi(problem):
+    fflist = problem.GetScalarFluxFieldFunction()
+    monitor_volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    field_interp = FieldFunctionInterpolationVolume()
+    field_interp.SetOperationType("max")
+    field_interp.SetLogicalVolume(monitor_volume)
+    field_interp.AddFieldFunction(fflist[0])
+    field_interp.Execute()
+    return field_interp.GetValue()
+
+
+def backward_euler_prompt_decay(phi_n, dt, sigma_t, velocity):
+    return phi_n / (1.0 + velocity * sigma_t * dt)
+
+
+def backward_euler_one_precursor(phi_n, c_n, dt, reactivity, beta, decay_const, generation_time):
+    a_coeff = (reactivity - beta) / generation_time
+    b_coeff = beta / generation_time
+
+    A = 1.0 - dt * a_coeff
+    D = 1.0 + dt * decay_const
+    det = A * D - (dt * decay_const) * (dt * b_coeff)
+
+    phi_np1 = (D * phi_n + dt * decay_const * c_n) / det
+    c_np1 = (dt * b_coeff * phi_n + A * c_n) / det
+    return phi_np1, c_np1
+
+
+if __name__ == "__main__":
+    n_cells = 40
+    length = 8.0
+    dx = length / n_cells
+    nodes = [i * dx for i in range(n_cells + 1)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    base_dir = os.path.dirname(__file__)
+    xs_crit_2p_path = os.path.join(base_dir, "xs1g_delayed_crit_2p.cxs")
+    xs_super_1p_path = os.path.join(base_dir, "xs1g_delayed_super_1p.cxs")
+
+    xs_crit_2p = MultiGroupXS()
+    xs_crit_2p.LoadFromOpenSn(xs_crit_2p_path)
+
+    xs_absorber = MultiGroupXS()
+    xs_absorber.CreateSimpleOneGroup(1.5, 0.0, 1.0)
+
+    xs_super_1p = MultiGroupXS()
+    xs_super_1p.LoadFromOpenSn(xs_super_1p_path)
+
+    pquad = GLProductQuadrature1DSlab(n_polar=4, scattering_order=0)
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": pquad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 200,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs_crit_2p}],
+        boundary_conditions=[
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": True,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+            "verbose_ags_iterations": False,
+        },
+    )
+
+    keigen = PowerIterationKEigenSolver(problem=problem, max_iters=200, k_tol=1.0e-10)
+    keigen.Initialize()
+    keigen.Execute()
+
+    problem.SetTimeDependentMode()
+
+    solver = TransientSolver(problem=problem, verbose=False, initial_state="existing")
+    solver.Initialize()
+
+    phi_initial = max_phi(problem)
+    if phi_initial <= 0.0:
+        raise RuntimeError("Initial scalar flux must be positive.")
+
+    dt_absorb = 5.0e-2
+    dt_fission = 1.0e-2
+    n_absorb_steps = 3
+    n_fission_steps = 10
+    rel_tol = 5.0e-6
+
+    ok = True
+    phi_ref = 1.0
+    c_ref = 0.0
+
+    absorber_sigma_t = xs_absorber.sigma_t[0]
+    absorber_velocity = 1.0 / xs_absorber.inv_velocity[0]
+
+    beta = read_precursor_values(xs_super_1p_path, "PRECURSOR_FRACTIONAL_YIELDS")[0]
+    decay_const = read_precursor_values(xs_super_1p_path, "PRECURSOR_DECAY_CONSTANTS")[0]
+    sigma_a = xs_super_1p.sigma_a[0]
+    nu_sigma_f = xs_super_1p.nu_sigma_f[0]
+    velocity = 1.0 / xs_super_1p.inv_velocity[0]
+    k_eff = nu_sigma_f / sigma_a
+    reactivity = (k_eff - 1.0) / k_eff
+    generation_time = 1.0 / (velocity * nu_sigma_f)
+
+    if rank == 0:
+        print("phase step time ratio_numeric ratio_reference")
+
+    problem.SetXSMap(xs_map=[{"block_ids": [0], "xs": xs_absorber}])
+    solver.SetTimeStep(dt_absorb)
+    solver.SetTheta(1.0)
+
+    for step in range(1, n_absorb_steps + 1):
+        solver.Advance()
+        phi_ref = backward_euler_prompt_decay(
+            phi_ref, dt_absorb, absorber_sigma_t, absorber_velocity
+        )
+        phi_num = max_phi(problem)
+        ratio_num = phi_num / phi_initial
+        time_now = problem.GetTime()
+        if rank == 0:
+            print(f"absorb {step:4d} {time_now:10.4e} {ratio_num:12.6e} {phi_ref:12.6e}")
+        if abs(ratio_num - phi_ref) > rel_tol * max(phi_ref, 1.0e-12):
+            ok = False
+
+    problem.SetXSMap(xs_map=[{"block_ids": [0], "xs": xs_super_1p}])
+    solver.SetTimeStep(dt_fission)
+    c_ref = 0.0
+
+    for step in range(1, n_fission_steps + 1):
+        solver.Advance()
+        phi_ref, c_ref = backward_euler_one_precursor(
+            phi_ref, c_ref, dt_fission, reactivity, beta, decay_const, generation_time
+        )
+        phi_num = max_phi(problem)
+        ratio_num = phi_num / phi_initial
+        time_now = problem.GetTime()
+        if rank == 0:
+            print(f"fission {step:3d} {time_now:10.4e} {ratio_num:12.6e} {phi_ref:12.6e}")
+        if abs(ratio_num - phi_ref) > rel_tol * max(phi_ref, 1.0e-12):
+            ok = False
+
+    if rank == 0:
+        print(f"PRECURSOR_SWAP_PASS {1 if ok else 0}")


### PR DESCRIPTION
When changing xs maps, `LBSProblem::SetBlock2XSMap` now correctly handles precursors, fissionable materials, and DSA setup. This fix also prompted the removal of cached problem members for solvers. This primarily targets the transient solver where changing the xs map between time steps could result in the solver using a cached problem member that is stale. Reverting to a non-cached design resolves this issue. And, given the cost of solve, should be a non-event performance-wise.

Added regression tests cover:
- precursor storage: 0p -> 2p
- precursor storage reset: 2p -> 0p -> 1p
- fissionable to non-fissionable material swap
- non-fissionable back to fissionable material swap
- transient source behavior after map changes
