### PR TITLE
Adding update functionality to field functions via callbacks

### DIFF
--- a/framework/field_functions/field_function_grid_based.cc
+++ b/framework/field_functions/field_function_grid_based.cc
@@ -135,6 +135,29 @@ FieldFunctionGridBased::UpdateFieldVector(const Vec& field_vector)
   ghosted_field_vector_->CommunicateGhostEntries();
 }
 
+bool
+FieldFunctionGridBased::CanUpdate() const
+{
+  return static_cast<bool>(update_callback_) and
+         (not can_update_callback_ or can_update_callback_());
+}
+
+void
+FieldFunctionGridBased::Update()
+{
+  OpenSnLogicalErrorIf(not CanUpdate(),
+                       "Field function \"" + GetName() + "\" is not currently updateable.");
+  update_callback_(*this);
+}
+
+void
+FieldFunctionGridBased::SetUpdateCallback(UpdateCallback callback,
+                                          CanUpdateCallback can_update_callback)
+{
+  update_callback_ = std::move(callback);
+  can_update_callback_ = std::move(can_update_callback);
+}
+
 std::vector<double>
 FieldFunctionGridBased::GetPointValue(const Vector3& point) const
 {

--- a/framework/field_functions/field_function_grid_based.h
+++ b/framework/field_functions/field_function_grid_based.h
@@ -6,6 +6,7 @@
 #include "framework/field_functions/field_function.h"
 #include "framework/data_types/parallel_vector/ghosted_parallel_stl_vector.h"
 #include "framework/mesh/mesh.h"
+#include <functional>
 #include <string>
 #include <memory>
 #include <vector>
@@ -21,6 +22,8 @@ class FieldFunctionGridBased : public FieldFunction
 public:
   using BoundingBox = std::pair<Vector3, Vector3>;
   using FFList = std::vector<std::shared_ptr<const FieldFunctionGridBased>>;
+  using UpdateCallback = std::function<void(FieldFunctionGridBased&)>;
+  using CanUpdateCallback = std::function<bool()>;
 
   explicit FieldFunctionGridBased(const InputParameters& params);
 
@@ -64,6 +67,15 @@ public:
   /// Updates the field vector with a PETSc vector. This only operates locally.
   void UpdateFieldVector(const Vec& field_vector);
 
+  /// Returns true if the field function can currently refresh itself from an owner callback.
+  bool CanUpdate() const;
+
+  /// Refreshes the field function by invoking its owner callback.
+  void Update();
+
+  /// Sets the callback used to refresh this field function.
+  void SetUpdateCallback(UpdateCallback callback, CanUpdateCallback can_update_callback = nullptr);
+
   /// Returns the component values at requested point.
   virtual std::vector<double> GetPointValue(const Vector3& point) const;
 
@@ -73,6 +85,8 @@ public:
 protected:
   std::shared_ptr<SpatialDiscretization> discretization_;
   std::unique_ptr<GhostedParallelSTLVector> ghosted_field_vector_;
+  UpdateCallback update_callback_;
+  CanUpdateCallback can_update_callback_;
 
 private:
   const BoundingBox local_grid_bounding_box_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -880,7 +880,22 @@ DiscreteOrdinatesProblem::CreateAngularFluxFieldFunctionList(
                              std::to_string(gs_id) + ".");
 
       auto ff_ptr = CreateEmptyFieldFunction(MakeAngularFieldFunctionName(gs_id, g, a));
-      ff_ptr->UpdateFieldVector(ComputeAngularFieldFunctionData(gs_id, g, a));
+      UpdateAngularFluxFieldFunction(*ff_ptr, gs_id, g, a);
+      const std::weak_ptr<LBSProblem> weak_owner = weak_from_this();
+      ff_ptr->SetUpdateCallback(
+        [weak_owner, gs_id, g, a](FieldFunctionGridBased& ff)
+        {
+          auto owner = weak_owner.lock();
+          OpenSnLogicalErrorIf(not owner,
+                               "Cannot update field function after its owning problem has "
+                               "been destroyed.");
+          auto do_owner = std::dynamic_pointer_cast<DiscreteOrdinatesProblem>(owner);
+          OpenSnLogicalErrorIf(not do_owner,
+                               "Angular flux field function owner is not a "
+                               "DiscreteOrdinatesProblem.");
+          do_owner->UpdateAngularFluxFieldFunction(ff, gs_id, g, a);
+        },
+        [weak_owner]() { return not weak_owner.expired(); });
       result.push_back(ff_ptr);
     }
   }
