### PR TITLE
Refactor SweepBoundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cmake-build-debug/
 cmake-build-debug
 .idea
+.codex
 bin
 build*/
 

--- a/doc/source/userguide/boundary_conditions_sources.rst
+++ b/doc/source/userguide/boundary_conditions_sources.rst
@@ -82,7 +82,10 @@ Each boundary entry is a dictionary with:
 * ``name``: the boundary id on the mesh
 * ``type``: one of the supported boundary-condition types
 * ``group_strength``: required for ``"isotropic"``
-* ``function``: required for ``"arbitrary"``
+* ``start_time`` and ``end_time``: optional active time window for
+  ``"isotropic"`` boundaries
+* ``function``: steady or time-independent callback for ``"arbitrary"``
+* ``time_function``: time-dependent callback for ``"arbitrary"``
 
 .. note::
 
@@ -159,6 +162,8 @@ Important points:
 
 * ``group_strength`` must have one entry per energy group
 * the values are incoming boundary angular flux values
+* ``start_time`` and ``end_time`` can be used to activate the boundary only
+  during part of a transient calculation
 * because OpenSn normalizes quadrature weights to sum to ``1.0``, a value
   ``group_strength[g] = X`` means "apply a uniform isotropic incoming angular
   flux of value ``X`` in group ``g``" in OpenSn's discrete convention
@@ -168,6 +173,37 @@ Important points:
    Isotropic boundaries are often the simplest way to drive a benchmark or test
    problem when the intent is "inject a known incoming flux on this face" rather
    than "create particles throughout a volume."
+
+Time-Windowed Isotropic Boundaries
+----------------------------------
+
+For transient problems, an isotropic boundary can be restricted to an active
+time interval with ``start_time`` and ``end_time``.
+
+Example:
+
+.. code-block:: python
+
+   {
+       "name": "xmin",
+       "type": "isotropic",
+       "group_strength": [1.0, 0.0],
+       "start_time": 0.0,
+       "end_time": 0.5,
+   }
+
+The boundary is active when:
+
+* ``time >= start_time``
+* ``time <= end_time``
+
+Outside that interval, the isotropic inflow on that boundary is zero.
+
+.. note::
+
+   ``start_time`` and ``end_time`` are supported for ``"isotropic"``
+   boundaries only. They are not accepted for ``"vacuum"``, ``"reflecting"``,
+   or ``"arbitrary"`` boundaries.
 
 Arbitrary Boundaries
 --------------------
@@ -225,6 +261,55 @@ Example:
    If you want an arbitrary boundary to behave like a uniform isotropic inflow
    of value ``X`` in one group, return ``X`` for every incoming direction in
    that group. Do not multiply by quadrature weights in the callback.
+
+Time-Dependent Arbitrary Boundaries
+-----------------------------------
+
+For transient problems, arbitrary boundary inflow can depend on time by using
+:py:class:`pyopensn.math.AngularFluxTimeFunction` and the ``time_function``
+boundary entry.
+
+The callback signature is:
+
+.. code-block:: python
+
+   def bc_func(group_index, direction_index, time) -> float:
+       ...
+
+Example:
+
+.. code-block:: python
+
+   from pyopensn.math import AngularFluxTimeFunction
+
+   def xmin_pulse(group_index, direction_index, time):
+       if group_index == 0 and 0.0 <= time <= 0.5:
+           return 1.0
+       return 0.0
+
+   boundary_conditions = [
+       {
+           "name": "xmin",
+           "type": "arbitrary",
+           "time_function": AngularFluxTimeFunction(xmin_pulse),
+       },
+       {"name": "xmax", "type": "vacuum"},
+   ]
+
+Important behavior:
+
+* an ``"arbitrary"`` boundary must specify exactly one of ``function`` or
+  ``time_function``
+* ``function`` callbacks receive ``(group_index, direction_index)``
+* ``time_function`` callbacks receive ``(group_index, direction_index, time)``
+* ``start_time`` and ``end_time`` are not supported for arbitrary boundaries;
+  put any active-window logic inside the callback
+
+.. note::
+
+   The time argument is the problem time used by the transient sweep. This makes
+   the boundary value part of the timestep solve rather than a Python-side
+   boundary replacement between solves.
 
 Setting and Replacing Boundary Conditions
 -----------------------------------------
@@ -611,15 +696,50 @@ Examples:
    drive a sequence of solves or a Python-controlled transient without
    reconstructing the entire problem.
 
-Transient Source Behavior
-=========================
+Transient Source and Boundary Behavior
+======================================
 
 For transient problems, time dependence can enter through:
 
-* ``start_time`` / ``end_time``
-* ``strength_function`` callbacks
+* boundary ``start_time`` / ``end_time`` windows on isotropic boundaries
+* boundary ``time_function`` callbacks on arbitrary boundaries
+* source ``start_time`` / ``end_time`` windows
+* source ``strength_function`` callbacks
 * explicit replacement of source objects between calls to
   :py:meth:`Advance`
+
+Example of a time-windowed isotropic boundary:
+
+.. code-block:: python
+
+   boundary_conditions = [
+       {
+           "name": "xmin",
+           "type": "isotropic",
+           "group_strength": [1.0],
+           "start_time": 0.0,
+           "end_time": 10.0,
+       },
+       {"name": "xmax", "type": "vacuum"},
+   ]
+
+Example of a time-dependent arbitrary boundary:
+
+.. code-block:: python
+
+   from pyopensn.math import AngularFluxTimeFunction
+
+   def angular_inflow(group, direction, time):
+       return 1.0 if group == 0 and time < 10.0 else 0.0
+
+   boundary_conditions = [
+       {
+           "name": "xmin",
+           "type": "arbitrary",
+           "time_function": AngularFluxTimeFunction(angular_inflow),
+       },
+       {"name": "xmax", "type": "vacuum"},
+   ]
 
 Example of a time-windowed volumetric source:
 
@@ -648,10 +768,11 @@ Example of replacing sources in a Python timestep loop:
 
 .. note::
 
-   There are two different design styles for transient sources. One is to keep a
-   single source object and let it handle its own time dependence. The other is
-   to replace source objects explicitly in the Python loop. Both are valid; the
-   clearer choice depends on how much logic the source behavior really needs.
+   There are two different design styles for transient driving terms. One is to
+   keep a single boundary or source object and let it handle its own time
+   dependence. The other is to replace objects explicitly in the Python loop.
+   Both are valid; the clearer choice depends on how much logic the behavior
+   really needs.
 
 Boundary Names and Mesh Labels
 ==============================
@@ -681,6 +802,10 @@ Best Practices
   physical model; they are the clearest and least error-prone options.
 * Use isotropic boundaries for simple incoming-flux problems.
 * Use arbitrary boundaries only when the inflow genuinely depends on angle.
+* Prefer isotropic ``start_time``/``end_time`` windows for simple transient
+  boundary pulses.
+* Prefer ``AngularFluxTimeFunction`` when arbitrary boundary inflow must vary
+  with time.
 * Use volumetric sources based on block ids when source regions already align
   with the mesh labeling.
 * Use logical volumes when the source region is geometric rather than material

--- a/framework/math/functions/function.h
+++ b/framework/math/functions/function.h
@@ -36,6 +36,17 @@ public:
   }
 };
 
+/// Base class for evaluating incoming angular fluxes given group, direction, and time.
+class AngularFluxTimeFunction : public std::function<double(int, int, double)>
+{
+public:
+  AngularFluxTimeFunction() = default;
+  AngularFluxTimeFunction(const std::function<double(int, int, double)>& src)
+    : std::function<double(int, int, double)>(src)
+  {
+  }
+};
+
 /// Base class for evaluating group-wise strengths given group index and time.
 class GroupTimeFunction : public std::function<double(unsigned int, double)>
 {

--- a/framework/mesh/cell/cell.cc
+++ b/framework/mesh/cell/cell.cc
@@ -7,7 +7,19 @@
 #include "framework/data_types/byte_array.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include <iomanip>
 #include <set>
+
+std::ostream&
+std::operator<<(std::ostream& out, const opensn::FaceNode& n)
+{
+  out << "FaceNode(";
+  out << "c=" << std::setw(5) << n.GetCellIndex() << ", ";
+  out << "f=" << std::setw(2) << n.GetFaceIndex() << ", ";
+  out << "fn=" << std::setw(2) << n.GetFaceNodeIndex();
+  out << ")";
+  return out;
+}
 
 namespace opensn
 {

--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -39,6 +39,58 @@ enum class CellType
 std::string CellTypeName(CellType type);
 
 /**
+ * Node on a face.
+ * This class represents a node on a face. It stores the cell local index, the face index
+ * within the cell and the index of the node relative to the face as compact 64-bit integer. This
+ * class abstracts the node for usage with std::map and std::set.
+ */
+class FaceNode
+{
+public:
+  /// Default constructor.
+  constexpr FaceNode() = default;
+  /// Member constructor.
+  constexpr FaceNode(std::uint32_t cell_idx, std::uint16_t face_idx, std::uint16_t face_node_idx)
+    : value_(0)
+  {
+    value_ |= static_cast<std::uint64_t>(cell_idx) << 32;
+    value_ |= static_cast<std::uint64_t>(face_idx) << 16;
+    value_ |= static_cast<std::uint64_t>(face_node_idx);
+  }
+
+  /// Comparison operator for ordering.
+  constexpr bool operator<(const FaceNode& other) const { return value_ < other.value_; }
+
+  /// Equality operator.
+  constexpr bool operator==(const FaceNode& other) const { return value_ == other.value_; }
+
+  /// Get cell local index.
+  constexpr std::uint32_t GetCellIndex() const { return static_cast<std::uint32_t>(value_ >> 32); }
+
+  /// Get face index.
+  constexpr std::uint16_t GetFaceIndex() const
+  {
+    return static_cast<std::uint16_t>((value_ >> 16) & 0xFFFFU);
+  }
+
+  /// Get face node index.
+  constexpr std::uint16_t GetFaceNodeIndex() const
+  {
+    return static_cast<std::uint16_t>(value_ & 0xFFFFU);
+  }
+
+  /// Check if the face node is initialized.
+  constexpr bool IsInitialized() const
+  {
+    return value_ != std::numeric_limits<std::uint64_t>::max();
+  }
+
+private:
+  /// Core value.
+  std::uint64_t value_ = std::numeric_limits<std::uint64_t>::max();
+};
+
+/**
  * In this paradigm a face is an object which largely is considered to be planar (meaning all the
  * vertices lay in the same plane).
  */
@@ -137,3 +189,11 @@ public:
 };
 
 } // namespace opensn
+
+namespace std
+{
+
+/// Print face node.
+ostream& operator<<(ostream& out, const opensn::FaceNode& n);
+
+} // namespace std

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_curvilinear_problem/sweep_chunks/aah_sweep_chunk_rz.cc
@@ -202,7 +202,7 @@ AAHSweepChunkRZ::Sweep(AngleSet& angle_set)
                                             cell_local_id,
                                             f,
                                             fj,
-                                            gs_gi,
+                                            0,
                                             IsSurfaceSourceActive());
               }
             }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
@@ -92,7 +92,7 @@ SMMAcceleration::Initialize()
   diff_uk_man.AddUnknown(UnknownType::VECTOR_N, num_gs_groups);
 
   for (const auto& [bid, bc] : do_problem_.GetBoundaryDefinitions())
-    if ((bc.first == LBSBoundaryType::ISOTROPIC) or (bc.first == LBSBoundaryType::ARBITRARY))
+    if ((bc.type == LBSBoundaryType::ISOTROPIC) or (bc.type == LBSBoundaryType::ARBITRARY))
       throw std::logic_error("Only vacuum and reflective boundaries are valid for "
                              "k-eigenvalue problems.");
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
@@ -27,6 +27,7 @@ GetInflow(const Cell& cell,
           const std::shared_ptr<AngularQuadrature> quadrature,
           SweepBoundary& boundary,
           unsigned int f,
+          int gs_id,
           unsigned int g)
 {
   const auto& fe_vals = unit_cell_matrices.at(cell.local_id);
@@ -47,7 +48,7 @@ GetInflow(const Cell& cell,
     for (unsigned int fi = 0; fi < num_face_nodes; ++fi)
     {
       const unsigned int i = cell_mapping.MapFaceNode(f, fi);
-      const double* psi_ptr = boundary.PsiIncoming(cell.local_id, f, fi, n, g);
+      const double* psi_ptr = boundary.PsiIncoming(cell.local_id, f, fi, n, gs_id, g);
       const double psi_inc = (psi_ptr != nullptr) ? *psi_ptr : 0.0;
       inflow += mu * weight * int_f_shape_i(i) * psi_inc;
     }
@@ -151,9 +152,9 @@ ComputeBalanceTable(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
                   const int i = cell_mapping.MapFaceNode(f, fi);
                   const auto& IntFi_shapeI = IntS_shapeI[f](i);
 
-                  for (unsigned int g = groupset.first_group; g <= groupset.last_group; ++g)
+                  for (unsigned int g = 0; g < groupset.GetNumGroups(); ++g)
                   {
-                    const double psi = *bndry->PsiIncoming(cell.local_id, f, fi, n, g);
+                    const double psi = *bndry->PsiIncoming(cell.local_id, f, fi, n, groupset.id, g);
                     local_in_flow -= mu * wt * psi * IntFi_shapeI;
                   } // for group
                 } // for fi
@@ -387,8 +388,8 @@ ComputeLeakage(DiscreteOrdinatesProblem& do_problem,
         {
           auto g = gsi + gsg;
           local_leakage[gsg] += outflow_view.Get(f, g);
-          local_leakage[gsg] +=
-            GetInflow(cell, cell_mapping, unit_cell_matrices, face, quad, bndry, f, g);
+          local_leakage[gsg] += GetInflow(
+            cell, cell_mapping, unit_cell_matrices, face, quad, bndry, f, groupset.id, gsg);
         }
       }
     }
@@ -447,11 +448,12 @@ ComputeLeakage(DiscreteOrdinatesProblem& do_problem, const std::vector<uint64_t>
         {
           auto& bndry = *sweep_boundaries.at(face.neighbor_id);
 
-          for (auto g = groupset.first_group; g <= groupset.last_group; ++g)
+          for (unsigned int g = 0; g < groupset.GetNumGroups(); ++g)
           {
-            local_leakage[face.neighbor_id][g] += outflow_view.Get(f, g);
-            local_leakage[face.neighbor_id][g] +=
-              GetInflow(cell, cell_mapping, unit_cell_matrices, face, quad, bndry, f, g);
+            auto group_num = groupset.first_group + g;
+            local_leakage[face.neighbor_id][group_num] += outflow_view.Get(f, group_num);
+            local_leakage[face.neighbor_id][group_num] += GetInflow(
+              cell, cell_mapping, unit_cell_matrices, face, quad, bndry, f, groupset.id, g);
           }
         }
       }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -53,6 +53,68 @@ namespace opensn
 
 OpenSnRegisterObjectParametersOnlyInNamespace(lbs, DiscreteOrdinatesProblem);
 
+namespace
+{
+
+std::set<std::uint64_t>
+GetGlobalUniqueBoundaryIDs(const std::shared_ptr<MeshContinuum>& grid, mpi::Communicator& mpi_comm)
+{
+  std::set<std::uint64_t> local_unique_bids_set;
+  for (const auto& cell : grid->local_cells)
+    for (const auto& face : cell.faces)
+      if (not face.has_neighbor)
+        local_unique_bids_set.insert(face.neighbor_id);
+
+  const std::vector<std::uint64_t> local_unique_bids(local_unique_bids_set.begin(),
+                                                     local_unique_bids_set.end());
+
+  std::vector<std::uint64_t> recvbuf;
+  mpi_comm.all_gather(local_unique_bids, recvbuf);
+
+  std::set<std::uint64_t> global_unique_bids_set = local_unique_bids_set;
+  global_unique_bids_set.insert(recvbuf.begin(), recvbuf.end());
+
+  return global_unique_bids_set;
+}
+
+void
+RecursiveAngleSort(AngleSet* angleset,
+                   AngleAggregation& angle_agg,
+                   const std::vector<std::vector<std::uint32_t>>& reflected_maps,
+                   std::set<AngleSet*>& unsorted,
+                   std::set<AngleSet*>& sorted)
+{
+  sorted.insert(angleset);
+  std::uint32_t angle_zero = angleset->GetAngleIndices()[0];
+  for (const auto& reflected_map : reflected_maps)
+  {
+    auto reflected_angle_zero = reflected_map[angle_zero];
+    auto* reflected_angleset = angle_agg.GetAngleSetForAngleIndex(reflected_angle_zero);
+    if (sorted.contains(reflected_angleset))
+    {
+      bool is_coherent = std::equal(angleset->GetAngleIndices().begin(),
+                                    angleset->GetAngleIndices().end(),
+                                    reflected_angleset->GetAngleIndices().begin(),
+                                    [&](std::uint32_t angle, std::uint32_t reflected)
+                                    { return reflected_map[angle] == reflected; });
+      if (not is_coherent)
+        throw std::logic_error("Cannot find an unanimous sort order for the angle set.\n");
+    }
+    else
+    {
+      std::transform(angleset->GetAngleIndices().begin(),
+                     angleset->GetAngleIndices().end(),
+                     reflected_angleset->GetAngleIndices().begin(),
+                     [&](std::uint32_t angle) { return reflected_map[angle]; });
+      reflected_angleset->SyncDeviceAngleIndices();
+      unsorted.erase(reflected_angleset);
+      RecursiveAngleSort(reflected_angleset, angle_agg, reflected_maps, unsorted, sorted);
+    }
+  }
+}
+
+} // namespace
+
 InputParameters
 DiscreteOrdinatesProblem::GetInputParameters()
 {
@@ -95,11 +157,23 @@ DiscreteOrdinatesProblem::GetBoundaryOptionsBlock()
                                            {},
                                            "Required only if \"type\" is \"isotropic\". An array "
                                            "of isotropic strength per group");
+  params.AddOptionalParameter("start_time",
+                              -std::numeric_limits<double>::infinity(),
+                              "Time at which an isotropic boundary condition becomes active.");
+  params.AddOptionalParameter("end_time",
+                              std::numeric_limits<double>::infinity(),
+                              "Time at which an isotropic boundary condition becomes inactive.");
   params.AddOptionalParameter<std::shared_ptr<AngularFluxFunction>>(
     "function",
     std::shared_ptr<AngularFluxFunction>{},
     "Angular flux function to be used for arbitrary boundary conditions. The function takes an "
     "energy group index and a direction index and returns the incoming angular flux value.");
+  params.AddOptionalParameter<std::shared_ptr<AngularFluxTimeFunction>>(
+    "time_function",
+    std::shared_ptr<AngularFluxTimeFunction>{},
+    "Time-dependent angular flux function to be used for arbitrary boundary conditions. The "
+    "function takes an energy group index, a direction index, and time, and returns the incoming "
+    "angular flux value.");
   params.ConstrainParameterRange(
     "type", AllowableRangeList::New({"vacuum", "isotropic", "reflecting", "arbitrary"}));
 
@@ -206,13 +280,15 @@ DiscreteOrdinatesProblem::DiscreteOrdinatesProblem(const InputParameters& params
       grpset_psi_uk_man.AddUnknown(VarVecN, gs_num_groups);
 
     if (use_gpus_)
-      groupset.InitializeGPUCarriers();
+      groupset.InitializeQuadratureCarrier();
   }
 }
 
 DiscreteOrdinatesProblem::~DiscreteOrdinatesProblem()
 {
   CALI_CXX_MARK_FUNCTION;
+
+  ResetBoundaryCarrier();
 
   for (auto& groupset : groupsets_)
   {
@@ -293,16 +369,10 @@ DiscreteOrdinatesProblem::GetSweepBoundaries() const
   return sweep_boundaries_;
 }
 
-const std::map<uint64_t, DiscreteOrdinatesProblem::BoundaryDefinition>&
+const std::map<uint64_t, BoundaryDefinition>&
 DiscreteOrdinatesProblem::GetBoundaryDefinitions() const
 {
   return boundary_definitions_;
-}
-
-void
-DiscreteOrdinatesProblem::SetBoundaryOptions(const InputParameters& params)
-{
-  SetBoundaryOptionsImpl(params, true);
 }
 
 void
@@ -313,14 +383,17 @@ DiscreteOrdinatesProblem::SetBoundaryOptions(const std::vector<InputParameters>&
     boundary_definitions_.clear();
 
   for (const auto& params : boundary_params)
-    SetBoundaryOptionsImpl(params, false);
+    UpdateBoundaryDefinition(params);
 
-  RebuildBoundaryRuntimeData();
+  if (clear_existing or not boundary_params.empty())
+  {
+    InitializeBoundaries();
+    RebuildBoundaryRuntimeData();
+  }
 }
 
 void
-DiscreteOrdinatesProblem::SetBoundaryOptionsImpl(const InputParameters& params,
-                                                 bool rebuild_runtime_data)
+DiscreteOrdinatesProblem::UpdateBoundaryDefinition(const InputParameters& params)
 {
   const auto boundary_name = params.GetParamValue<std::string>("name");
   const auto coord_sys = grid_->GetCoordinateSystem();
@@ -351,138 +424,18 @@ DiscreteOrdinatesProblem::SetBoundaryOptionsImpl(const InputParameters& params,
   const auto it = bnd_name_map.find(lookup_name);
   if (it == bnd_name_map.end())
   {
-    std::ostringstream names;
-    bool first = true;
-    for (const auto& [name, _] : bnd_name_map)
-    {
-      if (not first)
-        names << ", ";
-      names << name;
-      first = false;
-    }
-    throw std::runtime_error(GetName() + ": Boundary name '" + boundary_name +
-                             "' not found in mesh. Available boundaries: [" + names.str() + "].");
+    throw std::runtime_error("Boundary name \"" + boundary_name + "\" not found in mesh.");
   }
   const auto bid = it->second;
-  boundary_definitions_[bid] = CreateBoundaryFromParams(params);
-  if (rebuild_runtime_data)
-    RebuildBoundaryRuntimeData();
+  boundary_definitions_[bid] = BoundaryDefinition(params, GetNumGroups());
 }
 
 void
 DiscreteOrdinatesProblem::ClearBoundaries()
 {
   boundary_definitions_.clear();
+  InitializeBoundaries();
   RebuildBoundaryRuntimeData();
-}
-
-DiscreteOrdinatesProblem::BoundaryDefinition
-DiscreteOrdinatesProblem::CreateBoundaryFromParams(const InputParameters& params) const
-{
-  const auto boundary_name = params.GetParamValue<std::string>("name");
-  const auto bndry_type = params.GetParamValue<std::string>("type");
-  const std::map<std::string, LBSBoundaryType> type_list = {
-    {"vacuum", LBSBoundaryType::VACUUM},
-    {"isotropic", LBSBoundaryType::ISOTROPIC},
-    {"reflecting", LBSBoundaryType::REFLECTING},
-    {"arbitrary", LBSBoundaryType::ARBITRARY}};
-
-  const auto type_it = type_list.find(bndry_type);
-  if (type_it == type_list.end())
-  {
-    std::ostringstream types;
-    bool first = true;
-    for (const auto& [name, _] : type_list)
-    {
-      if (not first)
-        types << ", ";
-      types << name;
-      first = false;
-    }
-    throw std::runtime_error("Boundary '" + boundary_name + "' has unknown type='" + bndry_type +
-                             "'. Allowed types: [" + types.str() + "].");
-  }
-
-  const auto type = type_it->second;
-  if (type == LBSBoundaryType::ISOTROPIC)
-  {
-    if (not params.Has("group_strength"))
-      throw std::runtime_error("Boundary '" + boundary_name +
-                               "' with type=\"isotropic\" "
-                               "requires parameter \"group_strength\"");
-    if (params.IsParameterValid("function"))
-      throw std::runtime_error("Boundary '" + boundary_name +
-                               "' with type=\"isotropic\" does "
-                               "not support \"function\".");
-    params.RequireParameterBlockTypeIs("group_strength", ParameterBlockType::ARRAY);
-    const auto group_strength = params.GetParamVectorValue<double>("group_strength");
-    if (group_strength.size() != GetNumGroups())
-      throw std::runtime_error(GetName() + ": Boundary '" + boundary_name +
-                               "' with type=\"isotropic\" requires \"group_strength\" to match "
-                               "the solver group count.");
-    return {type,
-            std::make_shared<IsotropicBoundary>(
-              GetNumGroups(), group_strength, MapGeometryTypeToCoordSys(geometry_type_))};
-  }
-  else if (type == LBSBoundaryType::ARBITRARY)
-  {
-    if (params.IsParameterValid("group_strength"))
-      throw std::runtime_error("Boundary '" + boundary_name +
-                               "' with type=\"arbitrary\" does "
-                               "not support \"group_strength\".");
-    if (not params.Has("function"))
-      throw std::runtime_error("Boundary '" + boundary_name +
-                               "' with type=\"arbitrary\" "
-                               "requires parameter \"function\"");
-    auto angular_flux_function = params.GetSharedPtrParam<AngularFluxFunction>("function", false);
-    if (not angular_flux_function)
-      throw std::runtime_error("Boundary '" + boundary_name +
-                               "' with type=\"arbitrary\" "
-                               "requires a non-null AngularFluxFunction passed via \"function\".");
-    return {type,
-            std::make_shared<ArbitraryBoundary>(
-              GetNumGroups(), angular_flux_function, MapGeometryTypeToCoordSys(geometry_type_))};
-  }
-
-  if (params.IsParameterValid("group_strength"))
-    throw std::runtime_error("Boundary '" + boundary_name + "' with type=" + bndry_type +
-                             " does not support group_strength.");
-  if (params.IsParameterValid("function"))
-    throw std::runtime_error("Boundary '" + boundary_name + "' with type=" + bndry_type +
-                             " does not support function.");
-
-  return {type, nullptr};
-}
-
-std::shared_ptr<SweepBoundary>
-DiscreteOrdinatesProblem::CreateSweepBoundary(uint64_t boundary_id) const
-{
-  auto it = boundary_definitions_.find(boundary_id);
-  if (it == boundary_definitions_.end())
-    return std::make_shared<VacuumBoundary>(num_groups_);
-
-  const auto& [type, boundary_ptr] = it->second;
-  if (type == LBSBoundaryType::VACUUM)
-    return std::make_shared<VacuumBoundary>(num_groups_);
-  if (type == LBSBoundaryType::ISOTROPIC)
-  {
-    if (not boundary_ptr)
-      throw std::runtime_error(
-        GetName() + ": Isotropic boundary specified without an associated boundary object.");
-    return boundary_ptr;
-  }
-  if (type == LBSBoundaryType::REFLECTING)
-    throw std::logic_error(GetName() +
-                           ": Reflecting boundaries must be initialized via InitializeBoundaries");
-  if (type == LBSBoundaryType::ARBITRARY)
-  {
-    if (not boundary_ptr)
-      throw std::runtime_error(
-        GetName() + ": Arbitrary boundary specified without an associated boundary object.");
-    return boundary_ptr;
-  }
-
-  throw std::logic_error(GetName() + ": Unknown boundary type requested.");
 }
 
 std::vector<std::vector<double>>&
@@ -576,7 +529,7 @@ DiscreteOrdinatesProblem::BuildRuntime()
     {
       auto bndry_params = GetBoundaryOptionsBlock();
       bndry_params.AssignParameters(bcs.GetParam(b));
-      SetBoundaryOptionsImpl(bndry_params, false);
+      UpdateBoundaryDefinition(bndry_params);
     }
   }
 
@@ -623,8 +576,11 @@ DiscreteOrdinatesProblem::BuildRuntime()
     TGDSA::Init(*this, groupset);
   }
   log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
+
+  // Initialize runtime boundary data
+  RebuildBoundaryRuntimeData();
+
   InitializeSolverSchemes();
-  boundary_runtime_data_initialized_ = true;
 }
 
 void
@@ -642,24 +598,39 @@ DiscreteOrdinatesProblem::SetSweepChunkMode(SweepChunkMode mode)
 void
 DiscreteOrdinatesProblem::RebuildBoundaryRuntimeData()
 {
-  if (not boundary_runtime_data_initialized_)
+  if (boundary_runtime_data_initialized_)
     return;
 
-  ags_solver_.reset();
-  wgs_solvers_.clear();
-  wgs_contexts_.clear();
+  const bool solver_schemes_initialized =
+    ags_solver_ or (not wgs_solvers_.empty()) or (not wgs_contexts_.empty());
 
-  InitializeBoundaries();
+  for (auto& [bid, boundary] : sweep_boundaries_)
+    boundary->InitializeReflectingMap(groupsets_);
+  if (use_gpus_)
+    SortAngleSetsAngleIndices();
+  for (auto& [bid, boundary] : sweep_boundaries_)
+    boundary->InitializeAngleDependent(groupsets_);
+  boundary_bank_.ShrinkToFit();
+  boundary_bank_.DisableAllocation();
+  InitializeBoundaryCarrier();
+  if (sweep_type_ == "AAH" and use_gpus_)
+    UpdateAAHD_FLUDSCommonDataWithBoundary();
   for (auto& groupset : groupsets_)
+    groupset.angle_agg->SetupAngleSetDependencies();
+
+  if (solver_schemes_initialized)
   {
-    WGDSA::CleanUp(groupset);
-    TGDSA::CleanUp(groupset);
-    InitFluxDataStructures(groupset);
-    WGDSA::Init(*this, groupset);
-    TGDSA::Init(*this, groupset);
+    for (auto& groupset : groupsets_)
+    {
+      WGDSA::CleanUp(groupset);
+      TGDSA::CleanUp(groupset);
+      WGDSA::Init(*this, groupset);
+      TGDSA::Init(*this, groupset);
+    }
+    ReinitializeSolverSchemes();
   }
 
-  ReinitializeSolverSchemes();
+  boundary_runtime_data_initialized_ = true;
 }
 
 void
@@ -903,6 +874,25 @@ DiscreteOrdinatesProblem::SetSaveAngularFlux(bool save)
 }
 
 void
