### PR TITLE
Improvements for iteration logging

### DIFF
--- a/doc/source/tutorials/lbs/primer/adjoint_example.ipynb
+++ b/doc/source/tutorials/lbs/primer/adjoint_example.ipynb
@@ -331,15 +331,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0]  Using 1D Slab Gauss–Legendre product quadrature with 512 angles and weight sum of 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pquad = GLProductQuadrature1DSlab(n_polar=512, \n",
     "                                  scattering_order=0)"
@@ -443,7 +435,7 @@
      "output_type": "stream",
      "text": [
       "[0]  \n",
-      "[0]  Initializing LBS SteadyStateSourceSolver with name: LBSDiscreteOrdinatesProblem\n",
+      "[0]  00:00:00.0 Initializing solver SteadyStateSourceSolver.\n",
       "[0]  \n",
       "[0]  Scattering order    : 0\n",
       "[0]  Number of Groups    : 1\n",

--- a/doc/source/tutorials/lbs/src_driven/detector_adjoint/detector_adj.ipynb
+++ b/doc/source/tutorials/lbs/src_driven/detector_adjoint/detector_adj.ipynb
@@ -373,15 +373,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0]  Using 1D Slab Gauss–Legendre product quadrature with 512 angles and weight sum of 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pquad = GLProductQuadrature1DSlab(n_polar=512, \n",
     "                                  scattering_order=0)"
@@ -493,7 +485,7 @@
      "output_type": "stream",
      "text": [
       "[0]  \n",
-      "[0]  Initializing LBS SteadyStateSourceSolver with name: LBSDiscreteOrdinatesProblem\n",
+      "[0]  00:00:00.0 Initializing solver SteadyStateSourceSolver.\n",
       "[0]  \n",
       "[0]  Scattering order    : 0\n",
       "[0]  Number of Groups    : 69\n",

--- a/doc/source/tutorials/lbs/src_driven/detector_forward/detector.ipynb
+++ b/doc/source/tutorials/lbs/src_driven/detector_forward/detector.ipynb
@@ -374,15 +374,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0]  Using 1D Slab Gauss–Legendre product quadrature with 512 angles and weight sum of 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pquad = GLProductQuadrature1DSlab(n_polar=512, \n",
     "                                  scattering_order=0)"
@@ -505,7 +497,7 @@
      "output_type": "stream",
      "text": [
       "[0]  \n",
-      "[0]  Initializing LBS SteadyStateSourceSolver with name: LBSDiscreteOrdinatesProblem\n",
+      "[0]  00:00:00.0 Initializing solver SteadyStateSourceSolver.\n",
       "[0]  \n",
       "[0]  Scattering order    : 0\n",
       "[0]  Number of Groups    : 69\n",

--- a/doc/source/tutorials/lbs/transient/keigen_to_transient.ipynb
+++ b/doc/source/tutorials/lbs/transient/keigen_to_transient.ipynb
@@ -254,15 +254,7 @@
    "execution_count": 42,
    "id": "963454ce",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0]  Using 3D XYZ Gauss–Legendre/Chebyshev product quadrature with 8 angles and weight sum of 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pquad = GLCProductQuadrature3DXYZ(n_polar=2, n_azimuthal=4, scattering_order=0)"
    ]
@@ -347,7 +339,6 @@
     "        \"use_precursors\": False,\n",
     "        \"verbose_inner_iterations\": False,\n",
     "        \"verbose_outer_iterations\": True,\n",
-    "        \"verbose_ags_iterations\": False,\n",
     "    },\n",
     ")\n"
    ]
@@ -376,7 +367,7 @@
       "[0]          Final k-eigenvalue    :        1\n",
       "[0]          Final change          :        2.43605e-11 (Total number of sweeps:200)\n",
       "[0]  \n",
-      "[0]  LinearBoltzmann::KEigenvalueSolver execution completed\n",
+      "[0]  00:00:00.0 Finished solver execution PowerIterationKEigenSolver.\n",
       "[0]  \n"
      ]
     }
@@ -408,7 +399,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0]  Initializing TransientSolver.\n",
+      "[0]  00:00:00.0 Initializing solver TransientSolver.\n",
       "[0]  *** WARNING ***  TransientSolver: fissionable material is present but use_precursors is disabled. Running prompt-only transient.\n"
      ]
     }

--- a/doc/source/tutorials/lbs/transient/source_step_steady_to_transient_to_steady.ipynb
+++ b/doc/source/tutorials/lbs/transient/source_step_steady_to_transient_to_steady.ipynb
@@ -260,15 +260,7 @@
    "execution_count": 5,
    "id": "db9647f8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0]  Using 1D Slab Gauss–Legendre product quadrature with 4 angles and weight sum of 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pquad = GLProductQuadrature1DSlab(n_polar=4, scattering_order=0)\n"
    ]
@@ -344,7 +336,6 @@
     "        \"save_angular_flux\": True,\n",
     "        \"verbose_inner_iterations\": False,\n",
     "        \"verbose_outer_iterations\": False,\n",
-    "        \"verbose_ags_iterations\": False,\n",
     "    },\n",
     ")\n"
    ]

--- a/doc/source/userguide/discrete_ordinates_problems.rst
+++ b/doc/source/userguide/discrete_ordinates_problems.rst
@@ -206,7 +206,6 @@ The most important options for everyday use are:
 * ``max_ags_iterations``
 * ``ags_tolerance``
 * ``ags_convergence_check``
-* ``verbose_ags_iterations``
 * ``field_function_prefix_option``
 * ``field_function_prefix``
 

--- a/doc/source/userguide/groupsets.rst
+++ b/doc/source/userguide/groupsets.rst
@@ -438,7 +438,6 @@ Problem-level AGS controls live in the LBS options block:
 * ``max_ags_iterations``
 * ``ags_tolerance``
 * ``ags_convergence_check``
-* ``verbose_ags_iterations``
 
 Practical rule:
 

--- a/doc/source/userguide/iterative_methods.rst
+++ b/doc/source/userguide/iterative_methods.rst
@@ -94,9 +94,9 @@ These are specified in the problem ``options`` block:
 - ``max_ags_iterations``
 - ``ags_tolerance``
 - ``ags_convergence_check``
-- ``verbose_inner_iterations``
-- ``verbose_ags_iterations``
-- ``verbose_outer_iterations``
+- ``verbose_inner_iterations`` controls inner solver details, including WGS and AGS iterations.
+- ``verbose_outer_iterations`` controls outer solver progress, including PI/NLKE iterations and
+  transient step summaries.
 
 These settings control how the solver coordinates multiple groupsets and how
 much iteration information is printed.
@@ -399,7 +399,6 @@ The relevant problem options are:
 - ``max_ags_iterations``
 - ``ags_tolerance``
 - ``ags_convergence_check``
-- ``verbose_ags_iterations``
 
 What AGS does
 -------------
@@ -481,7 +480,6 @@ Example:
        "max_ags_iterations": 100,
        "ags_tolerance": 1.0e-6,
        "ags_convergence_check": "l2",
-       "verbose_ags_iterations": True,
    }
 
 
@@ -818,7 +816,6 @@ Two groupsets with AGS control
            "max_ags_iterations": 100,
            "ags_tolerance": 1.0e-6,
            "ags_convergence_check": "pointwise",
-           "verbose_ags_iterations": True,
        },
    )
 

--- a/doc/source/userguide/solvers.rst
+++ b/doc/source/userguide/solvers.rst
@@ -173,7 +173,6 @@ Problem options available in Python include:
 * ``max_ags_iterations``
 * ``ags_tolerance``
 * ``ags_convergence_check``
-* ``verbose_ags_iterations``
 * ``field_function_prefix_option``
 * ``field_function_prefix``
 

--- a/framework/logging/log_format.h
+++ b/framework/logging/log_format.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <iomanip>
+#include <ostream>
+#include <string>
+
+namespace opensn
+{
+
+enum class NumericFormatKind
+{
+  FIXED,
+  SCIENTIFIC,
+};
+
+struct NumericFormat
+{
+  int precision = 6;
+  NumericFormatKind kind = NumericFormatKind::SCIENTIFIC;
+};
+
+inline NumericFormat
+Fixed(const int precision)
+{
+  return {precision, NumericFormatKind::FIXED};
+}
+
+inline NumericFormat
+Scientific(const int precision)
+{
+  return {precision, NumericFormatKind::SCIENTIFIC};
+}
+
+inline void
+AppendNumericField(std::ostream& out,
+                   const std::string& label,
+                   const std::size_t value,
+                   const bool leading_separator = true)
+{
+  out << (leading_separator ? ", " : " ") << label << " = " << value;
+}
+
+inline void
+AppendNumericField(std::ostream& out,
+                   const std::string& label,
+                   const double value,
+                   const NumericFormat format,
+                   const bool leading_separator = true)
+{
+  out << (leading_separator ? ", " : " ") << label << " = ";
+  if (format.kind == NumericFormatKind::FIXED)
+    out << std::fixed;
+  else
+    out << std::scientific;
+  out << std::setprecision(format.precision) << value << std::defaultfloat;
+}
+
+} // namespace opensn

--- a/framework/math/nonlinear_solver/petsc_nonlinear_solver.cc
+++ b/framework/math/nonlinear_solver/petsc_nonlinear_solver.cc
@@ -4,8 +4,6 @@
 #include "framework/math/nonlinear_solver/petsc_nonlinear_solver.h"
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/runtime.h"
-#include "framework/logging/log.h"
-#include "framework/logging/stringstream_color.h"
 
 namespace opensn
 {
@@ -149,7 +147,6 @@ void
 PETScNonLinearSolver::Solve()
 {
   converged_ = false;
-  converged_reason_string_ = "Reason not obtained";
   PreSolveCallback();
   SetInitialGuess();
 
@@ -159,27 +156,8 @@ PETScNonLinearSolver::Solve()
   SNESConvergedReason conv_reason = SNES_CONVERGED_ITERATING;
   OpenSnPETScCall(SNESGetConvergedReason(nl_solver_, &conv_reason));
 
-  if (conv_reason > 0)
+  if (SNESReasonToPETScSolverStatus(conv_reason) == PETScSolverStatus::CONVERGED)
     converged_ = true;
-
-  const char* strreason = nullptr;
-  OpenSnPETScCall(SNESGetConvergedReasonString(nl_solver_, &strreason));
-
-  converged_reason_string_ = std::string(strreason);
-}
-
-std::string
-PETScNonLinearSolver::GetConvergedReasonString() const
-{
-  std::stringstream outstr;
-  if (converged_)
-    outstr << StringStreamColor(FG_GREEN) << std::string(10, ' ') << "Converged "
-           << converged_reason_string_ << StringStreamColor(RESET);
-  else
-    outstr << StringStreamColor(FG_RED) << std::string(10, ' ') << "Convergence failure "
-           << converged_reason_string_ << StringStreamColor(RESET);
-
-  return outstr.str();
 }
 
 } // namespace opensn

--- a/framework/math/nonlinear_solver/petsc_nonlinear_solver.h
+++ b/framework/math/nonlinear_solver/petsc_nonlinear_solver.h
@@ -30,8 +30,6 @@ public:
 
   bool IsConverged() const { return converged_; }
 
-  std::string GetConvergedReasonString() const;
-
   void Setup() override;
 
   void Solve() override;
@@ -67,7 +65,6 @@ protected:
 private:
   bool system_set_;
   bool converged_;
-  std::string converged_reason_string_;
 };
 
 } // namespace opensn

--- a/framework/math/petsc_utils/petsc_utils.cc
+++ b/framework/math/petsc_utils/petsc_utils.cc
@@ -3,9 +3,10 @@
 
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/data_types/parallel_vector/parallel_vector.h"
+#include "framework/logging/log_format.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include <iomanip>
+#include "framework/utils/timer.h"
 #include <sstream>
 #include <limits>
 
@@ -23,6 +24,53 @@ ToPetscInt(const int64_t value, const char* name)
   return static_cast<PetscInt>(value);
 }
 } // namespace
+
+PETScSolverStatus
+KSPReasonToPETScSolverStatus(const KSPConvergedReason reason)
+{
+  if (reason > 0)
+    return PETScSolverStatus::CONVERGED;
+  if (reason == KSP_DIVERGED_ITS)
+    return PETScSolverStatus::LIMIT;
+  if (reason < 0)
+    return PETScSolverStatus::FAILED;
+  if (reason == KSP_CONVERGED_ITERATING)
+    return PETScSolverStatus::ITERATING;
+  return PETScSolverStatus::NONE;
+}
+
+PETScSolverStatus
+SNESReasonToPETScSolverStatus(const SNESConvergedReason reason)
+{
+  if (reason > 0)
+    return PETScSolverStatus::CONVERGED;
+  if (reason == SNES_DIVERGED_MAX_IT or reason == SNES_DIVERGED_FUNCTION_COUNT)
+    return PETScSolverStatus::LIMIT;
+  if (reason < 0)
+    return PETScSolverStatus::FAILED;
+  if (reason == SNES_CONVERGED_ITERATING)
+    return PETScSolverStatus::ITERATING;
+  return PETScSolverStatus::NONE;
+}
+
+const char*
+PETScSolverStatusName(const PETScSolverStatus status)
+{
+  switch (status)
+  {
+    case PETScSolverStatus::CONVERGED:
+      return "converged";
+    case PETScSolverStatus::LIMIT:
+      return "iteration_limit";
+    case PETScSolverStatus::FAILED:
+      return "failed";
+    case PETScSolverStatus::ITERATING:
+      return "iterating";
+    case PETScSolverStatus::NONE:
+    default:
+      return "not_run";
+  }
+}
 
 [[noreturn]] void
 ThrowPETScError(int ierr, const char* expr, const char* file, int line)
