### PR TITLE
Clarify adjoint response source specification.

### DIFF
--- a/doc/source/tutorials/lbs/src_driven/detector_adjoint/detector_adj.ipynb
+++ b/doc/source/tutorials/lbs/src_driven/detector_adjoint/detector_adj.ipynb
@@ -111,7 +111,7 @@
     "from pyopensn.aquad import GLProductQuadrature1DSlab\n",
     "from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver\n",
     "from pyopensn.response import ResponseEvaluator\n",
-    "from pyopensn.math import Vector3, VectorSpatialFunction\n",
+    "from pyopensn.math import Vector3\n",
     "from pyopensn.fieldfunc import FieldFunctionInterpolationVolume, \\\n",
     "                               FieldFunctionInterpolationLine, \\\n",
     "                               FieldFunctionGridBased\n",
@@ -414,7 +414,7 @@
     "\n",
     "For solving the 1D transport problem via the adjoint operator we first define our adjoint source $q^{\\dagger}$ to be the detector volume and apply a source strength equivalent to the abosrption cross section of our detector $\\sigma^{He3,g}_a$. (By default, adjoint sources are isotoropically distributed in angle across the souce domain)\n",
     "\n",
-    "To do this we create a `ResponseFunction`. A response function takes the place of defining the group strength. This can be used to specifiy responses to specific energy bins, or this case, capture our detector response."
+    "To do this, we define the group-wise source strength directly from the detector absorption cross section. A spatial function is only needed for responses that vary over the detector volume."
    ]
   },
   {
@@ -423,12 +423,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def ResponseFunction(xyz, mat_id):\n",
-    "    response = xs_he3.sigma_a\n",
-    "    return response\n",
-    "response_func = VectorSpatialFunction(ResponseFunction)\n",
-    "\n",
-    "adj_src = VolumetricSource(logical_volume=det_he3, func=response_func)"
+    "Q_adj = xs_he3.sigma_a.tolist()\n",
+    "adj_src = VolumetricSource(logical_volume=det_he3, group_strength=Q_adj)"
    ]
   },
   {

--- a/doc/source/tutorials/lbs/src_driven/glovebox_adjoint/glovebox_adj.ipynb
+++ b/doc/source/tutorials/lbs/src_driven/glovebox_adjoint/glovebox_adj.ipynb
@@ -88,7 +88,6 @@
     "from pyopensn.aquad import GLCProductQuadrature2DXY\n",
     "from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver\n",
     "from pyopensn.response import ResponseEvaluator\n",
-    "from pyopensn.math import Vector3, VectorSpatialFunction\n",
     "from pyopensn.fieldfunc import FieldFunctionInterpolationVolume, \\\n",
     "                               FieldFunctionInterpolationLine, \\\n",
     "                               FieldFunctionGridBased\n",
@@ -260,7 +259,7 @@
     "\n",
     "To solve the 2D transport problem using the adjoint operator, we first define the adjoint source $q^{\\dagger}$ over the detector volume, assigning a source strength equal to the absorption cross section of the detector, $\\sigma_a^{\\text{He3},g}$. By default, adjoint sources are distributed isotropically in angle across the source domain.\n",
     "\n",
-    "To implement this, we create a `ResponseFunction`. A response function allows us to define the group-wise source strength, which can be used to specify responses in particular energy bins or, in this case, to capture the detector response. To record the response for a specific detector, we set the `logical_volume` of the adjoint source to the detector of interest. "
+    "To implement this, we define the group-wise source strength directly from the detector absorption cross section. To record the response for a specific detector, we set the `logical_volume` of the adjoint source to the detector of interest. "
    ]
   },
   {
@@ -296,12 +295,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def ResponseFunction(xyz, mat_id):\n",
-    "    response = xs_he3.sigma_a\n",
-    "    return response\n",
-    "response_func = VectorSpatialFunction(ResponseFunction)\n",
-    "\n",
-    "adj_src = VolumetricSource(logical_volume=det_logvols[0], func=response_func)"
+    "Q_adj = xs_he3.sigma_a.tolist()\n",
+    "adj_src = VolumetricSource(logical_volume=det_logvols[0], group_strength=Q_adj)"
    ]
   },
   {

--- a/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.cc
@@ -44,7 +44,7 @@ VolumetricSource::GetInputParameters()
   params.AddOptionalParameter<std::shared_ptr<VectorSpatialFunction>>(
     "func",
     std::shared_ptr<VectorSpatialFunction>{},
-    "SpatialMaterialFunction object to be used to define the source.");
+    "VectorSpatialFunction object to be used to define the source.");
   params.AddOptionalParameter<std::shared_ptr<GroupTimeFunction>>(
     "strength_function",
     std::shared_ptr<GroupTimeFunction>{},

--- a/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.h
@@ -21,8 +21,8 @@ class LBSProblem;
  * A class for multi-group isotropic volumetric sources.
  *
  * This class differs from the standard material property sources in that it can be specified
- * for an arbitrary logical volume that may span multiple material regions and with spatial,
- * material id, and group-wise behaviors via a VectorSpatialFunction.
+ * for an arbitrary logical volume that may span multiple material regions and with spatial and
+ * group-wise behaviors via a VectorSpatialFunction.
  *
  * The flexibility of this object allows for its use as a standard volumetric source or as
  * a volumetric response function for adjoint calculations.

--- a/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_adjoint/response_2d_3.py
@@ -35,7 +35,6 @@ if "opensn_console" not in globals():
     from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
     from pyopensn.response import ResponseEvaluator
     from pyopensn.fieldfunc import FieldFunctionInterpolationVolume
-    from pyopensn.math import VectorSpatialFunction
 else:
     barrier = MPIBarrier
 
@@ -130,17 +129,12 @@ if __name__ == "__main__":
         fwd_qois.append(value)
         fwd_qoi_sum += value
 
-    # Create adjoint source using a response function
-    def ResponseFunction(xyz, mat_id):
-        response = [0.0] * num_groups
-        response[5] = 1.0
-        return response
-    response_func = VectorSpatialFunction(ResponseFunction)
-
-    # Create the adjoint volumetric source with the response function over the QoI region.
+    # Create the adjoint volumetric source over the QoI region.
+    qoi_response = [0.0] * num_groups
+    qoi_response[5] = 1.0
     adjoint_source = VolumetricSource(
         logical_volume=qoi_vol,
-        func=response_func
+        group_strength=qoi_response
     )
 
     # Switch to adjoint mode


### PR DESCRIPTION
This PR updates the adjoint response examples to use `VolumetricSource(..., group_strength=...)` for detector responses that are spatially uniform over the selected detector volume.

Previously, these examples created a `VectorSpatialFunction` response callback even though the response did not depend on position. That was unnecessary and also made the callback signature look like it accepted a material ID, when the second argument is actually the number of groups. This PR replaces uniform adjoint detector response callbacks with `group_strength` and clarifies `VolumetricSource` documentation so `VectorSpatialFunction` is described as spatial/group-wise, not material-ID based.

Close #862.

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.