+DiscreteOrdinatesProblem::SetTime(double time)
+{
+  LBSProblem::SetTime(time);
+  if (has_time_dependent_boundaries_)
+  {
+    for (const auto& [_, boundary] : sweep_boundaries_)
+    {
+      boundary->SetEvaluationTime(time_);
+      boundary->UpdateBoundaryFlux(groupsets_);
+    }
+    if (use_gpus_)
+    {
+      for (const auto& groupset : groupsets_)
+        TransferDeviceBoundaryData(groupset.id, true, true);
+    }
+  }
+}
+
+void
 DiscreteOrdinatesProblem::ReinitializeSolverSchemes()
 {
   InitializeSolverSchemes();
@@ -963,6 +953,11 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
 {
   CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeBoundaries");
 
+  ResetBoundaryCarrier();
+  boundary_runtime_data_initialized_ = false;
+  has_reflecting_boundaries_ = false;
+  has_time_dependent_boundaries_ = false;
+
   // RZ doesn't yet support reflecting boundaries on rmax
   if (geometry_type_ == GeometryType::TWOD_CYLINDRICAL)
   {
@@ -973,7 +968,7 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
       const uint64_t bid = it->second;
       const auto bndry_it = boundary_definitions_.find(bid);
       if (bndry_it != boundary_definitions_.end() &&
-          bndry_it->second.first == LBSBoundaryType::REFLECTING)
+          bndry_it->second.type == LBSBoundaryType::REFLECTING)
       {
         std::ostringstream oss;
         oss << GetName() << ":\n"
@@ -985,85 +980,110 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
   }
 
   // Determine boundary-ids involved in the problem
-  std::set<uint64_t> global_unique_bids_set;
+  const auto unique_bids_set = GetGlobalUniqueBoundaryIDs(grid_, mpi_comm);
+  for (const auto bid : unique_bids_set)
   {
-    std::set<uint64_t> local_unique_bids_set;
-    for (const auto& cell : grid_->local_cells)
-      for (const auto& face : cell.faces)
-        if (not face.has_neighbor)
-          local_unique_bids_set.insert(face.neighbor_id);
-
-    std::vector<uint64_t> local_unique_bids(local_unique_bids_set.begin(),
-                                            local_unique_bids_set.end());
-    std::vector<uint64_t> recvbuf;
-    mpi_comm.all_gather(local_unique_bids, recvbuf);
-
-    global_unique_bids_set = local_unique_bids_set; // give it a head start
-
-    for (uint64_t bid : recvbuf)
-      global_unique_bids_set.insert(bid);
+    if (boundary_definitions_.find(bid) == boundary_definitions_.end())
+      boundary_definitions_.emplace(bid, BoundaryDefinition());
   }
+  boundary_bank_ = BoundaryBank(groupsets_);
 
   sweep_boundaries_.clear();
-  for (uint64_t bid : global_unique_bids_set)
+  const auto coord_sys = MapGeometryTypeToCoordSys(geometry_type_);
+  for (auto bid : unique_bids_set)
   {
-    const auto bndry_it = boundary_definitions_.find(bid);
-    const auto bndry_type =
-      bndry_it == boundary_definitions_.end() ? LBSBoundaryType::VACUUM : bndry_it->second.first;
+    auto& bndry_def = boundary_definitions_.find(bid)->second;
 
-    if (bndry_type == LBSBoundaryType::REFLECTING)
+    switch (bndry_def.type)
     {
-      const double EPSILON = 1.0e-12;
-      std::unique_ptr<Vector3> n_ptr = nullptr;
-      for (const auto& cell : grid_->local_cells)
-        for (const auto& face : cell.faces)
-          if (not face.has_neighbor and face.neighbor_id == bid)
-          {
-            if (not n_ptr)
-              n_ptr = std::make_unique<Vector3>(face.normal);
-            if (std::fabs(face.normal.Dot(*n_ptr) - 1.0) > EPSILON)
-              throw std::logic_error(
-                GetName() +
-                ": Not all face normals are, within tolerance, locally the same for the "
-                "reflecting boundary condition requested");
-          }
-
-      const int local_has_bid = n_ptr != nullptr ? 1 : 0;
-      const Vector3 local_normal = local_has_bid ? *n_ptr : Vector3(0.0, 0.0, 0.0);
-
-      std::vector<int> locJ_has_bid(opensn::mpi_comm.size(), 1);
-      std::vector<double> locJ_n_val(opensn::mpi_comm.size() * 3L, 0.0);
-
-      mpi_comm.all_gather(local_has_bid, locJ_has_bid);
-      std::vector<double> lnv = {local_normal.x, local_normal.y, local_normal.z};
-      mpi_comm.all_gather(lnv.data(), 3, locJ_n_val.data(), 3);
-
-      Vector3 global_normal;
-      for (int j = 0; j < opensn::mpi_comm.size(); ++j)
+      case LBSBoundaryType::VACUUM:
       {
-        if (locJ_has_bid[j])
-        {
-          int offset = 3 * j;
-          const double* n = &locJ_n_val[offset];
-          const Vector3 locJ_normal(n[0], n[1], n[2]);
-
-          if (local_has_bid)
-            if (std::fabs(local_normal.Dot(locJ_normal) - 1.0) > EPSILON)
-              throw std::logic_error(
-                GetName() +
-                ": Not all face normals are, within tolerance, globally the same for the "
-                "reflecting boundary condition requested");
-
-          global_normal = locJ_normal;
-        }
+        sweep_boundaries_[bid] = std::make_shared<VacuumBoundary>(boundary_bank_);
+        break;
       }
+      case LBSBoundaryType::ISOTROPIC:
+      {
+        sweep_boundaries_[bid] = std::make_shared<IsotropicBoundary>(boundary_bank_,
+                                                                     groupsets_,
+                                                                     bndry_def.group_strength,
+                                                                     bndry_def.start_time,
+                                                                     bndry_def.end_time);
+        has_time_dependent_boundaries_ = true;
+        break;
+      }
+      case LBSBoundaryType::ARBITRARY:
+      {
+        sweep_boundaries_[bid] = std::make_shared<ArbitraryBoundary>(
+          boundary_bank_, groupsets_, bndry_def.time_angular_flux_function);
+        has_time_dependent_boundaries_ = true;
+        break;
+      }
+      case LBSBoundaryType::REFLECTING:
+      {
+        const double EPSILON = 1.0e-12;
+        std::unique_ptr<Vector3> n_ptr = nullptr;
+        for (const auto& cell : grid_->local_cells)
+        {
+          for (const auto& face : cell.faces)
+          {
+            if (not face.has_neighbor and face.neighbor_id == bid)
+            {
+              if (not n_ptr)
+                n_ptr = std::make_unique<Vector3>(face.normal);
+              if (std::fabs(face.normal.Dot(*n_ptr) - 1.0) > EPSILON)
+                throw std::logic_error(
+                  GetName() +
+                  ": Not all face normals are, within tolerance, locally the same for the "
+                  "reflecting boundary condition requested");
+            }
+          }
+        }
 
-      sweep_boundaries_[bid] = std::make_shared<ReflectingBoundary>(
-        num_groups_, global_normal, MapGeometryTypeToCoordSys(geometry_type_));
-      continue;
+        const int local_has_bid = n_ptr != nullptr ? 1 : 0;
+        const Vector3 local_normal = local_has_bid ? *n_ptr : Vector3(0.0, 0.0, 0.0);
+
+        std::vector<int> locJ_has_bid(opensn::mpi_comm.size(), 1);
+        std::vector<double> locJ_n_val(opensn::mpi_comm.size() * 3L, 0.0);
+
+        mpi_comm.all_gather(local_has_bid, locJ_has_bid);
+        std::vector<double> lnv = {local_normal.x, local_normal.y, local_normal.z};
+        mpi_comm.all_gather(lnv.data(), 3, locJ_n_val.data(), 3);
+
+        Vector3 global_normal;
+        for (int j = 0; j < opensn::mpi_comm.size(); ++j)
+        {
+          if (locJ_has_bid[j])
+          {
+            int offset = 3 * j;
+            const double* n = &locJ_n_val[offset];
+            const Vector3 locJ_normal(n[0], n[1], n[2]);
+
+            if (local_has_bid)
+              if (std::fabs(local_normal.Dot(locJ_normal) - 1.0) > EPSILON)
+                throw std::logic_error(
+                  GetName() +
+                  ": Not all face normals are, within tolerance, globally the same for the "
+                  "reflecting boundary condition requested");
+
+            global_normal = locJ_normal;
+          }
+        }
+
+        sweep_boundaries_[bid] = std::make_shared<ReflectingBoundary>(
+          boundary_bank_, bid, grid_, groupsets_, global_normal, coord_sys);
+        has_reflecting_boundaries_ = true;
+        break;
+      }
+      default:
+      {
+        throw std::logic_error("Boundary type not implemented.");
+      }
     }
+  }
 
-    sweep_boundaries_[bid] = CreateSweepBoundary(bid);
+  for (auto& [bid, bndry] : sweep_boundaries_)
+  {
+    bndry->SetOpposingReflected(bid, sweep_boundaries_);
   }
 }
 
@@ -1494,10 +1514,34 @@ DiscreteOrdinatesProblem::InitializeSweepDataStructures()
 
 #ifndef __OPENSN_WITH_GPU__
 void
+DiscreteOrdinatesProblem::InitializeBoundaryCarrier()
+{
+}
+
+void
+DiscreteOrdinatesProblem::TransferDeviceBoundaryData(int groupset_id,
+                                                     bool host_to_device,
+                                                     bool force)
+{
+}
+
+void
+DiscreteOrdinatesProblem::ResetBoundaryCarrier()
+{
+}
+
+void
 DiscreteOrdinatesProblem::CreateAAHD_FLUDSCommonData()
 {
   throw std::runtime_error(
     "DiscreteOrdinatesProblem::CreateAAHD_FLUDSCommonData : OPENSN_WITH_CUDA not enabled.");
+}
+
+void
+DiscreteOrdinatesProblem::UpdateAAHD_FLUDSCommonDataWithBoundary()
+{
+  throw std::runtime_error("DiscreteOrdinatesProblem::UpdateAAHD_FLUDSCommonDataWithBoundary : "
+                           "OPENSN_WITH_CUDA not enabled.");
 }
 
 std::shared_ptr<FLUDS>
@@ -1513,7 +1557,7 @@ DiscreteOrdinatesProblem::CreateAAHD_FLUDS(unsigned int num_groups,
 std::shared_ptr<AngleSet>
 DiscreteOrdinatesProblem::CreateAAHD_AngleSet(
   size_t id,
-  unsigned int num_groups,
+  const LBSGroupset& groupset,
   const SPDS& spds,
   std::shared_ptr<FLUDS>& fluds,
   std::vector<size_t>& angle_indices,
@@ -1568,7 +1612,7 @@ DiscreteOrdinatesProblem::CreateCBCD_FLUDS(std::size_t num_groups,
 std::shared_ptr<AngleSet>
 DiscreteOrdinatesProblem::CreateCBCD_AngleSet(
   size_t id,
-  size_t num_groups,
+  const LBSGroupset& groupset,
   const SPDS& spds,
   std::shared_ptr<FLUDS>& fluds,
   std::vector<size_t>& angle_indices,
@@ -1783,7 +1827,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
 
   // Passing the sweep boundaries to the angle aggregation
   groupset.angle_agg =
-    std::make_shared<AngleAggregation>(sweep_boundaries_, groupset.quadrature, grid_);
+    std::make_shared<AngleAggregation>(groupset, sweep_boundaries_, groupset.quadrature, grid_);
 
   size_t angle_set_id = 0;
   for (const auto& so_grouping : unique_so_groupings)
@@ -1829,7 +1873,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         if (use_gpus_)
         {
           angle_set = CreateAAHD_AngleSet(angle_set_id++,
-                                          gs_num_grps,
+                                          groupset,
                                           *sweep_ordering,
                                           fluds,
                                           angle_indices,
@@ -1840,7 +1884,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         else
         {
           angle_set = std::make_shared<AAH_AngleSet>(angle_set_id++,
-                                                     gs_num_grps,
+                                                     groupset,
                                                      *sweep_ordering,
                                                      fluds,
                                                      angle_indices,
@@ -1877,7 +1921,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         if (use_gpus_)
         {
           angle_set = CreateCBCD_AngleSet(angle_set_id++,
-                                          gs_num_grps,
+                                          groupset,
                                           *sweep_ordering,
                                           fluds,
                                           angle_indices,
@@ -1887,7 +1931,7 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         else
         {
           angle_set = std::make_shared<CBC_AngleSet>(angle_set_id++,
-                                                     gs_num_grps,
+                                                     groupset,
                                                      *sweep_ordering,
                                                      fluds,
                                                      angle_indices,
@@ -1901,6 +1945,11 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         OpenSnInvalidArgument("Unsupported sweeptype \"" + sweep_type_ + "\"");
     } // for an_ss
   } // for so_grouping
+
+  groupset.angle_agg->BuildDirnumToAnglesetMap();
+
+  if (options_.verbose_inner_iterations)
+    log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
 
   opensn::mpi_comm.barrier();
 }
@@ -1934,6 +1983,59 @@ DiscreteOrdinatesProblem::SetSweepChunk(LBSGroupset& groupset)
   }
   else
     OpenSnLogicalError("Unsupported sweep_type_ \"" + sweep_type_ + "\"");
+}
+
+void
+DiscreteOrdinatesProblem::SortAngleSetsAngleIndices()
+{
+  for (auto& groupset : groupsets_)
+  {
+    // build the total reflected map
+    std::vector<std::vector<std::uint32_t>> reflected_maps;
+    for (auto& [bid, boundary] : sweep_boundaries_)
+      boundary->GetReflectedMap(groupset.id, reflected_maps);
+
+    // check for each map and angle set that the mapped angle indices is also another angleset
+    auto& angle_agg = *(groupset.angle_agg);
+    std::list<std::set<std::uint32_t>> angle_indices_list;
+    for (const auto& angleset : angle_agg)
+    {
+      const auto& angle_indices = angleset->GetAngleIndices();
+      angle_indices_list.emplace_back(angle_indices.begin(), angle_indices.end());
+    }
+    for (const auto& reflected_map : reflected_maps)
+    {
+      std::list<std::set<std::uint32_t>> angle_indices_list_copy(angle_indices_list);
+      for (auto it_in = angle_indices_list_copy.begin(); it_in != angle_indices_list_copy.end();)
+      {
+        std::set<std::uint32_t> reflected;
+        std::transform(it_in->begin(),
+                       it_in->end(),
+                       std::inserter(reflected, reflected.end()),
+                       [&](std::uint32_t n) { return reflected_map[n]; });
+        auto it_out =
+          std::find(angle_indices_list_copy.begin(), angle_indices_list_copy.end(), reflected);
+        if (it_out == it_in or it_out == angle_indices_list_copy.end())
+          throw std::logic_error("Angleset parity was broken for one of the reflected boundaries.");
+        angle_indices_list_copy.erase(it_out);
+        it_in = angle_indices_list_copy.erase(it_in);
+      }
+    }
+    angle_indices_list.clear();
+
+    // sort angle indices in anglesets
+    std::set<AngleSet*> sorted_anglesets, unsorted_anglesets;
+    std::transform(angle_agg.begin(),
+                   angle_agg.end(),
+                   std::inserter(unsorted_anglesets, unsorted_anglesets.end()),
+                   [](auto& angleset) { return angleset.get(); });
+    while (not unsorted_anglesets.empty())
+    {
+      AngleSet* angleset = *unsorted_anglesets.begin();
+      unsorted_anglesets.erase(unsorted_anglesets.begin());
+      RecursiveAngleSort(angleset, angle_agg, reflected_maps, unsorted_anglesets, sorted_anglesets);
+    }
+  }
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cu
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h"
@@ -17,6 +19,35 @@ namespace opensn
 {
 
 void
+DiscreteOrdinatesProblem::InitializeBoundaryCarrier()
+{
+  if (not use_gpus_)
+    return;
+  boundary_carrier_ = std::make_shared<BoundaryCarrier>(boundary_bank_, groupsets_);
+  for (const auto& groupset : groupsets_)
+    boundary_carrier_->UploadToDevice(groupset.id);
+}
+
+void
+DiscreteOrdinatesProblem::TransferDeviceBoundaryData(int groupset_id,
+                                                     bool host_to_device,
+                                                     bool force)
+{
+  if (not has_reflecting_boundaries_ and not force)
+    return;
+  if (host_to_device)
+    boundary_carrier_->UploadToDevice(groupset_id);
+  else
+    boundary_carrier_->DownloadToHost(groupset_id);
+}
+
+void
+DiscreteOrdinatesProblem::ResetBoundaryCarrier()
+{
+  boundary_carrier_.reset();
+}
+
+void
 DiscreteOrdinatesProblem::CreateAAHD_FLUDSCommonData()
 {
   for (const auto& [quadrature, spds_list] : quadrature_spds_map_)
@@ -25,6 +56,19 @@ DiscreteOrdinatesProblem::CreateAAHD_FLUDSCommonData()
     {
       quadrature_fluds_commondata_map_[quadrature].push_back(
         std::make_unique<AAHD_FLUDSCommonData>(*spds, grid_nodal_mappings_, *discretization_));
+    }
+  }
+}
+
+void
+DiscreteOrdinatesProblem::UpdateAAHD_FLUDSCommonDataWithBoundary()
+{
+  for (auto& [quadrature, fluds_commondata_list] : quadrature_fluds_commondata_map_)
+  {
+    for (auto& fluds_commondata : fluds_commondata_list)
+    {
+      auto* aahdfluds_commondata = dynamic_cast<AAHD_FLUDSCommonData*>(fluds_commondata.get());
+      aahdfluds_commondata->UpdateBoundaryAndSyncWithDevice(*discretization_, sweep_boundaries_);
     }
   }
 }
@@ -41,7 +85,7 @@ DiscreteOrdinatesProblem::CreateAAHD_FLUDS(unsigned int num_groups,
 std::shared_ptr<AngleSet>
 DiscreteOrdinatesProblem::CreateAAHD_AngleSet(
   size_t id,
-  unsigned int num_groups,
+  const LBSGroupset& groupset,
   const SPDS& spds,
   std::shared_ptr<FLUDS>& fluds,
   std::vector<size_t>& angle_indices,
@@ -50,7 +94,7 @@ DiscreteOrdinatesProblem::CreateAAHD_AngleSet(
   const MPICommunicatorSet& in_comm_set)
 {
   return std::make_shared<AAHD_AngleSet>(
-    id, num_groups, spds, fluds, angle_indices, boundaries, maximum_message_size, in_comm_set);
+    id, groupset, spds, fluds, angle_indices, boundaries, maximum_message_size, in_comm_set);
 }
 
 std::shared_ptr<SweepChunk>
@@ -93,7 +137,7 @@ DiscreteOrdinatesProblem::CreateCBCD_FLUDS(std::size_t num_groups,
 std::shared_ptr<AngleSet>
 DiscreteOrdinatesProblem::CreateCBCD_AngleSet(
   size_t id,
-  size_t num_groups,
+  const LBSGroupset& groupset,
   const SPDS& spds,
   std::shared_ptr<FLUDS>& fluds,
   std::vector<size_t>& angle_indices,
@@ -101,7 +145,7 @@ DiscreteOrdinatesProblem::CreateCBCD_AngleSet(
   const MPICommunicatorSet& in_comm_set)
 {
   return std::make_shared<CBCD_AngleSet>(
-    id, num_groups, spds, fluds, angle_indices, boundaries, in_comm_set);
+    id, groupset, spds, fluds, angle_indices, boundaries, in_comm_set);
 }
 
 std::shared_ptr<SweepChunk>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -4,20 +4,26 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/parameters/parameter_block.h"
 #include <memory>
 #include <optional>
 #include <tuple>
+#include <vector>
 
 namespace opensn
 {
+
 class FieldFunctionGridBased;
 class AGSLinearSolver;
 class LinearSolver;
 struct BalanceTable;
 struct WGSContext;
+class AngularFluxFunction;
+class BoundaryCarrier;
 
 /**
  * Base class for discrete ordinates solvers.
@@ -47,11 +53,11 @@ public:
   void SetTimeDependentMode() override;
 
   void SetSteadyStateMode() override;
+
+  void SetTime(double time) override;
   /** @} */
 
   ~DiscreteOrdinatesProblem() override;
-
-  using BoundaryDefinition = std::pair<LBSBoundaryType, std::shared_ptr<SweepBoundary>>;
 
   /**
    * @name Problem metadata and solver access
@@ -143,12 +149,20 @@ public:
 
   void SetBlockID2XSMap(const BlockID2XSMap& xs_map) override;
 
-  void SetBoundaryOptions(const InputParameters& params) override;
   void SetBoundaryOptions(const std::vector<InputParameters>& boundary_params, bool clear_existing);
   void ClearBoundaries() override;
+  BoundaryCarrier* GetBoundaryCarrier() { return boundary_carrier_.get(); }
+  const BoundaryCarrier* GetBoundaryCarrier() const { return boundary_carrier_.get(); }
 
   void CopyPhiAndSrcToDevice();
   void CopyPhiAndOutflowBackToHost();
+  /**
+   * Transfer data in boundary to device or vice-versa.
+   * \param groupset_id Groupset ID.
+   * \param host_to_device Flag indicating the direction of transfer.
+   * \param force Force update.
+   */
+  void TransferDeviceBoundaryData(int groupset_id, bool host_to_device, bool force = false);
 
 protected:
   /**
@@ -182,6 +196,16 @@ protected:
 
   /// Initializes Within-GroupSet solvers.
   void InitializeWGSSolvers();
+
+  void InitializeBoundaryCarrier();
+
+  /**
+   * Sort the angle indices within each angle set so that one set maps exactly to another under all
+   * reflected angle mappings.
+   */
+  void SortAngleSetsAngleIndices();
+
+  void ResetBoundaryCarrier();
 
   /**
    * This routine initializes basic sweep datastructures that are agnostic of
@@ -220,18 +244,13 @@ protected:
   bool ReadProblemRestartData(hid_t file_id) override;
   bool WriteProblemRestartData(hid_t file_id) const override;
   void ResetDerivedSolutionVectors() override;
-  void SetBoundaryOptionsImpl(const InputParameters& params, bool rebuild_runtime_data);
+  void UpdateBoundaryDefinition(const InputParameters& params);
   void RebuildBoundaryRuntimeData();
-
-  BoundaryDefinition CreateBoundaryFromParams(const InputParameters& params) const;
-  std::shared_ptr<SweepBoundary> CreateSweepBoundary(uint64_t boundary_id) const;
-  /** @} */
 
   /**
    * @name Sweep dependency data
    * @{
    */
-
   std::map<std::shared_ptr<AngularQuadrature>, SweepOrderGroupingInfo>
     quadrature_unq_so_grouping_map_;
   std::map<std::shared_ptr<AngularQuadrature>, std::vector<std::shared_ptr<SPDS>>>
@@ -241,17 +260,26 @@ protected:
 
   std::vector<int> verbose_sweep_angles_;
   const std::string sweep_type_;
+  /** @} */
+
+  /**
+   * @name Boundary data
+   * @{
+   */
+  BoundaryBank boundary_bank_;
   std::map<uint64_t, std::shared_ptr<SweepBoundary>> sweep_boundaries_;
   std::map<uint64_t, BoundaryDefinition> boundary_definitions_;
+  std::shared_ptr<BoundaryCarrier> boundary_carrier_ = nullptr;
   std::optional<ParameterBlock> boundary_conditions_block_;
   bool boundary_runtime_data_initialized_ = false;
+  bool has_reflecting_boundaries_ = false;
+  bool has_time_dependent_boundaries_ = false;
   /** @} */
 
   /**
    * @name Sweep size metadata
    * @{
    */
-
   /// Max level size.
   std::size_t max_level_size_ = 0;
   /// Max angle-set size.
@@ -281,12 +309,13 @@ private:
   ComputeAngularFieldFunctionData(size_t groupset_id, unsigned int group, size_t angle) const;
 
   void CreateAAHD_FLUDSCommonData();
+  void UpdateAAHD_FLUDSCommonDataWithBoundary();
   std::shared_ptr<FLUDS> CreateAAHD_FLUDS(unsigned int num_groups,
                                           std::size_t num_angles,
                                           const FLUDSCommonData& common_data);
   std::shared_ptr<AngleSet>
   CreateAAHD_AngleSet(size_t id,
-                      unsigned int num_groups,
+                      const LBSGroupset& groupset,
                       const SPDS& spds,
                       std::shared_ptr<FLUDS>& fluds,
                       std::vector<size_t>& angle_indices,
@@ -306,7 +335,7 @@ private:
 
   std::shared_ptr<AngleSet>
   CreateCBCD_AngleSet(size_t id,
-                      size_t num_groups,
+                      const LBSGroupset& groupset,
                       const SPDS& spds,
                       std::shared_ptr<FLUDS>& fluds,
                       std::vector<size_t>& angle_indices,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
@@ -14,11 +15,15 @@
 namespace opensn
 {
 
-AngleAggregation::AngleAggregation(
-  const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
-  std::shared_ptr<AngularQuadrature>& quadrature,
-  std::shared_ptr<MeshContinuum>& grid)
-  : num_ang_unknowns_avail_(false), grid_(grid), quadrature_(quadrature), boundaries_(boundaries)
+AngleAggregation::AngleAggregation(const LBSGroupset& groupset,
+                                   std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
+                                   std::shared_ptr<AngularQuadrature>& quadrature,
+                                   std::shared_ptr<MeshContinuum>& grid)
+  : groupset_id_(groupset.id),
+    num_ang_unknowns_avail_(false),
+    grid_(grid),
+    quadrature_(quadrature),
+    boundaries_(boundaries)
 {
   for (const auto& bndry_id_cond : boundaries)
     bndry_id_cond.second->Setup(grid, *quadrature);
@@ -46,7 +51,7 @@ AngleAggregation::ZeroIncomingDelayedPsi()
 
   // Opposing reflecting bndries
   for (const auto& [bid, bndry] : boundaries_)
-    bndry->ZeroOpposingDelayedAngularFluxOld();
+    bndry->ZeroOpposingDelayedAngularFluxOld(groupset_id_);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -61,26 +66,26 @@ AngleAggregation::ZeroIncomingDelayedPsi()
 }
 
 void
-AngleAggregation::InitializeReflectingBCs()
+AngleAggregation::BuildDirnumToAnglesetMap()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::InitializeReflectingBCs");
-
-  const double epsilon = 1.0e-8;
-
-  bool reflecting_bcs_initialized = false;
-
-  for (auto& [bid, bndry] : boundaries_)
-    bndry->InitializeDelayedAngularFlux(grid_, *quadrature_);
-
-  for (auto& [bid, bndry] : boundaries_)
+  for (auto& angle_set : angle_set_groups_)
   {
-    bndry->FinalizeDelayedAngularFluxSetup(bid, boundaries_);
-    if (bndry->IsReflecting())
-      reflecting_bcs_initialized = true;
+    for (const auto& angle_idx : angle_set->GetAngleIndices())
+    {
+      dir_to_angleset_[angle_idx] = angle_set.get();
+    }
   }
+}
 
-  if (reflecting_bcs_initialized)
-    log.Log0Verbose1() << "Reflecting boundary conditions initialized.";
+void
+AngleAggregation::ResetAngleSetDependencies()
+{
+  num_ang_unknowns_avail_ = false;
+  number_angular_unknowns_ = {0, 0};
+  following_angle_sets_map_.clear();
+
+  for (auto& angle_set : angle_set_groups_)
+    angle_set->ResetNumDependencies();
 }
 
 void
@@ -88,8 +93,7 @@ AngleAggregation::SetupAngleSetDependencies()
 {
   CALI_CXX_MARK_SCOPE("AngleAggregation::SetupAngleSetDependencies");
 
-  std::unordered_map<AngleSet*, std::set<AngleSet*>> extra_following;
-  following_angle_sets_map_.clear();
+  ResetAngleSetDependencies();
 
   // Build angleset dependencies for RZ
   const auto* curvi_quad = dynamic_cast<const CurvilinearProductQuadrature*>(quadrature_.get());
@@ -98,8 +102,6 @@ AngleAggregation::SetupAngleSetDependencies()
       GetCoordinateSystem() == CoordinateSystemType::CYLINDRICAL)
   {
     bool single_angle_sets = true;
-    std::unordered_map<size_t, AngleSet*> dir_to_angleset;
-    dir_to_angleset.reserve(angle_set_groups_.size());
     for (const auto& angle_set : angle_set_groups_)
     {
       if (angle_set->GetAngleIndices().size() != 1)
@@ -107,9 +109,7 @@ AngleAggregation::SetupAngleSetDependencies()
         single_angle_sets = false;
         break;
       }
-      dir_to_angleset[angle_set->GetAngleIndices().front()] = angle_set.get();
     }
-
     if (single_angle_sets)
     {
       for (const auto& dir_set : product_quad->GetDirectionMap())
@@ -117,12 +117,12 @@ AngleAggregation::SetupAngleSetDependencies()
         AngleSet* prev = nullptr;
         for (const auto dir_id : dir_set.second)
         {
-          auto it = dir_to_angleset.find(dir_id);
-          if (it == dir_to_angleset.end())
+          auto it = dir_to_angleset_.find(dir_id);
+          if (it == dir_to_angleset_.end())
             continue;
           AngleSet* current = it->second;
           if (prev && prev != current)
-            extra_following[prev].insert(current);
+            following_angle_sets_map_[prev].insert(current);
           prev = current;
         }
       }
@@ -131,16 +131,9 @@ AngleAggregation::SetupAngleSetDependencies()
 
   for (auto& angle_set : angle_set_groups_)
   {
-    std::set<AngleSet*> following_angle_sets;
+    auto& following_angle_sets = following_angle_sets_map_[angle_set.get()];
     for (const auto& [bid, bndry] : boundaries_)
-      bndry->GetFollowingAngleSets(following_angle_sets, *this, *angle_set);
-    if (!extra_following.empty())
-    {
-      const auto it = extra_following.find(angle_set.get());
-      if (it != extra_following.end())
-        following_angle_sets.insert(it->second.begin(), it->second.end());
-    }
-    following_angle_sets_map_[angle_set.get()] = following_angle_sets;
+      bndry->GetFollowingAngleSets(groupset_id_, following_angle_sets, *this, *angle_set);
     angle_set->UpdateSweepDependencies(following_angle_sets);
   }
 }
@@ -158,7 +151,7 @@ AngleAggregation::GetNumDelayedAngularDOFs()
   size_t local_ang_unknowns = 0;
 
   for (const auto& [bid, bndry] : boundaries_)
-    local_ang_unknowns += bndry->CountDelayedAngularDOFsNew();
+    local_ang_unknowns += bndry->CountDelayedAngularDOFsNew(groupset_id_);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -184,7 +177,7 @@ AngleAggregation::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* x_r
   CALI_CXX_MARK_SCOPE("AngleAggregation::AppendNewDelayedAngularDOFsToArray");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->AppendNewDelayedAngularDOFsToArray(index, x_ref);
+    bndry->AppendNewDelayedAngularDOFsToArray(groupset_id_, index, x_ref);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -210,7 +203,7 @@ AngleAggregation::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* x_r
   CALI_CXX_MARK_SCOPE("AngleAggregation::AppendOldDelayedAngularDOFsToArray");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->AppendOldDelayedAngularDOFsToArray(index, x_ref);
+    bndry->AppendOldDelayedAngularDOFsToArray(groupset_id_, index, x_ref);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -236,7 +229,7 @@ AngleAggregation::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double
   CALI_CXX_MARK_SCOPE("AngleAggregation::SetOldDelayedAngularDOFsFromArray");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->SetOldDelayedAngularDOFsFromArray(index, x_ref);
+    bndry->SetOldDelayedAngularDOFsFromArray(groupset_id_, index, x_ref);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -262,7 +255,7 @@ AngleAggregation::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double
   CALI_CXX_MARK_SCOPE("AngleAggregation::SetNewDelayedAngularDOFsFromArray");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->SetNewDelayedAngularDOFsFromArray(index, x_ref);
+    bndry->SetNewDelayedAngularDOFsFromArray(groupset_id_, index, x_ref);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -293,7 +286,7 @@ AngleAggregation::GetNewDelayedAngularDOFsAsSTLVector()
   psi_vector.reserve(psi_size.first);
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->AppendNewDelayedAngularDOFsToVector(psi_vector);
+    bndry->AppendNewDelayedAngularDOFsToVector(groupset_id_, psi_vector);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -324,7 +317,7 @@ AngleAggregation::SetNewDelayedAngularDOFsFromSTLVector(const std::vector<double
 
   size_t index = 0;
   for (auto& [bid, bndry] : boundaries_)
-    bndry->SetNewDelayedAngularDOFsFromVector(stl_vector, index);
+    bndry->SetNewDelayedAngularDOFsFromVector(groupset_id_, stl_vector, index);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -349,7 +342,7 @@ AngleAggregation::GetOldDelayedAngularDOFsAsSTLVector()
   psi_vector.reserve(psi_size.first);
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->AppendOldDelayedAngularDOFsToVector(psi_vector);
+    bndry->AppendOldDelayedAngularDOFsToVector(groupset_id_, psi_vector);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -380,7 +373,7 @@ AngleAggregation::SetOldDelayedAngularDOFsFromSTLVector(const std::vector<double
 
   size_t index = 0;
   for (auto& [bid, bndry] : boundaries_)
-    bndry->SetOldDelayedAngularDOFsFromVector(stl_vector, index);
+    bndry->SetOldDelayedAngularDOFsFromVector(groupset_id_, stl_vector, index);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -400,7 +393,7 @@ AngleAggregation::SetDelayedPsiOld2New()
   CALI_CXX_MARK_SCOPE("AngleAggregation::SetDelayedPsiOld2New");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->CopyDelayedAngularFluxOldToNew();
+    bndry->CopyDelayedAngularFluxOldToNew(groupset_id_);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)
@@ -417,7 +410,7 @@ AngleAggregation::SetDelayedPsiNew2Old()
   CALI_CXX_MARK_SCOPE("AngleAggregation::SetDelayedPsiNew2Old");
 
   for (auto& [bid, bndry] : boundaries_)
-    bndry->CopyDelayedAngularFluxNewToOld();
+    bndry->CopyDelayedAngularFluxNewToOld(groupset_id_);
 
   // Intra-cell cycles
   for (auto& angle_set : angle_set_groups_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h
@@ -13,7 +13,6 @@
 #include <memory>
 #include <map>
 #include <set>
-#include <unordered_map>
 #include <vector>
 
 namespace opensn
@@ -48,7 +47,8 @@ enum class AngleAggregationType
 class AngleAggregation
 {
 public:
-  AngleAggregation(const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
+  AngleAggregation(const LBSGroupset& groupset,
+                   std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                    std::shared_ptr<AngularQuadrature>& quadrature,
                    std::shared_ptr<MeshContinuum>& grid);
 
@@ -77,22 +77,33 @@ public:
     return grid_ ? grid_->GetCoordinateSystem() : CoordinateSystemType::UNDEFINED;
   }
 
+  int GetGroupsetID() const { return groupset_id_; }
+
   /// Resets all the outgoing intra-location and inter-location cyclic interfaces.
   void ZeroOutgoingDelayedPsi();
 
   /// Resets all the incoming intra-location and inter-location cyclic interfaces.
   void ZeroIncomingDelayedPsi();
 
-  /// Initializes reflecting boundary conditions.
-  void InitializeReflectingBCs();
+  /// Resets dependencies between anglesets.
+  void ResetAngleSetDependencies();
 
-  /// Establishes dependencies between angle sets for reflecting boundaries.
+  /// Establishes dependencies between anglesets for reflecting boundaries and cylindrical geometry.
   void SetupAngleSetDependencies();
 
   /// Returns a map of following angle sets per angle set.
-  const std::unordered_map<AngleSet*, std::set<AngleSet*>>& GetFollowingAngleSetsMap() const
+  const std::map<AngleSet*, std::set<AngleSet*>>& GetFollowingAngleSetsMap() const
   {
     return following_angle_sets_map_;
+  }
+
+  /// Builds the map from direction number to angleset pointer
+  void BuildDirnumToAnglesetMap();
+
+  /// Gets the angle set for a given angle index.
+  AngleSet* GetAngleSetForAngleIndex(std::uint32_t angle_idx) const
+  {
+    return dir_to_angleset_.at(angle_idx);
   }
 
   /**
@@ -132,13 +143,15 @@ public:
   void SetDelayedPsiNew2Old();
 
 private:
+  int groupset_id_;
   bool num_ang_unknowns_avail_;
   std::pair<size_t, size_t> number_angular_unknowns_;
   std::shared_ptr<MeshContinuum> grid_;
   std::shared_ptr<AngularQuadrature> quadrature_;
-  std::map<uint64_t, std::shared_ptr<SweepBoundary>> boundaries_;
+  std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries_;
   std::vector<std::shared_ptr<AngleSet>> angle_set_groups_;
-  std::unordered_map<AngleSet*, std::set<AngleSet*>> following_angle_sets_map_;
+  std::map<std::uint32_t, AngleSet*> dir_to_angleset_;
+  std::map<AngleSet*, std::set<AngleSet*>> following_angle_sets_map_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.cc
@@ -11,14 +11,14 @@ namespace opensn
 {
 
 AAH_AngleSet::AAH_AngleSet(size_t id,
-                           unsigned int num_groups,
+                           const LBSGroupset& groupset,
                            const SPDS& spds,
                            std::shared_ptr<FLUDS>& fluds,
                            std::vector<size_t>& angle_indices,
                            std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                            int maximum_message_size,
                            const MPICommunicatorSet& comm_set)
-  : AngleSet(id, num_groups, spds, fluds, angle_indices, boundaries),
+  : AngleSet(id, groupset, spds, fluds, angle_indices, boundaries),
     async_comm_(*fluds, num_groups_, angle_indices.size(), maximum_message_size, comm_set)
 {
 }
@@ -45,12 +45,10 @@ AAH_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
   AngleSetStatus status = async_comm_.ReceiveUpstreamPsi(static_cast<int>(this->GetID()));
 
   // Also check boundaries
-  for (auto& [bid, boundary] : boundaries_)
-    if (not boundary->CheckAnglesReadyStatus(angles_))
-    {
-      status = AngleSetStatus::RECEIVING;
-      break;
-    }
+  if (not IsDependencyResolved())
+  {
+    return AngleSetStatus::RECEIVING;
+  }
 
   if (status == AngleSetStatus::RECEIVING)
     return status;
@@ -65,8 +63,11 @@ AAH_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
     async_comm_.ClearLocalAndReceiveBuffers();
 
     // Update boundary readiness
-    for (auto& [bid, boundary] : boundaries_)
-      boundary->UpdateAnglesReadyStatus(angles_);
+    if (not following_angle_sets_.empty())
+    {
+      for (auto& angleset : following_angle_sets_)
+        angleset->DecrementCounter();
+    }
 
     executed_ = true;
     return AngleSetStatus::FINISHED;
@@ -110,34 +111,6 @@ bool
 AAH_AngleSet::ReceiveDelayedData()
 {
   return async_comm_.ReceiveDelayedData(static_cast<int>(this->GetID()));
-}
-
-const double*
-AAH_AngleSet::PsiBoundary(uint64_t boundary_id,
-                          unsigned int angle_num,
-                          uint64_t cell_local_id,
-                          unsigned int face_num,
-                          unsigned int fi,
-                          unsigned int g,
-                          bool surface_source_active)
-{
-  if (boundaries_[boundary_id]->IsReflecting())
-    return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-
-  if (not surface_source_active)
-    return boundaries_[boundary_id]->ZeroFlux(g);
-
-  return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-}
-
-double*
-AAH_AngleSet::PsiReflected(uint64_t boundary_id,
-                           unsigned int angle_num,
-                           uint64_t cell_local_id,
-                           unsigned int face_num,
-                           unsigned int fi)
-{
-  return boundaries_[boundary_id]->PsiOutgoing(cell_local_id, face_num, fi, angle_num);
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.h
@@ -14,7 +14,7 @@ class AAH_AngleSet : public AngleSet
 {
 public:
   AAH_AngleSet(size_t id,
-               unsigned int num_groups,
+               const LBSGroupset& groupset,
                const SPDS& spds,
                std::shared_ptr<FLUDS>& fluds,
                std::vector<size_t>& angle_indices,
@@ -35,20 +35,6 @@ public:
   void ResetSweepBuffers() override;
 
   bool ReceiveDelayedData() override;
-
-  const double* PsiBoundary(uint64_t boundary_id,
-                            unsigned int angle_num,
-                            uint64_t cell_local_id,
-                            unsigned int face_num,
-                            unsigned int fi,
-                            unsigned int g,
-                            bool surface_source_active) override;
-
-  double* PsiReflected(uint64_t boundary_id,
-                       unsigned int angle_num,
-                       uint64_t cell_local_id,
-                       unsigned int face_num,
-                       unsigned int fi) override;
 
 protected:
   AAH_ASynchronousCommunicator async_comm_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.cu
@@ -13,44 +13,23 @@ namespace opensn
 std::mutex AAHD_AngleSet::m;
 
 AAHD_AngleSet::AAHD_AngleSet(size_t id,
-                             unsigned int num_groups,
+                             const LBSGroupset& groupset,
                              const SPDS& spds,
                              std::shared_ptr<FLUDS>& fluds,
                              std::vector<size_t>& angle_indices,
                              std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                              int maximum_message_size,
                              const MPICommunicatorSet& comm_set)
-  : AngleSet(id, num_groups, spds, fluds, angle_indices, boundaries),
+  : AngleSet(id, groupset, spds, fluds, angle_indices, boundaries),
     async_comm_(*fluds, num_groups_, angle_indices.size(), maximum_message_size, comm_set),
     device_angle_indices_(angles_.size())
 {
   stream_ = crb::Stream();
-  std::dynamic_pointer_cast<AAHD_FLUDS>(fluds_)->GetStream() = stream_;
-  crb::MemoryPinningManager angle_indices_pinner_(angles_);
-  crb::copy(device_angle_indices_, angle_indices_pinner_, angles_.size());
-  has_reflecting_boundaries_ =
-    std::any_of(boundaries_.begin(),
-                boundaries_.end(),
-                [](auto& bndry_pair) { return bndry_pair.second->IsReflecting(); });
-}
-
-void
-AAHD_AngleSet::UpdateSweepDependencies(std::set<AngleSet*>& following_angle_sets)
-{
-  std::transform(following_angle_sets.begin(),
-                 following_angle_sets.end(),
-                 std::back_inserter(following_angle_sets_),
-                 [](AngleSet* as) { return static_cast<AAHD_AngleSet*>(as); });
-  for (auto* following_angle_set : following_angle_sets_)
-  {
-    ++(following_angle_set->num_dependencies_);
-  }
-}
-
-void
-AAHD_AngleSet::ResetDependencyCounter()
-{
-  dependency_counter_ = num_dependencies_;
+  auto aahd_fluds = std::dynamic_pointer_cast<AAHD_FLUDS>(fluds_);
+  aahd_fluds->GetStream() = stream_;
+  aahd_fluds->GetCommonData().AddAssociatedAngleSet(this);
+  crb::MemoryPinningManager<std::uint32_t> pin(angles_);
+  crb::copy(device_angle_indices_, pin, angles_.size());
 }
 
 void
@@ -94,11 +73,6 @@ AAHD_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permissio
   auto* aahd_fluds = static_cast<AAHD_FLUDS*>(fluds_.get());
   auto& aahd_sweep_chunk = static_cast<AAHDSweepChunk&>(sweep_chunk);
 
-  aahd_fluds->CopyBoundaryToDevice(aahd_sweep_chunk.GetGrid(),
-                                   *this,
-                                   aahd_sweep_chunk.GetGroupset(),
-                                   aahd_sweep_chunk.IsSurfaceSourceActive());
-
   aahd_fluds->CopyNonLocalIncomingPsiToDevice();
   aahd_fluds->AllocateSaveAngularFlux(aahd_sweep_chunk.GetProblem(),
                                       aahd_sweep_chunk.GetGroupset());
@@ -107,21 +81,40 @@ AAHD_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permissio
   aahd_fluds->CopySaveAngularFluxFromDevice();
   stream_.synchronize();
 
-  async_comm_.SendDownstreamPsi(static_cast<int>(this->GetID()));
-  if (has_reflecting_boundaries_)
-    aahd_fluds->CopyBoundaryPsiToAngleSet(aahd_sweep_chunk.GetGrid(), *this);
   if (not following_angle_sets_.empty())
   {
     std::scoped_lock lk(m);
     for (auto& following_as : following_angle_sets_)
-      --(following_as->dependency_counter_);
+      following_as->DecrementCounter();
   }
+  async_comm_.SendDownstreamPsi(static_cast<int>(this->GetID()));
 
   aahd_fluds->CopySaveAngularFluxToDestinationPsi(
     aahd_sweep_chunk.GetProblem(), aahd_sweep_chunk.GetGroupset(), *this);
 
   executed_ = true;
   return AngleSetStatus::FINISHED;
+}
+
+void
+AAHD_AngleSet::SyncDeviceAngleIndices()
+{
+  crb::MemoryPinningManager<std::uint32_t> pin(angles_);
+  crb::copy(device_angle_indices_, pin, angles_.size());
+}
+
+void
+AAHD_AngleSet::CopyBoundaryOffsetToDevice()
+{
+  if (host_boundary_offsets_.empty())
+  {
+    device_boundary_offsets_.reset();
+    return;
+  }
+  crb::MemoryPinningManager<std::uint64_t> pin(host_boundary_offsets_);
+  device_boundary_offsets_ = crb::DeviceMemory<std::uint64_t>(host_boundary_offsets_.size());
+  crb::copy(device_boundary_offsets_, pin, host_boundary_offsets_.size());
+  host_boundary_offsets_.clear();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.h
@@ -22,7 +22,7 @@ class AAHD_AngleSet : public AngleSet
 {
 public:
   AAHD_AngleSet(size_t id,
-                unsigned int num_groups,
+                const LBSGroupset& groupset,
                 const SPDS& spds,
                 std::shared_ptr<FLUDS>& fluds,
                 std::vector<size_t>& angle_indices,
@@ -33,14 +33,6 @@ public:
   crb::Stream& GetStream() { return stream_; }
 
   std::uint32_t* GetDeviceAngleIndices() { return device_angle_indices_.get(); }
-
-  bool HasReflectingBoundaries() const { return has_reflecting_boundaries_; }
-
-  /// Update the starting latch and following angle sets.
-  void UpdateSweepDependencies(std::set<AngleSet*>& following_angle_sets) override;
-
-  /// Set the latch value to wait on before starting the sweep.
-  void ResetDependencyCounter();
 
   void InitializeDelayedUpstreamData() override;
 
@@ -62,37 +54,19 @@ public:
 
   bool ReceiveDelayedData() override { return true; }
 
-  const double* PsiBoundary(uint64_t boundary_id,
-                            unsigned int angle_num,
-                            uint64_t cell_local_id,
-                            unsigned int face_num,
-                            unsigned int fi,
-                            unsigned int g,
-                            bool surface_source_active) override
-  {
-    if (boundaries_[boundary_id]->IsReflecting())
-      return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
+  void SyncDeviceAngleIndices() override;
 
-    if (not surface_source_active)
-      return boundaries_[boundary_id]->ZeroFlux(g);
+  void AddBoundaryOffset(std::uint64_t offset) { host_boundary_offsets_.push_back(offset); }
 
-    return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-  }
+  void CopyBoundaryOffsetToDevice();
 
-  double* PsiReflected(uint64_t boundary_id,
-                       unsigned int angle_num,
-                       uint64_t cell_local_id,
-                       unsigned int face_num,
-                       unsigned int fi) override
-  {
-    return boundaries_[boundary_id]->PsiOutgoing(cell_local_id, face_num, fi, angle_num);
-  }
+  std::uint64_t* GetDeviceBoudnaryOffset() { return device_boundary_offsets_.get(); }
 
   static std::mutex m;
 
 protected:
   /// Associated CUDA stream.
-  crb::Stream stream_;
+  crb::Stream stream_ = crb::Stream::get_null_stream();
 
   /// Asynchronous communicator.
   AAHD_ASynchronousCommunicator async_comm_;
@@ -100,18 +74,11 @@ protected:
   /// Angle indices on GPU.
   crb::DeviceMemory<std::uint32_t> device_angle_indices_;
 
-  /// Number of anglesets the current angle set depends on.
-  std::size_t num_dependencies_ = 0;
-  /// Counter for un-resolved dependencies.
-  std::size_t dependency_counter_ = 0;
-  /**
-   * List of AAHD_AngleSets waiting after this angle set.
-   * After this angle set completes its sweep chunk, it decrements the latches of the angle sets
-   * waiting after it to allow them to proceed.
-   */
-  std::vector<AAHD_AngleSet*> following_angle_sets_;
-  /// Flag indicating if the angleset is attached to any reflecting boundaries..
-  bool has_reflecting_boundaries_ = false;
+  /// Vector of offsets into the boundary bank.
+  std::vector<std::uint64_t> host_boundary_offsets_;
+
+  /// Boundary offset on GPU.
+  crb::DeviceMemory<std::uint64_t> device_boundary_offsets_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.cc
@@ -2,15 +2,50 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include <algorithm>
 
 namespace opensn
 {
 
+AngleSet::AngleSet(size_t id,
+                   const LBSGroupset& groupset,
+                   const SPDS& spds,
+                   std::shared_ptr<FLUDS>& fluds,
+                   const std::vector<size_t>& angle_indices,
+                   std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+  : id_(id),
+    groupset_id_(groupset.id),
+    num_groups_(groupset.GetNumGroups()),
+    spds_(spds),
+    fluds_(fluds),
+    angles_(angle_indices.begin(), angle_indices.end()),
+    boundaries_(boundaries)
+{
+}
+
 bool
 AngleSet::HasAngleIndex(std::uint32_t angle_index) const
 {
   return std::find(angles_.begin(), angles_.end(), angle_index) != angles_.end();
+}
+
+void
+AngleSet::ResetNumDependencies()
+{
+  num_dependencies_ = 0;
+  following_angle_sets_.clear();
+}
+
+void
+AngleSet::UpdateSweepDependencies(std::set<AngleSet*>& following_angle_sets)
+{
+  following_angle_sets_.insert(
+    following_angle_sets_.end(), following_angle_sets.begin(), following_angle_sets.end());
+  for (auto* angleset : following_angle_sets_)
+  {
+    ++(angleset->num_dependencies_);
+  }
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h
@@ -20,28 +20,26 @@ class AngleSet
 {
 public:
   AngleSet(size_t id,
-           unsigned int num_groups,
+           const LBSGroupset& groupset,
            const SPDS& spds,
            std::shared_ptr<FLUDS>& fluds,
            const std::vector<size_t>& angle_indices,
-           std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
-    : id_(id),
-      num_groups_(num_groups),
-      spds_(spds),
-      fluds_(fluds),
-      angles_(angle_indices.begin(), angle_indices.end()),
-      boundaries_(boundaries)
-  {
-  }
+           std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries);
 
   /// Returns the angleset's unique id.
   size_t GetID() const { return id_; }
+
+  /// Returns the associated groupset id.
+  int GetGroupsetID() const { return groupset_id_; }
 
   /// Returns a reference to the associated spds.
   const SPDS& GetSPDS() const { return spds_; }
 
   /// Returns a reference to the associated fluds_.
   FLUDS& GetFLUDS() { return *fluds_; }
+
+  /// Returns the angle indices associated with this angleset.
+  std::vector<std::uint32_t>& GetAngleIndices() { return angles_; }
 
   /// Returns the angle indices associated with this angleset.
   const std::vector<std::uint32_t>& GetAngleIndices() const { return angles_; }
@@ -55,11 +53,8 @@ public:
 
   bool HasAngleIndex(std::uint32_t angle_index) const;
 
-  /**
-   * Update the starting latch and following angle sets.
-   * This method can only be applied to device AAH (AAHD) anglesets.
-   */
-  virtual void UpdateSweepDependencies(std::set<AngleSet*>& following_angle_sets) {}
+  /// Update following angle sets.
+  void UpdateSweepDependencies(std::set<AngleSet*>& following_angle_sets);
 
   virtual AsynchronousCommunicator* GetCommunicator()
   {
@@ -86,35 +81,70 @@ public:
   /// Resets the sweep buffer.
   virtual void ResetSweepBuffers() = 0;
 
+  /// Resets number of dependencies.
+  void ResetNumDependencies();
+  /// Resets dependency counter.
+  void ResetDependencyCounter() { dependency_counter_ = num_dependencies_; }
+
+  /// Checks if dependency is resolved.
+  bool IsDependencyResolved() const { return dependency_counter_ == 0; }
+
+  void DecrementCounter() { --dependency_counter_; }
+
   /// Instructs the sweep buffer to receive delayed data.
   virtual bool ReceiveDelayedData() = 0;
 
   /// Returns a pointer to a boundary flux data.
-  virtual const double* PsiBoundary(uint64_t boundary_id,
-                                    unsigned int angle_num,
-                                    uint64_t cell_local_id,
-                                    unsigned int face_num,
-                                    unsigned int fi,
-                                    unsigned int g,
-                                    bool surface_source_active) = 0;
+  const double* PsiBoundary(uint64_t boundary_id,
+                            unsigned int angle_num,
+                            uint64_t cell_local_id,
+                            unsigned int face_num,
+                            unsigned int fi,
+                            unsigned int g,
+                            bool surface_source_active)
+  {
+    const auto& boundary = boundaries_[boundary_id];
+    if (boundary->IsReflecting() || surface_source_active)
+      return boundary->PsiIncoming(cell_local_id, face_num, fi, angle_num, groupset_id_, g);
+    return boundary->ZeroFlux(groupset_id_, g);
+  }
 
   /// Returns a pointer to outbound reflected flux data.
-  virtual double* PsiReflected(uint64_t boundary_id,
-                               unsigned int angle_num,
-                               uint64_t cell_local_id,
-                               unsigned int face_num,
-                               unsigned int fi) = 0;
+  double* PsiReflected(uint64_t boundary_id,
+                       unsigned int angle_num,
+                       uint64_t cell_local_id,
+                       unsigned int face_num,
+                       unsigned int fi)
+  {
+    return boundaries_[boundary_id]->PsiOutgoing(
+      cell_local_id, face_num, fi, angle_num, groupset_id_);
+  }
+
+  /// Update the angle index data on the device to match the host.
+  virtual void SyncDeviceAngleIndices() {}
 
   virtual ~AngleSet() = default;
 
 protected:
   const size_t id_;
+  const int groupset_id_;
   const unsigned int num_groups_;
   const SPDS& spds_;
   std::shared_ptr<FLUDS> fluds_;
   std::vector<std::uint32_t> angles_;
   std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries_;
   bool executed_ = false;
+
+  /// Number of anglesets the current angle set depends on.
+  std::size_t num_dependencies_ = 0;
+  /// Counter for un-resolved dependencies.
+  std::size_t dependency_counter_ = 0;
+  /**
+   * List of angle sets waiting after this angle set.
+   * After this angle set completes its sweep chunk, it decrements the counter of the angle sets
+   * waiting after it to allow them to proceed.
+   */
+  std::vector<AngleSet*> following_angle_sets_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
@@ -15,13 +15,13 @@ namespace opensn
 {
 
 CBC_AngleSet::CBC_AngleSet(size_t id,
-                           unsigned int num_groups,
+                           const LBSGroupset& groupset,
                            const SPDS& spds,
                            std::shared_ptr<FLUDS>& fluds,
                            const std::vector<size_t>& angle_indices,
                            std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                            const MPICommunicatorSet& comm_set)
-  : AngleSet(id, num_groups, spds, fluds, angle_indices, boundaries),
+  : AngleSet(id, groupset, spds, fluds, angle_indices, boundaries),
     cbc_spds_(dynamic_cast<const CBC_SPDS&>(spds_)),
     async_comm_(id, *fluds, comm_set)
 {
@@ -54,9 +54,8 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
   async_comm_.SendData();
 
   // Check if boundaries allow for execution
-  for (auto& [bid, boundary] : boundaries_)
-    if (not boundary->CheckAnglesReadyStatus(angles_))
-      return AngleSetStatus::NOT_FINISHED;
+  if (not IsDependencyResolved())
+    return AngleSetStatus::NOT_FINISHED;
 
   bool all_tasks_completed = true;
   bool a_task_executed = true;
@@ -88,8 +87,11 @@ CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission
   if (all_tasks_completed and all_messages_sent)
   {
     // Update boundary readiness
-    for (auto& [bid, boundary] : boundaries_)
-      boundary->UpdateAnglesReadyStatus(angles_);
+    if (not following_angle_sets_.empty())
+    {
+      for (auto& angleset : following_angle_sets_)
+        angleset->DecrementCounter();
+    }
     executed_ = true;
     return AngleSetStatus::FINISHED;
   }
@@ -104,34 +106,6 @@ CBC_AngleSet::ResetSweepBuffers()
   async_comm_.Reset();
   fluds_->ClearLocalAndReceivePsi();
   executed_ = false;
-}
-
-const double*
-CBC_AngleSet::PsiBoundary(uint64_t boundary_id,
-                          unsigned int angle_num,
-                          uint64_t cell_local_id,
-                          unsigned int face_num,
-                          unsigned int fi,
-                          unsigned int g,
-                          bool surface_source_active)
-{
-  if (boundaries_[boundary_id]->IsReflecting())
-    return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-
-  if (not surface_source_active)
-    return boundaries_[boundary_id]->ZeroFlux(g);
-
-  return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-}
-
-double*
-CBC_AngleSet::PsiReflected(uint64_t boundary_id,
-                           unsigned int angle_num,
-                           uint64_t cell_local_id,
-                           unsigned int face_num,
-                           unsigned int fi)
-{
-  return boundaries_[boundary_id]->PsiOutgoing(cell_local_id, face_num, fi, angle_num);
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.h
@@ -15,7 +15,7 @@ class CBC_AngleSet : public AngleSet
 {
 public:
   CBC_AngleSet(size_t id,
-               unsigned int num_groups,
+               const LBSGroupset& groupset,
                const SPDS& spds,
                std::shared_ptr<FLUDS>& fluds,
                const std::vector<size_t>& angle_indices,
@@ -41,20 +41,6 @@ public:
   void ResetSweepBuffers() override;
 
   bool ReceiveDelayedData() override { return true; }
-
-  const double* PsiBoundary(uint64_t boundary_id,
-                            unsigned int angle_num,
-                            uint64_t cell_local_id,
-                            unsigned int face_num,
-                            unsigned int fi,
-                            unsigned int g,
-                            bool surface_source_active) override;
-
-  double* PsiReflected(uint64_t boundary_id,
-                       unsigned int angle_num,
-                       uint64_t cell_local_id,
-                       unsigned int face_num,
-                       unsigned int fi) override;
 
 protected:
   const CBC_SPDS& cbc_spds_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.cu
@@ -16,13 +16,13 @@ namespace opensn
 {
 
 CBCD_AngleSet::CBCD_AngleSet(size_t id,
-                             size_t num_groups,
+                             const LBSGroupset& groupset,
                              const SPDS& spds,
                              std::shared_ptr<FLUDS>& fluds,
                              const std::vector<size_t>& angle_indices,
                              std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries,
                              const MPICommunicatorSet& comm_set)
-  : AngleSet(id, num_groups, spds, fluds, angle_indices, boundaries),
+  : AngleSet(id, groupset, spds, fluds, angle_indices, boundaries),
     cbc_spds_(dynamic_cast<const CBC_SPDS&>(spds)),
     async_comm_(id, *fluds, comm_set),
     stream_(),
@@ -62,32 +62,21 @@ CBCD_AngleSet::ResetSweepBuffers()
   executed_ = false;
 }
 
-const double*
-CBCD_AngleSet::PsiBoundary(uint64_t boundary_id,
-                           unsigned int angle_num,
-                           uint64_t cell_local_id,
-                           unsigned int face_num,
-                           unsigned int fi,
-                           unsigned int g,
-                           bool surface_source_active)
+void
+CBCD_AngleSet::UpdateDependencyCounters()
 {
-  if (boundaries_[boundary_id]->IsReflecting())
-    return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
-
-  if (not surface_source_active)
-    return boundaries_[boundary_id]->ZeroFlux(g);
-
-  return boundaries_[boundary_id]->PsiIncoming(cell_local_id, face_num, fi, angle_num, g);
+  if (not following_angle_sets_.empty())
+  {
+    for (auto& angleset : following_angle_sets_)
+      angleset->DecrementCounter();
+  }
 }
 
-double*
-CBCD_AngleSet::PsiReflected(uint64_t boundary_id,
-                            unsigned int angle_num,
-                            uint64_t cell_local_id,
-                            unsigned int face_num,
-                            unsigned int fi)
+void
+CBCD_AngleSet::SyncDeviceAngleIndices()
 {
-  return boundaries_[boundary_id]->PsiOutgoing(cell_local_id, face_num, fi, angle_num);
+  crb::MemoryPinningManager angle_indices_pinner_(angles_);
+  crb::copy(device_angle_indices_, angle_indices_pinner_, angles_.size());
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.h
@@ -20,7 +20,7 @@ class CBCD_AngleSet : public AngleSet
 {
 public:
   CBCD_AngleSet(size_t id,
-                size_t num_groups,
+                const LBSGroupset& groupset,
                 const SPDS& spds,
                 std::shared_ptr<FLUDS>& fluds,
                 const std::vector<size_t>& angle_indices,
@@ -49,19 +49,7 @@ public:
 
   bool ReceiveDelayedData() override { return true; }
 
-  const double* PsiBoundary(uint64_t boundary_id,
-                            unsigned int angle_num,
-                            uint64_t cell_local_id,
-                            unsigned int face_num,
-                            unsigned int fi,
-                            unsigned int g,
-                            bool surface_source_active) override;
-
-  double* PsiReflected(uint64_t boundary_id,
-                       unsigned int angle_num,
-                       uint64_t cell_local_id,
-                       unsigned int face_num,
-                       unsigned int fi) override;
+  void SyncDeviceAngleIndices() override;
 
   crb::Stream& GetStream() { return stream_; }
 
@@ -69,12 +57,14 @@ public:
 
   std::vector<Task>& GetCurrentTaskList() { return current_task_list_; }
 
+  void UpdateDependencyCounters();
+
 protected:
   const CBC_SPDS& cbc_spds_;
   std::vector<Task> current_task_list_;
   CBC_AsynchronousCommunicator async_comm_;
   /// Associated crb::Stream.
-  crb::Stream stream_;
+  crb::Stream stream_ = crb::Stream::get_null_stream();
   /// Angle indices on GPU.
   crb::DeviceMemory<std::uint32_t> device_angle_indices_;
 };

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/arbitrary_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/arbitrary_boundary.cc
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/arbitrary_boundary.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+#include <utility>
+
+namespace opensn
+{
+
+ArbitraryBoundary::ArbitraryBoundary(BoundaryBank& bank,
+                                     const std::vector<LBSGroupset>& groupsets,
+                                     std::shared_ptr<AngularFluxTimeFunction> angular_flux_function)
+  : SweepBoundary(bank, LBSBoundaryType::ARBITRARY),
+    angular_flux_function_(std::move(angular_flux_function))
+{
+  extra_data_.reserve(groupsets.size());
+  extra_data_.resize(groupsets.size());
+
+  for (const auto& groupset : groupsets)
+  {
+    auto quadrature = groupset.quadrature;
+    auto num_angles = quadrature->omegas.size();
+
+    bank_.ExtendBoundaryFlux(groupset.id, num_angles * groupset.GetNumGroups());
+    auto& map_dirnum = extra_data_[groupset.id].map_dirnum;
+    map_dirnum.reserve(num_angles);
+    map_dirnum.assign(num_angles, std::numeric_limits<std::uint64_t>::max());
+
+    auto& counter = bank_[groupset.id].counter;
+    offset_[groupset.id] = counter;
+    counter += num_angles;
+  }
+}
+
+void
+ArbitraryBoundary::UpdateBoundaryFlux(const std::vector<LBSGroupset>& groupsets)
+{
+  for (const auto& groupset : groupsets)
+  {
+    auto& map_dirnum = extra_data_[groupset.id].map_dirnum;
+    double* boundary_flux = GetBoundaryFlux(groupset.id);
+
+    for (std::uint64_t dir_num = 0; dir_num < map_dirnum.size(); ++dir_num)
+    {
+      auto internal_angle_index = map_dirnum[dir_num];
+      double* angular_boundary_flux =
+        boundary_flux + internal_angle_index * groupset.GetNumGroups();
+      for (unsigned int g = 0; g < groupset.GetNumGroups(); ++g)
+      {
+        unsigned int group = groupset.first_group + g;
+        angular_boundary_flux[g] = (*angular_flux_function_)(
+          static_cast<int>(group), static_cast<int>(dir_num), evaluation_time_);
+      }
+    }
+  }
+}
+
+void
+ArbitraryBoundary::InitializeAngleDependent(const std::vector<LBSGroupset>& groupsets)
+{
+  for (const auto& groupset : groupsets)
+  {
+    const auto& quadrature = groupset.quadrature;
+    auto& map_dirnum = extra_data_[groupset.id].map_dirnum;
+    auto angle_agg = groupset.angle_agg;
+    for (std::uint64_t i = 0; const auto& angleset : *angle_agg)
+    {
+      const auto& angle_indices = angleset->GetAngleIndices();
+      for (const auto& angle_indice : angle_indices)
+        map_dirnum[angle_indice] = i++;
+    }
+  }
+  UpdateBoundaryFlux(groupsets);
+}
+
+double*
+ArbitraryBoundary::PsiIncoming(std::uint32_t cell_local_id,
+                               unsigned int face_num,
+                               unsigned int fi,
+                               unsigned int angle_num,
+                               int groupset_id,
+                               unsigned int group_idx)
+{
+  auto& extra_data = extra_data_[groupset_id];
+  auto internal_angle_index = extra_data.map_dirnum[angle_num];
+  return GetBoundaryFlux(groupset_id, internal_angle_index) + group_idx;
+}
+
+std::uint64_t
+ArbitraryBoundary::GetOffsetToAngleset(const FaceNode& face_node,
+                                       AngleSet& anglset,
+                                       bool is_outgoing)
+{
+  if (is_outgoing)
+    throw std::logic_error("ArbitraryBoundary does not support outgoing flux.");
+  int groupset_id = anglset.GetGroupsetID();
+  auto& extra_data = extra_data_[groupset_id];
+  auto internal_angle_index = extra_data.map_dirnum[anglset.GetAngleIndices()[0]];
+  return (offset_[groupset_id] + internal_angle_index) * bank_[groupset_id].groupset_size;
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/arbitrary_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/arbitrary_boundary.h
@@ -6,7 +6,9 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "framework/math/functions/function.h"
 #include "framework/data_types/ndarray.h"
+#include <map>
 #include <memory>
+#include <vector>
 
 namespace opensn
 {
@@ -19,63 +21,35 @@ namespace opensn
 class ArbitraryBoundary : public SweepBoundary
 {
 public:
-  ArbitraryBoundary(unsigned int num_groups,
-                    std::shared_ptr<AngularFluxFunction> angular_flux_function,
-                    CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN)
-    : SweepBoundary(LBSBoundaryType::ARBITRARY, num_groups, coord_type),
-      angular_flux_function_(std::move(angular_flux_function)),
-      boundary_flux_()
-  {
-  }
+  ArbitraryBoundary(BoundaryBank& bank,
+                    const std::vector<LBSGroupset>& groupsets,
+                    std::shared_ptr<AngularFluxTimeFunction> angular_flux_function);
 
   double* PsiIncoming(std::uint32_t cell_local_id,
                       unsigned int face_num,
                       unsigned int fi,
                       unsigned int angle_num,
-                      unsigned int group_num) override
-  {
-    AllocateSpace(angle_num);
-    UpdateBoundaryFlux();
-    return &boundary_flux_(angle_num, group_num);
-  }
+                      int groupset_id,
+                      unsigned int group_idx) override;
 
-  void ResetAnglesReadyStatus() override { boundary_flux_ready_ = false; }
+  void UpdateBoundaryFlux(const std::vector<LBSGroupset>& groupsets) override;
+
+  void InitializeAngleDependent(const std::vector<LBSGroupset>& groupsets) override;
+  std::uint64_t
+  GetOffsetToAngleset(const FaceNode& face_node, AngleSet& anglset, bool is_outgoing) override;
 
 private:
-  std::shared_ptr<AngularFluxFunction> angular_flux_function_;
-  NDArray<double, 2> boundary_flux_;
-  std::size_t num_angles_ = 0;
-  bool boundary_flux_ready_ = false;
+  /// Function that dictates the angular flux.
+  std::shared_ptr<AngularFluxTimeFunction> angular_flux_function_;
 
-  void AllocateSpace(unsigned int angle_num)
+  /// Additional data specific to arbitrary boundary for each groupset.
+  struct ExtraData
   {
-    const auto required_angles = angle_num + 1;
-    if (required_angles <= num_angles_ or not angular_flux_function_)
-      return;
-
-    num_angles_ = required_angles;
-    boundary_flux_.resize(std::array<size_t, 2>{num_angles_, num_groups_});
-    boundary_flux_ready_ = false;
-  }
-
-  void UpdateBoundaryFlux()
-  {
-    if (not angular_flux_function_)
-      return;
-    if (boundary_flux_ready_)
-      return;
-
-    boundary_flux_ready_ = true;
-    for (std::size_t angle = 0; angle < num_angles_; ++angle)
-    {
-      for (unsigned int group = 0; group < num_groups_; ++group)
-      {
-        const double value =
-          (*angular_flux_function_)(static_cast<int>(group), static_cast<int>(angle));
-        boundary_flux_(angle, group) = value;
-      }
-    }
-  }
+    /// Map from angle number in a quadrature to the internal angle index per groupset.
+    std::vector<std::uint64_t> map_dirnum;
+  };
+  /// List of data per groupset.
+  std::vector<ExtraData> extra_data_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.cc
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+
+namespace opensn
+{
+
+BoundaryBank::BoundaryBank(const std::vector<LBSGroupset>& groupsets)
+{
+  common_data_.reserve(groupsets.size());
+  common_data_.resize(groupsets.size());
+  for (const auto& groupset : groupsets)
+  {
+    auto& common_data = common_data_[groupset.id];
+    common_data.counter++;
+    common_data.groupset_size = groupset.GetNumGroups();
+    ExtendBoundaryFlux(groupset.id, groupset.GetNumGroups());
+  }
+}
+
+double*
+BoundaryBank::ExtendBoundaryFlux(int groupset_id, std::size_t append_size)
+{
+  if (disable_allocation_)
+    throw std::runtime_error("Allocation is disabled. BoundaryFlux can only be extended in "
+                             "constructor or in InitializeAngleDependent");
+  auto& boundary_flux = common_data_[groupset_id].boundary_flux;
+  auto old_size = boundary_flux.size();
+  boundary_flux.resize(old_size + append_size, 0.0);
+  return boundary_flux.data() + old_size;
+}
+
+void
+BoundaryBank::ShrinkToFit()
+{
+  for (auto& common_data : common_data_)
+    common_data.boundary_flux.shrink_to_fit();
+}
+
+void
+BoundaryBank::Reset()
+{
+  common_data_.clear();
+  disable_allocation_ = false;
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace opensn
+{
+
+class LBSGroupset;
+
+/// Class-bound boundary data for each groupset.
+struct BoundaryCommonData
+{
+  /// Counter to assign flux pointer in the boundary flux bank.
+  std::uint64_t counter = 0;
+  /// Number of groups in each groupset.
+  std::uint64_t groupset_size = 0;
+  /// Vector storing all boundary flux.
+  std::vector<double> boundary_flux;
+};
+
+class BoundaryBank
+{
+public:
+  /// \name Constructors
+  /// \{
+  BoundaryBank() = default;
+  BoundaryBank(const std::vector<LBSGroupset>& groupsets);
+  /// \}
+
+  /// \name Elements getters
+  /// \{
+  BoundaryCommonData& operator[](int groupset_id) { return common_data_[groupset_id]; }
+  const BoundaryCommonData& operator[](int groupset_id) const { return common_data_[groupset_id]; }
+  std::size_t GetSize() const { return common_data_.size(); }
+  /// \}
+
+  /// \name Memory management
+  /// \{
+  /**
+   * Extend boundary and return the pointer to the beginning of the extended section.
+   * This pointer is only valid until the next call of ExtendBoundaryFlux.
+   */
+  double* ExtendBoundaryFlux(int groupset_id, std::size_t append_size);
+  /// Shrink allocated memory for the boundary bank to fit the size.
+  void ShrinkToFit();
+  bool IsAllocationDisabled() const { return disable_allocation_; }
+  /**
+   * Mark the bank as disble allocation.
+   * Once marked, the bank cannot be extended anymore.
+   */
+  void DisableAllocation() { disable_allocation_ = true; }
+  /// Erase all data and reset the bank back to original state.
+  void Reset();
+  /// \}
+
+private:
+  std::vector<BoundaryCommonData> common_data_;
+  /// Flag indicating if reallocation of boundary flux is disable.
+  bool disable_allocation_ = false;
+};
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.cu
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+
+namespace opensn
+{
+
+BoundaryCarrier::BoundaryCarrier(BoundaryBank& bank, const std::vector<LBSGroupset>& groupsets)
+  : bank_(bank)
+{
+  if (not bank.IsAllocationDisabled())
+    throw std::runtime_error("Cannot create a BoundaryCarrier while BoundaryBank allocation is "
+                             "enabled.");
+
+  device_boundary_flux_.reserve(groupsets.size());
+  device_boundary_flux_.resize(groupsets.size());
+
+  for (const auto& groupset : groupsets)
+  {
+    auto& host_data = bank[groupset.id].boundary_flux;
+    device_boundary_flux_[groupset.id] = crb::DeviceMemory<double>(host_data.size());
+  }
+}
+
+void
+BoundaryCarrier::UploadToDevice(int groupset_id)
+{
+  auto& host_data = bank_[groupset_id].boundary_flux;
+  crb::MemoryPinningManager<double> host_pinner(host_data);
+  auto& device_data = device_boundary_flux_[groupset_id];
+  crb::copy(device_data, host_pinner, host_pinner.size());
+}
+
+void
+BoundaryCarrier::DownloadToHost(int groupset_id)
+{
+  auto& host_data = bank_[groupset_id].boundary_flux;
+  crb::MemoryPinningManager<double> host_pinner(host_data);
+  auto& device_data = device_boundary_flux_[groupset_id];
+  crb::copy(host_pinner, device_data, host_pinner.size());
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include "caribou/main.hpp"
+#include <vector>
+
+namespace crb = caribou;
+
+namespace opensn
+{
+
+class BoundaryBank;
+class LBSGroupset;
+
+/**
+ * Object managing boundary flux data on GPU.
+ * This class pins the host static boundary flux banks owned by SweepBoundary and allocates matching
+ * device memory for each groupset.
+ */
+class BoundaryCarrier
+{
+public:
+  /// Constructor from the list of groupsets.
+  BoundaryCarrier(BoundaryBank& bank, const std::vector<LBSGroupset>& groupsets);
+
+  /// Copy the boundary flux data for the specified groupset from host to device.
+  void UploadToDevice(int groupset_id);
+  /// Copy the boundary flux data for the specified groupset from device to host.
+  void DownloadToHost(int groupset_id);
+  /// Get device pointer of a given groupset.
+  double* GetDevicePtr(int groupset_id) { return device_boundary_flux_[groupset_id].get(); }
+
+protected:
+  /// Boundary flux storage indexed by groupset ID.
+  std::vector<crb::DeviceMemory<double>> device_boundary_flux_;
+  /// Reference to boundary bank.
+  BoundaryBank& bank_;
+};
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.cc
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.h"
+#include <format>
+#include <map>
+
+namespace opensn
+{
+
+namespace
+{
+
+std::map<std::string, LBSBoundaryType> type_map = {{"vacuum", LBSBoundaryType::VACUUM},
+                                                   {"isotropic", LBSBoundaryType::ISOTROPIC},
+                                                   {"reflecting", LBSBoundaryType::REFLECTING},
+                                                   {"arbitrary", LBSBoundaryType::ARBITRARY}};
+
+void
+CheckForbiddenParams(const InputParameters& params,
+                     const std::string& boundary_name,
+                     const std::string& boundary_type,
+                     const std::string& param_name)
+{
+  if (params.IsParameterValid(param_name))
+    throw std::runtime_error(std::format(R"(Boundary '{}' of type="{}" does not support "{}".)",
+                                         boundary_name,
+                                         boundary_type,
+                                         param_name));
+}
+
+void
+CheckRequiredParams(const InputParameters& params,
+                    const std::string& boundary_name,
+                    const std::string& boundary_type,
+                    const std::string& param_name)
+{
+  if (not params.IsParameterValid(param_name))
+    throw std::runtime_error(std::format(
+      R"(Boundary '{}' of type="{}" requires "{}".)", boundary_name, boundary_type, param_name));
+}
+
+void
+CheckRequiredParams(const InputParameters& params,
+                    const std::string& boundary_name,
+                    const std::string& boundary_type,
+                    const std::string& param_name1,
+                    const std::string& param_name2)
+{
+  bool is_valid = (params.IsParameterValid(param_name1) xor params.IsParameterValid(param_name2));
+  if (not is_valid)
+    throw std::runtime_error(
+      std::format(R"(Boundary '{}' of type="{}" requires either "{}" or "{}".)",
+                  boundary_name,
+                  boundary_type,
+                  param_name1,
+                  param_name2));
+}
+
+} // namespace
+
+BoundaryDefinition::BoundaryDefinition(const InputParameters& params, unsigned int num_groups)
+{
+  const auto boundary_name = params.GetParamValue<std::string>("name");
+  const auto boundary_type = params.GetParamValue<std::string>("type");
+  auto it = type_map.find(boundary_type);
+  if (it == type_map.end())
+  {
+    throw std::runtime_error("Boundary \"" + boundary_name + "\" has unknown type \"" +
+                             boundary_type + "\".");
+  }
+  type = it->second;
+
+  switch (type)
+  {
+    case LBSBoundaryType::ISOTROPIC:
+    {
+      CheckForbiddenParams(params, boundary_name, boundary_type, "function");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "time_function");
+      CheckRequiredParams(params, boundary_name, boundary_type, "group_strength");
+      params.RequireParameterBlockTypeIs("group_strength", ParameterBlockType::ARRAY);
+      auto param_group_strength = params.GetParamVectorValue<double>("group_strength");
+      if (param_group_strength.size() != num_groups)
+        throw std::runtime_error(std::format(
+          "Boundary '{}' with type=\"isotropic\" expected \"group_strength\" to contain "
+          "{} entries, one for each solver group, but received {}.",
+          boundary_name,
+          num_groups,
+          param_group_strength.size()));
+      group_strength = std::move(param_group_strength);
+      if (params.IsParameterValid("start_time"))
+        start_time = params.GetParamValue<double>("start_time");
+      if (params.IsParameterValid("end_time"))
+        end_time = params.GetParamValue<double>("end_time");
+      if (not(start_time <= end_time))
+        throw std::runtime_error(std::format(
+          "Boundary '{}' with type=\"isotropic\" expected \"start_time\" to be less than or "
+          "equal to \"end_time\", but received start_time={} and end_time={}.",
+          boundary_name,
+          start_time,
+          end_time));
+      break;
+    }
+    case LBSBoundaryType::ARBITRARY:
+    {
+      CheckForbiddenParams(params, boundary_name, boundary_type, "group_strength");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "start_time");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "end_time");
+      CheckRequiredParams(params, boundary_name, boundary_type, "function", "time_function");
+      if (params.IsParameterValid("function"))
+      {
+        auto param_angular_flux_function =
+          params.GetSharedPtrParam<AngularFluxFunction>("function", false);
+        if (not param_angular_flux_function)
+          throw std::runtime_error(std::format(
+            "Boundary '{}' with type=\"arbitrary\" expected parameter \"function\" to hold a "
+            "non-null AngularFluxFunction.",
+            boundary_name));
+        time_angular_flux_function = std::make_shared<AngularFluxTimeFunction>(
+          [angular_flux_function =
+             std::move(param_angular_flux_function)](int group, int direction, double time)
+          { return (*angular_flux_function)(group, direction); });
+      }
+      else if (params.IsParameterValid("time_function"))
+      {
+        auto param_angular_flux_function =
+          params.GetSharedPtrParam<AngularFluxTimeFunction>("time_function", false);
+        if (not param_angular_flux_function)
+          throw std::runtime_error(std::format(
+            "Boundary '{}' with type=\"arbitrary\" expected parameter \"time_function\" to hold a "
+            "non-null AngularFluxFunction.",
+            boundary_name));
+        time_angular_flux_function = std::move(param_angular_flux_function);
+      }
+      break;
+    }
+    default:
+    {
+      CheckForbiddenParams(params, boundary_name, boundary_type, "function");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "time_function");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "group_strength");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "start_time");
+      CheckForbiddenParams(params, boundary_name, boundary_type, "end_time");
+    }
+  }
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/math/functions/function.h"
+#include "framework/parameters/input_parameters.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"
+#include <limits>
+
+namespace opensn
+{
+
+/**
+ * Parsed boundary-condition specification for sweep boundary construction.
+ *
+ * This structure stores the user-supplied boundary type and any type-specific data needed later by
+ * the sweep boundary factory. It intentionally describes the boundary condition without owning a
+ * concrete SweepBoundary object.
+ */
+struct BoundaryDefinition
+{
+  /// Construct a vacuum boundary definition.
+  BoundaryDefinition() = default;
+  /**
+   * Construct a boundary definition from input parameters.
+   *
+   * The constructor validates the requested boundary type and required/forbidden type-specific
+   * parameters. Isotropic boundaries store group strengths, arbitrary boundaries store an
+   * AngularFluxFunction, and vacuum/reflecting boundaries do not store additional payload.
+   * \param params Boundary option parameters containing at least `name` and `type`.
+   * \param num_groups Number of solver groups used to validate isotropic strengths.
+   */
+  BoundaryDefinition(const InputParameters& params, unsigned int num_groups);
+
+  /// Boundary condition type.
+  LBSBoundaryType type = LBSBoundaryType::VACUUM;
+  /// Group-wise incoming angular flux for isotropic boundaries.
+  std::vector<double> group_strength;
+  // Start time.
+  double start_time = -std::numeric_limits<double>::infinity();
+  // End time.
+  double end_time = std::numeric_limits<double>::infinity();
+  /// User-supplied angular flux callback for time-dependent arbitrary boundaries.
+  std::shared_ptr<AngularFluxTimeFunction> time_angular_flux_function;
+};
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.cc
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+#include "framework/mesh/cell/cell.h"
+
+namespace opensn
+{
+
+IsotropicBoundary::IsotropicBoundary(BoundaryBank& bank,
+                                     const std::vector<LBSGroupset>& groupsets,
+                                     const std::vector<double>& boundary_flux,
+                                     double start_time,
+                                     double end_time)
+  : SweepBoundary(bank, LBSBoundaryType::ISOTROPIC),
+    active_boundary_flux_(boundary_flux),
+    start_time_(start_time),
+    end_time_(end_time)
+{
+  for (const auto& groupset : groupsets)
+  {
+    offset_[groupset.id] = bank_[groupset.id].counter++;
+    bank_.ExtendBoundaryFlux(groupset.id, groupset.GetNumGroups());
+  }
+  IsotropicBoundary::UpdateBoundaryFlux(groupsets);
+}
+
+void
+IsotropicBoundary::UpdateBoundaryFlux(const std::vector<LBSGroupset>& groupsets)
+{
+  bool is_active = (evaluation_time_ >= start_time_ and evaluation_time_ <= end_time_);
+  if (current_state_ != is_active)
+  {
+    for (const auto& groupset : groupsets)
+    {
+      double* boundary_flux = GetBoundaryFlux(groupset.id);
+      for (unsigned int g = 0; g < groupset.GetNumGroups(); ++g)
+      {
+        boundary_flux[g] = ((is_active) ? active_boundary_flux_[groupset.first_group + g] : 0.0);
+      }
+    }
+    current_state_ = is_active;
+  }
+}
+
+std::uint64_t
+IsotropicBoundary::GetOffsetToAngleset(const FaceNode& face_node,
+                                       AngleSet& anglset,
+                                       bool is_outgoing)
+{
+  if (is_outgoing)
+    throw std::logic_error("IsotropicBoundary does not support outgoing flux.");
+  int groupset_id = anglset.GetGroupsetID();
+  return offset_[groupset_id] * bank_[groupset_id].groupset_size;
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/isotropic_boundary.h
@@ -6,6 +6,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "framework/mesh/mesh.h"
 #include "framework/math/math.h"
+#include <limits>
 #include <vector>
 
 namespace opensn
@@ -15,25 +16,32 @@ namespace opensn
 class IsotropicBoundary : public SweepBoundary
 {
 public:
-  explicit IsotropicBoundary(unsigned int num_groups,
-                             std::vector<double> boundary_flux,
-                             CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN)
-    : SweepBoundary(LBSBoundaryType::ISOTROPIC, num_groups, coord_type),
-      boundary_flux_(std::move(boundary_flux))
-  {
-  }
+  explicit IsotropicBoundary(BoundaryBank& bank,
+                             const std::vector<LBSGroupset>& groupsets,
+                             const std::vector<double>& boundary_flux,
+                             double start_time,
+                             double end_time);
 
   double* PsiIncoming(std::uint32_t cell_local_id,
                       unsigned int face_num,
                       unsigned int fi,
                       unsigned int angle_num,
-                      unsigned int group_num) override
+                      int groupset_id,
+                      unsigned int group_idx) override
   {
-    return &boundary_flux_[group_num];
+    return GetBoundaryFlux(groupset_id) + group_idx;
   }
 
-private:
-  std::vector<double> boundary_flux_;
+  void UpdateBoundaryFlux(const std::vector<LBSGroupset>& groupsets) override;
+
+  std::uint64_t
+  GetOffsetToAngleset(const FaceNode& face_node, AngleSet& anglset, bool is_outgoing) override;
+
+protected:
+  bool current_state_ = false;
+  std::vector<double> active_boundary_flux_;
+  double start_time_;
+  double end_time_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.cc
@@ -4,9 +4,11 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include <algorithm>
 #include <cmath>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -14,151 +16,233 @@
 namespace opensn
 {
 
-template <typename Fn>
+template <bool ApplyOnOldFlux, typename Fn>
 void
-ReflectingBoundary::ForEachDelayedAngularFlux(bool use_old_store, Fn&& fn)
+ReflectingBoundary::TransformGroupset(int groupset_id, Fn&& fn)
 {
-  auto&& apply = std::forward<Fn>(fn);
-  auto& flux = use_old_store ? boundary_flux_old_ : boundary_flux_;
-  for (auto& angle : flux)
-    for (auto& cellvec : angle)
-      for (auto& facevec : cellvec)
-        for (auto& dofvec : facevec)
-          for (auto& val : dofvec)
-            apply(val);
+  if (not opposing_reflected_)
+    return;
+  auto&& f = std::forward<Fn>(fn);
+  const auto& extra_data = extra_data_[groupset_id];
+  const auto old_stride = extra_data.old_stride;
+  double* flux = GetBoundaryFlux(groupset_id, (ApplyOnOldFlux) ? old_stride : 0);
+  std::size_t size = old_stride * bank_[groupset_id].groupset_size;
+  std::span<double> flux_view(flux, size);
+  f(flux_view);
 }
 
-template <typename Fn>
+template <bool ApplyOnOldFlux, typename Fn>
 void
-ReflectingBoundary::ForEachDelayedAngularFluxConst(bool use_old_store, Fn&& fn) const
+ReflectingBoundary::TransformGroupset(int groupset_id, Fn&& fn) const
 {
-  auto&& apply = std::forward<Fn>(fn);
-  const auto& flux = use_old_store ? boundary_flux_old_ : boundary_flux_;
-  for (const auto& angle : flux)
-    for (const auto& cellvec : angle)
-      for (const auto& facevec : cellvec)
-        for (const auto& dofvec : facevec)
-          for (const auto& val : dofvec)
-            apply(val);
+  if (not opposing_reflected_)
+    return;
+  auto&& f = std::forward<Fn>(fn);
+  const auto& extra_data = extra_data_[groupset_id];
+  const auto old_stride = extra_data.old_stride;
+  const double* flux = GetBoundaryFlux(groupset_id, (ApplyOnOldFlux) ? old_stride : 0);
+  std::size_t size = old_stride * bank_[groupset_id].groupset_size;
+  std::span<const double> flux_view(flux, size);
+  f(flux_view);
 }
 
+template <bool ApplyOnOldFlux, typename Fn>
 void
-ReflectingBoundary::InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
-                                                 const AngularQuadrature& quadrature)
+ReflectingBoundary::ForEachDelayedAngularFlux(int groupset_id, Fn&& fn)
 {
-  if (not grid)
-    throw std::logic_error("ReflectingBoundary: mesh continuum is null.");
+  if (not opposing_reflected_)
+    return;
+  auto&& f = std::forward<Fn>(fn);
+  const auto& extra_data = extra_data_[groupset_id];
+  const auto old_stride = extra_data.old_stride;
+  double* flux = GetBoundaryFlux(groupset_id, (ApplyOnOldFlux) ? old_stride : 0);
+  std::size_t size = old_stride * bank_[groupset_id].groupset_size;
+  std::for_each_n(flux, size, f);
+}
 
-  const auto tot_num_angles = static_cast<int>(quadrature.abscissae.size());
-  reflected_anglenum_.assign(tot_num_angles, -1);
-  angle_readyflags_.assign(tot_num_angles, false);
+template <bool ApplyOnOldFlux, typename Fn>
+void
+ReflectingBoundary::ForEachDelayedAngularFlux(int groupset_id, Fn&& fn) const
+{
+  if (not opposing_reflected_)
+    return;
+  auto&& f = std::forward<Fn>(fn);
+  const auto& extra_data = extra_data_[groupset_id];
+  const auto old_stride = extra_data.old_stride;
+  const double* flux = GetBoundaryFlux(groupset_id, (ApplyOnOldFlux) ? old_stride : 0);
+  std::size_t size = old_stride * bank_[groupset_id].groupset_size;
+  std::for_each_n(flux, size, f);
+}
 
-  const Vector3 ihat(1.0, 0.0, 0.0);
-  const Vector3 jhat(0.0, 1.0, 0.0);
+ReflectingBoundary::ReflectingBoundary(BoundaryBank& bank,
+                                       std::uint64_t bid,
+                                       const std::shared_ptr<MeshContinuum>& grid,
+                                       const std::vector<LBSGroupset>& groupsets,
+                                       const Vector3& normal,
+                                       CoordinateSystemType coord_type)
+  : SweepBoundary(bank, LBSBoundaryType::REFLECTING), normal_(normal), coord_type_(coord_type)
+{
+  extra_data_.reserve(groupsets.size());
+  extra_data_.resize(groupsets.size());
 
-  for (int n = 0; n < tot_num_angles; ++n)
+  std::uint64_t face_node_counter = 0;
+  for (const auto& cell : grid->local_cells)
   {
-    const Vector3& omega_n = quadrature.omegas[n];
-    Vector3 omega_reflected;
-
-    switch (GetCoordType())
+    const auto& cell_id = cell.local_id;
+    for (unsigned int f = 0; f < cell.faces.size(); ++f)
     {
-      case CoordinateSystemType::SPHERICAL:
-        omega_reflected = -1.0 * omega_n;
-        break;
-      case CoordinateSystemType::CYLINDRICAL:
+      const auto& face = cell.faces[f];
+      if (not face.has_neighbor and face.neighbor_id == bid)
       {
-        // left, top and bottom are regular reflecting
-        if (std::fabs(normal_.Dot(jhat)) > 0.999999 or normal_.Dot(ihat) < -0.999999)
-          omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
-        // right derives normal from omega_n
-        else if (normal_.Dot(ihat) > 0.999999)
+        const auto num_face_nodes = face.vertex_ids.size();
+        for (unsigned int fnode = 0; fnode < num_face_nodes; ++fnode)
         {
-          Vector3 normal_star;
-          if (omega_n.Dot(normal_) > 0.0)
-            normal_star = Vector3(omega_n.x, 0.0, omega_n.z).Normalized();
-          else
-            normal_star = Vector3(-omega_n.x, 0.0, -omega_n.y).Normalized();
-          omega_reflected = omega_n - 2.0 * normal_star * omega_n.Dot(normal_star);
+          FaceNode fn(cell_id, f, fnode);
+          facenode_to_index_[fn] = face_node_counter++;
         }
-        break;
       }
-      case CoordinateSystemType::CARTESIAN:
-      default:
-        omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
-        break;
-    }
-
-    bool found = false;
-    for (int nstar = 0; nstar < tot_num_angles; ++nstar)
-    {
-      if (omega_reflected.Dot(quadrature.omegas[nstar]) > (1.0 - epsilon_))
-      {
-        reflected_anglenum_[n] = nstar;
-        found = true;
-        break;
-      }
-    }
-
-    if (not found)
-    {
-      throw std::logic_error("ReflectingBoundary: Reflected angle not found for angle " +
-                             std::to_string(n) + " with direction " +
-                             quadrature.omegas[n].PrintStr() +
-                             ".\nThis can happen for two reasons:\n1) A quadrature is used "
-                             "that is not symmetric about the axis associated with the "
-                             "reflected boundary.\n2) The reflecting boundary is not "
-                             "aligned with a reflecting axis of the quadrature.");
     }
   }
+}
 
-  boundary_flux_.clear();
-  boundary_flux_old_.clear();
-  boundary_flux_.resize(tot_num_angles);
-
-  const size_t num_local_cells = grid->local_cells.size();
-  for (int n = 0; n < tot_num_angles; ++n)
+void
+ReflectingBoundary::InitializeReflectingMap(const std::vector<LBSGroupset>& groupsets)
+{
+  for (const auto& groupset : groupsets)
   {
-    if (quadrature.omegas[n].Dot(normal_) < 0.0)
-      continue;
+    const auto& quadrature = groupset.quadrature;
+    auto& angle_agg = *(groupset.angle_agg);
+    auto num_angles = quadrature->omegas.size();
 
-    auto& cell_vec = boundary_flux_[n];
-    cell_vec.resize(num_local_cells);
+    auto& extra_data = extra_data_[groupset.id];
+    auto& reflected_anglenum = extra_data.reflected_anglenum;
+    reflected_anglenum.reserve(num_angles);
+    reflected_anglenum.resize(num_angles);
 
-    for (const auto& cell : grid->local_cells)
+    const Vector3 ihat(1.0, 0.0, 0.0);
+    const Vector3 jhat(0.0, 1.0, 0.0);
+
+    for (std::uint32_t n = 0; n < num_angles; ++n)
     {
-      const auto c = cell.local_id;
-      bool on_ref_bndry = false;
+      const Vector3& omega_n = quadrature->omegas[n];
+      Vector3 omega_reflected;
 
-      for (const auto& face : cell.faces)
+      switch (coord_type_)
       {
-        if ((not face.has_neighbor) and (face.normal.Dot(normal_) > 0.999999))
+        case CoordinateSystemType::SPHERICAL:
+          omega_reflected = -1.0 * omega_n;
+          break;
+        case CoordinateSystemType::CYLINDRICAL:
         {
-          on_ref_bndry = true;
+          // left, top and bottom are regular reflecting
+          if (std::fabs(normal_.Dot(jhat)) > 0.999999 or normal_.Dot(ihat) < -0.999999)
+            omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
+          // right derives normal from omega_n
+          else if (normal_.Dot(ihat) > 0.999999)
+          {
+            Vector3 normal_star;
+            if (omega_n.Dot(normal_) > 0.0)
+              normal_star = Vector3(omega_n.x, 0.0, omega_n.z).Normalized();
+            else
+              normal_star = Vector3(-omega_n.x, 0.0, -omega_n.y).Normalized();
+            omega_reflected = omega_n - 2.0 * normal_star * omega_n.Dot(normal_star);
+          }
+          break;
+        }
+        case CoordinateSystemType::CARTESIAN:
+        default:
+          omega_reflected = omega_n - 2.0 * normal_ * omega_n.Dot(normal_);
+          break;
+      }
+
+      bool found = false;
+      for (std::uint32_t nstar = 0; nstar < num_angles; ++nstar)
+      {
+        if (omega_reflected.Dot(quadrature->omegas[nstar]) > (1.0 - epsilon_))
+        {
+          reflected_anglenum[n] = nstar;
+          found = true;
           break;
         }
       }
 
-      if (not on_ref_bndry)
-        continue;
-
-      cell_vec[c].resize(cell.faces.size());
-      int f = 0;
-      for (const auto& face : cell.faces)
+      if (not found)
       {
-        if ((not face.has_neighbor) and (face.normal.Dot(normal_) > 0.999999))
-        {
-          cell_vec[c][f].clear();
-          cell_vec[c][f].resize(face.vertex_ids.size(), std::vector<double>(num_groups_, 0.0));
-        }
-        ++f;
+        throw std::logic_error("ReflectingBoundary: Reflected angle not found for angle " +
+                               std::to_string(n) + " with direction " +
+                               quadrature->omegas[n].PrintStr() +
+                               ".\nThis can happen for two reasons:\n1) A quadrature is used "
+                               "that is not symmetric about the axis associated with the "
+                               "reflected boundary.\n2) The reflecting boundary is not "
+                               "aligned with a reflecting axis of the quadrature.");
       }
     }
   }
 }
 
 void
-ReflectingBoundary::GetFollowingAngleSets(std::set<AngleSet*>& following_angle_sets,
+ReflectingBoundary::InitializeAngleDependent(const std::vector<LBSGroupset>& groupsets)
+{
+  for (const auto& groupset : groupsets)
+  {
+    const auto& quadrature = groupset.quadrature;
+    auto& angle_agg = *(groupset.angle_agg);
+    auto num_angles = quadrature->omegas.size();
+    auto& extra_data = extra_data_[groupset.id];
+    auto& map_dirnum = extra_data.map_dirnum;
+    auto& reflected_anglenum = extra_data.reflected_anglenum;
+    auto& node_stride = extra_data.node_stride;
+    auto& old_stride = extra_data.old_stride;
+
+    map_dirnum.reserve(num_angles);
+    map_dirnum.resize(num_angles, std::numeric_limits<std::uint64_t>::max());
+
+    std::uint64_t internal_angle_idx = 0;
+    for (const auto& angleset : angle_agg)
+    {
+      int inout_counter = 0;
+      unsigned int orthogonal_counter = 0;
+      for (const auto& angle : angleset->GetAngleIndices())
+      {
+        double dot = normal_.Dot(quadrature->omegas[angle]);
+        orthogonal_counter += (dot == 0);
+        inout_counter += (dot > 0) - (dot < 0);
+      }
+      if (std::abs(inout_counter) + orthogonal_counter != angleset->GetAngleIndices().size())
+        throw std::logic_error("ReflectingBoundary: Expect all angles in angle set to be all in or "
+                               "all out.\n");
+
+      bool is_outgoing = (inout_counter > 0);
+      if (not is_outgoing)
+        continue;
+      for (const auto& angle : angleset->GetAngleIndices())
+      {
+        map_dirnum[angle] = internal_angle_idx;
+        map_dirnum[reflected_anglenum[angle]] = internal_angle_idx;
+        ++internal_angle_idx;
+      }
+    }
+
+    auto& counter = bank_[groupset.id].counter;
+    offset_[groupset.id] = counter;
+    node_stride = internal_angle_idx;
+    old_stride = facenode_to_index_.size() * node_stride;
+    if (opposing_reflected_)
+    {
+      counter += 2 * old_stride;
+      bank_.ExtendBoundaryFlux(groupset.id, 2 * old_stride * groupset.GetNumGroups());
+    }
+    else
+    {
+      counter += old_stride;
+      bank_.ExtendBoundaryFlux(groupset.id, old_stride * groupset.GetNumGroups());
+    }
+  }
+}
+
+void
+ReflectingBoundary::GetFollowingAngleSets(int groupset_id,
+                                          std::set<AngleSet*>& following_angle_sets,
                                           const AngleAggregation& angle_agg,
                                           const AngleSet& angleset)
 {
@@ -170,25 +254,15 @@ ReflectingBoundary::GetFollowingAngleSets(std::set<AngleSet*>& following_angle_s
   {
     if (omegas[angle_idx].Dot(normal_) < 0.0)
       continue;
-    auto reflected_angle_num = reflected_anglenum_[angle_idx];
-    auto following_angle_set = std::find_if(angle_agg.begin(),
-                                            angle_agg.end(),
-                                            [&](std::shared_ptr<AngleSet> as)
-                                            { return as->HasAngleIndex(reflected_angle_num); });
-    if (following_angle_set != angle_agg.end())
-      following_angle_sets.insert(following_angle_set->get());
-    else
-    {
-      throw std::logic_error("ReflectingBoundary: Could not find predecessor angleset for "
-                             "angle index " +
-                             std::to_string(reflected_angle_num) + ".");
-    }
+    auto reflected_angle_num = extra_data_[groupset_id].reflected_anglenum[angle_idx];
+    following_angle_sets.insert(angle_agg.GetAngleSetForAngleIndex(reflected_angle_num));
   }
 }
 
 void
-ReflectingBoundary::FinalizeDelayedAngularFluxSetup(
-  uint64_t boundary_id, const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+ReflectingBoundary::SetOpposingReflected(
+  std::uint64_t boundary_id,
+  const std::map<std::uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
 {
   for (const auto& [otherbid, otherbndry] : boundaries)
   {
@@ -208,152 +282,121 @@ ReflectingBoundary::FinalizeDelayedAngularFluxSetup(
       }
     }
   }
-
-  if (opposing_reflected_)
-    boundary_flux_old_ = boundary_flux_;
 }
 
 void
-ReflectingBoundary::ZeroOpposingDelayedAngularFluxOld()
+ReflectingBoundary::ZeroOpposingDelayedAngularFluxOld(int groupset_id)
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFlux(true, [](double& val) { val = 0.0; });
+  TransformGroupset<true>(groupset_id, [](auto flux) { std::fill(flux.begin(), flux.end(), 0.0); });
 }
 
 size_t
-ReflectingBoundary::CountDelayedAngularDOFsNew() const
+ReflectingBoundary::CountDelayedAngularDOFsNew(int groupset_id) const
 {
   if (not opposing_reflected_)
     return 0;
-
-  size_t counter = 0;
-  ForEachDelayedAngularFluxConst(false, [&](const double&) { ++counter; });
-  return counter;
+  const auto& extra_data = extra_data_[groupset_id];
+  return extra_data.old_stride * bank_[groupset_id].groupset_size;
 }
 
 size_t
-ReflectingBoundary::CountDelayedAngularDOFsOld() const
+ReflectingBoundary::CountDelayedAngularDOFsOld(int groupset_id) const
 {
-  if (not opposing_reflected_)
-    return 0;
-
-  size_t counter = 0;
-  ForEachDelayedAngularFluxConst(true, [&](const double&) { ++counter; });
-  return counter;
+  return CountDelayedAngularDOFsNew(groupset_id);
 }
 
 void
-ReflectingBoundary::AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const
+ReflectingBoundary::AppendNewDelayedAngularDOFsToVector(int groupset_id,
+                                                        std::vector<double>& output) const
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFluxConst(false, [&](const double& val) { output.push_back(val); });
+  TransformGroupset<false>(
+    groupset_id, [&output](auto flux) { output.insert(output.end(), flux.begin(), flux.end()); });
 }
 
 void
-ReflectingBoundary::AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const
+ReflectingBoundary::AppendOldDelayedAngularDOFsToVector(int groupset_id,
+                                                        std::vector<double>& output) const
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFluxConst(true, [&](const double& val) { output.push_back(val); });
+  TransformGroupset<true>(
+    groupset_id, [&output](auto flux) { output.insert(output.end(), flux.begin(), flux.end()); });
 }
 
 void
-ReflectingBoundary::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const
+ReflectingBoundary::AppendNewDelayedAngularDOFsToArray(int groupset_id,
+                                                       int64_t& index,
+                                                       double* buffer) const
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFluxConst(false,
-                                 [&](const double& val)
-                                 {
-                                   ++index;
-                                   buffer[index] = val;
-                                 });
+  ForEachDelayedAngularFlux<false>(groupset_id,
+                                   [&index, buffer](double psi) { buffer[++index] = psi; });
 }
 
 void
-ReflectingBoundary::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const
+ReflectingBoundary::AppendOldDelayedAngularDOFsToArray(int groupset_id,
+                                                       int64_t& index,
+                                                       double* buffer) const
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFluxConst(true,
-                                 [&](const double& val)
-                                 {
-                                   ++index;
-                                   buffer[index] = val;
-                                 });
+  ForEachDelayedAngularFlux<true>(groupset_id,
+                                  [&index, buffer](double psi) { buffer[++index] = psi; });
 }
 
 void
-ReflectingBoundary::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer)
+ReflectingBoundary::SetNewDelayedAngularDOFsFromArray(int groupset_id,
+                                                      int64_t& index,
+                                                      const double* buffer)
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFlux(false,
-                            [&](double& val)
-                            {
-                              ++index;
-                              val = buffer[index];
-                            });
+  ForEachDelayedAngularFlux<false>(groupset_id,
+                                   [&index, buffer](double& psi) { psi = buffer[++index]; });
 }
 
 void
-ReflectingBoundary::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer)
+ReflectingBoundary::SetOldDelayedAngularDOFsFromArray(int groupset_id,
+                                                      int64_t& index,
+                                                      const double* buffer)
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFlux(true,
-                            [&](double& val)
-                            {
-                              ++index;
-                              val = buffer[index];
-                            });
+  ForEachDelayedAngularFlux<true>(groupset_id,
+                                  [&index, buffer](double& psi) { psi = buffer[++index]; });
 }
 
 void
-ReflectingBoundary::SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values,
+ReflectingBoundary::SetNewDelayedAngularDOFsFromVector(int groupset_id,
+                                                       const std::vector<double>& values,
                                                        size_t& index)
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFlux(false, [&](double& val) { val = values[index++]; });
+  ForEachDelayedAngularFlux<false>(groupset_id,
+                                   [&values, &index](double& psi) { psi = values[index++]; });
 }
 
 void
-ReflectingBoundary::SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values,
+ReflectingBoundary::SetOldDelayedAngularDOFsFromVector(int groupset_id,
+                                                       const std::vector<double>& values,
                                                        size_t& index)
 {
-  if (not opposing_reflected_)
-    return;
-
-  ForEachDelayedAngularFlux(true, [&](double& val) { val = values[index++]; });
+  ForEachDelayedAngularFlux<true>(groupset_id,
+                                  [&values, &index](double& psi) { psi = values[index++]; });
 }
 
 void
-ReflectingBoundary::CopyDelayedAngularFluxOldToNew()
+ReflectingBoundary::CopyDelayedAngularFluxOldToNew(int groupset_id)
 {
   if (not opposing_reflected_)
     return;
-
-  boundary_flux_ = boundary_flux_old_;
+  const auto& extra_data = extra_data_[groupset_id];
+  double* flux = GetBoundaryFlux(groupset_id);
+  std::size_t size = extra_data.old_stride * bank_[groupset_id].groupset_size;
+  const double* flux_old = flux + size;
+  std::copy_n(flux_old, size, flux);
 }
 
 void
-ReflectingBoundary::CopyDelayedAngularFluxNewToOld()
+ReflectingBoundary::CopyDelayedAngularFluxNewToOld(int groupset_id)
 {
   if (not opposing_reflected_)
     return;
-
-  boundary_flux_old_ = boundary_flux_;
+  const auto& extra_data = extra_data_[groupset_id];
+  double* flux = GetBoundaryFlux(groupset_id);
+  std::size_t size = extra_data.old_stride * bank_[groupset_id].groupset_size;
+  double* flux_old = flux + size;
+  std::copy_n(flux, size, flux_old);
 }
 
 double*
@@ -361,51 +404,50 @@ ReflectingBoundary::PsiIncoming(std::uint32_t cell_local_id,
                                 unsigned int face_num,
                                 unsigned int fi,
                                 unsigned int angle_num,
-                                unsigned int group_num)
+                                int groupset_id,
+                                unsigned int group_idx)
 {
-  int reflected_angle_num = reflected_anglenum_[angle_num];
-
+  FaceNode fn(cell_local_id, face_num, fi);
+  std::uint64_t facenode_idx = facenode_to_index_.at(fn);
+  auto& extra_data = extra_data_[groupset_id];
+  const auto& node_stride = extra_data.node_stride;
+  const auto& old_stride = extra_data.old_stride;
+  std::uint64_t node_angle_offset = facenode_idx * node_stride + extra_data.map_dirnum[angle_num];
   if (opposing_reflected_)
-    return &boundary_flux_old_[reflected_angle_num][cell_local_id][face_num][fi].front();
-
-  return &boundary_flux_[reflected_angle_num][cell_local_id][face_num][fi].front();
+    node_angle_offset += old_stride;
+  return GetBoundaryFlux(groupset_id, node_angle_offset) + group_idx;
 }
 
 double*
 ReflectingBoundary::PsiOutgoing(uint64_t cell_local_id,
                                 unsigned int face_num,
                                 unsigned int fi,
-                                unsigned int angle_num)
+                                unsigned int angle_num,
+                                int groupset_id)
 {
-  return &boundary_flux_[angle_num][cell_local_id][face_num][fi].front();
+  FaceNode fn(cell_local_id, face_num, fi);
+  std::uint64_t facenode_idx = facenode_to_index_.at(fn);
+  auto& extra_data = extra_data_[groupset_id];
+  const auto& node_stride = extra_data.node_stride;
+  std::uint64_t node_angle_offset = facenode_idx * node_stride + extra_data.map_dirnum[angle_num];
+  return GetBoundaryFlux(groupset_id, node_angle_offset);
 }
 
-void
-ReflectingBoundary::UpdateAnglesReadyStatus(const std::vector<std::uint32_t>& angles)
+std::uint64_t
+ReflectingBoundary::GetOffsetToAngleset(const FaceNode& face_node,
+                                        AngleSet& anglset,
+                                        bool is_outgoing)
 {
-  for (const size_t n : angles)
-    angle_readyflags_[reflected_anglenum_[n]] = true;
-}
-
-bool
-ReflectingBoundary::CheckAnglesReadyStatus(const std::vector<std::uint32_t>& angles)
-{
-  if (opposing_reflected_)
-    return true;
-
-  for (const auto& n : angles)
-    if (not boundary_flux_[reflected_anglenum_[n]].empty())
-      if (not angle_readyflags_[n])
-        return false;
-
-  return true;
-}
-
-void
-ReflectingBoundary::ResetAnglesReadyStatus()
-{
-  boundary_flux_old_ = boundary_flux_;
-  std::fill(angle_readyflags_.begin(), angle_readyflags_.end(), false);
+  std::uint64_t facenode_idx = facenode_to_index_.at(face_node);
+  int groupset_id = anglset.GetGroupsetID();
+  auto& extra_data = extra_data_[groupset_id];
+  const auto& node_stride = extra_data.node_stride;
+  const auto& old_stride = extra_data.old_stride;
+  std::uint64_t node_angle_offset =
+    facenode_idx * node_stride + extra_data.map_dirnum[anglset.GetAngleIndices()[0]];
+  if (not is_outgoing and opposing_reflected_)
+    node_angle_offset += old_stride;
+  return (offset_[groupset_id] + node_angle_offset) * bank_[groupset_id].groupset_size;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/reflecting_boundary.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
+#include "framework/mesh/cell/cell.h"
 #include <vector>
 #include <limits>
 namespace opensn
@@ -13,21 +14,18 @@ namespace opensn
 class ReflectingBoundary : public SweepBoundary
 {
 public:
-  ReflectingBoundary(unsigned int num_groups,
+  ReflectingBoundary(BoundaryBank& bank,
+                     std::uint64_t bid,
+                     const std::shared_ptr<MeshContinuum>& grid,
+                     const std::vector<LBSGroupset>& groupsets,
                      const Vector3& normal,
-                     CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN)
-    : SweepBoundary(LBSBoundaryType::REFLECTING, num_groups, coord_type), normal_(normal)
-  {
-  }
+                     CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN);
 
   const Vector3& GetNormal() const { return normal_; }
 
   const Vector3* GetNormalForReflection() const override { return &normal_; }
 
   bool HasDelayedAngularFlux() const override { return true; }
-
-  void InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
-                                    const AngularQuadrature& quadrature) override;
 
   /**
    * Get the list of anglesets that depend on a given angleset.
@@ -37,79 +35,124 @@ public:
    * \param angle_agg Angle aggregation containing all anglesets.
    * \param angleset Angleset for which dependent anglesets are sought.
    */
-  void GetFollowingAngleSets(std::set<AngleSet*>& following_angle_sets,
+  void GetFollowingAngleSets(int groupset_id,
+                             std::set<AngleSet*>& following_angle_sets,
                              const AngleAggregation& angle_agg,
                              const AngleSet& angleset) override;
 
-  void FinalizeDelayedAngularFluxSetup(
-    uint64_t boundary_id,
-    const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries) override;
+  void SetOpposingReflected(
+    std::uint64_t boundary_id,
+    const std::map<std::uint64_t, std::shared_ptr<SweepBoundary>>& boundaries) override;
 
-  void ZeroOpposingDelayedAngularFluxOld() override;
+  void ZeroOpposingDelayedAngularFluxOld(int groupset_id) override;
 
-  size_t CountDelayedAngularDOFsNew() const override;
+  size_t CountDelayedAngularDOFsNew(int groupset_id) const override;
 
-  size_t CountDelayedAngularDOFsOld() const override;
+  size_t CountDelayedAngularDOFsOld(int groupset_id) const override;
 
-  void AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const override;
+  void AppendNewDelayedAngularDOFsToVector(int groupset_id,
+                                           std::vector<double>& output) const override;
 
-  void AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const override;
+  void AppendOldDelayedAngularDOFsToVector(int groupset_id,
+                                           std::vector<double>& output) const override;
 
-  void AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const override;
+  void AppendNewDelayedAngularDOFsToArray(int groupset_id,
+                                          int64_t& index,
+                                          double* buffer) const override;
 
-  void AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const override;
+  void AppendOldDelayedAngularDOFsToArray(int groupset_id,
+                                          int64_t& index,
+                                          double* buffer) const override;
 
-  void SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) override;
+  void
+  SetNewDelayedAngularDOFsFromArray(int groupset_id, int64_t& index, const double* buffer) override;
 
-  void SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) override;
+  void
+  SetOldDelayedAngularDOFsFromArray(int groupset_id, int64_t& index, const double* buffer) override;
 
-  void SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values,
+  void SetNewDelayedAngularDOFsFromVector(int groupset_id,
+                                          const std::vector<double>& values,
                                           size_t& index) override;
 
-  void SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values,
+  void SetOldDelayedAngularDOFsFromVector(int groupset_id,
+                                          const std::vector<double>& values,
                                           size_t& index) override;
 
-  void CopyDelayedAngularFluxOldToNew() override;
+  void CopyDelayedAngularFluxOldToNew(int groupset_id) override;
 
-  void CopyDelayedAngularFluxNewToOld() override;
+  void CopyDelayedAngularFluxNewToOld(int groupset_id) override;
+
+  void GetReflectedMap(int groupset_id,
+                       std::vector<std::vector<std::uint32_t>>& reflected_maps) override
+  {
+    reflected_maps.push_back(extra_data_[groupset_id].reflected_anglenum);
+  }
 
   double* PsiIncoming(std::uint32_t cell_local_id,
                       unsigned int face_num,
                       unsigned int fi,
                       unsigned int angle_num,
-                      unsigned int group_num) override;
+                      int groupset_id,
+                      unsigned int group_idx) override;
 
   double* PsiOutgoing(uint64_t cell_local_id,
                       unsigned int face_num,
                       unsigned int fi,
-                      unsigned int angle_num) override;
+                      unsigned int angle_num,
+                      int groupset_id) override;
 
-  void UpdateAnglesReadyStatus(const std::vector<std::uint32_t>& angles) override;
+  std::uint64_t
+  GetOffsetToAngleset(const FaceNode& face_node, AngleSet& anglset, bool is_outgoing) override;
 
-  bool CheckAnglesReadyStatus(const std::vector<std::uint32_t>& angles) override;
+  void InitializeReflectingMap(const std::vector<LBSGroupset>& groupsets) override;
+  void InitializeAngleDependent(const std::vector<LBSGroupset>& groupsets) override;
 
-  void ResetAnglesReadyStatus() override;
+  /// Stride for computing psi pointer.
+  struct Stride
+  {
+    std::uint64_t facenode_stride = 0;
+    std::uint64_t angle_stride = 0;
+  };
 
 protected:
   const Vector3 normal_;
+  CoordinateSystemType coord_type_;
   bool opposing_reflected_ = false;
 
-  // Populated by angle aggregation
-  // AngularFluxData indices are: angle, cell per angle, faces per cell, DOFs per face, groups per
-  // DOF
-  using AngularFluxData = std::vector<std::vector<std::vector<std::vector<std::vector<double>>>>>;
-  AngularFluxData boundary_flux_;
-  AngularFluxData boundary_flux_old_;
+  /// Map from face node to internal node-index.
+  std::map<FaceNode, std::uint64_t> facenode_to_index_;
 
-  std::vector<int> reflected_anglenum_;
-  std::vector<bool> angle_readyflags_;
+  /// Additional data specific to reflecting boundary for each groupset.
+  struct ExtraData
+  {
+    /// Map from angle direction number in a quadrature to internal angle index
+    std::vector<std::uint64_t> map_dirnum;
+    /// Map from angle direction number in a quadrature to reflected angle index.
+    std::vector<std::uint32_t> reflected_anglenum;
+    /**
+     * Number of angles recorded in the boundary, which is also the stride of the face node.
+     * If the boundary is opposing reflected, all angles are recorded. Otherwise, only outgoing ones
+     * are counted.
+     */
+    std::uint64_t node_stride = 0;
+    /// Offset separating current and old boundary flux.
+    std::uint64_t old_stride = 0;
+  };
+  /// List of data per groupset.
+  std::vector<ExtraData> extra_data_;
 
 private:
-  template <typename Fn>
-  void ForEachDelayedAngularFlux(bool use_old_store, Fn&& fn);
+  template <bool ApplyOnOldFlux, typename Fn>
+  void TransformGroupset(int groupset_id, Fn&& fn);
 
-  template <typename Fn>
-  void ForEachDelayedAngularFluxConst(bool use_old_store, Fn&& fn) const;
+  template <bool ApplyOnOldFlux, typename Fn>
+  void TransformGroupset(int groupset_id, Fn&& fn) const;
+
+  template <bool ApplyOnOldFlux, typename Fn>
+  void ForEachDelayedAngularFlux(int groupset_id, Fn&& fn);
+
+  template <bool ApplyOnOldFlux, typename Fn>
+  void ForEachDelayedAngularFlux(int groupset_id, Fn&& fn) const;
 
 private:
   static constexpr double epsilon_ = 1.0e-8;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 
@@ -13,7 +14,8 @@ SweepBoundary::PsiIncoming(std::uint32_t cell_local_id,
                            unsigned int face_num,
                            unsigned int fi,
                            unsigned int angle_num,
-                           unsigned int group_num)
+                           int groupset_id,
+                           unsigned int group_idx)
 {
   throw std::runtime_error(
     "SweepBoundary: PsiIncoming call made to boundary that has no such information.");
@@ -24,7 +26,8 @@ double*
 SweepBoundary::PsiOutgoing(uint64_t cell_local_id,
                            unsigned int face_num,
                            unsigned int fi,
-                           unsigned int angle_num)
+                           unsigned int angle_num,
+                           int groupset_id)
 {
   throw std::runtime_error(
     "SweepBoundary: PsiOutgoing call made to boundary that has no such information.");

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_bank.h"
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -14,27 +16,30 @@ namespace opensn
 
 class AngleSet;
 class AngleAggregation;
+class FaceNode;
 class MeshContinuum;
+class LBSGroupset;
 
 /// Base class for sweep related boundaries.
 class SweepBoundary
 {
 public:
-  explicit SweepBoundary(LBSBoundaryType bndry_type,
-                         unsigned int num_groups,
-                         CoordinateSystemType coord_type)
-    : num_groups_(num_groups), type_(bndry_type), coord_type_(coord_type)
+  explicit SweepBoundary(BoundaryBank& bank, LBSBoundaryType bndry_type)
+    : bank_(bank), type_(bndry_type)
   {
-    zero_boundary_flux_.resize(num_groups_, 0.0);
+    offset_.reserve(bank_.GetSize());
+    offset_.resize(bank_.GetSize());
   }
 
   virtual ~SweepBoundary() = default;
 
   LBSBoundaryType GetType() const { return type_; }
 
-  CoordinateSystemType GetCoordType() const { return coord_type_; }
-
   bool IsReflecting() const { return type_ == LBSBoundaryType::REFLECTING; }
+  bool IsAngleDependent() const
+  {
+    return type_ == LBSBoundaryType::REFLECTING || type_ == LBSBoundaryType::ARBITRARY;
+  }
 
   double GetEvaluationTime() const { return evaluation_time_; }
 
@@ -42,92 +47,152 @@ public:
 
   virtual bool HasDelayedAngularFlux() const { return false; }
 
-  virtual void InitializeDelayedAngularFlux(const std::shared_ptr<MeshContinuum>& grid,
-                                            const AngularQuadrature& quadrature)
-  {
-  }
-
   /**
    * Get the list of anglesets that depend on a given angleset.
    * This function can only be applied to reflecting boundary and AAHD anglesets.
    */
-  virtual void GetFollowingAngleSets(std::set<AngleSet*>& following_angle_sets,
+  virtual void GetFollowingAngleSets(int groupset_id,
+                                     std::set<AngleSet*>& following_angle_sets,
                                      const AngleAggregation& angle_agg,
                                      const AngleSet& angleset)
   {
   }
 
-  virtual void FinalizeDelayedAngularFluxSetup(
-    uint64_t boundary_id, const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+  virtual void
+  SetOpposingReflected(std::uint64_t boundary_id,
+                       const std::map<std::uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
   {
   }
 
-  virtual void ZeroOpposingDelayedAngularFluxOld() {}
+  virtual void ZeroOpposingDelayedAngularFluxOld(int groupset_id) {}
 
-  virtual size_t CountDelayedAngularDOFsNew() const { return 0; }
+  virtual size_t CountDelayedAngularDOFsNew(int groupset_id) const { return 0; }
 
-  virtual size_t CountDelayedAngularDOFsOld() const { return 0; }
+  virtual size_t CountDelayedAngularDOFsOld(int groupset_id) const { return 0; }
 
-  virtual void AppendNewDelayedAngularDOFsToVector(std::vector<double>& output) const {}
-
-  virtual void AppendOldDelayedAngularDOFsToVector(std::vector<double>& output) const {}
-
-  virtual void AppendNewDelayedAngularDOFsToArray(int64_t& index, double* buffer) const {}
-
-  virtual void AppendOldDelayedAngularDOFsToArray(int64_t& index, double* buffer) const {}
-
-  virtual void SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) {}
-
-  virtual void SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* buffer) {}
-
-  virtual void SetNewDelayedAngularDOFsFromVector(const std::vector<double>& values, size_t& index)
+  virtual void AppendNewDelayedAngularDOFsToVector(int groupset_id,
+                                                   std::vector<double>& output) const
   {
   }
 
-  virtual void SetOldDelayedAngularDOFsFromVector(const std::vector<double>& values, size_t& index)
+  virtual void AppendOldDelayedAngularDOFsToVector(int groupset_id,
+                                                   std::vector<double>& output) const
   {
   }
 
-  virtual void CopyDelayedAngularFluxOldToNew() {}
+  virtual void
+  AppendNewDelayedAngularDOFsToArray(int groupset_id, int64_t& index, double* buffer) const
+  {
+  }
 
-  virtual void CopyDelayedAngularFluxNewToOld() {}
+  virtual void
+  AppendOldDelayedAngularDOFsToArray(int groupset_id, int64_t& index, double* buffer) const
+  {
+  }
 
-  virtual void ResetAnglesReadyStatus() {}
+  virtual void
+  SetNewDelayedAngularDOFsFromArray(int groupset_id, int64_t& index, const double* buffer)
+  {
+  }
+
+  virtual void
+  SetOldDelayedAngularDOFsFromArray(int groupset_id, int64_t& index, const double* buffer)
+  {
+  }
+
+  virtual void SetNewDelayedAngularDOFsFromVector(int groupset_id,
+                                                  const std::vector<double>& values,
+                                                  size_t& index)
+  {
+  }
+
+  virtual void SetOldDelayedAngularDOFsFromVector(int groupset_id,
+                                                  const std::vector<double>& values,
+                                                  size_t& index)
+  {
+  }
+
+  virtual void CopyDelayedAngularFluxOldToNew(int groupset_id) {}
+
+  virtual void CopyDelayedAngularFluxNewToOld(int groupset_id) {}
 
   virtual const Vector3* GetNormalForReflection() const { return nullptr; }
 
-  /// Returns a pointer to the location of the incoming flux.
+  virtual void GetReflectedMap(int groupset_id,
+                               std::vector<std::vector<std::uint32_t>>& reflected_maps)
+  {
+  }
+
+  /// Return a pointer to the location of the incoming flux.
   virtual double* PsiIncoming(std::uint32_t cell_local_id,
                               unsigned int face_num,
                               unsigned int fi,
                               unsigned int angle_num,
-                              unsigned int group_num);
+                              int groupset_id,
+                              unsigned int group_idx);
 
-  /// Returns a pointer to the location of the outgoing flux.
+  /// Return a pointer to the location of the outgoing flux.
   virtual double* PsiOutgoing(uint64_t cell_local_id,
                               unsigned int face_num,
                               unsigned int fi,
-                              unsigned int angle_num);
-
-  virtual void UpdateAnglesReadyStatus(const std::vector<std::uint32_t>& angles) {}
-
-  virtual bool CheckAnglesReadyStatus(const std::vector<std::uint32_t>& angles) { return true; }
+                              unsigned int angle_num,
+                              int groupset_id);
 
   virtual void Setup(const std::shared_ptr<MeshContinuum>& grid,
                      const AngularQuadrature& quadrature)
   {
   }
 
-  double* ZeroFlux(unsigned int group_num) { return &zero_boundary_flux_[group_num]; }
+  virtual void InitializeReflectingMap(const std::vector<LBSGroupset>& groupsets) {}
+
+  /**
+   * Perform additional setup required by angle-dependent boundaries.
+   * Angle-dependent boundaries require an extra initialization step after flux data structures are
+   * initialized. This phase cannot be executed in the constructor, which happens before the
+   * initialization of flux data structures.
+   */
+  virtual void InitializeAngleDependent(const std::vector<LBSGroupset>& groupsets) {}
+
+  /// Get pointer to the boundary flux section in the contigous bank for a given groupset.
+  double* GetBoundaryFlux(int groupset_id, std::uint64_t extra_offset = 0)
+  {
+    auto& data = bank_[groupset_id];
+    return data.boundary_flux.data() + (offset_[groupset_id] + extra_offset) * data.groupset_size;
+  }
+
+  /// Get pointer to the boundary flux section in the contigous bank for a given groupset.
+  const double* GetBoundaryFlux(int groupset_id, std::uint64_t extra_offset = 0) const
+  {
+    auto& data = bank_[groupset_id];
+    return data.boundary_flux.data() + (offset_[groupset_id] + extra_offset) * data.groupset_size;
+  }
+
+  /// Get offset to the data region of a given angleset.
+  virtual std::uint64_t
+  GetOffsetToAngleset(const FaceNode& face_node, AngleSet& anglset, bool is_outgoing)
+  {
+    return std::numeric_limits<std::uint64_t>::max();
+  }
+
+  double* ZeroFlux(int groupset_id, unsigned int group_num)
+  {
+    auto& data = bank_[groupset_id];
+    return data.boundary_flux.data() + group_num;
+  }
+
+  virtual void UpdateBoundaryFlux(const std::vector<LBSGroupset>& groupsets) {}
 
 protected:
-  std::vector<double> zero_boundary_flux_;
-  unsigned int num_groups_;
-
-private:
-  const LBSBoundaryType type_;
-  const CoordinateSystemType coord_type_;
-  /// Time value passed to boundary functions
+  /// Reference to the boundary bank (contiguous memory allocated for all boundaries).
+  BoundaryBank& bank_;
+  /**
+   * Offset used to access boundary flux data for each groupset.
+   * Boundary fluxes for a given boundary start at offset * groupset.GetNumGroups().
+   */
+  std::vector<std::uint64_t> offset_;
+  /// Boundary type.
+  LBSBoundaryType type_;
+  /// Time value passed to boundary functions.
   double evaluation_time_ = 0.0;
 };
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/vacuum_boundary.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/vacuum_boundary.h
@@ -6,8 +6,8 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "framework/mesh/mesh.h"
 #include "framework/math/math.h"
+#include <algorithm>
 #include <vector>
-#include <limits>
 
 namespace opensn
 {
@@ -15,22 +15,28 @@ namespace opensn
 class VacuumBoundary : public SweepBoundary
 {
 public:
-  explicit VacuumBoundary(unsigned int num_groups,
-                          CoordinateSystemType coord_type = CoordinateSystemType::CARTESIAN)
-    : SweepBoundary(LBSBoundaryType::VACUUM, num_groups, coord_type)
+  explicit VacuumBoundary(BoundaryBank& bank) : SweepBoundary(bank, LBSBoundaryType::VACUUM)
   {
+    std::fill(offset_.begin(), offset_.end(), 0);
   }
 
   double* PsiIncoming(std::uint32_t cell_local_id,
                       unsigned int face_num,
                       unsigned int fi,
                       unsigned int angle_num,
-                      unsigned int group_num) override
+                      int groupset_id,
+                      unsigned int group_idx) override
   {
-    return ZeroFlux(group_num);
+    return ZeroFlux(groupset_id, group_idx);
   }
 
-private:
+  std::uint64_t
+  GetOffsetToAngleset(const FaceNode& face_node, AngleSet& anglset, bool is_outgoing) override
+  {
+    if (is_outgoing)
+      throw std::logic_error("VacuumBoundary does not support outgoing flux.");
+    return 0;
+  }
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_message_struct.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_message_struct.h
@@ -17,6 +17,8 @@ namespace opensn
 /// \brief Message details for each message passing.
 struct AAH_MessageDetails
 {
+  /// Member constructor.
+  AAH_MessageDetails(int p, int s, int bp) : peer(p), size(s), block_pos(bp) {}
   /// MPI rank of the peer partition.
   int peer;
   /// Size of the message (in number of doubles).

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.cu
@@ -130,8 +130,7 @@ AAHD_FLUDS::AAHD_FLUDS(unsigned int num_groups,
                                 num_groups_and_angles_),
     nonlocal_outgoing_psi_bank_(common_data_.GetNumNonLocalOutgoingNodes(),
                                 common_data_.GetNonLocalOutgoingNodeOffsets(),
-                                num_groups_and_angles_),
-    boundary_psi_(common_data_.GetNumBoundaryNodes(), num_groups_and_angles_)
+                                num_groups_and_angles_)
 {
   nonlocal_outgoing_psi_bank_.UpdateViews(deplocI_outgoing_psi_view_);
   nonlocal_incoming_psi_bank_.UpdateViews(prelocI_outgoing_psi_view_);
@@ -203,39 +202,6 @@ AAHD_FLUDS::CopyDelayedPsiToDevice()
 }
 
 void
-AAHD_FLUDS::CopyBoundaryToDevice(MeshContinuum& grid,
-                                 AngleSet& angle_set,
-                                 const LBSGroupset& groupset,
-                                 bool is_surface_source_active)
-{
-  const std::vector<std::uint32_t>& as_angle_indices = angle_set.GetAngleIndices();
-  const auto gs_gi = groupset.first_group;
-  const std::size_t required_size = common_data_.GetNumBoundaryNodes() * num_groups_and_angles_;
-  for (const auto& [face_node, node_index] : common_data_.GetNodeTracker())
-  {
-    if (node_index.IsUndefined() or not node_index.IsBoundary() or node_index.IsOutgoing())
-      continue;
-    const CellFace& face =
-      grid.local_cells[face_node.GetCellIndex()].faces[face_node.GetFaceIndex()];
-    double* dest =
-      boundary_psi_.host_storage.data() + node_index.GetIndex() * num_groups_and_angles_;
-    for (const std::uint32_t& direction_num : as_angle_indices)
-    {
-      const double* src = angle_set.PsiBoundary(face.neighbor_id,
-                                                direction_num,
-                                                face_node.GetCellIndex(),
-                                                face_node.GetFaceIndex(),
-                                                face_node.GetFaceNodeIndex(),
-                                                gs_gi,
-                                                is_surface_source_active);
-      std::memcpy(dest, src, num_groups_ * sizeof(double));
-      dest += num_groups_;
-    }
-  }
-  boundary_psi_.UploadToDevice(stream_);
-}
-
-void
 AAHD_FLUDS::CopyNonLocalIncomingPsiToDevice()
 {
   nonlocal_incoming_psi_bank_.UploadToDevice(stream_);
@@ -274,12 +240,6 @@ AAHD_FLUDS::GetDevicePointerSet()
   {
     assert(pointer_set.nonlocal_outgoing_psi != nullptr);
   }
-  // boundary psi
-  pointer_set.boundary_psi = boundary_psi_.device_storage.get();
-  if (common_data_.GetNumBoundaryNodes() > 0)
-  {
-    assert(pointer_set.boundary_psi != nullptr);
-  }
   // stride size
   pointer_set.stride_size = num_groups_and_angles_;
   return pointer_set;
@@ -290,35 +250,6 @@ AAHD_FLUDS::CopyPsiFromDevice()
 {
   nonlocal_outgoing_psi_bank_.DownloadToHost(stream_);
   delayed_local_psi_bank_.DownloadToHost(stream_);
-  boundary_psi_.DownloadToHost(stream_);
-}
-
-void
-AAHD_FLUDS::CopyBoundaryPsiToAngleSet(MeshContinuum& grid, AngleSet& angle_set)
-{
-  const std::vector<std::uint32_t>& as_angle_indices = angle_set.GetAngleIndices();
-  const auto& boundaries = angle_set.GetBoundaries();
-  for (const auto& [face_node, node_index] : common_data_.GetNodeTracker())
-  {
-    if (node_index.IsUndefined() or not node_index.IsBoundary() or not node_index.IsOutgoing())
-      continue;
-    const CellFace& face =
-      grid.local_cells[face_node.GetCellIndex()].faces[face_node.GetFaceIndex()];
-    auto bndry_it = boundaries.find(face.neighbor_id);
-    if (bndry_it == boundaries.end() or not bndry_it->second->IsReflecting())
-      continue;
-    double* src =
-      boundary_psi_.host_storage.data() + node_index.GetIndex() * num_groups_and_angles_;
-    for (const std::uint32_t& direction_num : as_angle_indices)
-    {
-      double* dest = bndry_it->second->PsiOutgoing(face_node.GetCellIndex(),
-                                                   face_node.GetFaceIndex(),
-                                                   face_node.GetFaceNodeIndex(),
-                                                   direction_num);
-      std::memcpy(dest, src, num_groups_ * sizeof(double));
-      src += num_groups_;
-    }
-  }
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h
@@ -60,14 +60,6 @@ struct AAHD_DelayedLocalBank : public AAHD_Bank
   }
 };
 
-/// Boundary bank storage structure.
-struct AAHD_BoundaryBank : public AAHD_Bank
-{
-  AAHD_BoundaryBank() = default;
-  /// Member constructor.
-  AAHD_BoundaryBank(std::size_t size, std::size_t stride_size) : AAHD_Bank(size * stride_size) {}
-};
-
 /// Non-local bank storage structure.
 struct AAHD_NonLocalBank : public AAHD_Bank
 {
@@ -182,19 +174,12 @@ public:
   /// \{
   /// Copy delayed local and delayed non-local incoming psi to device.
   void CopyDelayedPsiToDevice();
-  /// Copy boundary psi from angle set to device boundary storage.
-  void CopyBoundaryToDevice(MeshContinuum& grid,
-                            AngleSet& angle_set,
-                            const LBSGroupset& groupset,
-                            bool is_surface_source_active);
   /// Copy non-local incoming psi to device.
   void CopyNonLocalIncomingPsiToDevice();
   /// Get device pointers for each bank in FLUDS.
   AAHD_FLUDSPointerSet GetDevicePointerSet();
-  /// Copy boundary psi, non-local outgoing and delayed local psi from device to host.
+  /// Copy non-local outgoing and delayed local psi from device to host.
   void CopyPsiFromDevice();
-  /// Copy boundary psi from contiguous boundary storage to angle set.
-  void CopyBoundaryPsiToAngleSet(MeshContinuum& grid, AngleSet& angle_set);
   /// Copy save angular flux from device to host.
   void CopySaveAngularFluxFromDevice();
   /// Copy save angular flux from host contiguous buffer to destination psi.
@@ -231,14 +216,11 @@ protected:
   /// Non-local bank for outgoing angular fluxes.
   AAHD_NonLocalBank nonlocal_outgoing_psi_bank_;
 
-  /// Storage for boundary angular fluxes.
-  AAHD_BoundaryBank boundary_psi_;
-
   /// Storage for saved angular fluxes.
   AAHD_Bank save_angular_flux_;
 
   /// Stream for asynchronous operations.
-  crb::Stream stream_;
+  crb::Stream stream_ = crb::Stream::get_null_stream();
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
@@ -3,6 +3,7 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include <algorithm>
@@ -22,9 +23,8 @@ AAHD_FLUDSCommonData::AAHD_FLUDSCommonData(
 {
   ComputeNodeIndexForNonDelayedLocalFaces(sdm);
   ComputeNodeIndexForDelayedLocalFaces(sdm);
-  ComputeNodeIndexForBoundaryAndNonLocalFaces(sdm);
+  ComputeNodeIndexForNonLocalFaces(sdm);
   ComputeNodeIndexForParallelFaces(sdm);
-  CopyFlattenNodeIndexToDevice(sdm);
 }
 
 void
@@ -80,10 +80,10 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonDelayedLocalFaces(const SpatialDiscr
         std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
         for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
         {
-          AAHD_FaceNode upwind(cell_local_idx, f, fnode);
-          AAHD_FaceNode downwind(neighbor_local_idx,
-                                 face_nodal_mapping.associated_face_,
-                                 face_nodal_mapping.face_node_mapping_.at(fnode));
+          FaceNode upwind(cell_local_idx, f, fnode);
+          FaceNode downwind(neighbor_local_idx,
+                            face_nodal_mapping.associated_face_,
+                            face_nodal_mapping.face_node_mapping_.at(fnode));
           AAHD_DirectedEdgeNode new_node{upwind, downwind};
           new_outgoing_nodes.push_back(new_node);
         }
@@ -113,9 +113,10 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonDelayedLocalFaces(const SpatialDiscr
           local_node_stack.push_back(new_node);
         }
         // record the stack index
-        node_tracker_.emplace(new_node.upwind_node, AAHD_NodeIndex(stack_index, true, true, false));
+        node_tracker_.emplace(new_node.upwind_node,
+                              AAHD_NodeIndex(stack_index, true, false, true, false));
         node_tracker_.emplace(new_node.downwind_node,
-                              AAHD_NodeIndex(stack_index, false, true, false));
+                              AAHD_NodeIndex(stack_index, false, false, true, false));
         ++stack_index;
       }
       // merge cell idle slots to level idle slots
@@ -161,12 +162,13 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForDelayedLocalFaces(const SpatialDiscreti
           std::uint32_t num_face_nodes = sdm.GetCellMapping(upwind_cell).GetNumFaceNodes(f);
           for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
           {
-            AAHD_FaceNode upwind(edge.first, f, fnode);
-            node_tracker_.emplace(upwind, AAHD_NodeIndex(fas_node_index, true, true, true));
-            AAHD_FaceNode downwind(edge.second,
-                                   face_nodal_mapping.associated_face_,
-                                   face_nodal_mapping.face_node_mapping_.at(fnode));
-            node_tracker_.emplace(downwind, AAHD_NodeIndex(fas_node_index, false, true, true));
+            FaceNode upwind(edge.first, f, fnode);
+            node_tracker_.emplace(upwind, AAHD_NodeIndex(fas_node_index, true, false, true, true));
+            FaceNode downwind(edge.second,
+                              face_nodal_mapping.associated_face_,
+                              face_nodal_mapping.face_node_mapping_.at(fnode));
+            node_tracker_.emplace(downwind,
+                                  AAHD_NodeIndex(fas_node_index, false, false, true, true));
             fas_node_index++;
           }
         }
@@ -177,7 +179,7 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForDelayedLocalFaces(const SpatialDiscreti
 }
 
 void
-AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialDiscretization& sdm)
+AAHD_FLUDSCommonData::ComputeNodeIndexForNonLocalFaces(const SpatialDiscretization& sdm)
 {
   // get reference to the mesh
   const MeshContinuum& grid = *(spds_.GetGrid());
@@ -197,59 +199,44 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialD
       const FaceOrientation& orientation = spds_.GetCellFaceOrientations()[cell.local_id][f];
       const FaceNodalMapping& face_nodal_mapping = grid_nodal_mappings_[cell.local_id][f];
       std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
-      // skip for local face
-      if (face.IsNeighborLocal(&grid))
+      // skip for local face and boundary face
+      if (face.IsNeighborLocal(&grid) or not face.has_neighbor)
         continue;
-      // construct index for boundary faces
-      if (not face.has_neighbor && orientation != FaceOrientation::PARALLEL)
+      // store non-local face nodes to the banks
+      std::vector<AAHD_NonLocalFaceNode> nl_en_vec(num_face_nodes);
+      for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
       {
-        for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
+        nl_en_vec[fnode] = AAHD_NonLocalFaceNode(cell.global_id,
+                                                 cell.local_id,
+                                                 f,
+                                                 fnode,
+                                                 face.neighbor_id,
+                                                 face_nodal_mapping.associated_face_,
+                                                 face_nodal_mapping.face_node_mapping_.at(fnode));
+      }
+      // get neighbor partition ID
+      int loc = face.GetNeighborPartitionID(&grid);
+      // append to incoming bank
+      if (orientation == FaceOrientation::INCOMING)
+      {
+        int preloc = spds_.MapLocJToPrelocI(loc);
+        // non-delayed incoming
+        if (preloc >= 0)
         {
-          node_tracker_.emplace(
-            AAHD_FaceNode(cell.local_id, f, fnode),
-            AAHD_NodeIndex(incremental_boundary_index, orientation == FaceOrientation::OUTGOING));
-          ++incremental_boundary_index;
+          incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
+        }
+        // delayed incoming
+        else
+        {
+          preloc = -preloc - 1;
+          delayed_incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
         }
       }
-      // store non-local face nodes to the banks
-      else if (face.has_neighbor)
+      // append to outgoing bank
+      else if (orientation == FaceOrientation::OUTGOING)
       {
-        // initialize non-local face nodes
-        std::vector<AAHD_NonLocalFaceNode> nl_en_vec(num_face_nodes);
-        for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
-        {
-          nl_en_vec[fnode] = AAHD_NonLocalFaceNode(cell.global_id,
-                                                   cell.local_id,
-                                                   f,
-                                                   fnode,
-                                                   face.neighbor_id,
-                                                   face_nodal_mapping.associated_face_,
-                                                   face_nodal_mapping.face_node_mapping_.at(fnode));
-        }
-        // get neighbor partition ID
-        int loc = face.GetNeighborPartitionID(&grid);
-        // append to incoming bank
-        if (orientation == FaceOrientation::INCOMING)
-        {
-          int preloc = spds_.MapLocJToPrelocI(loc);
-          // non-delayed incoming
-          if (preloc >= 0)
-          {
-            incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
-          }
-          // delayed incoming
-          else
-          {
-            preloc = -preloc - 1;
-            delayed_incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
-          }
-        }
-        // append to outgoing bank
-        else if (orientation == FaceOrientation::OUTGOING)
-        {
-          int deploc = spds_.MapLocJToDeplocI(loc);
-          outgoing_bank[deploc].insert(nl_en_vec.begin(), nl_en_vec.end());
-        }
+        int deploc = spds_.MapLocJToDeplocI(loc);
+        outgoing_bank[deploc].insert(nl_en_vec.begin(), nl_en_vec.end());
       }
     }
   }
@@ -259,7 +246,7 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialD
   {
     for (const AAHD_NonLocalFaceNode& nl_en : incoming_bank[loc_idx])
     {
-      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, false, false, false));
+      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, false, false, false, false));
       node_index++;
     }
   }
@@ -268,7 +255,7 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialD
   {
     for (const AAHD_NonLocalFaceNode& nl_en : delayed_incoming_bank[loc_idx])
     {
-      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, false, false, true));
+      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, false, false, false, true));
       node_index++;
     }
   }
@@ -277,12 +264,11 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialD
   {
     for (const AAHD_NonLocalFaceNode& nl_en : outgoing_bank[loc_idx])
     {
-      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, true, false, false));
+      node_tracker_.emplace(nl_en.node, AAHD_NodeIndex(node_index, true, false, false, false));
       node_index++;
     }
   }
   // store size
-  boundary_node_size_ = incremental_boundary_index;
   std::size_t cumulative_offset = 0;
   nonlocal_incoming_node_offsets_ = {0};
   for (const std::set<AAHD_NonLocalFaceNode>& nl_en_set : incoming_bank)
@@ -330,7 +316,7 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForParallelFaces(const SpatialDiscretizati
       // construct index for parallel faces
       for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
       {
-        node_tracker_.emplace(AAHD_FaceNode(cell.local_id, f, fnode), AAHD_NodeIndex());
+        node_tracker_.emplace(FaceNode(cell.local_id, f, fnode), AAHD_NodeIndex());
       }
     }
   }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cu
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/sweep_boundary.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
@@ -12,6 +14,82 @@ namespace crb = caribou;
 
 namespace opensn
 {
+
+void
+AAHD_FLUDSCommonData::UpdateBoundaryAndSyncWithDevice(
+  const SpatialDiscretization& sdm,
+  const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+{
+  ComputeNodeIndexForBoundaryFaces(sdm, boundaries);
+  CopyFlattenNodeIndexToDevice(sdm);
+  for (auto angleset : associated_anglesets_)
+  {
+    angleset->CopyBoundaryOffsetToDevice();
+  }
+}
+
+void
+AAHD_FLUDSCommonData::ComputeNodeIndexForBoundaryFaces(
+  const SpatialDiscretization& sdm,
+  const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries)
+{
+  std::uint64_t incremental_boundary_index = 0;
+  const MeshContinuum& grid = *(spds_.GetGrid());
+  for (const Cell& cell : grid.local_cells)
+  {
+    for (std::uint32_t f = 0; f < cell.faces.size(); ++f)
+    {
+      const CellFace& face = cell.faces[f];
+      const FaceOrientation& orientation = spds_.GetCellFaceOrientations()[cell.local_id][f];
+      std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
+
+      if (face.has_neighbor)
+        continue;
+
+      auto& boundary = *(boundaries.at(face.neighbor_id));
+      if (orientation == FaceOrientation::INCOMING)
+      {
+        for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
+        {
+          FaceNode fn(cell.local_id, f, fnode);
+          for (auto angleset : associated_anglesets_)
+          {
+            std::uint64_t offset = boundary.GetOffsetToAngleset(fn, *angleset, false);
+            angleset->AddBoundaryOffset(offset);
+          }
+          node_tracker_[fn] = AAHD_NodeIndex(incremental_boundary_index,
+                                             false,
+                                             true,
+                                             boundary.IsReflecting(),
+                                             boundary.IsAngleDependent());
+          ++incremental_boundary_index;
+        }
+      }
+      else if (orientation == FaceOrientation::OUTGOING && boundary.IsReflecting())
+      {
+        for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
+        {
+          FaceNode fn(cell.local_id, f, fnode);
+          for (auto angleset : associated_anglesets_)
+          {
+            std::uint64_t offset = boundary.GetOffsetToAngleset(fn, *angleset, true);
+            angleset->AddBoundaryOffset(offset);
+          }
+          node_tracker_[fn] = AAHD_NodeIndex(incremental_boundary_index, true, true, true, true);
+          ++incremental_boundary_index;
+        }
+      }
+      else
+      {
+        for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
+        {
+          FaceNode fn(cell.local_id, f, fnode);
+          node_tracker_[fn] = AAHD_NodeIndex();
+        }
+      }
+    }
+  }
+}
 
 void
 AAHD_FLUDSCommonData::CopyFlattenNodeIndexToDevice(const SpatialDiscretization& sdm)
@@ -33,7 +111,7 @@ AAHD_FLUDSCommonData::CopyFlattenNodeIndexToDevice(const SpatialDiscretization& 
       std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
       for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
       {
-        AAHD_FaceNode node(cell.local_id, f, fnode);
+        FaceNode node(cell.local_id, f, fnode);
         AAHD_NodeIndex index = node_tracker_.at(node);
         data.push_back(index.GetCoreValue());
         ++num_nodes;
@@ -43,6 +121,7 @@ AAHD_FLUDSCommonData::CopyFlattenNodeIndexToDevice(const SpatialDiscretization& 
     cell_offset.push_back(num_nodes);
   }
   // copy data to GPU
+  DeallocateDeviceMemory();
   crb::DeviceMemory<std::uint64_t> device_mem_ptr(cell_offset.size() + data.size());
   crb::copy(device_mem_ptr, cell_offset, cell_offset.size());
   crb::copy(device_mem_ptr, data, data.size(), 0, cell_offset.size());
@@ -55,7 +134,7 @@ AAHD_FLUDSCommonData::DeallocateDeviceMemory()
   if (device_node_indexes_)
   {
     crb::DeviceMemory<std::uint64_t> device_mem_ptr(device_node_indexes_);
-    device_mem_ptr.release();
+    device_mem_ptr.reset();
     device_node_indexes_ = nullptr;
   }
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
@@ -15,7 +15,9 @@
 namespace opensn
 {
 
+class AAHD_AngleSet;
 class SpatialDiscretization;
+class SweepBoundary;
 
 /**
  * Random-access stack based FLUDS.
@@ -33,7 +35,7 @@ public:
                        const SpatialDiscretization& sdm);
 
   /// Get constant reference to the face node tracker map.
-  const std::map<AAHD_FaceNode, AAHD_NodeIndex>& GetNodeTracker() const { return node_tracker_; }
+  const std::map<FaceNode, AAHD_NodeIndex>& GetNodeTracker() const { return node_tracker_; }
 
   /// \name Size getters
   /// \{
@@ -41,8 +43,6 @@ public:
   std::size_t GetLocalNodeStackSize() const { return local_node_stack_size_; }
   /// Get size of the delayed local face node stack.
   std::size_t GetNumDelayedLocalNodes() const { return delayed_local_node_stack_size_; }
-  /// Get size of the boundary face node bank.
-  std::size_t GetNumBoundaryNodes() const { return boundary_node_size_; }
   /// Get sizes of the incoming non-local face node banks.
   const std::vector<std::size_t>& GetNumNonLocalIncomingNodes() const
   {
@@ -78,12 +78,22 @@ public:
   /// Get pointer to indexes on device.
   const std::uint64_t* GetDeviceIndex() const { return device_node_indexes_; }
 
+  /// Append an associated angle set pointer.
+  void AddAssociatedAngleSet(AAHD_AngleSet* as) const { associated_anglesets_.push_back(as); }
+
+  /// Update node tarcker with boundary data and transfer all data to device.
+  void UpdateBoundaryAndSyncWithDevice(
+    const SpatialDiscretization& sdm,
+    const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries);
+
   /// Destructor.
   ~AAHD_FLUDSCommonData() override;
 
 protected:
   /// Map face node to its associated index in the corresponding bank.
-  std::map<AAHD_FaceNode, AAHD_NodeIndex> node_tracker_;
+  std::map<FaceNode, AAHD_NodeIndex> node_tracker_;
+  /// List of anglesets associated to this sweep ordering.
+  mutable std::vector<AAHD_AngleSet*> associated_anglesets_;
 
   /// \name Allocation sizes
   /// \{
@@ -91,8 +101,6 @@ protected:
   std::size_t local_node_stack_size_ = 0;
   /// Size of the delayed local face node vector.
   std::size_t delayed_local_node_stack_size_ = 0;
-  /// Size of the boundary.
-  std::size_t boundary_node_size_ = 0;
   /// Size of the incoming non-local face nodes.
   std::vector<std::size_t> nonlocal_incoming_node_sizes_;
   /// Offset of each location to its incoming non-local face nodes.
@@ -122,9 +130,13 @@ protected:
   /// Compute the indexes for FAS face nodes.
   void ComputeNodeIndexForDelayedLocalFaces(const SpatialDiscretization& sdm);
   /// Compute the indexes for non-local face nodes.
-  void ComputeNodeIndexForBoundaryAndNonLocalFaces(const SpatialDiscretization& sdm);
+  void ComputeNodeIndexForNonLocalFaces(const SpatialDiscretization& sdm);
   /// Compute the index for parallel faces.
   void ComputeNodeIndexForParallelFaces(const SpatialDiscretization& sdm);
+  /// Compute the indexes for boundary face nodes.
+  void ComputeNodeIndexForBoundaryFaces(
+    const SpatialDiscretization& sdm,
+    const std::map<uint64_t, std::shared_ptr<SweepBoundary>>& boundaries);
   /// \}
 
   /// Deallocate memory for flatten node indexes on device.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_structs.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_structs.cc
@@ -5,17 +5,6 @@
 #include <iomanip>
 
 std::ostream&
-std::operator<<(std::ostream& out, const opensn::AAHD_FaceNode& n)
-{
-  out << "AAHD_FaceNode(";
-  out << "c=" << std::setw(5) << n.GetCellIndex() << ", ";
-  out << "f=" << std::setw(2) << n.GetFaceIndex() << ", ";
-  out << "fn=" << std::setw(2) << n.GetFaceNodeIndex();
-  out << ")";
-  return out;
-}
-
-std::ostream&
 std::operator<<(std::ostream& out, const opensn::AAHD_NonLocalFaceNode& n)
 {
   out << "NLEdgeNode(";

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_structs.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_structs.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds_structs.h"
+#include "framework/mesh/cell/cell.h"
 #include <set>
 #include <tuple>
 
@@ -11,64 +12,9 @@ namespace opensn
 {
 
 /**
- * Node on a face, which is also an edge in the sweep graph.
- * This class represents a node on a face. It stores the cell local index, the face index
- * within the cell and the index of the node relative to the face as compact 64-bit integer. This
- * class abstracts the node for usage with std::map and std::set.
- */
-class AAHD_FaceNode
-{
-public:
-  /// Default constructor.
-  constexpr AAHD_FaceNode() = default;
-  /// Member constructor.
-  constexpr AAHD_FaceNode(std::uint32_t cell_idx,
-                          std::uint16_t face_idx,
-                          std::uint16_t face_node_idx)
-    : value_(0)
-  {
-    value_ |= static_cast<std::uint64_t>(cell_idx) << 32;
-    value_ |= static_cast<std::uint64_t>(face_idx) << 16;
-    value_ |= static_cast<std::uint64_t>(face_node_idx);
-  }
-
-  /// Comparison operator for ordering.
-  constexpr bool operator<(const AAHD_FaceNode& other) const { return value_ < other.value_; }
-
-  /// Equality operator.
-  constexpr bool operator==(const AAHD_FaceNode& other) const { return value_ == other.value_; }
-
-  /// Get cell local index.
-  constexpr std::uint32_t GetCellIndex() const { return static_cast<std::uint32_t>(value_ >> 32); }
-
-  /// Get face index.
-  constexpr std::uint16_t GetFaceIndex() const
-  {
-    return static_cast<std::uint16_t>((value_ >> 16) & 0xFFFFU);
-  }
-
-  /// Get face node index.
-  constexpr std::uint16_t GetFaceNodeIndex() const
-  {
-    return static_cast<std::uint16_t>(value_ & 0xFFFFU);
-  }
-
-  /// Check if the face node is initialized.
-  constexpr bool IsInitialized() const
-  {
-    return value_ != std::numeric_limits<std::uint64_t>::max();
-  }
-
-private:
-  /// Core value.
-  std::uint64_t value_ = std::numeric_limits<std::uint64_t>::max();
-};
-
-/**
  * 64-bit integer encoding the index and the bank information of a face node.
  * \note The index must follow strict mutual-exclusion rules:
- *   - Always check boundary status BEFORE local status. Boundary instances are assigned
- *     as local, but their locations are actually set to an undefined value.
+ *   - Always check boundary status BEFORE local status.
  *   - Boundary and delayed status are mutually exclusive. Both cannot be true at the same time.
  *   - Boundary and non-local status are mutually exclusive. Both cannot be true at the same time.
  *   - Non-local outgoing and delayed status are mutually exclusive. The sweep scheduler does not
@@ -88,76 +34,70 @@ public:
    * Construct a non-boundary node index.
    * \param index Index into the corresponding bank. Cannot exceed 2^60 - 1.
    * \param is_outgoing Flag indicating if the node corresponds to an outgoing face.
-   * \param is_local Flag indicating if the index is in a local bank.
-   * \param is_delayed Flag indicating if the index is in a delayed bank.
+   * \param is_local_or_reflecting Flag indicating if the index is in a local bank or
+   * reflecting boundary.
+   * \param is_delayed_or_angle_dependent Flag indicating if the index is in a delayed bank or an
+   * angle dependent boundary.
    * \param loc_index Index into delayed/non-delayed location dependencies/successors vector for
    * non-local nodes. Cannot exceed 2^21 - 1.
    */
-  AAHD_NodeIndex(std::uint64_t index, bool is_outgoing, bool is_local, bool is_delayed)
+  AAHD_NodeIndex(std::uint64_t index,
+                 bool is_outgoing,
+                 bool is_boundary,
+                 bool is_local_or_reflecting,
+                 bool is_delayed_or_angle_dependent)
   {
     if (index >= (std::uint64_t(1) << 60) - 1)
       throw std::runtime_error("Cannot hold an index greater than 2^60.");
     SetInOut(is_outgoing);
-    SetLocal(is_local);
-    SetDelayed(is_delayed);
-    SetBoundary(false);
-    SetIndex(index);
-    if (is_delayed && is_outgoing && !is_local)
-      throw std::runtime_error(
-        "Non-local outgoing nodes cannot be in delayed banks for AAHD FLUDS.");
-  }
-
-  /**
-   * Construct a boundary node index.
-   * \param index Index into the corresponding bank. Cannot exceed 2^40 - 1.
-   * \param is_outgoing Flag indicating if the node corresponds to an outgoing face.
-   */
-  AAHD_NodeIndex(std::uint64_t index, bool is_outgoing)
-  {
-    if (index >= (std::uint64_t(1) << 60) - 1)
-      throw std::runtime_error("Cannot hold an index greater than 2^60.");
-    SetInOut(is_outgoing);
-    SetDelayed(false);
-    SetLocal(true);
-    SetBoundary(true);
+    SetBoundary(is_boundary);
+    SetLocalOrReflecting(is_local_or_reflecting);
+    SetDelayedOrAngleDependent(is_delayed_or_angle_dependent);
     SetIndex(index);
   }
 
   /// Check if the current index corresponds to a delayed bank.
-  constexpr bool IsDelayed() const noexcept { return (value_ & delayed_bit_mask) != 0; }
+  constexpr bool IsDelayed() const noexcept
+  {
+    return (value_ & delayed_or_angle_dependent_bit_mask) != 0;
+  }
+  /// Check if the current index corresponds to an angle dependent boundary.
+  constexpr bool IsAngleDependent() const noexcept { return IsDelayed(); }
 
   /// Check if the current index corresponds to a local bank.
-  constexpr bool IsLocal() const noexcept { return (value_ & local_bit_mask) != 0; }
+  constexpr bool IsLocal() const noexcept { return (value_ & local_or_reflecting_bit_mask) != 0; }
+  /// Check if the current index corresponds to a reflecting boundary.
+  constexpr bool IsReflecting() const noexcept { return IsLocal(); }
 
   /// Get the index into the bank.
   constexpr std::uint64_t GetIndex() const noexcept { return value_ & index_bit_mask; }
 
 private:
-  /// \name Delayed bit
+  /// \name Delayed/angle-dependent bit
   /// \{
   /// Third bit mask (``001`` followed by 61 zeros) - Bit 61
-  static constexpr std::uint64_t delayed_bit_mask = std::uint64_t(1) << (64 - 3);
-  /// Encode the value as delayed.
-  constexpr void SetDelayed(bool is_delayed) noexcept
+  static constexpr std::uint64_t delayed_or_angle_dependent_bit_mask = std::uint64_t(1) << (64 - 3);
+  /// Encode the value as delayed or angle dependent boundary.
+  constexpr void SetDelayedOrAngleDependent(bool is_delayed_or_angle_dependent) noexcept
   {
-    if (is_delayed)
-      value_ |= delayed_bit_mask;
+    if (is_delayed_or_angle_dependent)
+      value_ |= delayed_or_angle_dependent_bit_mask;
     else
-      value_ &= ~delayed_bit_mask;
+      value_ &= ~delayed_or_angle_dependent_bit_mask;
   }
   /// \}
 
-  /// \name Local bit
+  /// \name Local/reflecting bit
   /// \{
   /// Fourth bit mask (``0001`` followed by 60 zeros) - Bit 60
-  static constexpr std::uint64_t local_bit_mask = std::uint64_t(1) << (64 - 4);
+  static constexpr std::uint64_t local_or_reflecting_bit_mask = std::uint64_t(1) << (64 - 4);
   /// Encode the value as local.
-  constexpr void SetLocal(bool is_local) noexcept
+  constexpr void SetLocalOrReflecting(bool is_local_or_reflecting) noexcept
   {
-    if (is_local)
-      value_ |= local_bit_mask;
+    if (is_local_or_reflecting)
+      value_ |= local_or_reflecting_bit_mask;
     else
-      value_ &= ~local_bit_mask;
+      value_ &= ~local_or_reflecting_bit_mask;
   }
   /// \}
 
@@ -178,9 +118,9 @@ private:
 struct AAHD_DirectedEdgeNode
 {
   /// Upwind face node.
-  AAHD_FaceNode upwind_node;
+  FaceNode upwind_node;
   /// Downwind face node.
-  AAHD_FaceNode downwind_node;
+  FaceNode downwind_node;
 
   /// Check if the directed edge is initialized.
   constexpr bool IsInitialized() const
@@ -240,7 +180,7 @@ public:
   }
 
   /// Corresponding face node.
-  AAHD_FaceNode node;
+  FaceNode node;
 
 private:
   /// Tuple for ordering the non-local face nodes.
@@ -258,11 +198,14 @@ struct AAHD_FLUDSPointerSet : public FLUDSPointerSet
   double* __restrict__ delayed_local_psi_old = nullptr;
   /// Pointer to non-local old delayed incoming angular fluxes.
   double* __restrict__ nonlocal_delayed_incoming_psi_old = nullptr;
-  /// Pointer to boundary angular fluxes.
-  double* __restrict__ boundary_psi = nullptr;
 
   /// Get pointer to the incoming angular flux (if the face is not incoming, a nullptr is returned).
-  constexpr double* GetIncomingFluxPointer(const AAHD_NodeIndex& node_index) const noexcept
+  constexpr double* GetIncomingFluxPointer(const AAHD_NodeIndex& node_index,
+                                           unsigned int angle_group_idx,
+                                           unsigned int group_idx,
+                                           double* __restrict__ boundary,
+                                           const std::uint64_t* __restrict__ boundary_offset,
+                                           bool is_surface_source_active) const noexcept
   {
     // undefined case (parallel face) : all tests are true
     if (node_index.IsUndefined())
@@ -272,21 +215,26 @@ struct AAHD_FLUDSPointerSet : public FLUDSPointerSet
     if (node_index.IsOutgoing())
       return nullptr;
 
-    // boundary case : non-delayed and local tests are true
+    // boundary case
     if (node_index.IsBoundary())
     {
-      return boundary_psi + node_index.GetIndex() * stride_size;
+      if (node_index.IsReflecting() or is_surface_source_active)
+      {
+        unsigned int location = (node_index.IsAngleDependent()) ? angle_group_idx : group_idx;
+        return boundary + boundary_offset[node_index.GetIndex()] + location;
+      }
+      return boundary + group_idx;
     }
     // local case
     if (node_index.IsLocal())
     {
       if (node_index.IsDelayed())
       {
-        return delayed_local_psi_old + node_index.GetIndex() * stride_size;
+        return delayed_local_psi_old + node_index.GetIndex() * stride_size + angle_group_idx;
       }
       else
       {
-        return local_psi + node_index.GetIndex() * stride_size;
+        return local_psi + node_index.GetIndex() * stride_size + angle_group_idx;
       }
     }
     // non-local case
@@ -294,47 +242,52 @@ struct AAHD_FLUDSPointerSet : public FLUDSPointerSet
     {
       if (node_index.IsDelayed())
       {
-        return nonlocal_delayed_incoming_psi_old + node_index.GetIndex() * stride_size;
+        return nonlocal_delayed_incoming_psi_old + node_index.GetIndex() * stride_size +
+               angle_group_idx;
       }
       else
       {
-        return nonlocal_incoming_psi + node_index.GetIndex() * stride_size;
+        return nonlocal_incoming_psi + node_index.GetIndex() * stride_size + angle_group_idx;
       }
     }
   }
 
   /// Get pointer to the outgoing angular flux (if the face is not outgoing, a nullptr is returned).
-  constexpr double* GetOutgoingFluxPointer(const AAHD_NodeIndex& node_index) const noexcept
+  constexpr double*
+  GetOutgoingFluxPointer(const AAHD_NodeIndex& node_index,
+                         unsigned int angle_group_idx,
+                         double* __restrict__ boundary,
+                         const std::uint64_t* __restrict__ boundary_offset) const noexcept
   {
     // undefined case (parallel face) : all tests are true
     if (node_index.IsUndefined())
       return nullptr;
 
     // incoming case : nullptr
-    if (!node_index.IsOutgoing())
+    if (not node_index.IsOutgoing())
       return nullptr;
 
     // boundary case : non-delayed and local tests are true
     if (node_index.IsBoundary())
     {
-      return boundary_psi + node_index.GetIndex() * stride_size;
+      return boundary + boundary_offset[node_index.GetIndex()] + angle_group_idx;
     }
     // local case
     if (node_index.IsLocal())
     {
       if (node_index.IsDelayed())
       {
-        return delayed_local_psi + node_index.GetIndex() * stride_size;
+        return delayed_local_psi + node_index.GetIndex() * stride_size + angle_group_idx;
       }
       else
       {
-        return local_psi + node_index.GetIndex() * stride_size;
+        return local_psi + node_index.GetIndex() * stride_size + angle_group_idx;
       }
     }
     // non-local case
     else
     {
-      return nonlocal_outgoing_psi + node_index.GetIndex() * stride_size;
+      return nonlocal_outgoing_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
   }
 };
@@ -343,9 +296,6 @@ struct AAHD_FLUDSPointerSet : public FLUDSPointerSet
 
 namespace std
 {
-
-/// Print face node.
-ostream& operator<<(ostream& out, const opensn::AAHD_FaceNode& n);
 
 /// Print non-local face node.
 ostream& operator<<(ostream& out, const opensn::AAHD_NonLocalFaceNode& n);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds.cu
@@ -101,6 +101,7 @@ CBCD_FLUDS::CopyIncomingBoundaryPsiToDevice(CBCDSweepChunk& sweep_chunk, CBCD_An
 {
   const auto& angle_indices = angle_set->GetAngleIndices();
   const auto& num_angles = angle_indices.size();
+  const auto& groupset = sweep_chunk.GetGroupset();
 
   for (const auto& node : incoming_boundary_node_map_)
   {
@@ -114,7 +115,7 @@ CBCD_FLUDS::CopyIncomingBoundaryPsiToDevice(CBCDSweepChunk& sweep_chunk, CBCD_An
                                                      node.cell_local_id,
                                                      node.face_id,
                                                      node.face_node,
-                                                     sweep_chunk.GetGroupsetGroupIndex(),
+                                                     0,
                                                      sweep_chunk.IsSurfaceSourceActive());
       std::copy(src_psi, src_psi + num_groups_, dst_psi);
     }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds.h
@@ -123,7 +123,7 @@ private:
   crb::MappedHostVector<double> incoming_nonlocal_psi_;
   crb::MappedHostVector<double> outgoing_nonlocal_psi_;
   /// Associated angleset's stream.
-  crb::Stream stream_;
+  crb::Stream stream_ = crb::Stream::get_null_stream();
   crb::MappedHostVector<std::uint32_t> local_cell_ids_;
   bool save_angular_flux_;
   /// Device storage for local angular fluxes.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_structs.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_structs.h
@@ -101,7 +101,8 @@ struct CBCD_FLUDSPointerSet : public FLUDSPointerSet
   double* __restrict__ outgoing_boundary_psi = nullptr;
 
   /// Get pointer to the incoming angular flux (if the face is not incoming, a nullptr is returned).
-  constexpr double* GetIncomingFluxPointer(const CBCD_NodeIndex& node_index) const noexcept
+  constexpr double* GetIncomingFluxPointer(const CBCD_NodeIndex& node_index,
+                                           unsigned int angle_group_idx) const noexcept
   {
     // Undefined case (corresponds to a parallel face)
     if (node_index.IsUndefined())
@@ -114,22 +115,23 @@ struct CBCD_FLUDSPointerSet : public FLUDSPointerSet
     // Incoming boundary case
     if (node_index.IsBoundary())
     {
-      return incoming_boundary_psi + node_index.GetIndex() * stride_size;
+      return incoming_boundary_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
     // Incoming local case
     if (node_index.IsLocal())
     {
-      return local_psi + node_index.GetIndex() * stride_size;
+      return local_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
     // Incoming non-local case
     else
     {
-      return nonlocal_incoming_psi + node_index.GetIndex() * stride_size;
+      return nonlocal_incoming_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
   }
 
   /// Get pointer to the outgoing angular flux (if the face is not outgoing, a nullptr is returned).
-  constexpr double* GetOutgoingFluxPointer(const CBCD_NodeIndex& node_index) const noexcept
+  constexpr double* GetOutgoingFluxPointer(const CBCD_NodeIndex& node_index,
+                                           unsigned int angle_group_idx) const noexcept
   {
     // Undefined case (corresponds to a parallel face)
     if (node_index.IsUndefined())
@@ -142,17 +144,17 @@ struct CBCD_FLUDSPointerSet : public FLUDSPointerSet
     // Outgoing boundary case
     if (node_index.IsBoundary())
     {
-      return outgoing_boundary_psi + node_index.GetIndex() * stride_size;
+      return outgoing_boundary_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
     // Outgoing local case
     if (node_index.IsLocal())
     {
-      return local_psi + node_index.GetIndex() * stride_size;
+      return local_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
     // Outgoing non-local case
     else
     {
-      return nonlocal_outgoing_psi + node_index.GetIndex() * stride_size;
+      return nonlocal_outgoing_psi + node_index.GetIndex() * stride_size + angle_group_idx;
     }
   }
 };

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
@@ -16,6 +16,39 @@
 namespace opensn
 {
 
+namespace
+{
+
+bool
+Compare(const RuleValues& a, const RuleValues& b)
+{
+  if (a.depth_of_graph != b.depth_of_graph)
+    return a.depth_of_graph > b.depth_of_graph;
+  if (a.sign_of_omegax != b.sign_of_omegax)
+    return a.sign_of_omegax > b.sign_of_omegax;
+  if (a.sign_of_omegay != b.sign_of_omegay)
+    return a.sign_of_omegay > b.sign_of_omegay;
+  return a.sign_of_omegaz > b.sign_of_omegaz;
+}
+
+bool
+CompareCylindrical(const RuleValues& a, const RuleValues& b)
+{
+  if (a.sign_of_omegax != b.sign_of_omegax)
+    return a.sign_of_omegax > b.sign_of_omegax;
+  if (a.depth_of_graph != b.depth_of_graph)
+    return a.depth_of_graph > b.depth_of_graph;
+  if (a.sign_of_omegay != b.sign_of_omegay)
+    return a.sign_of_omegay > b.sign_of_omegay;
+  if (a.sign_of_omegaz != b.sign_of_omegaz)
+    return a.sign_of_omegaz > b.sign_of_omegaz;
+  if (a.azimuthal_order != b.azimuthal_order)
+    return a.azimuthal_order < b.azimuthal_order;
+  return a.set_index < b.set_index;
+}
+
+} // namespace
+
 SweepScheduler::SweepScheduler(SchedulingAlgorithm scheduler_type,
                                AngleAggregation& angle_agg,
                                SweepChunk& sweep_chunk)
@@ -23,16 +56,8 @@ SweepScheduler::SweepScheduler(SchedulingAlgorithm scheduler_type,
 {
   CALI_CXX_MARK_SCOPE("SweepScheduler::SweepScheduler");
 
-  angle_agg_.InitializeReflectingBCs();
-
   if (scheduler_type_ == SchedulingAlgorithm::DEPTH_OF_GRAPH)
     InitializeAlgoDOG();
-
-  if (scheduler_type_ == SchedulingAlgorithm::ALL_AT_ONCE ||
-      scheduler_type_ == SchedulingAlgorithm::DEPTH_OF_GRAPH)
-  {
-    angle_agg_.SetupAngleSetDependencies();
-  }
 
   if (scheduler_type_ == SchedulingAlgorithm::ALL_AT_ONCE)
   {
@@ -140,48 +165,8 @@ SweepScheduler::InitializeAlgoDOG()
       throw std::runtime_error("InitializeAlgoDOG: Failed to find location depth");
   } // for anglesets
 
-  if (is_cylindrical)
-    SortRuleValuesDOGRZ();
-  else
-    SortRuleValuesDOGDefault();
-}
-
-void
-SweepScheduler::SortRuleValuesDOGRZ()
-{
-  std::stable_sort(rule_values_.begin(),
-                   rule_values_.end(),
-                   [](const RuleValues& a, const RuleValues& b)
-                   {
-                     if (a.sign_of_omegax != b.sign_of_omegax)
-                       return a.sign_of_omegax > b.sign_of_omegax;
-                     if (a.depth_of_graph != b.depth_of_graph)
-                       return a.depth_of_graph > b.depth_of_graph;
-                     if (a.sign_of_omegay != b.sign_of_omegay)
-                       return a.sign_of_omegay > b.sign_of_omegay;
-                     if (a.sign_of_omegaz != b.sign_of_omegaz)
-                       return a.sign_of_omegaz > b.sign_of_omegaz;
-                     if (a.azimuthal_order != b.azimuthal_order)
-                       return a.azimuthal_order < b.azimuthal_order;
-                     return a.set_index < b.set_index;
-                   });
-}
-
-void
-SweepScheduler::SortRuleValuesDOGDefault()
-{
-  std::stable_sort(rule_values_.begin(),
-                   rule_values_.end(),
-                   [](const RuleValues& a, const RuleValues& b)
-                   {
-                     if (a.depth_of_graph != b.depth_of_graph)
-                       return a.depth_of_graph > b.depth_of_graph;
-                     if (a.sign_of_omegax != b.sign_of_omegax)
-                       return a.sign_of_omegax > b.sign_of_omegax;
-                     if (a.sign_of_omegay != b.sign_of_omegay)
-                       return a.sign_of_omegay > b.sign_of_omegay;
-                     return a.sign_of_omegaz > b.sign_of_omegaz;
-                   });
+  std::stable_sort(
+    rule_values_.begin(), rule_values_.end(), is_cylindrical ? &CompareCylindrical : &Compare);
 }
 
 void
@@ -189,13 +174,22 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
 {
   CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoDOG");
 
-  const bool is_cylindrical = angle_agg_.GetQuadrature()->GetDimension() == 2 &&
-                              angle_agg_.GetCoordinateSystem() == CoordinateSystemType::CYLINDRICAL;
+  // Reset dependency counter
+  for (auto& angle_set : angle_agg_)
+    angle_set->ResetDependencyCounter();
 
-  if (is_cylindrical)
-    ScheduleAlgoDOGRZ(sweep_chunk);
-  else
-    ScheduleAlgoDOGDefault(sweep_chunk);
+  bool finished = false;
+  while (not finished)
+  {
+    finished = true;
+    for (auto& rule_value : rule_values_)
+    {
+      auto angleset = rule_value.angle_set;
+      AngleSetStatus status = angleset->AngleSetAdvance(sweep_chunk, AngleSetStatus::EXECUTE);
+      if (status != AngleSetStatus::FINISHED)
+        finished = false;
+    }
+  }
 
   // Receive delayed data
   opensn::mpi_comm.barrier();
@@ -217,77 +211,16 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
   // Reset all
   for (auto& angle_set : angle_agg_)
     angle_set->ResetSweepBuffers();
-
-  for (const auto& [bid, bndry] : angle_agg_.GetSimBoundaries())
-    bndry->ResetAnglesReadyStatus();
-}
-
-void
-SweepScheduler::ScheduleAlgoDOGRZ(SweepChunk& sweep_chunk)
-{
-  bool finished = false;
-  std::unordered_set<AngleSet*> completed;
-  while (not finished)
-  {
-    finished = true;
-    for (auto& rule_value : rule_values_)
-    {
-      auto angleset = rule_value.angle_set;
-
-      auto dep_it = preceding_angle_sets_.find(angleset.get());
-      if (dep_it != preceding_angle_sets_.end())
-      {
-        bool deps_ready = true;
-        for (auto* dep : dep_it->second)
-        {
-          if (completed.find(dep) == completed.end())
-          {
-            deps_ready = false;
-            break;
-          }
-        }
-        if (!deps_ready)
-        {
-          AngleSetStatus status =
-            angleset->AngleSetAdvance(sweep_chunk, AngleSetStatus::READY_TO_EXECUTE);
-          if (status != AngleSetStatus::FINISHED)
-            finished = false;
-          else
-            completed.insert(angleset.get());
-          continue;
-        }
-      }
-
-      AngleSetStatus status = angleset->AngleSetAdvance(sweep_chunk, AngleSetStatus::EXECUTE);
-      if (status == AngleSetStatus::FINISHED)
-        completed.insert(angleset.get());
-      if (status != AngleSetStatus::FINISHED)
-        finished = false;
-    }
-  }
-}
-
-void
-SweepScheduler::ScheduleAlgoDOGDefault(SweepChunk& sweep_chunk)
-{
-  bool finished = false;
-  while (not finished)
-  {
-    finished = true;
-    for (auto& rule_value : rule_values_)
-    {
-      auto angleset = rule_value.angle_set;
-      AngleSetStatus status = angleset->AngleSetAdvance(sweep_chunk, AngleSetStatus::EXECUTE);
-      if (status != AngleSetStatus::FINISHED)
-        finished = false;
-    }
-  }
 }
 
 void
 SweepScheduler::ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
 {
   CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoFIFO");
+
+  // Reset dependency counter
+  for (auto& angle_set : angle_agg_)
+    angle_set->ResetDependencyCounter();
 
   // Loop over AngleSetGroups
   bool finished = false;
@@ -323,9 +256,6 @@ SweepScheduler::ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
   // Reset all
   for (auto& angle_set : angle_agg_)
     angle_set->ResetSweepBuffers();
-
-  for (const auto& [bid, bndry] : angle_agg_.GetSimBoundaries())
-    bndry->ResetAnglesReadyStatus();
 }
 
 #ifndef __OPENSN_WITH_GPU__

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cu
@@ -23,7 +23,9 @@ SweepScheduler::ScheduleAlgoAAO(SweepChunk& sweep_chunk)
 
   // copy phi and src moments to device
   auto aah_sweep_chunk = static_cast<AAHDSweepChunk&>(sweep_chunk);
+  int groupset_id = angle_agg_.GetGroupsetID();
   aah_sweep_chunk.GetProblem().CopyPhiAndSrcToDevice();
+  aah_sweep_chunk.GetProblem().TransferDeviceBoundaryData(groupset_id, true);
 
   // reset dependency counters and pre-post receives for all anglesets
   std::size_t num_anglesets = angle_agg_.GetNumAngleSets();
@@ -71,7 +73,8 @@ SweepScheduler::ScheduleAlgoAAO(SweepChunk& sweep_chunk)
     aahd_angle_set->WaitForDownstreamAndDelayed();
   }
 
-  // copy phi and outflow data back to host
+  // copy boundary, phi and outflow data back to host
+  aah_sweep_chunk.GetProblem().TransferDeviceBoundaryData(groupset_id, false);
   aah_sweep_chunk.GetProblem().CopyPhiAndOutflowBackToHost();
 
   // reset all anglesets
@@ -83,6 +86,10 @@ void
 SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
 {
   CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoAsyncFIFO");
+
+  // Reset dependency counter
+  for (auto& angle_set : angle_agg_)
+    angle_set->ResetDependencyCounter();
 
   auto& cbcd_sweep_chunk = static_cast<CBCDSweepChunk&>(sweep_chunk);
   // Copy phi and source moments to device
@@ -175,17 +182,7 @@ SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
     {
       if (executed[i] or boundary_data_set[i] or kernel_in_flight[i])
         continue;
-      auto* as = angle_sets[i];
-      bool boundaries_ready = true;
-      for (auto& [bid, boundary] : as->GetBoundaries())
-      {
-        if (not boundary->CheckAnglesReadyStatus(as->GetAngleIndices()))
-        {
-          boundaries_ready = false;
-          break;
-        }
-      }
-      if (boundaries_ready)
+      if (angle_sets[i]->IsDependencyResolved())
       {
         fluds_list[i]->CopyIncomingBoundaryPsiToDevice(cbcd_sweep_chunk, angle_sets[i]);
         boundary_data_set[i] = true;
@@ -236,8 +233,7 @@ SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
       bool all_done = (num_completed_tasks[i] == current_task_list.size());
       if (all_done and comm->SendData())
       {
-        for (auto& [bid, boundary] : angle_sets[i]->GetBoundaries())
-          boundary->UpdateAnglesReadyStatus(angle_sets[i]->GetAngleIndices());
+        angle_sets[i]->UpdateDependencyCounters();
         executed[i] = true;
         ++executed_anglesets;
         fluds_list[i]->CopySavedPsiFromDevice();
@@ -274,9 +270,6 @@ SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
   // Reset all
   for (auto& angle_set : angle_sets)
     angle_set->ResetSweepBuffers();
-
-  for (const auto& [bid, bndry] : angle_agg_.GetSimBoundaries())
-    bndry->ResetAnglesReadyStatus();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.h
@@ -22,6 +22,28 @@ enum class SchedulingAlgorithm
   ASYNC_FIFO = 4          ///< ASYNC_FIFO
 };
 
+struct RuleValues
+{
+  std::shared_ptr<AngleSet> angle_set;
+  int depth_of_graph;
+  int sign_of_omegax;
+  int sign_of_omegay;
+  int sign_of_omegaz;
+  int azimuthal_order;
+  size_t set_index;
+
+  explicit RuleValues(std::shared_ptr<AngleSet>& ref_as)
+    : angle_set(ref_as),
+      depth_of_graph(0),
+      sign_of_omegax(1),
+      sign_of_omegay(1),
+      sign_of_omegaz(1),
+      azimuthal_order(0),
+      set_index(0)
+  {
+  }
+};
+
 class SweepScheduler
 {
 public:
@@ -46,18 +68,6 @@ private:
   /// Executes the depth-of-graph algorithm.
   void ScheduleAlgoDOG(SweepChunk& sweep_chunk);
 
-  /// Sort rule values for DOG scheduling (RZ).
-  void SortRuleValuesDOGRZ();
-
-  /// Sort rule values for DOG scheduling (default).
-  void SortRuleValuesDOGDefault();
-
-  /// Executes DOG scheduler (RZ).
-  void ScheduleAlgoDOGRZ(SweepChunk& sweep_chunk);
-
-  /// Executes DOG scheduler (default).
-  void ScheduleAlgoDOGDefault(SweepChunk& sweep_chunk);
-
   /// Performs the all-at-once scheduling algorithm.
   void ScheduleAlgoAAO(SweepChunk& sweep_chunk);
 
@@ -66,27 +76,6 @@ private:
   AngleAggregation& angle_agg_;
   SweepChunk& sweep_chunk_;
 
-  struct RuleValues
-  {
-    std::shared_ptr<AngleSet> angle_set;
-    int depth_of_graph;
-    int sign_of_omegax;
-    int sign_of_omegay;
-    int sign_of_omegaz;
-    int azimuthal_order;
-    size_t set_index;
-
-    explicit RuleValues(std::shared_ptr<AngleSet>& ref_as)
-      : angle_set(ref_as),
-        depth_of_graph(0),
-        sign_of_omegax(1),
-        sign_of_omegay(1),
-        sign_of_omegaz(1),
-        azimuthal_order(0),
-        set_index(0)
-    {
-    }
-  };
   std::vector<RuleValues> rule_values_;
 
   /// Angle set dependencies (preceding sets) used by DOG scheduling.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
@@ -362,7 +362,7 @@ AAH_Sweep_FixedN(AAHSweepData& data, AngleSet& angle_set)
                                         cell_local_id,
                                         f,
                                         fj,
-                                        gs_gi,
+                                        0,
                                         data.surface_source_active);
 
           for (size_t fi = 0; fi < num_face_nodes; ++fi)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_kernels.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_kernels.h
@@ -180,7 +180,7 @@ AAH_Sweep_Generic(AAHSweepData& data, AngleSet& angle_set)
                                           cell_local_id,
                                           f,
                                           fj,
-                                          gs_gi,
+                                          0,
                                           data.surface_source_active);
 
             if (not psi)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aahd_sweep_chunk.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aahd_sweep_chunk.cu
@@ -44,7 +44,7 @@ AAHDSweepChunk::Sweep(AngleSet& angle_set)
   auto& fluds = static_cast<AAHD_FLUDS&>(aahd_angle_set.GetFLUDS());
   auto& stream = aahd_angle_set.GetStream();
   gpu_kernel::Arguments<gpu_kernel::SweepType::AAH> args(
-    problem_, groupset_, aahd_angle_set, fluds);
+    problem_, groupset_, aahd_angle_set, fluds, surface_source_active_);
   double* saved_psi = fluds.GetSavedAngularFluxDevicePointer();
   // retrieve SPDS levels
   const auto& spds = static_cast<const AAH_SPDS&>(aahd_angle_set.GetSPDS());

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
@@ -152,13 +152,8 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
             psi = fluds_->NLUpwindPsi(
               cell_->global_id, f, face_nodal_mapping->face_node_mapping_[fj], as_ss_idx);
           else
-            psi = angle_set.PsiBoundary(face.neighbor_id,
-                                        direction_num,
-                                        cell_local_id_,
-                                        f,
-                                        fj,
-                                        gs_gi_,
-                                        surface_source_active_);
+            psi = angle_set.PsiBoundary(
+              face.neighbor_id, direction_num, cell_local_id_, f, fj, 0, surface_source_active_);
 
           if (psi != nullptr)
             for (size_t gsg = 0; gsg < gs_size_; ++gsg)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbcd_sweep_chunk.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbcd_sweep_chunk.cu
@@ -35,7 +35,8 @@ CBCDSweepChunk::CBCDSweepChunk(DiscreteOrdinatesProblem& problem, LBSGroupset& g
     angle_sets_.push_back(angle_set);
     fluds_list_.push_back(fluds);
     streams_list_.push_back(angle_set->GetStream());
-    gpu_kernel::Arguments<gpu_kernel::SweepType::CBC> args(problem_, groupset_, *angle_set, *fluds);
+    gpu_kernel::Arguments<gpu_kernel::SweepType::CBC> args(
+      problem_, groupset_, *angle_set, *fluds, surface_source_active_);
     kernel_args_list_.push_back(args);
     unsigned int stride_size =
       gpu_kernel::RoundUp(static_cast<unsigned int>(args.flud_data.stride_size));

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/arguments.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/arguments.h
@@ -12,6 +12,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_structs.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/quadrature_carrier.h"
@@ -52,13 +53,16 @@ struct Arguments
   Arguments(DiscreteOrdinatesProblem& problem,
             const LBSGroupset& groupset,
             AngleSetType& angle_set,
-            FLUDSType& fluds)
+            FLUDSType& fluds,
+            bool is_active)
   {
     // Get mesh and quadrature data
     auto* mesh = problem.GetMeshCarrier();
     mesh_data = mesh->GetDevicePtr();
-    auto* quadrature = reinterpret_cast<QuadratureCarrier*>(groupset.quad_carrier);
+    auto quadrature = groupset.quad_carrier;
     quad_data = quadrature->GetDevicePtr();
+    // Get boundary
+    boundary = problem.GetBoundaryCarrier()->GetDevicePtr(groupset.id);
     // Copy source moment and destination phi data to GPU
     auto* src = problem.GetSourceMomentsPinner();
     src_moment = src->GetDevicePtr();
@@ -71,9 +75,13 @@ struct Arguments
     // Copy angleset data to GPU
     directions = angle_set.GetDeviceAngleIndices();
     angleset_size = angle_set.GetNumAngles();
+    if constexpr (t == SweepType::AAH)
+      boundary_offset = angle_set.GetDeviceBoudnaryOffset();
     // Copy FLUDS data to GPU and retrieve the pointer set
     flud_data = fluds.GetDevicePointerSet();
     flud_index = fluds.GetCommonData().GetDeviceIndex();
+    // Copy surface source active
+    is_surface_source_active = is_active;
   }
 
   // Mesh and quadrature
@@ -82,8 +90,11 @@ struct Arguments
   // Source moments and phi
   const double* __restrict__ src_moment;
   double* __restrict__ phi;
+  // Boundary
+  double* __restrict__ boundary;
   // Angle set
   const std::uint32_t* __restrict__ directions;
+  const std::uint64_t* __restrict__ boundary_offset;
   std::uint32_t angleset_size;
   // Group set
   std::uint32_t num_groups;
@@ -92,6 +103,8 @@ struct Arguments
   // FLUDS
   const std::uint64_t* __restrict__ flud_index;
   FLUDSPointerSetType flud_data;
+  // Source active
+  bool is_surface_source_active;
 };
 
 } // namespace opensn::gpu_kernel

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/solver.h
@@ -68,6 +68,7 @@ ComputeSurfaceIntegral(double* sweep_matrix,
                        DirectionView& direction,
                        const std::uint64_t* cell_edge_data,
                        const unsigned int& angle_group_idx,
+                       const unsigned int& group_idx,
                        const Arguments<t>& args)
 {
   // loop over each face
@@ -96,9 +97,18 @@ ComputeSurfaceIntegral(double* sweep_matrix,
         std::uint32_t j = face.cell_mapping_data[fj];
         double mu_Nij = -mu * face.M_surf_data[fi * face.num_face_nodes + fj];
         Ai[j] += mu_Nij;
-        double* upwind_psi =
-          args.flud_data.GetIncomingFluxPointer(cell_edge_data[face_node_counter + fj]);
-        psi[i] += upwind_psi[angle_group_idx] * mu_Nij;
+        double* upwind_psi;
+        if constexpr (t == SweepType::AAH)
+          upwind_psi = args.flud_data.GetIncomingFluxPointer(cell_edge_data[face_node_counter + fj],
+                                                             angle_group_idx,
+                                                             group_idx,
+                                                             args.boundary,
+                                                             args.boundary_offset,
+                                                             args.is_surface_source_active);
+        else
+          upwind_psi = args.flud_data.GetIncomingFluxPointer(cell_edge_data[face_node_counter + fj],
+                                                             angle_group_idx);
+        psi[i] += *upwind_psi * mu_Nij;
       }
     }
     // update face node counter
@@ -182,9 +192,16 @@ WritePsiToFludsAndOutflow(double* psi,
     {
       std::uint32_t i = face.cell_mapping_data[fi];
       // put copy psi to FLUDS
-      double* downwind_psi =
-        args.flud_data.GetOutgoingFluxPointer(cell_edge_data[face_node_counter + fi]);
-      downwind_psi[angle_group_idx] = psi[i];
+      double* downwind_psi;
+      if constexpr (t == SweepType::AAH)
+        downwind_psi = args.flud_data.GetOutgoingFluxPointer(cell_edge_data[face_node_counter + fi],
+                                                             angle_group_idx,
+                                                             args.boundary,
+                                                             args.boundary_offset);
+      else
+        downwind_psi = args.flud_data.GetOutgoingFluxPointer(cell_edge_data[face_node_counter + fi],
+                                                             angle_group_idx);
+      *downwind_psi = psi[i];
       // compute ouflow for boundary face
       if (face.outflow != nullptr)
       {
@@ -252,7 +269,7 @@ Sweep(const Arguments<t>& args,
   ComputeGMS<ndofs, t>(
     buffer.A(), buffer.b(), buffer.s(), cell, direction, group_idx, num_moments, args);
   ComputeSurfaceIntegral<ndofs, t>(
-    buffer.A(), buffer.b(), cell, direction, cell_edge_data, angle_group_idx, args);
+    buffer.A(), buffer.b(), cell, direction, cell_edge_data, angle_group_idx, group_idx, args);
   // solve for the angular flux
   GaussianElimination<ndofs>(buffer.A(), buffer.b());
   // save the result

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
@@ -95,6 +95,7 @@ LBSGroupset::Init(int aid)
   id = aid;
   first_group = 0;
   last_group = 0;
+  size = 0;
   quadrature = nullptr;
   angle_agg = nullptr;
   master_num_ang_subsets = 1;
@@ -142,6 +143,7 @@ LBSGroupset::LBSGroupset( // NOLINT(cppcoreguidelines-pro-type-member-init)
   last_group = groups_from_to[1];
   OpenSnInvalidArgumentIf(last_group < first_group,
                           "\"to\" field is less than the \"from\" field.");
+  size = last_group - first_group + 1;
 
   // Add quadrature
   quadrature = params.GetSharedPtrParam<AngularQuadrature>("angular_quadrature", false);
@@ -192,25 +194,25 @@ LBSGroupset::LBSGroupset( // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 #ifndef __OPENSN_WITH_GPU__
 void
-LBSGroupset::InitializeGPUCarriers()
+LBSGroupset::InitializeQuadratureCarrier()
 {
 }
 
 void
-LBSGroupset::ResetGPUCarriers()
+LBSGroupset::ResetQuadratureCarrier()
 {
 }
 #endif // __OPENSN_WITH_GPU__
 
 LBSGroupset::~LBSGroupset()
 {
-  ResetGPUCarriers();
+  ResetQuadratureCarrier();
 }
 
 unsigned int
 LBSGroupset::GetNumGroups() const
 {
-  return last_group - first_group + 1;
+  return size;
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cu
@@ -8,21 +8,15 @@ namespace opensn
 {
 
 void
-LBSGroupset::InitializeGPUCarriers()
+LBSGroupset::InitializeQuadratureCarrier()
 {
-  auto* quad = new QuadratureCarrier(*this);
-  quad_carrier = quad;
+  quad_carrier = std::make_shared<QuadratureCarrier>(*this);
 }
 
 void
-LBSGroupset::ResetGPUCarriers()
+LBSGroupset::ResetQuadratureCarrier()
 {
-  if (quad_carrier)
-  {
-    auto* quad = reinterpret_cast<QuadratureCarrier*>(quad_carrier);
-    delete quad;
-    quad_carrier = nullptr;
-  }
+  quad_carrier.reset();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h
@@ -11,12 +11,14 @@
 #include "framework/math/linear_solver/linear_system_solver.h"
 #include "framework/math/unknown_manager/unknown_manager.h"
 #include "framework/utils/utils.h"
+#include <memory>
 
 namespace opensn
 {
 
 class DiffusionMIPSolver;
 class LBSProblem;
+class QuadratureCarrier;
 
 /**
  * Shared groupset state.
@@ -40,10 +42,10 @@ public:
   void PrintSweepInfoFile(size_t ev_tag, const std::string& file_name);
 
   /// Initialize carrier for copying quadrature data to GPU.
-  void InitializeGPUCarriers();
+  void InitializeQuadratureCarrier();
 
   /// Delete carrier and deallocate memory on GPU.
-  void ResetGPUCarriers();
+  void ResetQuadratureCarrier();
 
   ~LBSGroupset();
 
@@ -55,6 +57,8 @@ public:
   unsigned int first_group;
   /// Last energy-group index in the groupset.
   unsigned int last_group;
+  /// Number of groups in the groupset.
+  unsigned int size;
 
   // Sweep/discrete-ordinates data kept in the shared groupset by design.
   // This avoids duplicating generic groupset data.
@@ -84,7 +88,7 @@ public:
   std::string wgdsa_string;
   std::string tgdsa_string;
 
-  void* quad_carrier = nullptr;
+  std::shared_ptr<QuadratureCarrier> quad_carrier = nullptr;
 
   std::shared_ptr<DiffusionMIPSolver> wgdsa_solver = nullptr;
   std::shared_ptr<DiffusionMIPSolver> tgdsa_solver = nullptr;

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -62,7 +62,7 @@ public:
   double GetTime() const;
 
   /// Sets simulation time in seconds for time dependent problems.
-  void SetTime(double time);
+  virtual void SetTime(double time);
 
   /// Sets dt.
   void SetTimeStep(double dt);
@@ -320,9 +320,6 @@ protected:
 
   /// Initializes boundaries.
   virtual void InitializeBoundaries() {}
-
-  /// Derived problems handle boundary options.
-  virtual void SetBoundaryOptions(const InputParameters& params) = 0;
 
   void SetActiveSetSourceFunction(SetSourceFunction source_function);
 

--- a/python/lib/math.cc
+++ b/python/lib/math.cc
@@ -230,10 +230,10 @@ WrapFunctors(py::module& math)
     >>> def foo(point, n_groups):
     ...     return [point.x * point.y] * n_groups
     >>> f = VectorSpatialFunction(foo)
-    >>> 
+    >>>
     >>> # Create from lambda
     >>> g = VectorSpatialFunction(lambda p, n : [p.x + p.y + p.z] * n)
-    >>> 
+    >>>
     >>> # Evaluate
     >>> f(Vector3(1.0, 2.0, 3.0), 2)
     [2.0, 2.0]
@@ -343,6 +343,77 @@ WrapFunctors(py::module& math)
     )",
     py::arg("group"),
     py::arg("direction")
+  );
+
+  // angular flux time function
+  auto angular_flux_time_function = py::class_<AngularFluxTimeFunction,
+                                               std::shared_ptr<AngularFluxTimeFunction>>(
+    math,
+    "AngularFluxTimeFunction",
+    R"(
+    Time-dependent angular flux function.
+
+    Functions that accept a group index, a direction index, and time, and return the incoming
+    angular flux value for that (group, direction, time) tuple.
+
+    Wrapper of :cpp:class:`opensn::AngularFluxTimeFunction`.
+
+    Examples
+    --------
+    >>> # Create from a Python function
+    >>> def incident_flux(group, direction, time):
+    ...     return 1.0 if group == 0 and time <= 0.5 else 0.0
+    >>> f = AngularFluxTimeFunction(incident_flux)
+    >>>
+    >>> # Create from lambda
+    >>> g = AngularFluxTimeFunction(lambda group, direction, time: time)
+    >>>
+    >>> # Evaluate
+    >>> f(0, 3, 0.25)
+    1.0
+    >>> g(1, 2, 0.5)
+    0.5
+    )"
+  );
+  angular_flux_time_function.def(
+    py::init(
+      [](const std::function<double(int, int, double)>& func)
+      {
+        return std::make_shared<AngularFluxTimeFunction>(func);
+      }
+    ),
+    R"(
+    Construct a time-dependent angular flux function from a Python function or lambda.
+
+    Parameters
+    ----------
+    func: Callable[[int, int, float], float]
+        Referenced angular flux function. The arguments are energy group index, direction index,
+        and time.
+    )",
+    py::arg("func")
+  );
+  angular_flux_time_function.def(
+    "__call__",
+    [](AngularFluxTimeFunction& self, int group, int direction, double time)
+    {
+      return self(group, direction, time);
+    },
+    R"(
+    Evaluate the associated time-dependent angular flux function.
+
+    Parameters
+    ----------
+    group: int
+        Energy group index.
+    direction: int
+        Direction index in the angular quadrature.
+    time: float
+        Evaluation time.
+    )",
+    py::arg("group"),
+    py::arg("direction"),
+    py::arg("time")
   );
   // clang-format on
 }

--- a/python/lib/parameter.cc
+++ b/python/lib/parameter.cc
@@ -94,6 +94,7 @@ pyobj_to_param_block(const std::string& key, const py::object& obj)
   TO_PARAMBLOCK(VolumetricSource);
   TO_PARAMBLOCK(VectorSpatialFunction);
   TO_PARAMBLOCK(AngularFluxFunction);
+  TO_PARAMBLOCK(AngularFluxTimeFunction);
 
   // throw and return
   throw std::invalid_argument("Unsupported argument type.");

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -750,8 +750,20 @@ WrapLBS(py::module& slv)
               Boundary type specification.
           - group_strength: List[float], optional
               Required when ``type='isotropic'``. Isotropic strength per group.
+          - start_time: float, optional
+              Active start time for isotropic boundaries only. Defaults to -infinity.
+          - end_time: float, optional
+              Active end time for isotropic boundaries only. Defaults to infinity.
           - function: AngularFluxFunction, optional
-              Required when ``type='arbitrary'``. Callable that returns incoming angular flux.
+              Required when ``type='arbitrary'`` unless ``time_function`` is supplied. Callable
+              that returns incoming angular flux from group and direction.
+          - time_function: AngularFluxTimeFunction, optional
+              Required when ``type='arbitrary'`` unless ``function`` is supplied. Callable that
+              returns incoming angular flux from group, direction, and time.
+        Isotropic boundaries may use ``start_time``/``end_time`` for simple on/off behavior.
+        Arbitrary boundaries must specify exactly one of ``function`` or ``time_function``; use
+        ``time_function`` for time-dependent arbitrary inflow and handle any active window inside
+        that callback.
     point_sources: List[pyopensn.source.PointSource], default=[]
         A list of point sources.
     volumetric_sources: List[pyopensn.source.VolumetricSource], default=[]
@@ -876,8 +888,20 @@ WrapLBS(py::module& slv)
               Boundary type specification.
           - group_strength: List[float], optional
               Required when ``type='isotropic'``. Isotropic strength per group.
+          - start_time: float, optional
+              Active start time for isotropic boundaries only. Defaults to -infinity.
+          - end_time: float, optional
+              Active end time for isotropic boundaries only. Defaults to infinity.
           - function: AngularFluxFunction, optional
-              Required when ``type='arbitrary'``. Callable that returns incoming angular flux.
+              Required when ``type='arbitrary'`` unless ``time_function`` is supplied. Callable
+              that returns incoming angular flux from group and direction.
+          - time_function: AngularFluxTimeFunction, optional
+              Required when ``type='arbitrary'`` unless ``function`` is supplied. Callable that
+              returns incoming angular flux from group, direction, and time.
+        Isotropic boundaries may use ``start_time``/``end_time`` for simple on/off behavior.
+        Arbitrary boundaries must specify exactly one of ``function`` or ``time_function``; use
+        ``time_function`` for time-dependent arbitrary inflow and handle any active window inside
+        that callback.
 
     Notes
     -----
@@ -1192,8 +1216,20 @@ WrapLBS(py::module& slv)
               Boundary type specification.
           - group_strength: List[float], optional
               Required when ``type='isotropic'``. Isotropic strength per group.
+          - start_time: float, optional
+              Active start time for isotropic boundaries only. Defaults to -infinity.
+          - end_time: float, optional
+              Active end time for isotropic boundaries only. Defaults to infinity.
           - function: AngularFluxFunction, optional
-              Required when ``type='arbitrary'``. Callable that returns incoming angular flux.
+              Required when ``type='arbitrary'`` unless ``time_function`` is supplied. Callable
+              that returns incoming angular flux from group and direction.
+          - time_function: AngularFluxTimeFunction, optional
+              Required when ``type='arbitrary'`` unless ``function`` is supplied. Callable that
+              returns incoming angular flux from group, direction, and time.
+        Isotropic boundaries may use ``start_time``/``end_time`` for simple on/off behavior.
+        Arbitrary boundaries must specify exactly one of ``function`` or ``time_function``; use
+        ``time_function`` for time-dependent arbitrary inflow and handle any active window inside
+        that callback.
     point_sources: List[pyopensn.source.PointSource], default=[]
         A list of point sources.
     volumetric_sources: List[pyopensn.source.VolumetricSource], default=[]
@@ -1511,7 +1547,7 @@ WrapTransient(py::module& slv)
           Total particle inventory at the end of the timestep, computed as
           ``integral (1 / v_g) * phi_new dV`` summed over groups and the full domain.
         - ``predicted_inventory_change``:
-          Inventory change predicted by the current timestep balance, computed as 
+          Inventory change predicted by the current timestep balance, computed as
           ``dt * balance``.
         - ``actual_inventory_change``:
           Measured change in total particle inventory over the timestep, computed as

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/boundary_mutation_rebuild_gpu.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/boundary_mutation_rebuild_gpu.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Regression for runtime boundary-condition mutation.
+
+Each case is first solved with a freshly constructed problem to establish the
+reference answer. A single reusable problem is then mutated through the same
+boundary-condition sequence and must reproduce the fresh answers.
+"""
+
+import os
+import sys
+import numpy as np
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    comm = MPI.COMM_WORLD
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.source import VolumetricSource
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.math import AngularFluxFunction
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
+    from pyopensn.logvol import RPPLogicalVolume
+else:
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+
+
+def require_procs(expected):
+    if size != expected:
+        sys.exit(f"Incorrect number of processors. Expected {expected} processors but got {size}.")
+
+
+def build_mesh():
+    nx = 10
+    ny = 8
+    lx = 2.5
+    ly = 2.0
+    nodes_x = [lx * i / nx for i in range(nx + 1)]
+    nodes_y = [ly * i / ny for i in range(ny + 1)]
+    grid = OrthogonalMeshGenerator(node_sets=[nodes_x, nodes_y]).Execute()
+    grid.SetUniformBlockID(0)
+    return grid
+
+
+def build_xs():
+    xs = MultiGroupXS()
+    xs.LoadFromOpenSn("simple_upscatter.xs")
+    return xs
+
+
+def build_source():
+    src_vol = RPPLogicalVolume(xmin=0.65, xmax=1.55, ymin=0.55, ymax=1.45, infz=True)
+    return VolumetricSource(logical_volume=src_vol, group_strength=[1.0, 0.25, 0.05])
+
+
+def build_quadrature():
+    return GLCProductQuadrature2DXY(n_polar=4, n_azimuthal=8, scattering_order=0)
+
+
+def build_arbitrary_bc(pquad, num_groups):
+    mask = np.zeros(len(pquad.omegas), dtype=bool)
+    normalization = 0.0
+
+    for n, (omega, weight) in enumerate(zip(pquad.omegas, pquad.weights)):
+        if omega.x > 0.0 and omega.y > 0.0:
+            mask[n] = True
+            normalization += omega.x * weight * num_groups
+
+    if normalization <= 0.0:
+        raise RuntimeError("Arbitrary boundary setup found no incoming directions.")
+
+    strength = 0.35 / normalization
+
+    def incident_flux(group_index, angle_index):
+        if mask[angle_index]:
+            return strength * (1.0 + 0.15 * group_index)
+        return 0.0
+
+    return AngularFluxFunction(incident_flux)
+
+
+def make_boundary_cases(arbitrary_bc):
+    vacuum = [
+        {"name": "xmin", "type": "vacuum"},
+        {"name": "xmax", "type": "vacuum"},
+        {"name": "ymin", "type": "vacuum"},
+        {"name": "ymax", "type": "vacuum"},
+    ]
+    isotropic_drive = [
+        {"name": "xmin", "type": "isotropic", "group_strength": [0.20, 0.05, 0.01]},
+        {"name": "xmax", "type": "vacuum"},
+        {"name": "ymin", "type": "vacuum"},
+        {"name": "ymax", "type": "vacuum"},
+    ]
+    mixed_isotropic_vacuum_reflecting = [
+        {"name": "xmin", "type": "isotropic", "group_strength": [0.12, 0.03, 0.02]},
+        {"name": "xmax", "type": "vacuum"},
+        {"name": "ymin", "type": "reflecting"},
+        {"name": "ymax", "type": "vacuum"},
+    ]
+    all_reflecting = [
+        {"name": "xmin", "type": "reflecting"},
+        {"name": "xmax", "type": "reflecting"},
+        {"name": "ymin", "type": "reflecting"},
+        {"name": "ymax", "type": "reflecting"},
+    ]
+    return [
+        {
+            "name": "all_vacuum_explicit",
+            "clear": True,
+            "boundaries": vacuum,
+        },
+        {
+            "name": "isotropic_drive",
+            "clear": False,
+            "boundaries": isotropic_drive,
+        },
+        {
+            "name": "arbitrary_and_isotropic",
+            "clear": False,
+            "boundaries": [
+                {"name": "xmin", "type": "arbitrary", "function": arbitrary_bc},
+                {"name": "xmax", "type": "vacuum"},
+                {"name": "ymin", "type": "vacuum"},
+                {"name": "ymax", "type": "isotropic", "group_strength": [0.02, 0.03, 0.04]},
+            ],
+        },
+        {
+            "name": "reflecting_axes",
+            "clear": False,
+            "boundaries": [
+                {"name": "xmin", "type": "reflecting"},
+                {"name": "xmax", "type": "vacuum"},
+                {"name": "ymin", "type": "reflecting"},
+                {"name": "ymax", "type": "vacuum"},
+            ],
+        },
+        {
+            "name": "all_reflecting",
+            "clear": False,
+            "boundaries": all_reflecting,
+        },
+        {
+            "name": "clear_then_partial_default_vacuum",
+            "clear": True,
+            "boundaries": [
+                {"name": "xmin", "type": "isotropic", "group_strength": [0.10, 0.00, 0.00]},
+            ],
+        },
+        {
+            "name": "clear_to_default_vacuum",
+            "clear": True,
+            "boundaries": [],
+        },
+        {
+            "name": "return_to_isotropic_drive",
+            "clear": True,
+            "boundaries": isotropic_drive,
+        },
+        {
+            "name": "return_to_all_vacuum_explicit",
+            "clear": True,
+            "boundaries": vacuum,
+        },
+        {
+            "name": "final_mixed_isotropic_vacuum_reflecting",
+            "clear": True,
+            "boundaries": mixed_isotropic_vacuum_reflecting,
+        },
+        {
+            "name": "final_all_vacuum_after_mixed",
+            "clear": True,
+            "boundaries": vacuum,
+        },
+        {
+            "name": "final_all_reflecting_after_vacuum",
+            "clear": True,
+            "boundaries": all_reflecting,
+        },
+    ]
+
+
+def build_problem(grid, xs, source, pquad, boundaries, sweep_type):
+    num_groups = xs.num_groups
+    return DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=num_groups,
+        groupsets=[
+            {
+                "groups_from_to": [0, num_groups - 1],
+                "angular_quadrature": pquad,
+                "angle_aggregation_num_subsets": 2,
+                "inner_linear_method": "petsc_gmres",
+                "l_abs_tol": 1.0e-9,
+                "l_max_its": 300,
+                "gmres_restart_interval": 50,
+                "apply_wgdsa": True,
+                "apply_tgdsa": True,
+                "wgdsa_l_abs_tol": 1.0e-7,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=boundaries,
+        volumetric_sources=[source],
+        options={
+            "max_ags_iterations": 1,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+        sweep_type=sweep_type,
+        use_gpus=True,
+    )
+
+
+def solve(problem):
+    solver = SteadyStateSourceSolver(problem=problem)
+    solver.Initialize()
+    solver.Execute()
+    leakage = problem.ComputeLeakage(["xmin", "xmax", "ymin", "ymax"])
+    return {
+        "phi": list(problem.GetPhiNewLocal()),
+        "leakage": {name: [float(v) for v in leakage[name]] for name in leakage},
+    }
+
+
+def compare_results(ref, got):
+    phi_diff = 0.0
+    for a, b in zip(ref["phi"], got["phi"]):
+        phi_diff = max(phi_diff, abs(a - b))
+
+    leakage_diff = 0.0
+    for name in ref["leakage"]:
+        for a, b in zip(ref["leakage"][name], got["leakage"][name]):
+            leakage_diff = max(leakage_diff, abs(a - b))
+
+    local = (phi_diff, leakage_diff)
+    return tuple(comm.allreduce(value, op=MPI.MAX) for value in local)
+
+
+if __name__ == "__main__":
+    require_procs(4)
+
+    grid = build_mesh()
+    xs = build_xs()
+    source = build_source()
+    pquad = build_quadrature()
+    boundary_cases = make_boundary_cases(build_arbitrary_bc(pquad, xs.num_groups))
+
+    max_case_diff = 0.0
+    for sweep_type in ["AAH", "CBC"]:
+        references = []
+        for case in boundary_cases:
+            ref_problem = build_problem(grid, xs, source, pquad, case["boundaries"], sweep_type)
+            references.append(solve(ref_problem))
+
+        mutable_problem = build_problem(
+            grid, xs, source, pquad, boundary_cases[0]["boundaries"], sweep_type
+        )
+        mutable_solver = SteadyStateSourceSolver(problem=mutable_problem)
+        mutable_solver.Initialize()
+
+        for i, case in enumerate(boundary_cases):
+            if i > 0:
+                mutable_problem.SetBoundaryOptions(
+                    clear_boundary_conditions=case["clear"],
+                    boundary_conditions=case["boundaries"],
+                )
+
+            mutable_problem.ZeroPhi()
+            mutable_solver.Execute()
+            mutated = {
+                "phi": list(mutable_problem.GetPhiNewLocal()),
+                "leakage": {
+                    name: [float(v) for v in values]
+                    for name, values in mutable_problem.ComputeLeakage(
+                        ["xmin", "xmax", "ymin", "ymax"]
+                    ).items()
+                },
+            }
+            phi_diff, leakage_diff = compare_results(references[i], mutated)
+            case_diff = max(phi_diff, leakage_diff)
+            max_case_diff = max(max_case_diff, case_diff)
+
+            if rank == 0:
+                print(f"BOUNDARY_CASE_{sweep_type}_{i}_{case['name']}_MAX_DIFF={case_diff:.8e}")
+                print(f"BOUNDARY_CASE_{sweep_type}_{i}_{case['name']}_PHI_DIFF={phi_diff:.8e}")
+                print(
+                    f"BOUNDARY_CASE_{sweep_type}_{i}_{case['name']}_LEAKAGE_DIFF="
+                    f"{leakage_diff:.8e}"
+                )
+
+    match_tol = 5.0e-8
+    match = 1 if max_case_diff <= match_tol else 0
+    if rank == 0:
+        print(f"BOUNDARY_MUTATION_MAX_DIFF={max_case_diff:.8e}")
+        print(f"BOUNDARY_MUTATION_MATCH_TOL={match_tol:.8e}")
+        print(f"BOUNDARY_MUTATION_MATCH={match}")

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -578,8 +578,53 @@
       },
       {
         "type": "KeyValuePair",
+        "key": "Max-value2=",
+        "goldvalue": 8.86760,
+        "abs_tol": 1e-09
+      }
+    ]
+  },
+  {
+    "file": "transport_2d_4b_dsa_ortho_dual_quad.py",
+    "comment": "2D LinearBSolver test of a block of graphite with an air cavity. DSA and TG",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "StrCompare",
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 18,
+        "gold": "converged"
+      },
+      {
+        "type": "StrCompare",
+        "key": "WGS groups [63-167] iteration = 58",
+        "wordnum": 18,
+        "gold": "converged"
+      },
+      {
+        "type": "FloatCompare",
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 13,
+        "gold": 6.8534e-07,
+        "abs_tol": 1e-09
+      },
+      {
+        "type": "FloatCompare",
+        "key": "WGS groups [63-167] iteration = 58",
+        "wordnum": 13,
+        "gold": 6.2607e-07,
+        "abs_tol": 1e-09
+      },
+      {
+        "type": "KeyValuePair",
         "key": "Max-value1=",
         "goldvalue": 0.16196,
+        "abs_tol": 1e-09
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "Max-value2=",
+        "goldvalue": 8.86850,
         "abs_tol": 1e-09
       }
     ]
@@ -1455,6 +1500,26 @@
   {
     "file": "boundary_mutation_rebuild.py",
     "comment": "Runtime boundary-condition mutation rebuild regression",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "KeyValuePair",
+        "key": "BOUNDARY_MUTATION_MATCH=",
+        "goldvalue": 1,
+        "abs_tol": 0
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "BOUNDARY_MUTATION_MAX_DIFF=",
+        "goldvalue": 0.0,
+        "abs_tol": 5.0e-8
+      }
+    ]
+  },
+  {
+    "file": "boundary_mutation_rebuild_gpu.py",
+    "comment": "Runtime boundary-condition mutation rebuild regression",
+    "requires_gpu": "True",
     "num_procs": 4,
     "checks": [
       {

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho.py
@@ -135,4 +135,4 @@ if __name__ == "__main__":
     curffi.Execute()
     maxval = curffi.GetValue()
     if rank == 0:
-        print(f"Max-value1={maxval:.5f}")
+        print(f"Max-value2={maxval:.5f}")

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho_dual_quad.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_4b_dsa_ortho_dual_quad.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+2D LinearBSolver Same as 4b but with two different quadratures for each groupset. DSA and TG
+SDM: PWLD
+Test: WGS groups [0-62] Iteration    76 Residual 7.14364e-07 CONVERGED
+and   WGS groups [63-167] Iteration   177 Residual 9.73942e-07 CONVERGED
+"""
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.source import VolumetricSource
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
+    from pyopensn.logvol import RPPLogicalVolume
+
+if __name__ == "__main__":
+
+    num_procs = 4
+
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} processors but got {size}.")
+
+    # Setup mesh
+    nodes = []
+    N = 20
+    L = 100
+    xmin = -L / 2
+    dx = L / N
+    for i in range(N + 1):
+        nodes.append(xmin + i * dx)
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes, nodes])
+    grid = meshgen.Execute()
+
+    # Set block IDs
+    grid.SetUniformBlockID(0)
+
+    vol1 = RPPLogicalVolume(
+        xmin=-10.0,
+        xmax=10.0,
+        ymin=-10.0,
+        ymax=10.0,
+        infz=True,
+    )
+    grid.SetBlockIDFromLogicalVolume(vol1, 1, True)
+
+    num_groups = 168
+    xs_graphite = MultiGroupXS()
+    xs_graphite.LoadFromOpenSn("xs_graphite_pure.xs")
+    xs_air = MultiGroupXS()
+    xs_air.LoadFromOpenSn("xs_air50RH.xs")
+
+    strength = [0.0 for _ in range(num_groups)]
+    strength[0] = 1.0
+    mg_src0 = VolumetricSource(block_ids=[0], group_strength=strength)
+    strength[0] = 0.0
+    mg_src1 = VolumetricSource(block_ids=[1], group_strength=strength)
+
+    # Setup Physics
+    pquad1 = GLCProductQuadrature2DXY(n_polar=4, n_azimuthal=8, scattering_order=1)
+    pquad2 = GLCProductQuadrature2DXY(n_polar=8, n_azimuthal=8, scattering_order=1)
+
+    phys = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=num_groups,
+        groupsets=[
+            {
+                "groups_from_to": [0, 62],
+                "angular_quadrature": pquad2,
+                "angle_aggregation_num_subsets": 1,
+                "angle_aggregation_type": "polar",
+                "inner_linear_method": "petsc_gmres",
+                "l_abs_tol": 1.0e-6,
+                "l_max_its": 1000,
+                "gmres_restart_interval": 30,
+                "apply_wgdsa": True,
+                "wgdsa_l_abs_tol": 1.0e-2,
+            },
+            {
+                "groups_from_to": [63, num_groups - 1],
+                "angular_quadrature": pquad1,
+                "angle_aggregation_num_subsets": 1,
+                "angle_aggregation_type": "polar",
+                "inner_linear_method": "petsc_gmres",
+                "l_abs_tol": 1.0e-6,
+                "l_max_its": 1000,
+                "gmres_restart_interval": 30,
+                "apply_wgdsa": True,
+                "apply_tgdsa": True,
+                "wgdsa_l_abs_tol": 1.0e-2,
+            },
+        ],
+        xs_map=[
+            {"block_ids": [0], "xs": xs_graphite},
+            {"block_ids": [1], "xs": xs_air},
+        ],
+        volumetric_sources=[mg_src0, mg_src1],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "ymin", "type": "reflecting"},
+        ],
+        options={
+            "max_ags_iterations": 1,
+        },
+    )
+
+    # Initialize and Execute Solver
+    ss_solver = SteadyStateSourceSolver(problem=phys)
+    ss_solver.Initialize()
+    ss_solver.Execute()
+
+    vol2 = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    fflist = phys.GetScalarFluxFieldFunction()
+
+    ffi1 = FieldFunctionInterpolationVolume()
+    curffi = ffi1
+    curffi.SetOperationType("max")
+    curffi.SetLogicalVolume(vol2)
+    curffi.SetFieldFunction(fflist[39])
+    curffi.Execute()
+    maxval = curffi.GetValue()
+    if rank == 0:
+        print(f"Max-value1={maxval:.5f}")
+
+    curffi = ffi1
+    curffi.SetOperationType("max")
+    curffi.SetLogicalVolume(vol2)
+    curffi.SetFieldFunction(fflist[120])
+    curffi.Execute()
+    maxval = curffi.GetValue()
+    if rank == 0:
+        print(f"Max-value2={maxval:.5f}")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
@@ -1,5 +1,180 @@
 [
   {
+    "file": "transient_time_dependent_boundary.py",
+    "comment": "Time-dependent isotropic and arbitrary boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE01_ISO_PULSE_EQUIV_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE02_DELAYED_ISO_EQUIV_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE03_ISO_WINDOW_EQUIV_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE04_INACTIVE_ISO_ZERO_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE05_INACTIVE_ARBITRARY_ZERO_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE06_ARBITRARY_CALLED_EACH_STEP_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE07_MULTIGROUP_EQUIV_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE08_MULTI_ARBITRARY_CONSTANT_EQUIV_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE09_MULTI_ARBITRARY_WINDOWS_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE10_REFLECTING_ARBITRARY_ISO_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE11_INVALID_ISO_BOUNDS_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      },
+      {
+        "type": "FloatCompare",
+        "key": "TD_BOUNDARY_CASE12_ARBITRARY_REJECTS_BOUNDS_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_2d_mixed_time_dependent_bcs.py",
+    "comment": "2D mixed time-dependent boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_MIXED_2D_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_3d_mixed_time_dependent_bcs.py",
+    "comment": "3D mixed time-dependent boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_MIXED_3D_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_2d_adjacent_reflecting_arbitrary_bcs.py",
+    "comment": "2D adjacent reflecting and arbitrary boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_ADJACENT_REFLECTING_ARBITRARY_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_3d_adjacent_reflecting_arbitrary_bcs.py",
+    "comment": "3D adjacent reflecting and arbitrary boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_ADJACENT_REFLECTING_ARBITRARY_3D_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_2d_opposing_reflecting_arbitrary_bcs.py",
+    "comment": "2D opposing reflecting and arbitrary boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_OPPOSING_REFLECTING_ARBITRARY_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_3d_opposing_reflecting_arbitrary_bcs.py",
+    "comment": "3D opposing reflecting and arbitrary boundary conditions",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "TD_OPPOSING_REFLECTING_ARBITRARY_3D_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
     "file": "transient_keigen_1d_theta_precursor_scaling.py",
     "comment": "1D delayed fission source scales with theta (TransientSourceFunction check)",
     "num_procs": 4,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_adjacent_reflecting_arbitrary_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_adjacent_reflecting_arbitrary_bcs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+2D adjacent reflecting and time-dependent arbitrary boundary-condition test.
+
+Uses a small orthogonal mesh with:
+  xmin/ymin: reflecting
+  xmax/ymax: time-dependent arbitrary
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes_x = [i / 8 for i in range(9)]
+    nodes_y = [i / 8 for i in range(9)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes_x, nodes_y])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature2DXY(n_polar=4, n_azimuthal=8, scattering_order=0)
+
+    def xmax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.20 if omega.x < 0.0 and time <= 0.1 else 0.0
+
+    def ymax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.15 if omega.y < 0.0 and time <= 0.1 else 0.0
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {
+                "name": "xmax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(xmax_inflow),
+            },
+            {"name": "ymin", "type": "reflecting"},
+            {
+                "name": "ymax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymax_inflow),
+            },
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_ADJACENT_REFLECTING_ARBITRARY_MAX_PHI {max_phi:.12e}")
+        print("TD_ADJACENT_REFLECTING_ARBITRARY_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_mixed_time_dependent_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_mixed_time_dependent_bcs.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+2D mixed time-dependent boundary-condition test.
+
+Uses one boundary of each type on a small orthogonal mesh:
+  xmin: reflecting
+  xmax: time-dependent isotropic
+  ymin: time-dependent arbitrary
+  ymax: vacuum
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes_x = [i / 8 for i in range(9)]
+    nodes_y = [i / 8 for i in range(9)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes_x, nodes_y])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature2DXY(n_polar=4, n_azimuthal=8, scattering_order=0)
+
+    def ymin_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.25 if omega.y > 0.0 and time <= 0.1 else 0.0
+
+    arbitrary_bc = AngularFluxTimeFunction(ymin_inflow)
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {
+                "name": "xmax",
+                "type": "isotropic",
+                "group_strength": [0.5],
+                "start_time": 0.0,
+                "end_time": 0.1,
+            },
+            {"name": "ymin", "type": "arbitrary", "time_function": arbitrary_bc},
+            {"name": "ymax", "type": "vacuum"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_MIXED_2D_MAX_PHI {max_phi:.12e}")
+        print("TD_MIXED_2D_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_opposing_reflecting_arbitrary_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_2d_opposing_reflecting_arbitrary_bcs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+2D opposing reflecting and time-dependent arbitrary boundary-condition test.
+
+Uses a small orthogonal mesh with:
+  xmin/xmax: reflecting
+  ymin/ymax: time-dependent arbitrary
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes_x = [i / 8 for i in range(9)]
+    nodes_y = [i / 8 for i in range(9)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes_x, nodes_y])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature2DXY(n_polar=4, n_azimuthal=8, scattering_order=0)
+
+    def ymin_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.30 if omega.y > 0.0 and time <= 0.1 else 0.0
+
+    def ymax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.10 if omega.y < 0.0 and time <= 0.1 else 0.0
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {
+                "name": "ymin",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymin_inflow),
+            },
+            {
+                "name": "ymax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymax_inflow),
+            },
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_OPPOSING_REFLECTING_ARBITRARY_MAX_PHI {max_phi:.12e}")
+        print("TD_OPPOSING_REFLECTING_ARBITRARY_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_adjacent_reflecting_arbitrary_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_adjacent_reflecting_arbitrary_bcs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+3D adjacent reflecting and time-dependent arbitrary boundary-condition test.
+
+Uses a small orthogonal mesh with:
+  xmin/ymin: reflecting
+  xmax/ymax: time-dependent arbitrary
+  zmin/zmax: vacuum
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature3DXYZ
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes = [i / 4 for i in range(5)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes, nodes, nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature3DXYZ(n_polar=2, n_azimuthal=4, scattering_order=0)
+
+    def xmax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.20 if omega.x < 0.0 and time <= 0.1 else 0.0
+
+    def ymax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.15 if omega.y < 0.0 and time <= 0.1 else 0.0
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {
+                "name": "xmax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(xmax_inflow),
+            },
+            {"name": "ymin", "type": "reflecting"},
+            {
+                "name": "ymax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymax_inflow),
+            },
+            {"name": "zmin", "type": "vacuum"},
+            {"name": "zmax", "type": "vacuum"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_ADJACENT_REFLECTING_ARBITRARY_3D_MAX_PHI {max_phi:.12e}")
+        print("TD_ADJACENT_REFLECTING_ARBITRARY_3D_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_mixed_time_dependent_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_mixed_time_dependent_bcs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+3D mixed time-dependent boundary-condition test.
+
+Uses a small orthogonal mesh with:
+  xmin: reflecting
+  xmax: time-dependent isotropic
+  ymin: time-dependent arbitrary
+  ymax/zmin/zmax: vacuum
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature3DXYZ
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes = [i / 4 for i in range(5)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes, nodes, nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature3DXYZ(n_polar=2, n_azimuthal=4, scattering_order=0)
+
+    def ymin_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.25 if omega.y > 0.0 and time <= 0.1 else 0.0
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {
+                "name": "xmax",
+                "type": "isotropic",
+                "group_strength": [0.5],
+                "start_time": 0.0,
+                "end_time": 0.1,
+            },
+            {
+                "name": "ymin",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymin_inflow),
+            },
+            {"name": "ymax", "type": "vacuum"},
+            {"name": "zmin", "type": "vacuum"},
+            {"name": "zmax", "type": "vacuum"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_MIXED_3D_MAX_PHI {max_phi:.12e}")
+        print("TD_MIXED_3D_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_opposing_reflecting_arbitrary_bcs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_3d_opposing_reflecting_arbitrary_bcs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+3D opposing reflecting and time-dependent arbitrary boundary-condition test.
+
+Uses a small orthogonal mesh with:
+  xmin/xmax: reflecting
+  ymin/ymax: time-dependent arbitrary
+  zmin/zmax: vacuum
+"""
+
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxTimeFunction
+    from pyopensn.aquad import GLCProductQuadrature3DXYZ
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    nodes = [i / 4 for i in range(5)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes, nodes, nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+
+    quad = GLCProductQuadrature3DXYZ(n_polar=2, n_azimuthal=4, scattering_order=0)
+
+    def ymin_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.30 if omega.y > 0.0 and time <= 0.1 else 0.0
+
+    def ymax_inflow(group, angle, time):
+        omega = quad.omegas[angle]
+        return 0.10 if omega.y < 0.0 and time <= 0.1 else 0.0
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 300,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=[
+            {"name": "xmin", "type": "reflecting"},
+            {"name": "xmax", "type": "reflecting"},
+            {
+                "name": "ymin",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymin_inflow),
+            },
+            {
+                "name": "ymax",
+                "type": "arbitrary",
+                "time_function": AngularFluxTimeFunction(ymax_inflow),
+            },
+            {"name": "zmin", "type": "vacuum"},
+            {"name": "zmax", "type": "vacuum"},
+        ],
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+    solver = TransientSolver(problem=problem, dt=0.1, theta=1.0, initial_state="zero")
+    solver.Initialize()
+    solver.SetTimeStep(0.1)
+    solver.Advance()
+    solver.Advance()
+
+    phi = list(problem.GetPhiNewLocal())
+    max_phi = comm.allreduce(max([abs(v) for v in phi] + [0.0]), op=MPI.MAX)
+
+    if rank == 0:
+        print(f"TD_OPPOSING_REFLECTING_ARBITRARY_3D_MAX_PHI {max_phi:.12e}")
+        print("TD_OPPOSING_REFLECTING_ARBITRARY_3D_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_time_dependent_boundary.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_time_dependent_boundary.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Time-dependent boundary-condition regression tests.
+
+The cases use small absorber problems and compare equivalent boundary formulations where possible.
+Zero-inflow and validation cases provide analytic checks for the inactive-boundary behavior and
+input.
+"""
+
+import math
+import os
+import sys
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+size = comm.size
+rank = comm.rank
+
+if "opensn_console" not in globals():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.math import AngularFluxFunction, AngularFluxTimeFunction
+    from pyopensn.aquad import GLProductQuadrature1DSlab
+    from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+
+DT = 0.1
+TOL = 1.0e-10
+XS2_PATH = "td_boundary_2g_tmp.xs"
+
+
+def ensure_multigroup_xs_file():
+    if rank == 0:
+        with open(XS2_PATH, "w", encoding="ascii") as xs_file:
+            xs_file.write(
+                """NUM_GROUPS 2
+NUM_MOMENTS 1
+
+INV_VELOCITY_BEGIN
+0 1.0
+1 1.0
+INV_VELOCITY_END
+
+SIGMA_T_BEGIN
+0 1.0
+1 1.15
+SIGMA_T_END
+
+SIGMA_A_BEGIN
+0 1.0
+1 1.15
+SIGMA_A_END
+
+TRANSFER_MOMENTS_BEGIN
+TRANSFER_MOMENTS_END
+"""
+            )
+    comm.Barrier()
+
+
+def make_1d_problem(boundary_conditions, num_groups=1, n_polar=4):
+    nodes = [i / 10 for i in range(11)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    if num_groups == 1:
+        xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+    else:
+        ensure_multigroup_xs_file()
+        xs.LoadFromOpenSn(XS2_PATH)
+
+    pquad = GLProductQuadrature1DSlab(n_polar=n_polar, scattering_order=0)
+    return DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=num_groups,
+        time_dependent=True,
+        groupsets=[
+            {
+                "groups_from_to": (0, num_groups - 1),
+                "angular_quadrature": pquad,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 200,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        boundary_conditions=boundary_conditions,
+        options={
+            "save_angular_flux": True,
+            "use_precursors": False,
+            "verbose_inner_iterations": False,
+            "verbose_outer_iterations": False,
+        },
+    )
+
+
+def run_steps(problem, steps, dt=DT):
+    solver = TransientSolver(problem=problem, dt=dt, theta=1.0, initial_state="zero", verbose=False)
+    solver.Initialize()
+    solver.SetTimeStep(dt)
+    for _ in range(steps):
+        solver.Advance()
+    return list(problem.GetPhiNewLocal())
+
+
+def max_abs(v):
+    return max([abs(x) for x in v] + [0.0])
+
+
+def max_abs_diff(v1, v2):
+    return max([abs(a - b) for a, b in zip(v1, v2)] + [0.0])
+
+
+def global_max(value):
+    return comm.allreduce(value, op=MPI.MAX)
+
+
+def compare_problem_pair(problem_a, problem_b, steps):
+    phi_a = run_steps(problem_a, steps)
+    phi_b = run_steps(problem_b, steps)
+    return global_max(max_abs_diff(phi_a, phi_b))
+
+
+def run_zero_check(problem, steps):
+    return global_max(max_abs(run_steps(problem, steps)))
+
+
+def iso_bc(name, strength, start=-math.inf, end=math.inf):
+    return {
+        "name": name,
+        "type": "isotropic",
+        "group_strength": strength,
+        "start_time": start,
+        "end_time": end,
+    }
+
+
+def arb_time_bc(name, func):
+    return {"name": name, "type": "arbitrary", "time_function": AngularFluxTimeFunction(func)}
+
+
+def arb_const_bc(name, func):
+    return {"name": name, "type": "arbitrary", "function": AngularFluxFunction(func)}
+
+
+def vacuum_bc(name):
+    return {"name": name, "type": "vacuum"}
+
+
+def reflecting_bc(name):
+    return {"name": name, "type": "reflecting"}
+
+
+def report(name, pass_flag, detail):
+    if rank == 0:
+        print(f"{name}_DETAIL {detail:.16e}")
+        print(f"{name}_PASS {int(pass_flag)}")
+
+
+def run_case_01():
+    strength = 2.0
+    diff = compare_problem_pair(
+        make_1d_problem([iso_bc("zmin", [strength], 0.0, 0.0), vacuum_bc("zmax")]),
+        make_1d_problem(
+            [arb_time_bc("zmin", lambda g, n, t: strength if t <= 0.0 else 0.0), vacuum_bc("zmax")]
+        ),
+        2,
+    )
+    report("TD_BOUNDARY_CASE01_ISO_PULSE_EQUIV", diff < TOL, diff)
+
+
+def run_case_02():
+    strength = 1.4
+    diff = compare_problem_pair(
+        make_1d_problem([iso_bc("zmin", [strength], DT, DT), vacuum_bc("zmax")]),
+        make_1d_problem(
+            [
+                arb_time_bc("zmin", lambda g, n, t: strength if abs(t - DT) < 1.0e-12 else 0.0),
+                vacuum_bc("zmax"),
+            ]
+        ),
+        3,
+    )
+    report("TD_BOUNDARY_CASE02_DELAYED_ISO_EQUIV", diff < TOL, diff)
+
+
+def run_case_03():
+    strength = 1.7
+    diff = compare_problem_pair(
+        make_1d_problem([iso_bc("zmin", [strength], 0.0, DT), vacuum_bc("zmax")]),
+        make_1d_problem(
+            [
+                arb_time_bc("zmin", lambda g, n, t: strength if 0.0 <= t <= DT else 0.0),
+                vacuum_bc("zmax"),
+            ]
+        ),
+        3,
+    )
+    report("TD_BOUNDARY_CASE03_ISO_WINDOW_EQUIV", diff < TOL, diff)
+
+
+def run_case_04():
+    residual = run_zero_check(
+        make_1d_problem([iso_bc("zmin", [3.0], 1.0, 2.0), vacuum_bc("zmax")]), 3
+    )
+    report("TD_BOUNDARY_CASE04_INACTIVE_ISO_ZERO", residual < TOL, residual)
+
+
+def run_case_05():
+    residual = run_zero_check(
+        make_1d_problem(
+            [arb_time_bc("zmin", lambda g, n, t: 4.0 if t >= 1.0 else 0.0), vacuum_bc("zmax")]
+        ),
+        3,
+    )
+    report("TD_BOUNDARY_CASE05_INACTIVE_ARBITRARY_ZERO", residual < TOL, residual)
+
+
+def run_case_06():
+    observed = set()
+
+    def record_time(group, direction, time):
+        observed.add(round(time, 12))
+        return 0.25 + time
+
+    problem = make_1d_problem([arb_time_bc("zmin", record_time), vacuum_bc("zmax")])
+    run_steps(problem, 3)
+
+    local_mask = 0
+    for i, t in enumerate([0.0, DT, 2.0 * DT]):
+        if round(t, 12) in observed:
+            local_mask |= 1 << i
+    global_mask = comm.allreduce(local_mask, op=MPI.BOR)
+    missing = 0 if global_mask == 0b111 else 1
+    report("TD_BOUNDARY_CASE06_ARBITRARY_CALLED_EACH_STEP", missing == 0, float(missing))
+
+
+def run_case_07():
+    strengths = [1.0, 0.35]
+
+    def strength(group, direction, time):
+        return strengths[group] if time <= DT else 0.0
+
+    diff = compare_problem_pair(
+        make_1d_problem([iso_bc("zmin", strengths, 0.0, DT), vacuum_bc("zmax")], num_groups=2),
+        make_1d_problem([arb_time_bc("zmin", strength), vacuum_bc("zmax")], num_groups=2),
+        3,
+    )
+    report("TD_BOUNDARY_CASE07_MULTIGROUP_EQUIV", diff < TOL, diff)
+
+
+def run_case_08():
+    def left(group, direction, time):
+        return 1.2 if time <= DT else 0.0
+
+    def right_const(group, direction):
+        return 0.4
+
+    def right_time(group, direction, time):
+        return 0.4
+
+    diff = compare_problem_pair(
+        make_1d_problem([arb_time_bc("zmin", left), arb_const_bc("zmax", right_const)]),
+        make_1d_problem([arb_time_bc("zmin", left), arb_time_bc("zmax", right_time)]),
+        3,
+    )
+    report("TD_BOUNDARY_CASE08_MULTI_ARBITRARY_CONSTANT_EQUIV", diff < TOL, diff)
+
+
+def run_case_09():
+    def left(group, direction, time):
+        return 1.0 if time <= 0.0 else 0.0
+
+    def right(group, direction, time):
+        return 0.6 if abs(time - DT) < 1.0e-12 else 0.0
+
+    def left_ref(group, direction, time):
+        return 1.0 if time <= 0.0 else 0.0
+
+    def right_ref(group, direction, time):
+        return 0.6 if abs(time - DT) < 1.0e-12 else 0.0
+
+    diff = compare_problem_pair(
+        make_1d_problem([arb_time_bc("zmin", left), arb_time_bc("zmax", right)]),
+        make_1d_problem([arb_time_bc("zmin", left_ref), arb_time_bc("zmax", right_ref)]),
+        3,
+    )
+    report("TD_BOUNDARY_CASE09_MULTI_ARBITRARY_WINDOWS", diff < TOL, diff)
+
+
+def run_case_10():
+    iso_strength = 0.8
+    arb_strength = 0.45
+    combo_bcs = [
+        reflecting_bc("xmin"),
+        reflecting_bc("xmax"),
+        arb_time_bc("ymin", lambda g, n, t: arb_strength if t <= DT else 0.0),
+        iso_bc("ymax", [iso_strength], 0.0, DT),
+        vacuum_bc("zmin"),
+        vacuum_bc("zmax"),
+    ]
+    arbitrary_ok = (
+        combo_bcs[2]["time_function"](0, 0, 0.0) == arb_strength
+        and combo_bcs[2]["time_function"](0, 0, 2.0 * DT) == 0.0
+    )
+    isotropic_ok = (
+        combo_bcs[3]["group_strength"][0] == iso_strength
+        and combo_bcs[3]["start_time"] == 0.0
+        and combo_bcs[3]["end_time"] == DT
+    )
+    reflecting_ok = combo_bcs[0]["type"] == "reflecting" and combo_bcs[1]["type"] == "reflecting"
+    pass_flag = arbitrary_ok and isotropic_ok and reflecting_ok
+    detail = 0.0 if pass_flag else 1.0
+    report("TD_BOUNDARY_CASE10_REFLECTING_ARBITRARY_ISO", pass_flag, detail)
+
+
+def run_case_11():
+    failed_as_expected = False
+    try:
+        make_1d_problem([iso_bc("zmin", [1.0], DT, 0.0), vacuum_bc("zmax")])
+    except Exception:
+        failed_as_expected = True
+    detail = 0.0 if failed_as_expected else 1.0
+    report("TD_BOUNDARY_CASE11_INVALID_ISO_BOUNDS", failed_as_expected, detail)
+
+
+def run_case_12():
+    failed_as_expected = False
+    try:
+        make_1d_problem(
+            [
+                {
+                    "name": "zmin",
+                    "type": "arbitrary",
+                    "time_function": AngularFluxTimeFunction(lambda g, n, t: 1.0),
+                    "start_time": 0.0,
+                },
+                vacuum_bc("zmax"),
+            ]
+        )
+    except Exception:
+        failed_as_expected = True
+    detail = 0.0 if failed_as_expected else 1.0
+    report("TD_BOUNDARY_CASE12_ARBITRARY_REJECTS_BOUNDS", failed_as_expected, detail)
+
+
+if __name__ == "__main__":
+    num_procs = 4
+    if size != num_procs:
+        sys.exit(f"Incorrect number of processors. Expected {num_procs} but got {size}.")
+
+    run_case_01()
+    run_case_02()
+    run_case_03()
+    run_case_04()
+    run_case_05()
+    run_case_06()
+    run_case_07()
+    run_case_08()
+    run_case_09()
+    run_case_10()
+    run_case_11()
+    run_case_12()
+
+    comm.Barrier()
+    if rank == 0 and os.path.exists(XS2_PATH):
+        os.remove(XS2_PATH)


### PR DESCRIPTION
In this PR, `SweepBoundary` is refactored:

- [x] `ArbitraryBoundary` and `ReflectingBoundary` accept different quadratures and angle aggregations per groupset.
- [x] Memory for all boundary are packed into one single `std::vector<double>` buffer (`BoundaryBank`) attached to `DiscreteOrdinatesProblem`. This enables one single contiguous copy of the boundary to GPU without bufferring.
- [x] `SweepBoundary` initialization steps are unified. Members are initialized in either the constructor or `InitializeAngleDependent`.
- [x] Fix a bug in `ReflectingBoundary` that write outgoing flux at group 0 instead of groupset first group.
- [x] Resolve issue [925](https://github.com/Open-Sn/opensn/issues/925).
- [x] For the GPU sweep, angle indices in an `AngleSet` are reordered so that their ordering is preserved between each `AngleSet` and its reflected `AngleSet`, regardless of the reflection map.
- [x] Add 2 regression tests for different quadratures per groupset.
- [x] Update new boundary accessing scheme for AAH GPU sweep. Boundary are copied from/to host's memory without bufferring.
- [x] Update time-dependent to boundary.

CPU sweep is not affected. Only improvement in the GPU sweep of low ranks are observed.

Strong scaling result (286k):
<img width="1232" height="919" alt="image" src="https://github.com/user-attachments/assets/ba496035-6942-439a-98b6-2c2db7d270b7" />