@@ -213,8 +261,8 @@ KSPMonitorRelativeToRHS(KSP ksp, PetscInt n, PetscReal rnorm, void* /* context *
 
   // Print message
   std::stringstream buff;
-  buff << ksp_name << " iteration " << std::setw(4) << n << " - Residual " << std::scientific
-       << std::setprecision(7) << rnorm / rhs_norm << std::endl;
+  buff << program_timer.GetTimeString() << " " << ksp_name << " iteration = " << n;
+  AppendNumericField(buff, "residual", rnorm / rhs_norm, Scientific(6));
 
   log.Log() << buff.str();
 
@@ -401,7 +449,6 @@ GetPETScConvergedReasonstring(KSPConvergedReason reason)
     case KSP_CONVERGED_HAPPY_BREAKDOWN:
       ostr << "KSP_CONVERGED_HAPPY_BREAKDOWN";
       break;
-      /* diverged */
     case KSP_DIVERGED_NULL:
       ostr << "KSP_DIVERGED_NULL";
       break;
@@ -429,7 +476,73 @@ GetPETScConvergedReasonstring(KSPConvergedReason reason)
     case KSP_DIVERGED_INDEFINITE_MAT:
       ostr << "KSP_DIVERGED_INDEFINITE_MAT";
       break;
+    default:
+      ostr << "Unknown convergence reason.";
+  }
 
+  return ostr.str();
+}
+
+std::string
+GetPETScConvergedReasonstring(SNESConvergedReason reason)
+{
+  std::stringstream ostr;
+  switch (reason)
+  {
+    case SNES_CONVERGED_FNORM_ABS:
+      ostr << "SNES_CONVERGED_FNORM_ABS";
+      break;
+    case SNES_CONVERGED_FNORM_RELATIVE:
+      ostr << "SNES_CONVERGED_FNORM_RELATIVE";
+      break;
+    case SNES_CONVERGED_SNORM_RELATIVE:
+      ostr << "SNES_CONVERGED_SNORM_RELATIVE";
+      break;
+    case SNES_CONVERGED_ITS:
+      ostr << "SNES_CONVERGED_ITS";
+      break;
+    case SNES_CONVERGED_USER:
+      ostr << "SNES_CONVERGED_USER";
+      break;
+    case SNES_DIVERGED_FUNCTION_DOMAIN:
+      ostr << "SNES_DIVERGED_FUNCTION_DOMAIN";
+      break;
+    case SNES_DIVERGED_FUNCTION_COUNT:
+      ostr << "SNES_DIVERGED_FUNCTION_COUNT";
+      break;
+    case SNES_DIVERGED_LINEAR_SOLVE:
+      ostr << "SNES_DIVERGED_LINEAR_SOLVE";
+      break;
+    case SNES_DIVERGED_FNORM_NAN:
+      ostr << "SNES_DIVERGED_FNORM_NAN";
+      break;
+    case SNES_DIVERGED_MAX_IT:
+      ostr << "SNES_DIVERGED_MAX_IT";
+      break;
+    case SNES_DIVERGED_LINE_SEARCH:
+      ostr << "SNES_DIVERGED_LINE_SEARCH";
+      break;
+    case SNES_DIVERGED_INNER:
+      ostr << "SNES_DIVERGED_INNER";
+      break;
+    case SNES_DIVERGED_LOCAL_MIN:
+      ostr << "SNES_DIVERGED_LOCAL_MIN";
+      break;
+    case SNES_DIVERGED_DTOL:
+      ostr << "SNES_DIVERGED_DTOL";
+      break;
+    case SNES_DIVERGED_JACOBIAN_DOMAIN:
+      ostr << "SNES_DIVERGED_JACOBIAN_DOMAIN";
+      break;
+    case SNES_DIVERGED_TR_DELTA:
+      ostr << "SNES_DIVERGED_TR_DELTA";
+      break;
+    case SNES_DIVERGED_USER:
+      ostr << "SNES_DIVERGED_USER";
+      break;
+    case SNES_CONVERGED_ITERATING:
+      ostr << "SNES_CONVERGED_ITERATING";
+      break;
     default:
       ostr << "Unknown convergence reason.";
   }

--- a/framework/math/petsc_utils/petsc_utils.h
+++ b/framework/math/petsc_utils/petsc_utils.h
@@ -5,6 +5,7 @@
 
 #include "framework/utils/error.h"
 #include <petscksp.h>
+#include <petscsnes.h>
 #include <vector>
 
 namespace opensn
@@ -25,6 +26,19 @@ struct PETScSolverSetup
   double relative_residual_tol = 1.0e-6;
   int maximum_iterations = 100;
 };
