### PR TITLE
Remove unsafe mesh-pointer cache from SPDS face-neighbor setup.

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
@@ -13,7 +13,6 @@
 #include <vector>
 #include <queue>
 #include <limits>
-#include <unordered_map>
 
 namespace opensn
 {
@@ -33,14 +32,9 @@ struct FaceNeighborInfo
 
 using FaceNeighborInfoVec = std::vector<std::vector<FaceNeighborInfo>>;
 
-FaceNeighborInfoVec&
+FaceNeighborInfoVec
 GetFaceNeighborInfo(const MeshContinuum& grid)
 {
-  static std::unordered_map<const MeshContinuum*, FaceNeighborInfoVec> cache;
-  auto it = cache.find(&grid);
-  if (it != cache.end())
-    return it->second;
-
   FaceNeighborInfoVec info;
   info.resize(grid.local_cells.size());
   for (const auto& cell : grid.local_cells)
@@ -72,8 +66,7 @@ GetFaceNeighborInfo(const MeshContinuum& grid)
     }
   }
 
-  auto [ins_it, _] = cache.emplace(&grid, std::move(info));
-  return ins_it->second;
+  return info;
 }
 
 } // namespace


### PR DESCRIPTION
This PR fixes an intermittent PETSc segmentation fault that can occur during sweep data-structure initialization in repeated transport solves with different meshes but the same problem instance.

`SPDS::PopulateCellRelationships()` uses `GetFaceNeighborInfo()`, which cached face-neighbor data in a function-static map keyed by `const MeshContinuum*`. In stress tests that repeatedly construct and destroy meshes, allocator reuse can give a new `MeshContinuum` the same address as a previously destroyed one. The cache then returns stale topology data for the new mesh, resulting in invalid sweep data and memory access failures during sweep initialization.

This fix removes the static raw-pointer cache and computes the face-neighbor metadata for the mesh directly.