@@ -932,6 +947,15 @@ DiscreteOrdinatesProblem::ComputeAngularFieldFunctionData(const size_t groupset_
   }
 
   return data_vector_local;
+}
+
+void
+DiscreteOrdinatesProblem::UpdateAngularFluxFieldFunction(FieldFunctionGridBased& ff,
+                                                         const size_t groupset_id,
+                                                         const unsigned int group,
+                                                         const size_t angle)
+{
+  ff.UpdateFieldVector(ComputeAngularFieldFunctionData(groupset_id, group, angle));
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -232,6 +232,10 @@ private:
                             GeometryType lbs_geo_type);
 
   void UpdateAngularFluxStorage();
+  void UpdateAngularFluxFieldFunction(FieldFunctionGridBased& ff,
+                                      size_t groupset_id,
+                                      unsigned int group,
+                                      size_t angle);
 
 public:
   static InputParameters GetInputParameters();

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <unordered_map>
 #include <functional>
+#include <utility>
 
 namespace opensn
 {
@@ -527,7 +528,19 @@ LBSProblem::CreateScalarFluxFieldFunction(unsigned int g, unsigned int m)
   OpenSnLogicalErrorIf(m >= num_moments_, GetName() + ": Moment index out of range.");
 
   auto ff_ptr = CreateEmptyFieldFunction(MakeScalarFluxFieldFunctionName(g, m));
-  ff_ptr->UpdateFieldVector(ComputeScalarFluxFieldFunctionData(g, m));
+  UpdateScalarFluxFieldFunction(*ff_ptr, g, m);
+
+  const std::weak_ptr<LBSProblem> weak_owner = weak_from_this();
+  ff_ptr->SetUpdateCallback(
+    [weak_owner, g, m](FieldFunctionGridBased& ff)
+    {
+      auto owner = weak_owner.lock();
+      OpenSnLogicalErrorIf(not owner,
+                           "Cannot update field function after its owning problem has "
+                           "been destroyed.");
+      owner->UpdateScalarFluxFieldFunction(ff, g, m);
+    },
+    [weak_owner]() { return not weak_owner.expired(); });
   return ff_ptr;
 }
 
@@ -539,24 +552,21 @@ LBSProblem::CreateFieldFunction(const std::string& name,
   const std::string ff_name = MakeFieldFunctionName(name);
   auto ff_ptr = CreateEmptyFieldFunction(ff_name);
 
-  std::vector<double> data_vector_local;
-  if (xs_name == "power")
-  {
-    double local_total_power = 0.0;
-    data_vector_local = ComputePowerFieldFunctionData(local_total_power);
-  }
-  else
-  {
-    data_vector_local = ComputeXSFieldFunctionData(xs_name);
-  }
+  UpdateDerivedFieldFunction(*ff_ptr, xs_name, power_normalization_target);
 
-  if (power_normalization_target > 0.0)
-  {
-    const double scale_factor = ComputeFieldFunctionPowerScaleFactor(power_normalization_target);
-    Scale(data_vector_local, scale_factor);
-  }
-
-  ff_ptr->UpdateFieldVector(data_vector_local);
+  const std::weak_ptr<LBSProblem> weak_owner = weak_from_this();
+  auto xs_name_copy = xs_name;
+  ff_ptr->SetUpdateCallback(
+    [weak_owner, xs_name = std::move(xs_name_copy), power_normalization_target](
+      FieldFunctionGridBased& ff)
+    {
+      auto owner = weak_owner.lock();
+      OpenSnLogicalErrorIf(not owner,
+                           "Cannot update field function after its owning problem has "
+                           "been destroyed.");
+      owner->UpdateDerivedFieldFunction(ff, xs_name, power_normalization_target);
+    },
+    [weak_owner]() { return not weak_owner.expired(); });
   return ff_ptr;
 }
 