+
+enum class PETScSolverStatus
+{
+  NONE,
+  ITERATING,
+  CONVERGED,
+  LIMIT,
+  FAILED,
+};
+
+PETScSolverStatus KSPReasonToPETScSolverStatus(KSPConvergedReason reason);
+PETScSolverStatus SNESReasonToPETScSolverStatus(SNESConvergedReason reason);
+const char* PETScSolverStatusName(PETScSolverStatus status);
 
 /**
  * Creates a general vector.
@@ -227,5 +241,8 @@ void RestoreGhostVectorLocalViewRead(Vec x, GhostVecLocalRaw& local_data);
 
 /// Gets the string value of a converged reason.
 std::string GetPETScConvergedReasonstring(KSPConvergedReason reason);
+
+/// Gets the string value of a converged reason.
+std::string GetPETScConvergedReasonstring(SNESConvergedReason reason);
 
 } // namespace opensn

--- a/framework/math/quadratures/angular/angular_quadrature.cc
+++ b/framework/math/quadratures/angular/angular_quadrature.cc
@@ -17,6 +17,12 @@
 namespace opensn
 {
 
+double
+AngularQuadrature::GetWeightSum() const
+{
+  return std::accumulate(weights.begin(), weights.end(), 0.0);
+}
+
 void
 AngularQuadrature::MakeHarmonicIndices()
 {

--- a/framework/math/quadratures/angular/angular_quadrature.h
+++ b/framework/math/quadratures/angular/angular_quadrature.h
@@ -6,6 +6,7 @@
 #include "framework/data_types/vector3.h"
 #include "framework/data_types/ndarray.h"
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace opensn
@@ -132,6 +133,12 @@ public:
   unsigned int GetNumMoments() const { return m_to_ell_em_map_.size(); }
 
   AngularQuadratureType GetType() const { return type_; }
+
+  /// Return a user-facing quadrature name.
+  virtual std::string GetName() const = 0;
+
+  /// Return the sum of all quadrature weights.
+  virtual double GetWeightSum() const;
 
   /// Set the quadrature-specific order parameter.
   /// For Lebedev: Lebedev order {3, 5, 7, ...}; for SLDFESQ: uniform refinement level.

--- a/framework/math/quadratures/angular/curvilinear_product_quadrature.h
+++ b/framework/math/quadratures/angular/curvilinear_product_quadrature.h
@@ -49,6 +49,8 @@ public:
 
   ~GLCProductQuadrature2DRZ() override = default;
 
+  std::string GetName() const override { return "2D RZ Gauss-Legendre/Chebyshev product"; }
+
   void MakeHarmonicIndices();
 
 private:
@@ -71,6 +73,8 @@ public:
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
 
   ~GLProductQuadrature1DSpherical() override = default;
+
+  std::string GetName() const override { return "1D Spherical Gauss-Legendre product"; }
 
   void MakeHarmonicIndices();
 

--- a/framework/math/quadratures/angular/lebedev_quadrature.h
+++ b/framework/math/quadratures/angular/lebedev_quadrature.h
@@ -29,6 +29,8 @@ public:
                          bool verbose = false,
                          OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
 
+  std::string GetName() const override { return "3D XYZ Lebedev"; }
+
 private:
   /// Load quadrature points for the given order from predefined tabulated data.
   void LoadFromOrder(unsigned int quadrature_order, bool verbose = false);
@@ -51,6 +53,8 @@ public:
                         unsigned int scattering_order,
                         bool verbose = false,
                         OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
+
+  std::string GetName() const override { return "2D XY Lebedev"; }
 
 private:
   /// Load upper-hemisphere points for the given order, halving weights at the equator.

--- a/framework/math/quadratures/angular/product_quadrature.cc
+++ b/framework/math/quadratures/angular/product_quadrature.cc
@@ -124,10 +124,6 @@ GLProductQuadrature1DSlab::GLProductQuadrature1DSlab(unsigned int Npolar,
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
-
-  log.Log() << "Using 1D Slab Gauss–Legendre product quadrature with " << omegas.size()
-            << " angles and weight sum of " << std::fixed << std::setprecision(2) << weight_sum_
-            << std::endl;
 }
 
 GLCProductQuadrature2DXY::GLCProductQuadrature2DXY(unsigned int Npolar,
@@ -172,10 +168,6 @@ GLCProductQuadrature2DXY::GLCProductQuadrature2DXY(unsigned int Npolar,
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
-
-  log.Log() << "Using 2D XY Gauss–Legendre/Chebyshev product quadrature with " << omegas.size()
-            << " angles and weight sum of " << std::fixed << std::setprecision(2) << weight_sum_
-            << std::endl;
 }
 
 GLCProductQuadrature3DXYZ::GLCProductQuadrature3DXYZ(unsigned int Npolar,
@@ -219,10 +211,6 @@ GLCProductQuadrature3DXYZ::GLCProductQuadrature3DXYZ(unsigned int Npolar,
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
-
-  log.Log() << "Using 3D XYZ Gauss–Legendre/Chebyshev product quadrature with " << omegas.size()
-            << " angles and weight sum of " << std::fixed << std::setprecision(2) << weight_sum_
-            << std::endl;
 }
 
 } // namespace opensn

--- a/framework/math/quadratures/angular/product_quadrature.h
+++ b/framework/math/quadratures/angular/product_quadrature.h
@@ -63,6 +63,8 @@ public:
     unsigned int scattering_order,
     bool verbose = false,
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
+
+  std::string GetName() const override { return "1D Slab Gauss-Legendre product"; }
 };
 
 class GLCProductQuadrature2DXY : public ProductQuadrature
@@ -75,6 +77,8 @@ public:
     unsigned int scattering_order,
     bool verbose = false,
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
+
+  std::string GetName() const override { return "2D XY Gauss-Legendre/Chebyshev product"; }
 };
 
 class GLCProductQuadrature3DXYZ : public ProductQuadrature
@@ -87,6 +91,8 @@ public:
     unsigned int scattering_order,
     bool verbose = false,
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
+
+  std::string GetName() const override { return "3D XYZ Gauss-Legendre/Chebyshev product"; }
 };
 
 } // namespace opensn

--- a/framework/math/quadratures/angular/sldfe_sq_quadrature.h
+++ b/framework/math/quadratures/angular/sldfe_sq_quadrature.h
@@ -185,6 +185,8 @@ public:
                          OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
 
   ~SLDFEsqQuadrature3DXYZ() override = default;
+
+  std::string GetName() const override { return "3D XYZ SLDFE square"; }
 };
 
 class SLDFEsqQuadrature2DXY : public SLDFEsqQuadrature
@@ -196,6 +198,8 @@ public:
                         OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
 
   ~SLDFEsqQuadrature2DXY() override = default;
+
+  std::string GetName() const override { return "2D XY SLDFE square"; }
 
 protected:
   bool FilterQuadraturePoint(const Vector3& omega) const override;

--- a/framework/math/quadratures/angular/triangular_quadrature.cc
+++ b/framework/math/quadratures/angular/triangular_quadrature.cc
@@ -6,8 +6,6 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include <cmath>
-#include <sstream>
-#include <iomanip>
 
 namespace opensn
 {
@@ -167,27 +165,6 @@ GLCTriangularQuadrature3DXYZ::GLCTriangularQuadrature3DXYZ(unsigned int Npolar,
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
-
-  // Count total number of angles
-  size_t total_angles = 0;
-  for (unsigned int j = 0; j < Npolar; ++j)
-    total_angles += num_azimuthal_per_level[j];
-
-  log.Log() << "Using 3D XYZ Triangular quadrature with " << total_angles << " angles (" << Npolar
-            << " polar levels, " << Nazimuthal << " max azimuthal)"
-            << " and weight sum of " << std::fixed << std::setprecision(2) << weight_sum_;
-
-  // Log the number of azimuthal angles at each polar level
-  std::stringstream ss;
-  ss << "Azimuthal angles per polar level: [";
-  for (unsigned int j = 0; j < Npolar; ++j)
-  {
-    if (j > 0)
-      ss << ", ";
-    ss << num_azimuthal_per_level[j];
-  }
-  ss << "]";
-  log.Log() << ss.str();
 }
 
 void
@@ -335,27 +312,6 @@ GLCTriangularQuadrature2DXY::GLCTriangularQuadrature2DXY(unsigned int Npolar,
   MakeHarmonicIndices();
   BuildDiscreteToMomentOperator();
   BuildMomentToDiscreteOperator();
-
-  // Count total number of angles
-  size_t total_angles = 0;
-  for (unsigned int j = 0; j < half; ++j)
-    total_angles += num_azimuthal_per_level[j];
-
-  log.Log() << "Using 2D XY Triangular quadrature with " << total_angles << " angles (" << half
-            << " polar levels, " << Nazimuthal << " max azimuthal)"
-            << " and weight sum of " << std::fixed << std::setprecision(2) << weight_sum_;
-
-  // Log the number of azimuthal angles at each polar level
-  std::stringstream ss;
-  ss << "Azimuthal angles per polar level: [";
-  for (unsigned int j = 0; j < half; ++j)
-  {
-    if (j > 0)
-      ss << ", ";
-    ss << num_azimuthal_per_level[j];
-  }
-  ss << "]";
-  log.Log() << ss.str();
 }
 
 } // namespace opensn

--- a/framework/math/quadratures/angular/triangular_quadrature.h
+++ b/framework/math/quadratures/angular/triangular_quadrature.h
@@ -80,6 +80,8 @@ public:
     bool verbose = false,
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
 
+  std::string GetName() const override { return "3D XYZ Triangular"; }
+
 private:
   /// Assemble quadrature points and weights for the varying azimuthal angles per polar level.
   void AssembleTriangularCosines(const std::vector<std::vector<double>>& azimuthal_per_polar,
@@ -108,6 +110,8 @@ public:
     unsigned int scattering_order,
     bool verbose = false,
     OperatorConstructionMethod method = OperatorConstructionMethod::STANDARD);
+
+  std::string GetName() const override { return "2D XY Triangular"; }
 
 private:
   /// Assemble quadrature points and weights for the varying azimuthal angles per polar level.

--- a/modules/diffusion/diffusion.cc
+++ b/modules/diffusion/diffusion.cc
@@ -2,14 +2,56 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/diffusion/diffusion.h"
+#include "framework/logging/log_format.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include "framework/utils/timer.h"
+#include <sstream>
 
 namespace opensn
 {
+
+namespace
+{
+
+void
+LogDiffusionSolveStart(const std::string& name, Vec rhs)
+{
+  double rhs_norm = 0.0;
+  OpenSnPETScCall(VecNorm(rhs, NORM_2, &rhs_norm));
+
+  std::ostringstream out;
+  out << name << " solve";
+  AppendNumericField(out, "rhs_norm", rhs_norm, Scientific(6));
+  log.Log() << program_timer.GetTimeString() << " " << out.str();
+}
+
+void
+LogDiffusionSolveFinal(const std::string& name, KSP ksp, Vec x)
+{
+  double solution_norm = 0.0;
+  OpenSnPETScCall(VecNorm(x, NORM_2, &solution_norm));
+
+  KSPConvergedReason reason = KSP_CONVERGED_ITERATING;
+  OpenSnPETScCall(KSPGetConvergedReason(ksp, &reason));
+  PetscInt iterations = 0;
+  OpenSnPETScCall(KSPGetIterationNumber(ksp, &iterations));
+
+  const auto status = KSPReasonToPETScSolverStatus(reason);
+
+  std::ostringstream out;
+  out << name << " final, status = " << PETScSolverStatusName(status);
+  AppendNumericField(out, "iterations", static_cast<std::size_t>(iterations));
+  AppendNumericField(out, "solution_norm", solution_norm, Scientific(6));
+  if (log.GetVerbosity() >= 2)
+    out << ", detail = " << GetPETScConvergedReasonstring(reason);
+  log.Log() << program_timer.GetTimeString() << " " << out.str();
+}
+
+} // namespace
 
 DiffusionSolver::DiffusionSolver(std::string name,
                                  const opensn::SpatialDiscretization& sdm,
@@ -209,10 +251,7 @@ DiffusionSolver::Solve(std::vector<double>& solution, bool use_initial_guess)
   if (options.verbose)
   {
     OpenSnPETScCall(KSPMonitorSet(ksp_, &KSPMonitorRelativeToRHS, nullptr, nullptr));
-
-    double rhs_norm = 0.0;
-    OpenSnPETScCall(VecNorm(rhs_, NORM_2, &rhs_norm));
-    log.Log() << "RHS-norm " << rhs_norm;
+    LogDiffusionSolveStart(name_, rhs_);
   }
 
   if (use_initial_guess)
@@ -230,16 +269,7 @@ DiffusionSolver::Solve(std::vector<double>& solution, bool use_initial_guess)
 
   // Print convergence info
   if (options.verbose)
-  {
-    double sol_norm = 0.0;
-    OpenSnPETScCall(VecNorm(x, NORM_2, &sol_norm));
-    log.Log() << "Solution-norm " << sol_norm;
-
-    KSPConvergedReason reason = KSP_CONVERGED_ITERATING;
-    OpenSnPETScCall(KSPGetConvergedReason(ksp_, &reason));
-
-    log.Log() << "Convergence Reason: " << GetPETScConvergedReasonstring(reason);
-  }
+    LogDiffusionSolveFinal(name_, ksp_, x);
 
   // Transfer petsc solution to vector
   if (requires_ghosts_)
@@ -281,10 +311,7 @@ DiffusionSolver::Solve(Vec petsc_solution, bool use_initial_guess)
   if (options.verbose)
   {
     OpenSnPETScCall(KSPMonitorSet(ksp_, &KSPMonitorRelativeToRHS, nullptr, nullptr));
-
-    double rhs_norm = 0.0;
-    OpenSnPETScCall(VecNorm(rhs_, NORM_2, &rhs_norm));
-    log.Log() << "RHS-norm " << rhs_norm;
+    LogDiffusionSolveStart(name_, rhs_);
   }
 
   if (use_initial_guess)
@@ -297,16 +324,7 @@ DiffusionSolver::Solve(Vec petsc_solution, bool use_initial_guess)
 
   // Print convergence info
   if (options.verbose)
-  {
-    double sol_norm = 0.0;
-    OpenSnPETScCall(VecNorm(x, NORM_2, &sol_norm));
-    log.Log() << "Solution-norm " << sol_norm;
-
-    KSPConvergedReason reason = KSP_CONVERGED_ITERATING;
-    OpenSnPETScCall(KSPGetConvergedReason(ksp_, &reason));
-
-    log.Log() << "Convergence Reason: " << GetPETScConvergedReasonstring(reason);
-  }
+    LogDiffusionSolveFinal(name_, ksp_, x);
 
   // Transfer petsc solution to vector
   OpenSnPETScCall(VecCopy(x, petsc_solution));

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/nl_keigen_acc_solver.cc
@@ -7,10 +7,11 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.h"
+#include "framework/logging/log_format.h"
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include <iomanip>
+#include "framework/utils/timer.h"
 
 namespace opensn
 {
@@ -117,12 +118,22 @@ NLKEigenDiffSolver::PostSolveCallback()
 
   PetscInt number_of_func_evals = 0;
   OpenSnPETScCall(SNESGetNumberFunctionEvals(nl_solver_, &number_of_func_evals));
+  SNESConvergedReason reason = SNES_CONVERGED_ITERATING;
+  OpenSnPETScCall(SNESGetConvergedReason(nl_solver_, &reason));
+  const auto status = SNESReasonToPETScSolverStatus(reason);
 
   // Print summary
   if (nl_context_ptr->verbosity_level >= 1)
-    log.Log() << "        Final lambda-eigenvalue    :        " << std::fixed << std::setw(10)
-              << std::setprecision(7) << k_eff << " (num_DOps:" << number_of_func_evals << ")"
-              << "\n";
+  {
+    std::stringstream summary;
+    summary << "NLKE diffusion final, status = " << PETScSolverStatusName(status);
+    AppendNumericField(summary, "k_eff", k_eff, Fixed(7));
+    AppendNumericField(
+      summary, "function_evaluations", static_cast<std::size_t>(number_of_func_evals));
+    if (log.GetVerbosity() >= 2)
+      summary << ", detail = " << GetPETScConvergedReasonstring(reason);
+    log.Log() << program_timer.GetTimeString() << " " << summary.str();
+  }
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
@@ -4,6 +4,7 @@
 #include "framework/data_types/vector_ghost_communicator/vector_ghost_communicator.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
 #include "framework/runtime.h"
+#include "framework/utils/timer.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "modules/diffusion/diffusion_pwlc_solver.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
@@ -11,6 +12,8 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
+#include <sstream>
 namespace opensn
 {
 OpenSnRegisterObjectInNamespace(lbs, SCDSAAcceleration);
@@ -210,11 +213,20 @@ SCDSAAcceleration::PostPowerIteration()
     lambda_kp1 = production_kp1 / (production_k / lambda_k);
 
     const double lambda_change = std::fabs(lambda_kp1 / lambda_k - 1.0);
+    const bool converged = lambda_change < pi_k_tol_;
+    const auto status = IterationStatusFromSolve(converged, k + 1 == pi_max_its_);
     if (verbose_ >= 1)
-      log.Log() << "PISCDSA iteration " << k << " lambda " << lambda_kp1 << " lambda change "
-                << lambda_change;
+    {
+      std::ostringstream out;
+      out << "PISCDSA iteration = " << k;
+      AppendNumericField(out, "lambda", lambda_kp1, Fixed(7));
+      AppendNumericField(out, "lambda_change", lambda_change, Scientific(6));
+      if (status != IterationStatus::NONE)
+        out << ", status = " << IterationStatusName(status);
+      log.Log() << program_timer.GetTimeString() << " " << out.str();
+    }
 
-    if (lambda_change < pi_k_tol_)
+    if (converged)
       break;
 
     lambda_k = lambda_kp1;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #include "framework/object_factory.h"
 #include "framework/runtime.h"
+#include "framework/utils/timer.h"
 #include "framework/data_types/parallel_vector/ghosted_parallel_stl_vector.h"
 #include "framework/data_types/parallel_vector/parallel_stl_vector.h"
 #include "framework/math/spatial_discretization/finite_element/finite_element_data.h"
@@ -14,6 +15,8 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/acceleration.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
+#include <sstream>
 
 namespace opensn
 {
@@ -169,6 +172,7 @@ SMMAcceleration::PostPowerIteration()
   double lambda = solver_->GetEigenvalue();
   double lambda_old = solver_->GetEigenvalue();
   double F0_old = ComputeFissionProduction(do_problem_, phi_new_local_);
+  bool converged = false;
 
   for (int m = 0; m < pi_max_its_; ++m)
   {
@@ -206,10 +210,21 @@ SMMAcceleration::PostPowerIteration()
 
     // Check for convergence
     const double lambda_change = std::fabs(lambda / lambda_old - 1.0);
-    const auto converged = lambda_change < pi_k_tol_;
+    const bool converged_this_iteration = lambda_change < pi_k_tol_;
+    const auto status = IterationStatusFromSolve(converged_this_iteration, m + 1 == pi_max_its_);
     if (verbose_)
-      log.Log() << "SMM PI iteration " << m << "  lambda " << lambda << "  change " << lambda_change
-                << (converged ? "  CONVERGED" : "");
+    {
+      std::ostringstream out;
+      out << "SMM PI iteration = " << m;
+      AppendNumericField(out, "lambda", lambda, Fixed(7));
+      AppendNumericField(out, "lambda_change", lambda_change, Scientific(6));
+      if (status != IterationStatus::NONE)
+        out << ", status = " << IterationStatusName(status);
+      log.Log() << program_timer.GetTimeString() << " " << out.str();
+    }
+
+    if (converged_this_iteration)
+      converged = true;
 
     // Bump variables for next iteration
     lambda_old = lambda;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -45,7 +45,6 @@
 #include <cassert>
 #include <cmath>
 #include <iomanip>
-#include <numeric>
 #include <sstream>
 #include <stdexcept>
 
@@ -521,7 +520,10 @@ DiscreteOrdinatesProblem::PrintSimHeader()
     for (const auto& groupset : groupsets_)
     {
       outstr << "***** Groupset " << groupset.id << " *****\n"
+             << "Quadrature type : " << groupset.quadrature->GetName() << "\n"
              << "Number of angles: " << groupset.quadrature->abscissae.size() << "\n"
+             << "Quadrature norm : " << std::fixed << std::setprecision(2)
+             << groupset.quadrature->GetWeightSum() << std::defaultfloat << "\n"
              << "Groups:\n";
       const auto n_gs_groups = groupset.GetNumGroups();
       constexpr int groups_per_line = 12;
@@ -599,6 +601,7 @@ DiscreteOrdinatesProblem::BuildRuntime()
     WGDSA::Init(*this, groupset);
     TGDSA::Init(*this, groupset);
   }
+  log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
   InitializeSolverSchemes();
 }
 
@@ -633,7 +636,7 @@ DiscreteOrdinatesProblem::InitializeSolverSchemes()
   else
   {
     ags_solver_->SetMaxIterations(options_.max_ags_iterations);
-    ags_solver_->SetVerbosity(options_.verbose_ags_iterations);
+    ags_solver_->SetVerbosity(options_.verbose_inner_iterations);
   }
   ags_solver_->SetTolerance(options_.ags_tolerance);
 }
@@ -1866,9 +1869,6 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
         OpenSnInvalidArgument("Unsupported sweeptype \"" + sweep_type_ + "\"");
     } // for an_ss
   } // for so_grouping
-
-  if (options_.verbose_inner_iterations)
-    log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
 
   opensn::mpi_comm.barrier();
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
@@ -3,12 +3,13 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/convergence.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
-#include <iomanip>
 
 namespace opensn
 {
@@ -18,8 +19,8 @@ AGSLinearSolver::Solve()
 {
   CALI_CXX_MARK_SCOPE("AGSLinearSolver::Solve");
   const bool is_multi_groupset = wgs_solvers_.size() > 1;
-  const bool does_ags_iterations = max_iterations_ > 1;
-  const bool print_ags_stats = verbose_ and is_multi_groupset and does_ags_iterations;
+  const bool print_ags_stats = verbose_ and is_multi_groupset;
+  last_solve_ = {};
 
   phi_old_ = lbs_problem_.GetPhiOldLocal();
 
@@ -28,47 +29,62 @@ AGSLinearSolver::Solve()
   const auto saved_qmoms = lbs_problem_.GetQMomentsLocal();
 
   double pw_change_prev = 1.0;
+  double last_error = 0.0;
   bool converged = false;
+  bool failed = false;
+  bool child_limited = false;
+  unsigned int num_iterations = 0;
+  const bool reports_as_iteration = is_multi_groupset;
   for (unsigned int iter = 0; iter < max_iterations_; ++iter)
   {
+    num_iterations = iter + 1;
     for (auto& solver : wgs_solvers_)
     {
       solver->Setup();
       solver->Solve();
     }
 
+    std::vector<IterationSummary> wgs_summaries;
+    wgs_summaries.reserve(wgs_solvers_.size());
+    for (size_t gsid = 0; gsid < wgs_solvers_.size(); ++gsid)
+    {
+      auto wgs_context = std::dynamic_pointer_cast<WGSContext>(wgs_solvers_[gsid]->GetContext());
+      if (wgs_context and HasIterationStatus(wgs_context->last_solve))
+        wgs_summaries.emplace_back(wgs_context->last_solve);
+    }
+    const auto wgs_status = MostSevereIterationStatus(wgs_summaries);
+
     std::stringstream iter_stats;
-    iter_stats << program_timer.GetTimeString() << " AGS Iteration ";
+    iter_stats << program_timer.GetTimeString() << " AGS iteration = " << iter;
 
     if (lbs_problem_.GetOptions().ags_pointwise_convergence)
     {
       double pw_change = ComputePointwisePhiChange(lbs_problem_, phi_old_);
+      last_error = pw_change;
       double rho = (iter == 0) ? 0.0 : sqrt(pw_change / pw_change_prev);
       pw_change_prev = pw_change;
 
-      iter_stats << std::left << std::setw(5) << iter << " Point-wise change " << std::left
-                 << std::setw(14) << pw_change << " Spectral-radius estimate " << std::left
-                 << std::setw(10) << rho;
+      AppendNumericField(iter_stats, "pw_change", pw_change, Scientific(6));
+      AppendNumericField(iter_stats, "rho_est", rho, Fixed(4));
 
       if (pw_change < std::max(tolerance_ * (1.0 - rho), 1.0e-10))
-      {
         converged = true;
-        iter_stats << " CONVERGED";
-      }
     }
     else
     {
       double norm = ComputeL2PhiChange(lbs_problem_, phi_old_);
+      last_error = norm;
 
-      iter_stats << std::left << std::setw(5) << iter << " Error Norm " << std::left
-                 << std::setw(14) << norm;
+      AppendNumericField(iter_stats, "l2_change", norm, Scientific(6));
 
       if (norm < tolerance_)
-      {
         converged = true;
-        iter_stats << " CONVERGED";
-      }
     }
+
+    const auto iteration_status = IterationStatusFromSolve(converged, false, wgs_status);
+    if (iteration_status != IterationStatus::NONE)
+      iter_stats << ", status = " << IterationStatusName(iteration_status);
+    iter_stats << FormatNestedStatusCounts("WGS", wgs_summaries);
 
     if (print_ags_stats)
       log.Log() << iter_stats.str();
@@ -76,10 +92,80 @@ AGSLinearSolver::Solve()
     // Restore qmoms
     lbs_problem_.SetQMomentsFrom(saved_qmoms);
 
-    if (converged)
+    if (wgs_status == IterationStatus::FAILED)
+    {
+      failed = true;
+      break;
+    }
+    else if (wgs_status == IterationStatus::LIMIT)
+    {
+      child_limited = true;
+      break;
+    }
+    else if (converged)
       break;
     else
       phi_old_ = lbs_problem_.GetPhiNewLocal();
+  }
+
+  const auto inner_status = failed
+                              ? IterationStatus::FAILED
+                              : (child_limited ? IterationStatus::LIMIT : IterationStatus::NONE);
+  last_solve_.num_iterations = reports_as_iteration ? num_iterations : 0;
+  last_solve_.status = reports_as_iteration
+                         ? IterationStatusFromSolve(converged, true, inner_status)
+                         : IterationStatus::NONE;
+  last_solve_.metric_name =
+    lbs_problem_.GetOptions().ags_pointwise_convergence ? "pw_change" : "l2_change";
+  last_solve_.metric_value = last_error;
+  if (print_ags_stats and not converged)
+    log.Log() << program_timer.GetTimeString() << " " << FormatIterationSummary("AGS", last_solve_);
+
+  for (const auto& solver : wgs_solvers_)
+  {
+    auto sweep_context = std::dynamic_pointer_cast<SweepWGSContext>(solver->GetContext());
+    if (not sweep_context or not sweep_context->log_info)
+      continue;
+
+    const auto stats = sweep_context->GetAccumulatedSweepStats();
+    if (stats.num_sweeps == 0)
+      continue;
+
+    const double avg_sweep_time = stats.total_sweep_time / static_cast<double>(stats.num_sweeps);
+    const auto& groupset = sweep_context->groupset;
+    const size_t num_angles = groupset.quadrature->abscissae.size();
+    const size_t num_unknowns =
+      lbs_problem_.GetGlobalNodeCount() * num_angles * groupset.GetNumGroups();
+    const auto num_delayed_psi_info = groupset.angle_agg->GetNumDelayedAngularDOFs();
+    const size_t num_delayed_unknowns = num_delayed_psi_info.second;
+    const double delayed_unknown_percent =
+      (num_unknowns > 0)
+        ? static_cast<double>(num_delayed_unknowns) * 100.0 / static_cast<double>(num_unknowns)
+        : 0.0;
+    double max_avg_sweep_time = 0.0;
+    opensn::mpi_comm.all_reduce(&avg_sweep_time, 1, &max_avg_sweep_time, mpi::op::max<double>());
+
+    const double sweep_time_per_unknown =
+      num_unknowns > 0 ? max_avg_sweep_time * 1.0e9 / static_cast<double>(num_unknowns) : 0.0;
+    const std::string label = "WGS groups [" + std::to_string(groupset.first_group) + "-" +
+                              std::to_string(groupset.last_group) + "]";
+    std::stringstream sweep_timing;
+    sweep_timing << label;
+    AppendNumericField(sweep_timing, "avg_sweep_time", max_avg_sweep_time, Scientific(6), false);
+    sweep_timing << " s";
+    AppendNumericField(
+      sweep_timing, "sweep_time_per_unknown", sweep_time_per_unknown, Scientific(6));
+    sweep_timing << " ns";
+    log.Log() << program_timer.GetTimeString() << " " << sweep_timing.str();
+
+    std::stringstream sweep_work;
+    sweep_work << label;
+    AppendNumericField(sweep_work, "unknowns", num_unknowns, false);
+    AppendNumericField(sweep_work, "lagged_unknowns", num_delayed_unknowns);
+    AppendNumericField(sweep_work, "lagged_pct", delayed_unknown_percent, Fixed(2));
+    log.Log() << program_timer.GetTimeString() << " " << sweep_work.str();
+
+    sweep_context->ResetAccumulatedSweepStats();
   }
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "framework/math/linear_solver/linear_system_solver.h"
 #include "framework/utils/timer.h"
 #include <vector>
@@ -42,6 +43,8 @@ public:
 
   void SetMaxIterations(unsigned int max_iterations) { max_iterations_ = max_iterations; }
 
+  const IterationSummary& GetLastSolveSummary() const { return last_solve_; }
+
 private:
   LBSProblem& lbs_problem_; // NOLINT(clang-diagnostic-unused-private-field)
   std::vector<std::shared_ptr<LinearSolver>> wgs_solvers_;
@@ -49,6 +52,7 @@ private:
   unsigned int max_iterations_;
   double tolerance_;
   bool verbose_;
+  IterationSummary last_solve_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
@@ -4,6 +4,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/convergence.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/tgdsa.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
@@ -14,7 +15,6 @@
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
 #include <memory>
-#include <iomanip>
 
 namespace opensn
 {
@@ -45,14 +45,18 @@ ClassicRichardson::Solve()
 
   auto& groupset = gs_context_ptr->groupset;
   auto& do_problem = gs_context_ptr->do_problem;
+  gs_context_ptr->last_solve = {};
   const auto scope = gs_context_ptr->lhs_src_scope | gs_context_ptr->rhs_src_scope;
   saved_q_moments_local_ = do_problem.GetQMomentsLocal();
   psi_old_ = groupset.angle_agg->GetOldDelayedAngularDOFsAsSTLVector();
 
   double pw_phi_change_prev = 1.0;
+  double last_pw_phi_change = 0.0;
   bool converged = false;
+  unsigned int num_iterations = 0;
   for (unsigned int k = 0; k < groupset.max_iterations; ++k)
   {
+    num_iterations = k + 1;
     do_problem.SetQMomentsFrom(saved_q_moments_local_);
     gs_context_ptr->set_source_function(
       groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
@@ -83,6 +87,7 @@ ClassicRichardson::Solve()
     }
 
     double pw_phi_change = ComputePointwisePhiChange(do_problem, groupset.id);
+    last_pw_phi_change = pw_phi_change;
     double rho = (k == 0) ? 0.0 : sqrt(pw_phi_change / pw_phi_change_prev);
     pw_phi_change_prev = pw_phi_change;
 
@@ -101,18 +106,16 @@ ClassicRichardson::Solve()
     {
       std::stringstream iter_stats;
       iter_stats << program_timer.GetTimeString() << " WGS groups [" << groupset.first_group << "-"
-                 << groupset.last_group << "]:"
-                 << " Iteration = " << std::left << std::setw(5) << k
-                 << " Point-wise change = " << std::left << std::setw(14) << pw_phi_change
-                 << " Spectral-radius estimate = " << std::left << std::setw(10) << rho;
+                 << groupset.last_group << "]"
+                 << " iteration = " << k;
+      AppendNumericField(iter_stats, "phi_change", pw_phi_change, Scientific(6));
+      if (not psi_new_.empty())
+        AppendNumericField(iter_stats, "psi_change", pw_psi_change, Scientific(6));
+      AppendNumericField(iter_stats, "rho_est", rho, Fixed(4));
 
       if (converged)
-      {
-        iter_stats << " CONVERGED";
-        log.Log() << iter_stats.str();
-      }
-      else
-        log.Log() << iter_stats.str();
+        iter_stats << ", status = " << IterationStatusName(IterationStatus::CONVERGED);
+      log.Log() << iter_stats.str();
     }
 
     if (converged)
@@ -121,6 +124,18 @@ ClassicRichardson::Solve()
       break;
     }
   }
+
+  gs_context_ptr->last_solve.num_iterations = num_iterations;
+  gs_context_ptr->last_solve.status = IterationStatusFromSolve(converged, true);
+  gs_context_ptr->last_solve.detail = converged ? "pointwise_converged" : "iteration_limit";
+  gs_context_ptr->last_solve.metric_name = "phi_change";
+  gs_context_ptr->last_solve.metric_value = last_pw_phi_change;
+
+  if (verbose_ and not converged)
+    log.Log() << program_timer.GetTimeString() << " "
+              << FormatIterationSummary("WGS groups [" + std::to_string(groupset.first_group) +
+                                          "-" + std::to_string(groupset.last_group) + "]",
+                                        gs_context_ptr->last_solve);
 
   do_problem.SetQMomentsFrom(saved_q_moments_local_);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_residual_func.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
@@ -9,8 +10,8 @@
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
+#include "framework/utils/timer.h"
 #include <petscsnes.h>
-#include <iomanip>
 
 namespace opensn
 {
@@ -132,12 +133,21 @@ NLKEigenvalueAGSSolver::PostSolveCallback()
 
   PetscInt number_of_func_evals = 0;
   OpenSnPETScCall(SNESGetNumberFunctionEvals(nl_solver_, &number_of_func_evals));
+  SNESConvergedReason reason = SNES_CONVERGED_ITERATING;
+  OpenSnPETScCall(SNESGetConvergedReason(nl_solver_, &reason));
+  const auto status = SNESReasonToPETScSolverStatus(reason);
 
   // Print summary
-  log.Log() << "\n"
-            << "        Final k-eigenvalue    :        " << std::fixed << std::setw(10)
-            << std::setprecision(7) << k_eff << " (Number of Sweeps:" << number_of_func_evals << ")"
-            << "\n";
+  std::stringstream summary;
+  summary << FormatKEigenFinalSummary("NLKE",
+                                      k_eff,
+                                      -1.0,
+                                      static_cast<std::size_t>(number_of_func_evals),
+                                      "func evals",
+                                      PETScSolverStatusToIterationStatus(status));
+  if (log.GetVerbosity() >= 2)
+    summary << ", detail = " << GetPETScConvergedReasonstring(reason);
+  log.Log() << program_timer.GetTimeString() << " " << summary.str();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
@@ -6,11 +6,11 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
-#include <iomanip>
 
 namespace opensn
 {
@@ -51,9 +51,8 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
   double F_prev = ComputeFissionProduction(lbs_problem, phi_old_local);
 
   // Start power iterations
-  const bool print_ags_iters = lbs_problem.GetOptions().verbose_ags_iterations and
-                               groupsets.size() > 1 and
-                               lbs_problem.GetOptions().max_ags_iterations > 1;
+  const bool print_ags_iters =
+    lbs_problem.GetOptions().verbose_inner_iterations and groupsets.size() > 1;
   ags_solver->SetVerbosity(print_ags_iters);
   unsigned int nit = 0;
   bool converged = false;
@@ -88,15 +87,32 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
     // Print iteration summary
     if (lbs_problem.GetOptions().verbose_outer_iterations)
     {
-      std::stringstream k_iter_info;
-      k_iter_info << program_timer.GetTimeString() << " "
-                  << "  Iteration " << std::setw(5) << nit << "  k_eff " << std::setw(11)
-                  << std::setprecision(7) << k_eff << "  k_eff change " << std::setw(12)
-                  << k_eff_change << "  reactivity " << std::setw(10) << reactivity * 1e5;
-      if (converged)
-        k_iter_info << " CONVERGED\n";
+      std::vector<IterationSummary> wgs_summaries;
+      wgs_summaries.reserve(do_problem->GetNumWGSSolvers());
+      for (size_t gsid = 0; gsid < do_problem->GetNumWGSSolvers(); ++gsid)
+      {
+        auto wgs_context =
+          std::dynamic_pointer_cast<WGSContext>(do_problem->GetWGSSolver(gsid)->GetContext());
+        if (wgs_context and HasIterationStatus(wgs_context->last_solve))
+          wgs_summaries.emplace_back(wgs_context->last_solve);
+      }
 
-      log.Log() << k_iter_info.str();
+      const auto ags_summary = ags_solver->GetLastSolveSummary();
+      const auto ags_status =
+        HasIterationStatus(ags_summary) ? ags_summary.status : IterationStatus::NONE;
+      const auto inner_status =
+        MostSevereIterationStatus(ags_status, MostSevereIterationStatus(wgs_summaries));
+      const auto outer_status =
+        IterationStatusFromSolve(converged, nit >= max_iterations, inner_status);
+      log.Log() << program_timer.GetTimeString() << " "
+                << FormatKEigenOuterIteration("PI",
+                                              nit,
+                                              k_eff,
+                                              k_eff_change,
+                                              reactivity * 1.0e5,
+                                              ags_summary,
+                                              wgs_summaries,
+                                              outer_status);
     }
 
     if (converged)
@@ -113,12 +129,13 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
       total_sweeps += wgs_context->counter_applications_of_inv_op;
   }
 
-  log.Log() << "\n";
-  log.Log() << "        Final k-eigenvalue    :        " << std::setprecision(7) << k_eff;
-  log.Log() << "        Final change          :        " << std::setprecision(6) << k_eff_change
-            << " (Number of Sweeps:" << total_sweeps << ")"
-            << "\n";
-  log.Log() << "\n";
+  log.Log() << program_timer.GetTimeString() << " "
+            << FormatKEigenFinalSummary("PI",
+                                        k_eff,
+                                        k_eff_change,
+                                        total_sweeps,
+                                        "sweeps",
+                                        IterationStatusFromSolve(converged, true));
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.cc
@@ -2,46 +2,56 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_residual_func_context.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include <petscsnes.h>
-#include <iomanip>
 
 namespace opensn
 {
 
 PetscErrorCode
-KEigenSNESMonitor(SNES /*unused*/, PetscInt iter, PetscReal rnorm, void* ctx)
+KEigenSNESMonitor(SNES snes, PetscInt iter, PetscReal rnorm, void* ctx)
 {
   auto& residual_context = *static_cast<KResidualFunctionContext*>(ctx);
 
   double k_eff = residual_context.k_eff;
   double reactivity = (k_eff - 1.0) / k_eff;
 
-  std::stringstream iter_info;
-  iter_info << program_timer.GetTimeString() << " " << residual_context.solver_name
-            << "_NonLinearK_Outer"
-            << " Iteration " << std::setw(5) << iter << " Residual " << std::setw(11) << rnorm
-            << " k_eff " << std::fixed << std::setw(10) << std::setprecision(7) << k_eff
-            << std::setprecision(2) << "  reactivity " << std::setw(10) << reactivity * 1e5;
+  KSP ksp = nullptr;
+  OpenSnPETScCall(SNESGetKSP(snes, &ksp));
+  KSPConvergedReason linear_reason = KSP_CONVERGED_ITERATING;
+  OpenSnPETScCall(KSPGetConvergedReason(ksp, &linear_reason));
+  const auto inner_status = KSPReasonToIterationStatus(linear_reason);
 
-  log.Log() << iter_info.str();
+  std::stringstream out;
+  out << "NLKE outer iteration = " << iter;
+  AppendNumericField(out, "residual", rnorm, Scientific(6));
+  AppendNumericField(out, "k_eff", k_eff, Fixed(7));
+  AppendNumericField(out, "rho_pcm", reactivity * 1.0e5, Fixed(2));
+  if (inner_status != IterationStatus::NONE)
+  {
+    out << FormatNestedStatusSummary("NLKE inners", inner_status);
+    if (log.GetVerbosity() >= 2)
+      out << ", detail = " << GetPETScConvergedReasonstring(linear_reason);
+  }
+  log.Log() << program_timer.GetTimeString() << " " << out.str();
 
   return 0;
 }
 
 PetscErrorCode