@@ -1222,6 +1232,39 @@ LBSProblem::CreateEmptyFieldFunction(const std::string& name) const
   auto discretization = discretization_;
   return std::make_shared<FieldFunctionGridBased>(
     name, discretization, Unknown(UnknownType::SCALAR));
+}
+
+void
+LBSProblem::UpdateScalarFluxFieldFunction(FieldFunctionGridBased& ff,
+                                          const unsigned int g,
+                                          const unsigned int m)
+{
+  ff.UpdateFieldVector(ComputeScalarFluxFieldFunctionData(g, m));
+}
+
+void
+LBSProblem::UpdateDerivedFieldFunction(FieldFunctionGridBased& ff,
+                                       const std::string& xs_name,
+                                       const double power_normalization_target)
+{
+  std::vector<double> data_vector_local;
+  if (xs_name == "power")
+  {
+    double local_total_power = 0.0;
+    data_vector_local = ComputePowerFieldFunctionData(local_total_power);
+  }
+  else
+  {
+    data_vector_local = ComputeXSFieldFunctionData(xs_name);
+  }
+
+  if (power_normalization_target > 0.0)
+  {
+    const double scale_factor = ComputeFieldFunctionPowerScaleFactor(power_normalization_target);
+    Scale(data_vector_local, scale_factor);
+  }
+
+  ff.UpdateFieldVector(data_vector_local);
 }
 
 std::vector<double>

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -36,7 +36,7 @@ template <typename T>
 class MemoryPinner;
 
 /// Base class for all Linear Boltzmann Solvers.
-class LBSProblem : public Problem
+class LBSProblem : public Problem, public std::enable_shared_from_this<LBSProblem>
 {
 public:
   LBSProblem(const LBSProblem&) = delete;
@@ -321,6 +321,10 @@ protected:
 
   std::shared_ptr<FieldFunctionGridBased> CreateEmptyFieldFunction(const std::string& name) const;
   std::string MakeFieldFunctionName(const std::string& base_name) const;
+  void UpdateScalarFluxFieldFunction(FieldFunctionGridBased& ff, unsigned int g, unsigned int m);
+  void UpdateDerivedFieldFunction(FieldFunctionGridBased& ff,
+                                  const std::string& xs_name,
+                                  double power_normalization_target);
 
   LBSOptions options_;
   double time_ = 0.0;

--- a/python/lib/fieldfunc.cc
+++ b/python/lib/fieldfunc.cc
@@ -107,6 +107,26 @@ WrapFieldFunctionGridBased(py::module& ffunc)
     )",
     py::arg("ff_list"), py::arg("base_name")
   );
+  field_func_grid_based.def(
+    "CanUpdate",
+    &FieldFunctionGridBased::CanUpdate,
+    R"(
+    Return whether this field function can currently refresh itself from its owning solver.
+
+    This returns ``False`` if the field function has no update callback or if the owning solver
+    has already been destroyed.
+    )"
+  );
+  field_func_grid_based.def(
+    "Update",
+    &FieldFunctionGridBased::Update,
+    R"(
+    Refresh this field function from its owning solver.
+
+    Raises an error if the field function is not refreshable or if its owning solver has already
+    been destroyed.
+    )"
+  );
   // clang-format on
 }
 

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -141,17 +141,20 @@ WrapLBS(py::module& slv)
 
     Notes
     -----
-    Field functions are created on demand from the current solver state. The solver does
-    not retain or continuously update scalar-flux field functions between calls.
+    Field functions are created on demand from the current solver state.
 
-    These returned field functions are snapshots. If the solver state changes,
-    previously returned field functions are not refreshed in place.
+    The returned field functions are snapshots of the solver state at creation time; they are not
+    refreshed automatically if the solver state changes.
+
+    They support ``CanUpdate()`` and ``Update()`` while their owning solver is still alive.
+    Calling ``Update()`` explicitly refreshes the same field-function object from the solver's
+    latest state.
 
     Calling ``GetScalarFluxFieldFunction(only_scalar_flux=False)`` creates all requested
     moments from the current ``phi`` iterate at the time of the call.
 
-    To obtain field functions from a newer solver state, call
-    ``GetScalarFluxFieldFunction(...)`` again.
+    To obtain independent field functions from a newer solver state, call
+    ``GetScalarFluxFieldFunction(...)`` again instead of updating the existing objects.
 
     In the nested form (``only_scalar_flux=False``), the moment index varies fastest
     within each group (inner index = moment, outer index = group).
@@ -180,11 +183,10 @@ WrapLBS(py::module& slv)
     The returned field function is created on demand from the current scalar-flux iterate.
     For ordinary XS names this computes ``sum_g xs[g] * phi_g`` at each node.
 
-    The returned field function is a snapshot. If the solver state changes,
-    call ``CreateFieldFunction(...)`` again to obtain a new field function.
-
-    To obtain a field function from a newer solver state, call
-    ``CreateFieldFunction(...)`` again.
+    The returned field function is a snapshot of the solver state at creation time; it is not
+    refreshed automatically if the solver state changes. It supports ``CanUpdate()`` and
+    ``Update()`` while its owning solver is still alive. Calling ``Update()`` explicitly
+    recomputes the same field function from the solver's latest state.
 
     If ``xs_name == "power"``, the same power-generation formula used elsewhere by the solver
     is applied on demand.
@@ -949,18 +951,9 @@ WrapLBS(py::module& slv)
     Returns
     -------
     List[pyopensn.fieldfunc.FieldFunctionGridBased]
-        Field functions for the requested (group, angle) pairs.
-
-    Notes
-    -----
-    Field functions are created on demand from the currently stored angular flux. The solver does
-    not retain or continuously update angular field functions between calls.
-
-    The returned field functions are snapshots. If the solver state changes,
-    previously returned angular field functions are not refreshed in place.
-
-    To obtain angular field functions from a newer solver state, call
-    ``GetAngularFieldFunctionList(...)`` again.
+        Field functions for the requested ``(group, angle)`` pairs. Each returned field function
+        is a snapshot, but supports ``CanUpdate()`` and ``Update()`` while its owning solver is
+        alive.
     )",
     py::arg("groups"),
     py::arg("angles")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr.py
@@ -108,6 +108,19 @@ if __name__ == "__main__":
     solver.SetTheta(theta)
 
     monitor_volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    fflist = phys.GetScalarFluxFieldFunction()
+
+    # Group 0
+    ff_interp_g0 = FieldFunctionInterpolationVolume()
+    ff_interp_g0.SetOperationType("max")
+    ff_interp_g0.SetLogicalVolume(monitor_volume)
+    ff_interp_g0.AddFieldFunction(fflist[0])
+
+    # Group 1
+    ff_interp_g1 = FieldFunctionInterpolationVolume()
+    ff_interp_g1.SetOperationType("max")
+    ff_interp_g1.SetLogicalVolume(monitor_volume)
+    ff_interp_g1.AddFieldFunction(fflist[1])
 
     phi0 = []
     phi1 = []
@@ -130,22 +143,13 @@ if __name__ == "__main__":
 
         # Advance the solution from current_time to target_time
         solver.Advance()
-        fflist = phys.GetScalarFluxFieldFunction()
+        fflist[0].Update()
+        fflist[1].Update()
 