-KEigenKSPMonitor(KSP ksp, PetscInt iter, PetscReal rnorm, void* ctx)
+KEigenKSPMonitor(KSP /*ksp*/, PetscInt iter, PetscReal rnorm, void* ctx)
 {
   auto& residual_context = *static_cast<KResidualFunctionContext*>(ctx);
 
   std::stringstream iter_info;
-  iter_info << "      " << program_timer.GetTimeString() << " " << residual_context.solver_name
-            << "_NonLinearK_Inner"
-            << " Iteration " << std::setw(5) << iter << " Residual " << std::setw(11) << rnorm;
-
+  iter_info << program_timer.GetTimeString() << " NLKE inner"
+            << " iteration = " << iter;
+  AppendNumericField(iter_info, "residual", rnorm, Scientific(6));
   log.Log() << iter_info.str();
 
   return 0;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -8,9 +8,9 @@
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include "framework/utils/timer.h"
 #include "caliper/cali.h"
 #include <petscksp.h>
-#include <iomanip>
 
 namespace opensn
 {
@@ -102,19 +102,6 @@ SweepWGSContext::GetSystemSize()
     local_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.first;
   const size_t global_size =
     global_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.second;
-  const size_t num_angles = groupset.quadrature->abscissae.size();
-  const size_t num_psi_global = global_node_count * num_angles * groupset.GetNumGroups();
-  const size_t num_delayed_psi_global = num_delayed_psi_info.second;
-
-  if (log_info)
-  {
-    log.Log() << "Total number of angular unknowns: " << num_psi_global << "\n"
-              << "Number of lagged angular unknowns: " << num_delayed_psi_global << "("
-              << std::setprecision(2)
-              << static_cast<double>(num_delayed_psi_global) * 100 /
-                   static_cast<double>(num_psi_global)
-              << "%)";
-  }
 
   return {static_cast<int64_t>(local_size), static_cast<int64_t>(global_size)};
 }
@@ -122,7 +109,6 @@ SweepWGSContext::GetSystemSize()
 void
 SweepWGSContext::PreSolveCallback()
 {
-  sweep_times.clear();
 }
 
 void
@@ -145,7 +131,8 @@ SweepWGSContext::ApplyInverseTransportOperator(SourceFlags scope)
 
   auto sweep_time =
     static_cast<double>(duration_cast<nanoseconds>(sweep_end - sweep_start).count()) / 1.0e+9;
-  sweep_times.push_back(sweep_time);
+  sweep_stats_.total_sweep_time += sweep_time;
+  ++sweep_stats_.num_sweeps;
 }
 
 void
@@ -163,29 +150,6 @@ SweepWGSContext::PostSolveCallback()
   {
     RebuildAngularFluxFromConvergedPhi(sweep_chunk->IsTimeDependent());
   }
-
-  if (log_info)
-  {
-    if (not sweep_times.empty())
-    {
-      double tot_sweep_time = 0.0;
-      auto num_sweeps = static_cast<double>(sweep_times.size());
-      for (auto time : sweep_times)
-        tot_sweep_time += time;
-      double avg_sweep_time = tot_sweep_time / num_sweeps;
-      size_t num_angles = groupset.quadrature->abscissae.size();
-      size_t num_unknowns = do_problem.GetGlobalNodeCount() * num_angles * groupset.GetNumGroups();
-      double max_avg_sweep_time = 0.0;
-      opensn::mpi_comm.all_reduce(&avg_sweep_time, 1, &max_avg_sweep_time, mpi::op::max<double>());
-
-      log.Log() << "\n       Average sweep time (s):        " << max_avg_sweep_time
-                << "\n       Sweep Time/Unknown (ns):       "
-                << max_avg_sweep_time * 1.0e9 / static_cast<double>(num_unknowns)
-                << "\n       Number of unknowns per sweep:  " << num_unknowns << "\n\n";
-    }
-  }
-
-  sweep_times.clear();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
@@ -13,6 +13,12 @@ namespace opensn
 
 struct SweepWGSContext : public WGSContext
 {
+  struct SweepStats
+  {
+    double total_sweep_time = 0.0;
+    size_t num_sweeps = 0;
+  };
+
   SweepWGSContext(DiscreteOrdinatesProblem& do_problem,
                   LBSGroupset& groupset,
                   const SetSourceFunction& set_source_function,
@@ -31,10 +37,12 @@ struct SweepWGSContext : public WGSContext
 
   void PostSolveCallback() override;
   void RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term);
+  SweepStats GetAccumulatedSweepStats() const { return sweep_stats_; }
+  void ResetAccumulatedSweepStats() { sweep_stats_ = {}; }
 
   std::shared_ptr<SweepChunk> sweep_chunk;
   SweepScheduler sweep_scheduler;
-  std::vector<double> sweep_times;
+  SweepStats sweep_stats_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "framework/math/linear_solver/linear_solver_context.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/source_functions/source_flags.h"
 #include <vector>
 #include <functional>
@@ -52,6 +53,7 @@ struct WGSContext : public LinearSystemContext
   SourceFlags rhs_src_scope;
   bool log_info = true;
   size_t counter_applications_of_inv_op = 0;
+  IterationSummary last_solve;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
@@ -3,12 +3,13 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
-#include <iomanip>
 
 namespace opensn
 {
@@ -57,24 +58,20 @@ GSConvergenceTest(
   double scaled_residual = rnorm * residual_scale;
 
   // Print iteration information
-  std::string offset;
-  if (context->groupset.apply_wgdsa or context->groupset.apply_tgdsa)
-    offset = std::string("    ");
-
   std::stringstream iter_info;
-  iter_info << program_timer.GetTimeString() << " " << offset << "WGS groups ["
-            << context->groupset.first_group << "-" << context->groupset.last_group << "]"
-            << " Iteration " << std::setw(5) << n << " Residual " << std::setw(9)
-            << scaled_residual;
+  iter_info << program_timer.GetTimeString() << " WGS groups [" << context->groupset.first_group
+            << "-" << context->groupset.last_group << "]"
+            << " iteration = " << n;
+  AppendNumericField(iter_info, "residual", scaled_residual, Scientific(6));
 
   if (scaled_residual < tol)
   {
-    *convergedReason = KSP_CONVERGED_RTOL;
-    iter_info << " CONVERGED\n";
+    *convergedReason = KSP_CONVERGED_ATOL;
+    iter_info << ", status = " << IterationStatusName(KSPReasonToIterationStatus(*convergedReason));
   }
 
   if (context->log_info)
-    log.Log() << iter_info.str() << std::endl;
+    log.Log() << iter_info.str();
 
   return PETSC_SUCCESS;
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
@@ -13,7 +13,6 @@
 #include <petscksp.h>
 #include "caliper/cali.h"
 #include <memory>
-#include <iomanip>
 
 namespace opensn
 {
@@ -106,14 +105,7 @@ void
 WGSLinearSolver::PreSolveCallback()
 {
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
-  auto& groupset = gs_context_ptr->groupset;
-  auto& do_problem = gs_context_ptr->do_problem;
-  if (do_problem.GetOptions().verbose_inner_iterations)
-  {
-    log.Log() << "Solving groupset " << groupset.id << " with " << this->GetIterativeMethodName()
-              << " (groups " << groupset.first_group << "-" << groupset.last_group << ", "
-              << groupset.quadrature->abscissae.size() << " angles)\n";
-  }
+  gs_context_ptr->last_solve = {};
   gs_context_ptr->PreSolveCallback();
 }
 
@@ -134,11 +126,7 @@ WGSLinearSolver::SetInitialGuess()
   OpenSnPETScCall(KSPSetInitialGuessNonzero(ksp_, PETSC_FALSE));
 
   if (init_guess_norm > 1.0e-10)
-  {
     OpenSnPETScCall(KSPSetInitialGuessNonzero(ksp_, PETSC_TRUE));
-    if (gs_context_ptr->log_info)
-      log.Log() << "Using phi_old as initial guess.";
-  }
 }
 
 void
@@ -149,9 +137,6 @@ WGSLinearSolver::SetRHS()
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   auto& groupset = gs_context_ptr->groupset;
   auto& do_problem = gs_context_ptr->do_problem;
-
-  if (gs_context_ptr->log_info)
-    log.Log() << program_timer.GetTimeString() << " Computing b";
 
   // SetSource for RHS
   saved_q_moments_local_ = do_problem.GetQMomentsLocal();
@@ -220,6 +205,11 @@ WGSLinearSolver::SetRHS()
 void
 WGSLinearSolver::PostSolveCallback()
 {
+  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
+  auto& groupset = gs_context_ptr->groupset;
+  auto& do_problem = gs_context_ptr->do_problem;
+  const bool report_nonfatal = do_problem.GetOptions().verbose_inner_iterations;
+
   // Get convergence reason
   if (not GetKSPSolveSuppressionFlag())
   {
@@ -227,29 +217,20 @@ WGSLinearSolver::PostSolveCallback()
     OpenSnPETScCall(KSPGetConvergedReason(ksp_, &reason));
     PetscInt its = 0;
     OpenSnPETScCall(KSPGetIterationNumber(ksp_, &its));
-    if (reason < 0)
-      log.Log0Warning() << "Krylov solver diverged. "
-                        << "Reason: " << GetPETScConvergedReasonstring(reason);
-    else if (reason == KSP_CONVERGED_RTOL)
+    gs_context_ptr->last_solve.num_iterations = static_cast<unsigned int>(its);
+    gs_context_ptr->last_solve.status = KSPReasonToIterationStatus(reason);
+    gs_context_ptr->last_solve.detail = GetPETScConvergedReasonstring(reason);
+    if (report_nonfatal and (gs_context_ptr->last_solve.status == IterationStatus::FAILED or
+                             gs_context_ptr->last_solve.status == IterationStatus::LIMIT))
     {
-      auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
-      if (gs_context_ptr && gs_context_ptr->log_info && its == 0)
-        log.Log() << program_timer.GetTimeString() << " CONVERGED (relative tolerance)";
+      log.Log() << program_timer.GetTimeString() << " "
+                << FormatIterationSummary("WGS groups [" + std::to_string(groupset.first_group) +
+                                            "-" + std::to_string(groupset.last_group) + "]",
+                                          gs_context_ptr->last_solve);
     }
-    else if (reason == KSP_CONVERGED_ATOL)
-    {
-      auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
-      if (gs_context_ptr && gs_context_ptr->log_info && its == 0)
-        log.Log() << program_timer.GetTimeString() << " CONVERGED (absolute tolerance)";
-    }
-    else if (reason == KSP_DIVERGED_ITS)
-      log.Log0Warning() << "Krylov solver reached iteration limit.";
   }
 
   // Copy x to local solution
-  auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
-  auto& groupset = gs_context_ptr->groupset;
-  auto& do_problem = gs_context_ptr->do_problem;
   LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(do_problem, groupset, x_, PhiSTLOption::PHI_NEW);
   LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(do_problem, groupset, x_, PhiSTLOption::PHI_OLD);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/nl_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/nl_keigen_solver.cc
@@ -9,6 +9,7 @@
 #include "framework/object_factory.h"
 #include "framework/logging/log.h"
 #include "framework/utils/error.h"
+#include "framework/utils/timer.h"
 #include "framework/runtime.h"
 
 namespace opensn
@@ -81,6 +82,8 @@ NonLinearKEigenSolver::NonLinearKEigenSolver(const InputParameters& params)
 void
 NonLinearKEigenSolver::Initialize()
 {
+  log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
+
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
                           GetName() + ": Problem is in time-dependent mode. Call problem."
                                       "SetSteadyStateMode() before initializing this solver.");
@@ -90,6 +93,8 @@ NonLinearKEigenSolver::Initialize()
 void
 NonLinearKEigenSolver::Execute()
 {
+  log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
+
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   if (reset_phi0_)
@@ -117,7 +122,7 @@ NonLinearKEigenSolver::Execute()
     log.Log() << "Balance table uses k-eigenvalue normalization (production scaled by 1/k_eff)";
   }
 
-  log.Log() << "LinearBoltzmann::NonLinearKEigenvalueSolver execution completed\n\n";
+  log.Log() << program_timer.GetTimeString() << " Finished solver execution " << GetName() << ".";
 }
 
 double

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
@@ -66,6 +67,8 @@ PowerIterationKEigenSolver::PowerIterationKEigenSolver(const InputParameters& pa
 void
 PowerIterationKEigenSolver::Initialize()
 {
+  log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
+
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
                           GetName() + ": Problem is in time-dependent mode. Call problem."
                                       "SetSteadyStateMode() before initializing this solver.");
@@ -85,9 +88,8 @@ PowerIterationKEigenSolver::Initialize()
     wgs_context->rhs_src_scope.Unset(APPLY_AGS_FISSION_SOURCES); // rhs_scope
   }
 
-  const bool print_ags_iters = options.verbose_ags_iterations and
-                               do_problem_->GetNumGroupsets() > 1 and
-                               options.max_ags_iterations > 1;
+  const bool print_ags_iters =
+    options.verbose_inner_iterations and do_problem_->GetNumGroupsets() > 1;
   auto ags_solver = do_problem_->GetAGSSolver();
   OpenSnLogicalErrorIf(not ags_solver, GetName() + ": AGS solver not available.");
   ags_solver->SetVerbosity(print_ags_iters);
@@ -109,6 +111,8 @@ PowerIterationKEigenSolver::Initialize()
 void
 PowerIterationKEigenSolver::Execute()
 {
+  log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
+
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   if (acceleration_)
@@ -168,15 +172,33 @@ PowerIterationKEigenSolver::Execute()
     // Print iteration summary
     if (options.verbose_outer_iterations)
     {
-      std::stringstream k_iter_info;
-      k_iter_info << program_timer.GetTimeString() << " "
-                  << "  Iteration " << std::setw(5) << nit << "  k_eff " << std::setw(11)
-                  << std::setprecision(7) << k_eff_ << "  k_eff change " << std::setw(12)
-                  << k_eff_change << "  reactivity " << std::setw(10) << reactivity * 1e5;
-      if (converged)
-        k_iter_info << " CONVERGED\n";
+      std::vector<IterationSummary> wgs_summaries;
+      wgs_summaries.reserve(do_problem_->GetNumWGSSolvers());
+      for (size_t gsid = 0; gsid < do_problem_->GetNumWGSSolvers(); ++gsid)
+      {
+        auto context =
+          std::dynamic_pointer_cast<WGSContext>(do_problem_->GetWGSSolver(gsid)->GetContext());
+        OpenSnLogicalErrorIf(not context, GetName() + ": Cast to WGSContext failed.");
+        if (HasIterationStatus(context->last_solve))
+          wgs_summaries.emplace_back(context->last_solve);
+      }
 
-      log.Log() << k_iter_info.str();
+      const auto ags_summary = ags_solver->GetLastSolveSummary();
+      const auto ags_status =
+        HasIterationStatus(ags_summary) ? ags_summary.status : IterationStatus::NONE;
+      const auto inner_status =
+        MostSevereIterationStatus(ags_status, MostSevereIterationStatus(wgs_summaries));
+      const auto outer_status =
+        IterationStatusFromSolve(converged, nit >= max_iters_, inner_status);
+      log.Log() << program_timer.GetTimeString() << " "
+                << FormatKEigenOuterIteration("PI",
+                                              nit,
+                                              k_eff_,
+                                              k_eff_change,
+                                              reactivity * 1.0e5,
+                                              ags_summary,
+                                              wgs_summaries,
+                                              outer_status);
     }
 
     if (options.restart_writes_enabled and do_problem_->TriggerRestartDump())
@@ -202,11 +224,13 @@ PowerIterationKEigenSolver::Execute()
     total_num_sweeps += wgs_context->counter_applications_of_inv_op;
   }
 
-  log.Log() << "\n";
-  log.Log() << "        Final k-eigenvalue    :        " << std::setprecision(7) << k_eff_;
-  log.Log() << "        Final change          :        " << std::setprecision(6) << k_eff_change
-            << " (Total number of sweeps:" << total_num_sweeps << ")"
-            << "\n\n";
+  log.Log() << program_timer.GetTimeString() << " "
+            << FormatKEigenFinalSummary("PI",
+                                        k_eff_,
+                                        k_eff_change,
+                                        total_num_sweeps,
+                                        "sweeps",
+                                        IterationStatusFromSolve(converged, true));
 
   if (options.use_precursors)
   {
@@ -220,7 +244,7 @@ PowerIterationKEigenSolver::Execute()
     log.Log() << "Balance table uses k-eigenvalue normalization (production scaled by 1/k_eff)";
   }
 
-  log.Log() << "LinearBoltzmann::KEigenvalueSolver execution completed\n\n";
+  log.Log() << program_timer.GetTimeString() << " Finished solver execution " << GetName() << ".";
 }
 
 BalanceTable

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
@@ -47,6 +47,7 @@ void
 SteadyStateSourceSolver::Initialize()
 {
   CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Initialize");
+  log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
 
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
                           GetName() + ": Problem is in time-dependent mode. Call problem."
@@ -61,6 +62,7 @@ void
 SteadyStateSourceSolver::Execute()
 {
   CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Execute");
+  log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
 
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
@@ -80,6 +82,8 @@ SteadyStateSourceSolver::Execute()
 
   if (IsBalanceEnabled())
     ComputeBalance(*do_problem_);
+
+  log.Log() << program_timer.GetTimeString() << " Finished solver execution " << GetName() << ".";
 }
 
 BalanceTable

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/logging/log.h"
 #include "framework/utils/error.h"
@@ -95,7 +96,7 @@ TransientSolver::TransientSolver(const InputParameters& params)
 void
 TransientSolver::Initialize()
 {
-  log.Log() << "Initializing " << GetName() << ".";
+  log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
   enforce_stop_time_ = false;
 
   const auto& options = do_problem_->GetOptions();
@@ -158,7 +159,7 @@ TransientSolver::Initialize()
 void
 TransientSolver::Execute()
 {
-  log.Log() << "Executing " << GetName() << ".";
+  log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   const auto& options = do_problem_->GetOptions();
@@ -222,7 +223,7 @@ TransientSolver::Execute()
   if (options.restart_writes_enabled)
     WriteRestartData();
 
-  log.Log() << "Done executing " << GetName() << ".";
+  log.Log() << program_timer.GetTimeString() << " Finished solver execution " << GetName() << ".";
 }
 
 void
@@ -264,12 +265,6 @@ TransientSolver::Advance()
 
   do_problem_->SetTime(current_time_);
 
-  if (verbose_)
-  {
-    log.Log() << GetName() << " dt = " << std::scientific << std::setprecision(1) << dt
-              << " time = " << std::fixed << std::setprecision(4) << (current_time_ + dt);
-  }
-
   // Zero source moments before recomputing sources for this step
   do_problem_->ZeroQMoments();
 
@@ -291,6 +286,24 @@ TransientSolver::Advance()
   for (const auto& sweep_context : transient_sweep_contexts)
     sweep_context->sweep_chunk->IncludeRHSTimeTerm(false);
 
+  if (verbose_)
+  {
+    std::vector<IterationSummary> wgs_summaries;
+    wgs_summaries.reserve(do_problem_->GetNumWGSSolvers());
+    for (size_t gsid = 0; gsid < do_problem_->GetNumWGSSolvers(); ++gsid)
+    {
+      auto wgs_context =
+        std::dynamic_pointer_cast<WGSContext>(do_problem_->GetWGSSolver(gsid)->GetContext());
+      if (wgs_context and HasIterationStatus(wgs_context->last_solve))
+        wgs_summaries.emplace_back(wgs_context->last_solve);
+    }
+
+    const auto ags_summary = ags_solver->GetLastSolveSummary();
+    log.Log() << program_timer.GetTimeString() << " "
+              << FormatTransientStepSummary(
+                   "TS", step_ + 1, dt, current_time_ + dt, ags_summary, wgs_summaries);
+  }
+
   // Compute t^{n+1}
   const double inv_theta = 1.0 / theta;
   const auto& phi_prev = phi_prev_local_;
@@ -300,7 +313,7 @@ TransientSolver::Advance()
   if (options.use_precursors)
     StepPrecursors();
 
-  if (verbose_ and (has_fissionable_material or options.use_precursors))
+  if (verbose_ and has_fissionable_material and options.use_precursors)
   {
     const double FP_new = ComputeFissionProduction(*do_problem_, phi_new_local);
     log.Log() << GetName() << " FP = " << std::scientific << std::setprecision(6) << FP_new;

--- a/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework/logging/log_format.h"
+#include "framework/logging/log.h"
+#include "framework/math/petsc_utils/petsc_utils.h"
+#include "framework/runtime.h"
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace opensn
+{
+
+enum class IterationStatus
+{
+  NONE,
+  CONVERGED,
+  LIMIT,
+  FAILED,
+};
+
+struct IterationSummary
+{
+  unsigned int num_iterations = 0;
+  IterationStatus status = IterationStatus::NONE;
+  std::string detail;
+  std::string metric_name;
+  double metric_value = 0.0;
+};
+
+inline const char*
+IterationStatusName(const IterationStatus status)
+{
+  switch (status)
+  {
+    case IterationStatus::CONVERGED:
+      return "converged";
+    case IterationStatus::LIMIT:
+      return "iteration_limit";
+    case IterationStatus::FAILED:
+      return "failed";
+    case IterationStatus::NONE:
+    default:
+      return "not_run";
+  }
+}
+
+inline bool
+HasIterationStatus(const IterationSummary& summary)
+{
+  return summary.status != IterationStatus::NONE;
+}
+
+inline IterationStatus
+PETScSolverStatusToIterationStatus(const PETScSolverStatus status)
+{
+  switch (status)
+  {
+    case PETScSolverStatus::CONVERGED:
+      return IterationStatus::CONVERGED;
+    case PETScSolverStatus::LIMIT:
+      return IterationStatus::LIMIT;
+    case PETScSolverStatus::FAILED:
+      return IterationStatus::FAILED;
+    case PETScSolverStatus::ITERATING:
+    case PETScSolverStatus::NONE:
+    default:
+      return IterationStatus::NONE;
+  }
+}
+
+inline IterationStatus
+KSPReasonToIterationStatus(const KSPConvergedReason reason)
+{
+  return PETScSolverStatusToIterationStatus(KSPReasonToPETScSolverStatus(reason));
+}
+
+inline IterationStatus
+MostSevereIterationStatus(const IterationStatus lhs, const IterationStatus rhs)
+{
+  const auto severity = [](const IterationStatus status)
+  {
+    switch (status)
+    {
+      case IterationStatus::FAILED:
+        return 3;
+      case IterationStatus::LIMIT:
+        return 2;
+      case IterationStatus::CONVERGED:
+        return 1;
+      case IterationStatus::NONE:
+      default:
+        return 0;
+    }
+  };
+  return severity(lhs) >= severity(rhs) ? lhs : rhs;
+}
+
+inline IterationStatus
+MostSevereIterationStatus(const std::vector<IterationSummary>& summaries)
+{
+  IterationStatus status = IterationStatus::NONE;
+  for (const auto& summary : summaries)
+    status = MostSevereIterationStatus(status, summary.status);
+  return status;
+}
+
+inline IterationStatus
+IterationStatusFromSolve(const bool converged,
+                         const bool reached_iteration_limit,
+                         const IterationStatus inner_status = IterationStatus::NONE)
+{
+  if (inner_status == IterationStatus::FAILED or inner_status == IterationStatus::LIMIT)
+    return inner_status;
+  if (converged)
+    return IterationStatus::CONVERGED;
+  return reached_iteration_limit ? IterationStatus::LIMIT : IterationStatus::NONE;
+}
+
+inline std::string
+FormatNestedStatusSummary(const std::string& level_name, const IterationStatus status)
+{
+  return "; " + level_name + " = " + IterationStatusName(status);
+}
+
+inline std::string
+FormatNestedStatusCounts(const std::string& level_name,
+                         const std::vector<IterationSummary>& summaries)
+{
+  if (summaries.empty())
+    return "";
+
+  const auto first_status = summaries.front().status;
+  const bool all_same =
+    std::all_of(summaries.begin(),
+                summaries.end(),
+                [first_status](const auto& summary) { return summary.status == first_status; });
+  if (all_same)
+    return FormatNestedStatusSummary(level_name, first_status);
+
+  const auto count = [&summaries](const IterationStatus status) -> std::size_t
+  {
+    return static_cast<std::size_t>(std::count_if(summaries.begin(),
+                                                  summaries.end(),
+                                                  [status](const auto& summary)
+                                                  { return summary.status == status; }));
+  };
+  const auto append_count =
+    [](std::ostringstream& out, const char* label, const std::size_t value, bool& first)
+  {
+    if (value == 0)
+      return;
+    out << (first ? "" : ", ") << label << " = " << value;
+    first = false;
+  };
+
+  std::ostringstream out;
+  bool first = true;
+  out << "; " << level_name << " = mixed (";
+  append_count(out, "converged", count(IterationStatus::CONVERGED), first);
+  append_count(out, "iteration_limit", count(IterationStatus::LIMIT), first);
+  append_count(out, "failed", count(IterationStatus::FAILED), first);
+  append_count(out, "not_run", count(IterationStatus::NONE), first);
+  out << ")";
+  return out.str();
+}
+
+inline std::string
+FormatIterationSummary(const std::string& label, const IterationSummary& summary)
+{
+  std::ostringstream out;
+  out << label << " final, status = " << IterationStatusName(summary.status);
+  AppendNumericField(out, "iterations", summary.num_iterations);
+  if (opensn::log.GetVerbosity() >= 2 and not summary.detail.empty())
+    out << ", detail = " << summary.detail;
+  if (not summary.metric_name.empty())
+    AppendNumericField(out, summary.metric_name, summary.metric_value, Scientific(6));
+  return out.str();
+}
+
+inline std::string
+FormatKEigenOuterIteration(const std::string& phase_name,
+                           const unsigned int iteration,
+                           const double k_eff,
+                           const double k_eff_change,
+                           const double reactivity_pcm,
+                           const IterationSummary& ags_summary,
+                           const std::vector<IterationSummary>& wgs_summaries,
+                           const IterationStatus outer_status)
+{
+  std::ostringstream out;
+  out << phase_name << " iteration = " << iteration;
+  AppendNumericField(out, "k_eff", k_eff, Fixed(7));
+  AppendNumericField(out, "k_eff_change", k_eff_change, Scientific(5));
+  AppendNumericField(out, "rho_pcm", reactivity_pcm, Fixed(2));
+  if (outer_status != IterationStatus::NONE)
+    out << ", status = " << IterationStatusName(outer_status);
+  if (HasIterationStatus(ags_summary))
+    out << FormatNestedStatusSummary("AGS", ags_summary.status);
+  out << FormatNestedStatusCounts("WGS", wgs_summaries);
+  return out.str();
+}
+
+inline std::string
+FormatTransientStepSummary(const std::string& phase_name,
+                           const unsigned int step,
+                           const double dt,
+                           const double time,
+                           const IterationSummary& ags_summary,
+                           const std::vector<IterationSummary>& wgs_summaries)
+{
+  std::ostringstream out;
+  out << phase_name << " step = " << step;
+  AppendNumericField(out, "dt", dt, Scientific(1));
+  AppendNumericField(out, "time", time, Fixed(4));
+  const auto ags_status =
+    HasIterationStatus(ags_summary) ? ags_summary.status : IterationStatus::NONE;
+  const auto inner_status =
+    MostSevereIterationStatus(ags_status, MostSevereIterationStatus(wgs_summaries));
+  if (inner_status != IterationStatus::NONE)
+    out << ", status = " << IterationStatusName(inner_status);
+  if (HasIterationStatus(ags_summary))
+    out << FormatNestedStatusSummary("AGS", ags_summary.status);
+  out << FormatNestedStatusCounts("WGS", wgs_summaries);
+  return out.str();
+}
+
+inline std::string
+FormatKEigenFinalSummary(const std::string& phase_name,
+                         const double k_eff,
+                         const double change,
+                         const std::size_t count,
+                         const std::string& count_label,
+                         const IterationStatus status = IterationStatus::NONE)
+{
+  std::ostringstream out;
+  out << phase_name << " final";
+  if (status != IterationStatus::NONE)
+    out << ", status = " << IterationStatusName(status);
+  AppendNumericField(out, "k_eff", k_eff, Fixed(7));
+  if (change >= 0.0)
+    AppendNumericField(out, "k_eff_change", change, Scientific(6));
+  AppendNumericField(out, count_label, count);
+  return out.str();
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -524,9 +524,11 @@ LBSProblem::GetOptionsBlock()
   params.AddOptionalParameter(
     "adjoint", false, "Flag for toggling whether the solver is in adjoint mode.");
   params.AddOptionalParameter(
-    "verbose_inner_iterations", true, "Flag to control verbosity of inner iterations.");
+    "verbose_inner_iterations",
+    true,
+    "Flag to control verbosity of inner iterations, including WGS and AGS iterations.");
   params.AddOptionalParameter(
-    "verbose_outer_iterations", true, "Flag to control verbosity of across-groupset iterations.");
+    "verbose_outer_iterations", true, "Flag to control verbosity of outer iterations.");
   params.AddOptionalParameter(
     "max_ags_iterations", 100, "Maximum number of across-groupset iterations.");
   params.AddOptionalParameter("ags_tolerance", 1.0e-6, "Across-groupset iterations tolerance.");
@@ -534,8 +536,6 @@ LBSProblem::GetOptionsBlock()
                               "l2",
                               "Type of convergence check for AGS iterations. Valid values are "
                               "`\"l2\"` and '\"pointwise\"'");
-  params.AddOptionalParameter(
-    "verbose_ags_iterations", true, "Flag to control verbosity of across-groupset iterations.");
   params.AddOptionalParameter("power_default_kappa",
                               3.20435e-11,
                               "Default `kappa` value (Energy released per fission) to use for "
@@ -624,9 +624,6 @@ LBSProblem::ParseOptions(const InputParameters& input)
     {"ags_convergence_check",
      [this](const ParameterBlock& spec)
      { options_.ags_pointwise_convergence = (spec.GetValue<std::string>() == "pointwise"); }},
-    {"verbose_ags_iterations",
-     [this](const ParameterBlock& spec)
-     { options_.verbose_ags_iterations = spec.GetValue<bool>(); }},
     {"verbose_outer_iterations",
      [this](const ParameterBlock& spec)
      { options_.verbose_outer_iterations = spec.GetValue<bool>(); }},

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
@@ -48,7 +48,6 @@ struct LBSOptions
   bool adjoint = false;
 
   bool verbose_inner_iterations = true;
-  bool verbose_ags_iterations = true;
   bool verbose_outer_iterations = true;
   bool ags_pointwise_convergence = false;
   unsigned int max_ags_iterations = 100;

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -778,11 +778,12 @@ WrapLBS(py::module& slv)
             field functions, and angular-flux I/O.
           - adjoint: bool, default=False
           - verbose_inner_iterations: bool, default=True
+            Print inner iteration details, including WGS and AGS iterations.
           - verbose_outer_iterations: bool, default=True
+            Print outer solver progress, including PI/NLKE iterations and transient steps.
           - max_ags_iterations: int, default=100
           - ags_tolerance: float, default=1.0e-6
           - ags_convergence_check: {'l2', 'pointwise'}, default='l2'
-          - verbose_ags_iterations: bool, default=True
           - power_default_kappa: float, default=3.20435e-11
           - field_function_prefix_option: {'prefix', 'solver_name'}, default='prefix'
           - field_function_prefix: str, default=''
@@ -1210,11 +1211,12 @@ WrapLBS(py::module& slv)
             Store angular flux state (`psi`) for transient mode, angular-flux
             field functions, and angular-flux I/O.
           - verbose_inner_iterations: bool, default=True
+            Print inner iteration details, including WGS and AGS iterations.
           - verbose_outer_iterations: bool, default=True
+            Print outer solver progress, including PI/NLKE iterations and transient steps.
           - max_ags_iterations: int, default=100
           - ags_tolerance: float, default=1.0e-6
           - ags_convergence_check: {'l2', 'pointwise'}, default='l2'
-          - verbose_ags_iterations: bool, default=True
           - power_default_kappa: float, default=3.20435e-11
           - field_function_prefix_option: {'prefix', 'solver_name'}, default='prefix'
           - field_function_prefix: str, default=''

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/mode_switch_forward_adjoint_forward.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/mode_switch_forward_adjoint_forward.py
@@ -95,7 +95,6 @@ if __name__ == "__main__":
         options={
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_keigen/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_keigen/tests.json
@@ -6,8 +6,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 0.99454,
         "abs_tol": 1e-05
       }
@@ -20,14 +20,14 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "Iteration    21",
-        "wordnum": 11,
-        "gold": "CONVERGED"
+        "key": "PI final",
+        "wordnum": 8,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 0.5969127,
         "abs_tol": 1e-07
       }
@@ -94,15 +94,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Iteration     3",
-        "wordnum": 8,
-        "gold": 0.5969127,
-        "abs_tol": 1e-07
-      },
-      {
-        "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 0.5969127,
         "abs_tol": 1e-07
       }
@@ -115,8 +108,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 0.5969127,
         "abs_tol": 1e-07
       }
@@ -129,8 +122,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 0.99454,
         "abs_tol": 1e-05
       }
@@ -143,14 +136,14 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "Iteration    21",
-        "wordnum": 11,
-        "gold": "CONVERGED"
+        "key": "PI final",
+        "wordnum": 8,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 0.5969127,
         "abs_tol": 1e-07
       }