-        # Group 0
-        ff_interp_g0 = FieldFunctionInterpolationVolume()
-        ff_interp_g0.SetOperationType("max")
-        ff_interp_g0.SetLogicalVolume(monitor_volume)
-        ff_interp_g0.AddFieldFunction(fflist[0])
         ff_interp_g0.Execute()
         flux_max_g0 = ff_interp_g0.GetValue()
         phi0.append(flux_max_g0)
 
-        # Group 1
-        ff_interp_g1 = FieldFunctionInterpolationVolume()
-        ff_interp_g1.SetOperationType("max")
-        ff_interp_g1.SetLogicalVolume(monitor_volume)
-        ff_interp_g1.AddFieldFunction(fflist[1])
         ff_interp_g1.Execute()
         flux_max_g1 = ff_interp_g1.GetValue()
         phi1.append(flux_max_g1)

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr_ramp_dt.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_2g_inf_med_pydrvr_ramp_dt.py
@@ -100,6 +100,17 @@ if __name__ == "__main__":
     solver.Initialize()
 
     monitor_volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    fflist = phys.GetScalarFluxFieldFunction()
+
+    ff_interp_g0 = FieldFunctionInterpolationVolume()
+    ff_interp_g0.SetOperationType("max")
+    ff_interp_g0.SetLogicalVolume(monitor_volume)
+    ff_interp_g0.AddFieldFunction(fflist[0])
+
+    ff_interp_g1 = FieldFunctionInterpolationVolume()
+    ff_interp_g1.SetOperationType("max")
+    ff_interp_g1.SetLogicalVolume(monitor_volume)
+    ff_interp_g1.AddFieldFunction(fflist[1])
 
     # Time stepping parameters
     theta = 0.5
@@ -140,19 +151,12 @@ if __name__ == "__main__":
 
         # Advance the solution
         solver.Advance()
-        fflist = phys.GetScalarFluxFieldFunction()
+        fflist[0].Update()
+        fflist[1].Update()
 
-        ff_interp_g0 = FieldFunctionInterpolationVolume()
-        ff_interp_g0.SetOperationType("max")
-        ff_interp_g0.SetLogicalVolume(monitor_volume)
-        ff_interp_g0.AddFieldFunction(fflist[0])
         ff_interp_g0.Execute()
         flux_max_g0 = ff_interp_g0.GetValue()
 
-        ff_interp_g1 = FieldFunctionInterpolationVolume()
-        ff_interp_g1.SetOperationType("max")
-        ff_interp_g1.SetLogicalVolume(monitor_volume)
-        ff_interp_g1.AddFieldFunction(fflist[1])
         ff_interp_g1.Execute()
         flux_max_g1 = ff_interp_g1.GetValue()
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_openmc_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_3d_openmc_xs.py
@@ -84,6 +84,12 @@ if __name__ == "__main__":
     current_time = 0.0
     flux_max = 0.0
     step = 0
+    fflist = phys.GetScalarFluxFieldFunction()
+    field_interp = FieldFunctionInterpolationVolume()
+    field_interp.SetOperationType("max")
+    field_interp.SetLogicalVolume(monitor_volume)
+    field_interp.AddFieldFunction(fflist[3])
+
     while current_time < stop_time - 1.0e-14:
         target_time = min(current_time + dt, stop_time)
         solver.SetTimeStep(target_time - current_time)
@@ -91,12 +97,7 @@ if __name__ == "__main__":
         solver.SetTheta(theta_step)
         solver.Advance()
         current_time = target_time
-        fflist = phys.GetScalarFluxFieldFunction()
-
-        field_interp = FieldFunctionInterpolationVolume()
-        field_interp.SetOperationType("max")
-        field_interp.SetLogicalVolume(monitor_volume)
-        field_interp.AddFieldFunction(fflist[3])
+        fflist[3].Update()
         field_interp.Execute()
         flux_max = field_interp.GetValue()
         step += 1


### PR DESCRIPTION
This PR adds two new methods to field functions: `CanUpdate` and `Update`.  Users can call `Update` to refresh the contents of a field function without having to create a new one. This can be useful, for example, for interpolators that hold field functions.