@@ -163,8 +156,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 0.5969127,
         "abs_tol": 1e-07
       }
@@ -190,8 +183,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 1.5029618,
         "abs_tol": 1e-05
       }
@@ -204,8 +197,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "NLKE final",
+        "wordnum": 13,
         "gold": 1.5029618,
         "abs_tol": 1e-05
       }
@@ -219,8 +212,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 1.192559,
         "abs_tol": 0.0001
       }
@@ -287,8 +280,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 0.929337,
         "abs_tol": 1e-06
       }
@@ -301,8 +294,8 @@
     "checks": [
       {
         "type": "FloatCompare",
-        "key": "Final k-eigenvalue",
-        "wordnum": 4,
+        "key": "PI final",
+        "wordnum": 13,
         "gold": 0.995,
         "abs_tol": 1e-04
       },

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -352,27 +352,27 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] Iteration    28",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [0-62] iteration = 28",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] Iteration    39",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [63-167] iteration = 39",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] Iteration    28",
-        "wordnum": 8,
+        "key": "WGS groups [0-62] iteration = 28",
+        "wordnum": 13,
         "gold": 6.74299e-07,
         "abs_tol": 1e-09
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [63-167] Iteration    39",
-        "wordnum": 8,
+        "key": "WGS groups [63-167] iteration = 39",
+        "wordnum": 13,
         "gold": 8.73816e-07,
         "abs_tol": 1e-09
       }
@@ -501,27 +501,27 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] Iteration    53",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [0-62] iteration = 53",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] Iteration    60",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [63-167] iteration = 60",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] Iteration    53",
-        "wordnum": 8,
+        "key": "WGS groups [0-62] iteration = 53",
+        "wordnum": 13,
         "gold": 7.78662e-07,
         "abs_tol": 1e-09
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [63-167] Iteration    60",
-        "wordnum": 8,
+        "key": "WGS groups [63-167] iteration = 60",
+        "wordnum": 13,
         "gold": 4.83429e-07,
         "abs_tol": 1e-09
       },
@@ -546,27 +546,27 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] Iteration    54",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] Iteration    58",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [63-167] iteration = 58",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] Iteration    54",
-        "wordnum": 8,
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 13,
         "gold": 6.24484e-07,
         "abs_tol": 1e-09
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [63-167] Iteration    58",
-        "wordnum": 8,
+        "key": "WGS groups [63-167] iteration = 58",
+        "wordnum": 13,
         "gold": 6.25993e-07,
         "abs_tol": 1e-09
       },
@@ -842,27 +842,27 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] Iteration    54",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] Iteration    57",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [63-167] iteration = 57",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] Iteration    54",
-        "wordnum": 8,
+        "key": "WGS groups [0-62] iteration = 54",
+        "wordnum": 13,
         "gold": 5.47188e-07,
         "abs_tol": 1e-09
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [63-167] Iteration    57",
-        "wordnum": 8,
+        "key": "WGS groups [63-167] iteration = 57",
+        "wordnum": 13,
         "gold": 6.98369e-07,
         "abs_tol": 1e-09
       },
@@ -1189,27 +1189,27 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] Iteration    22",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [0-62] iteration = 22",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] Iteration    59",
-        "wordnum": 9,
-        "gold": "CONVERGED"
+        "key": "WGS groups [63-167] iteration = 59",
+        "wordnum": 18,
+        "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] Iteration    22",
-        "wordnum": 8,
+        "key": "WGS groups [0-62] iteration = 22",
+        "wordnum": 13,
         "gold": 9.6079e-08,
         "abs_tol": 1e-09
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [63-167] Iteration    59",
-        "wordnum": 8,
+        "key": "WGS groups [63-167] iteration = 59",
+        "wordnum": 13,
         "gold": 4.73732e-07,
         "abs_tol": 1e-09
       }

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_1_poly_balance_mg.py
@@ -95,7 +95,6 @@ if __name__ == "__main__":
             },
         ],
         options={
-            "verbose_ags_iterations": True,
             "max_ags_iterations": 100,
             "ags_tolerance": 1.0e-6,
         },

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_ags_upscatter.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_3d_ags_upscatter.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         ],
         volumetric_sources=[mg_src],
         options={
-            "verbose_ags_iterations": True,
+            "verbose_inner_iterations": False,
             "max_ags_iterations": 30,
             "ags_tolerance": 1.0e-6,
         },

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_leakage_pulse_decay.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_leakage_pulse_decay.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
             "save_angular_flux": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_count_xs_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_count_xs_swap.py
@@ -140,7 +140,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_decay.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_precursor_decay.py
@@ -102,7 +102,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_steady_state_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_steady_state_source.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
             "save_angular_flux": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_time_dependent_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_time_dependent_source.py
@@ -79,7 +79,6 @@ if __name__ == "__main__":
             "save_angular_flux": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_zero_absorber_source.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_zero_absorber_source.py
@@ -78,7 +78,6 @@ if __name__ == "__main__":
             "save_angular_flux": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_fission_prod_count.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_fission_prod_count.py
@@ -58,7 +58,6 @@ def solve_and_get_fission_prod(xs_path):
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_prke_vs_stk.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_delayed_prke_vs_stk.py
@@ -110,7 +110,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_precursor_count_xs_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_precursor_count_xs_swap.py
@@ -140,7 +140,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_prompt_step.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_prompt_step.py
@@ -65,7 +65,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_theta_precursor_scaling.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_1d_theta_precursor_scaling.py
@@ -58,7 +58,6 @@ def run_case(theta, use_precursors, xs):
             "use_precursors": use_precursors,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_delayed_step.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_delayed_step.py
@@ -73,7 +73,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_2g_prompt_combine_velocities.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_delayed_prke_vs_stk_2p.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_delayed_prke_vs_stk_2p.py
@@ -147,7 +147,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_prompt_ramp_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_2d_prompt_ramp_xs.py
@@ -68,7 +68,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_2g_prompt_step_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_2g_prompt_step_xs.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_6g_delayed_step_nu_sigma_f.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_6g_delayed_step_nu_sigma_f.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_analytic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_analytic.py
@@ -99,7 +99,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p.py
@@ -153,7 +153,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p_callbacks.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_prke_vs_stk_2p_callbacks.py
@@ -152,7 +152,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_ramp_xs.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_ramp_xs.py
@@ -110,7 +110,6 @@ if __name__ == "__main__":
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_stiff_dt_sensitivity.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_delayed_stiff_dt_sensitivity.py
@@ -71,7 +71,6 @@ def run_transient(dt, t_end, xs_crit, xs_super):
             "use_precursors": True,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_analytic.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_analytic.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_bc_leakage.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_bc_leakage.py
@@ -68,7 +68,6 @@ def run_case(bc_type, xs_crit, xs_super):
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_mid_step_swap.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_keigen_3d_prompt_mid_step_swap.py
@@ -75,7 +75,6 @@ if __name__ == "__main__":
             "use_precursors": False,
             "verbose_inner_iterations": False,
             "verbose_outer_iterations": False,
-            "verbose_ags_iterations": False,
         },
     )
 

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_1d_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_zero_1d_restart.py
@@ -71,7 +71,6 @@ def make_problem(xs_path, restart_read="", restart_write=""):
         "save_angular_flux": True,
         "verbose_inner_iterations": True,
         "verbose_outer_iterations": False,
-        "verbose_ags_iterations": False,
     }
     if restart_read:
         options["read_restart_path"] = restart_read

--- a/test/unit/linear_boltzmann_solver/dsa/acceleration_diffusion_cfem.cc
+++ b/test/unit/linear_boltzmann_solver/dsa/acceleration_diffusion_cfem.cc
@@ -116,5 +116,5 @@ TEST(LBS_DSA_Test, CFEM)
   opensn::mpi_comm.barrier();
 
   auto out = testing::internal::GetCapturedStdout();
-  EXPECT_THAT(out, testing::HasSubstr("Convergence Reason: KSP_CONVERGED_RTOL"));
+  EXPECT_THAT(out, testing::HasSubstr("SimTest92b_DSA_PWLC final, status = converged"));
 }


### PR DESCRIPTION
This commit refactors our iteration logging to improve readability, consistency, user-friendliness, and to better handle nested iterations. Example of the improved log formatting are below:

```
[0]  00:00:00.7 WGS groups [0-0] iteration = 0, residual = 1.000000e+00
[0]  00:00:00.9 WGS groups [0-0] iteration = 1, residual = 3.039139e-08, status = converged
[0]  00:00:01.5 AGS iteration = 0, l2_change = 2.131414e+02; WGS = converged
...
[0]  00:00:11.6 AGS iteration = 15, l2_change = 7.496550e-07, status = converged; WGS = converged
...
[0]  00:00:11.6 WGS groups [0-0] avg_sweep_time = 5.878930e-02 s, sweep_time_per_unknown = 5.431545e+01 ns
[0]  00:00:11.6 WGS groups [0-0] unknowns = 1082368, lagged_unknowns = 0, lagged_pct = 0.00

[0]  00:00:00.1 NLKE outer iteration = 1, residual = 3.064045e-03, k_eff = 0.9883712, rho_pcm = -1176.56; NLKE inners = converged, detail = KSP_CONVERGED_RTOL
[0]  00:00:00.1 NLKE outer iteration = 2, residual = 3.965984e-04, k_eff = 0.9945879, rho_pcm = -544.16; NLKE inners = iteration_limit, detail = KSP_DIVERGED_ITS
[0]  00:00:00.1 NLKE final, status = converged, k_eff = 0.9945457, func evals = 123, detail = SNES_CONVERGED_FNORM_RELATIVE
```

`options.verbose_ags_iterations` has been removed. `options.verbose_inner_iterations` now controls both AGS and WGS iteration output. When running with `-v 2`, PETSc convergence details are added to the status lines. This commit touches a number of files and there's quite a bit of churn in loc, but the bulk of the changes are concentrated in two files:

`framework/math/petsc_utils/petsc_utils.cc`
`modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h`

Even with the high churn, this should be a fairly easy review since there are no changes in physics or numerics. This is entirely an output formatting PR.  This partially addresses #331.

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.




