### PR TITLE
Improving Caliper instrumentation.

### DIFF
--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -32,7 +32,7 @@ Initialize()
     cali_mgr.start();
   }
 
-  CALI_MARK_BEGIN(opensn::program.c_str());
+  CALI_MARK_PHASE_BEGIN(opensn::program.c_str());
 
   // Disable internal HDF error reporting
   H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
@@ -50,7 +50,7 @@ Finalize()
 
   opensn::mpi_comm.barrier();
 
-  CALI_MARK_END(opensn::program.c_str());
+  CALI_MARK_PHASE_END(opensn::program.c_str());
 }
 
 std::string

--- a/framework/utils/caliper_scopes.h
+++ b/framework/utils/caliper_scopes.h
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "caliper/cali.h"
+
+namespace opensn
+{
+
+class CaliperPhaseScope
+{
+public:
+  CaliperPhaseScope(const char* name, int& depth)
+    : name_(name), depth_(depth), active_(depth_++ == 0)
+  {
+    if (active_)
+      CALI_MARK_PHASE_BEGIN(name_);
+  }
+
+  ~CaliperPhaseScope()
+  {
+    --depth_;
+    if (active_)
+      CALI_MARK_PHASE_END(name_);
+  }
+
+  CaliperPhaseScope(const CaliperPhaseScope&) = delete;
+  CaliperPhaseScope& operator=(const CaliperPhaseScope&) = delete;
+
+private:
+  const char* name_;
+  int& depth_;
+  bool active_ = false;
+};
+
+class CaliperRegionScope
+{
+public:
+  CaliperRegionScope(const char* name, int& depth)
+    : name_(name), depth_(depth), active_(depth_++ == 0)
+  {
+    if (active_)
+      CALI_MARK_BEGIN(name_);
+  }
+
+  ~CaliperRegionScope()
+  {
+    --depth_;
+    if (active_)
+      CALI_MARK_END(name_);
+  }
+
+  CaliperRegionScope(const CaliperRegionScope&) = delete;
+  CaliperRegionScope& operator=(const CaliperRegionScope&) = delete;
+
+private:
+  const char* name_;
+  int& depth_;
+  bool active_ = false;
+};
+
+inline int&
+CaliperSetupPhaseDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperSolvePhaseDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperPostPhaseDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperAGSScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperWGSScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperWGSMethodScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperSteadyStateScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperTransientScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperPIScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperNLKEScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperNLKEMethodScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperSweepScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/tgdsa.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/tgdsa.cc
@@ -12,10 +12,10 @@ namespace opensn
 void
 TGDSA::Init(DiscreteOrdinatesProblem& do_problem, LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("TGDSA::Init");
-
   if (groupset.apply_tgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/TGDSA");
+
     const auto& sdm = do_problem.GetSpatialDiscretization();
     const auto& uk_man = sdm.UNITARY_UNKNOWN_MANAGER;
     const auto& block_id_to_xs_map = do_problem.GetBlockID2XSMap();
@@ -81,7 +81,6 @@ TGDSA::AssembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
                               const std::vector<double>& phi_in,
                               std::vector<double>& delta_phi_local)
 {
-  CALI_CXX_MARK_SCOPE("TGDSA::AssembleDeltaPhiVector");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
@@ -128,7 +127,6 @@ TGDSA::DisassembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
                                  const std::vector<double>& delta_phi_local,
                                  std::vector<double>& ref_phi_new)
 {
-  CALI_CXX_MARK_SCOPE("TGDSA::DisassembleDeltaPhiVector");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
@@ -163,7 +161,6 @@ TGDSA::DisassembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
 void
 TGDSA::CleanUp(LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("TGDSA::CleanUp");
 
   if (groupset.apply_tgdsa)
     groupset.tgdsa_solver = nullptr;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.cc
@@ -14,10 +14,10 @@ WGDSA::Init(DiscreteOrdinatesProblem& do_problem,
             LBSGroupset& groupset,
             bool vaccum_bcs_are_dirichlet)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::Init");
-
   if (groupset.apply_wgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/WGDSA");
+
     // Make UnknownManager
     const auto num_gs_groups = groupset.GetNumGroups();
     opensn::UnknownManager uk_man;
@@ -66,7 +66,6 @@ WGDSA::AssembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
                               const std::vector<double>& phi_in,
                               std::vector<double>& delta_phi_local)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::AssembleDeltaPhiVector");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
@@ -108,7 +107,6 @@ WGDSA::DisassembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
                                  const std::vector<double>& delta_phi_local,
                                  std::vector<double>& ref_phi_new)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::DisassembleDeltaPhiVector");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
@@ -140,7 +138,6 @@ WGDSA::DisassembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
 void
 WGDSA::CleanUp(LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::CleanUp");
 
   if (groupset.apply_wgdsa)
     groupset.wgdsa_solver = nullptr;
@@ -151,7 +148,6 @@ WGDSA::WGSCopyOnlyPhi0(DiscreteOrdinatesProblem& do_problem,
                        const LBSGroupset& groupset,
                        const std::vector<double>& phi_in)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::WGSCopyOnlyPhi0");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();
@@ -192,7 +188,6 @@ WGDSA::GSProjectBackPhi0(DiscreteOrdinatesProblem& do_problem,
                          const std::vector<double>& input,
                          std::vector<double>& output)
 {
-  CALI_CXX_MARK_SCOPE("WGDSA::GSProjectBackPhi0");
 
   const auto grid = do_problem.GetGrid();
   const auto& sdm = do_problem.GetSpatialDiscretization();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
@@ -7,6 +7,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include "framework/utils/caliper_scopes.h"
 #include "caliper/cali.h"
 #include <algorithm>
 #include <cmath>
@@ -62,8 +63,6 @@ GetInflow(const Cell& cell,
 BalanceTable
 ComputeBalanceTable(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ComputeBalanceTable");
-
   opensn::mpi_comm.barrier();
 
   const auto& grid_ = do_problem.GetGrid();
@@ -313,7 +312,8 @@ ComputeBalanceTable(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
 void
 ComputeBalance(DiscreteOrdinatesProblem& do_problem, double scaling_factor)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ComputeBalance");
+  CaliperPhaseScope cali_post_phase("Post", CaliperPostPhaseDepth());
+  CALI_CXX_MARK_SCOPE("Balance");
 
   const auto table = ComputeBalanceTable(do_problem, scaling_factor);
   const auto time_dependent = do_problem.IsTimeDependent();
@@ -354,7 +354,6 @@ ComputeLeakage(DiscreteOrdinatesProblem& do_problem,
                const unsigned int groupset_id,
                const uint64_t boundary_id)
 {
-  CALI_CXX_MARK_SCOPE("ComputeLeakage");
 
   OpenSnInvalidArgumentIf(groupset_id >= do_problem.GetNumGroupsets(), "Invalid groupset id.");
 
@@ -408,7 +407,6 @@ ComputeLeakage(DiscreteOrdinatesProblem& do_problem,
 std::map<uint64_t, std::vector<double>>
 ComputeLeakage(DiscreteOrdinatesProblem& do_problem, const std::vector<uint64_t>& boundary_ids)
 {
-  CALI_CXX_MARK_SCOPE("ComputeLeakage");
 
   const auto& grid = do_problem.GetGrid();
   const auto uniq = grid->GetUniqueBoundaryIDs();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -37,6 +37,7 @@
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_discontinuous.h"
 #include "framework/logging/log.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
 #include "framework/utils/utils.h"
 #include "framework/runtime.h"
@@ -191,8 +192,11 @@ DiscreteOrdinatesProblem::Create(const ParameterBlock& params)
   input_params.SetErrorOriginScope("lbs::DiscreteOrdinatesProblem");
   input_params.AssignParameters(params);
 
-  auto problem =
-    std::shared_ptr<DiscreteOrdinatesProblem>(new DiscreteOrdinatesProblem(input_params));
+  std::shared_ptr<DiscreteOrdinatesProblem> problem;
+  {
+    CaliperPhaseScope cali_setup_phase("Setup", CaliperSetupPhaseDepth());
+    problem = std::shared_ptr<DiscreteOrdinatesProblem>(new DiscreteOrdinatesProblem(input_params));
+  }
   problem->discretization_ = discretization;
   problem->BuildRuntime();
   return problem;
@@ -286,7 +290,6 @@ DiscreteOrdinatesProblem::DiscreteOrdinatesProblem(const InputParameters& params
 
 DiscreteOrdinatesProblem::~DiscreteOrdinatesProblem()
 {
-  CALI_CXX_MARK_FUNCTION;
 
   ResetBoundaryCarrier();
 
@@ -304,7 +307,6 @@ DiscreteOrdinatesProblem::~DiscreteOrdinatesProblem()
 std::pair<std::uint64_t, std::uint64_t>
 DiscreteOrdinatesProblem::GetNumPhiIterativeUnknowns()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::GetNumPhiIterativeUnknowns");
   const auto& sdm = *discretization_;
   const auto num_local_phi_dofs = sdm.GetNumLocalDOFs(flux_moments_uk_man_);
   const auto num_global_phi_dofs = sdm.GetNumGlobalDOFs(flux_moments_uk_man_);
@@ -520,7 +522,7 @@ DiscreteOrdinatesProblem::PrintSimHeader()
 void
 DiscreteOrdinatesProblem::BuildRuntime()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::BuildRuntime");
+  CaliperPhaseScope cali_setup_phase("Setup", CaliperSetupPhaseDepth());
 
   if (boundary_conditions_block_)
   {
@@ -575,6 +577,7 @@ DiscreteOrdinatesProblem::BuildRuntime()
     WGDSA::Init(*this, groupset);
     TGDSA::Init(*this, groupset);
   }
+
   log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
 
   // Initialize runtime boundary data
@@ -636,7 +639,6 @@ DiscreteOrdinatesProblem::RebuildBoundaryRuntimeData()
 void
 DiscreteOrdinatesProblem::InitializeSolverSchemes()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeSolverSchemes");
   ags_solver_.reset();
   wgs_solvers_.clear();
   wgs_contexts_.clear();
@@ -951,7 +953,7 @@ DiscreteOrdinatesProblem::UpdateAngularFluxStorage()
 void
 DiscreteOrdinatesProblem::InitializeBoundaries()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeBoundaries");
+  CALI_CXX_MARK_SCOPE("Boundaries");
 
   ResetBoundaryCarrier();
   boundary_runtime_data_initialized_ = false;
@@ -1090,7 +1092,6 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
 void
 DiscreteOrdinatesProblem::InitializeWGSContexts()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeWGSContexts");
 
   // Determine max size and number of matrices along sweep front
   max_groupset_size_ = 0;
@@ -1133,7 +1134,6 @@ DiscreteOrdinatesProblem::InitializeWGSContexts()
 void
 DiscreteOrdinatesProblem::InitializeWGSSolvers()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeWGSSolvers");
 
   OpenSnLogicalErrorIf(wgs_contexts_.empty(),
                        GetName() + ": Cannot initialize WGS solvers before WGS contexts.");
@@ -1158,7 +1158,6 @@ DiscreteOrdinatesProblem::InitializeWGSSolvers()
 void
 DiscreteOrdinatesProblem::ReorientAdjointSolution()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ReorientAdjointSolution");
 
   for (const auto& groupset : groupsets_)
   {
@@ -1264,7 +1263,6 @@ DiscreteOrdinatesProblem::ReorientAdjointSolution()
 void
 DiscreteOrdinatesProblem::ZeroOutflowBalanceVars(LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ZeroOutflowBalanceVars");
 
   for (const auto& cell : grid_->local_cells)
     for (int f = 0; f < cell.faces.size(); ++f)
@@ -1275,7 +1273,7 @@ DiscreteOrdinatesProblem::ZeroOutflowBalanceVars(LBSGroupset& groupset)
 void
 DiscreteOrdinatesProblem::InitializeSweepDataStructures()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeSweepDataStructures");
+  CALI_CXX_MARK_SCOPE("SweepDataStructures");
 
   log.Log() << program_timer.GetTimeString() << " Initializing sweep datastructures.\n";
 
@@ -1639,7 +1637,6 @@ DiscreteOrdinatesProblem::AssociateSOsAndDirections(const std::shared_ptr<MeshCo
                                                     const AngleAggregationType agg_type,
                                                     const GeometryType lbs_geo_type)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::AssociateSOsAndDirections");
 
   // Checks
   if (quadrature.GetOmegas().empty())
@@ -1818,7 +1815,7 @@ DiscreteOrdinatesProblem::AssociateSOsAndDirections(const std::shared_ptr<MeshCo
 void
 DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitFluxDataStructures");
+  CALI_CXX_MARK_SCOPE("FluxDataStructures");
 
   const auto& quadrature_sweep_info = quadrature_unq_so_grouping_map_[groupset.quadrature];
 
@@ -1959,7 +1956,6 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
 std::shared_ptr<SweepChunk>
 DiscreteOrdinatesProblem::SetSweepChunk(LBSGroupset& groupset)
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::SetSweepChunk");
 
   const auto mode = sweep_chunk_mode_.value_or(SweepChunkMode::DEFAULT);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
@@ -8,6 +8,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
 
@@ -17,7 +18,8 @@ namespace opensn
 void
 AGSLinearSolver::Solve()
 {
-  CALI_CXX_MARK_SCOPE("AGSLinearSolver::Solve");
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_ags("AGS", CaliperAGSScopeDepth());
   const bool is_multi_groupset = wgs_solvers_.size() > 1;
   const bool print_ags_stats = verbose_ and is_multi_groupset;
   last_solve_ = {};
@@ -35,8 +37,11 @@ AGSLinearSolver::Solve()
   bool child_limited = false;
   unsigned int num_iterations = 0;
   const bool reports_as_iteration = is_multi_groupset;
+  CALI_CXX_MARK_LOOP_BEGIN(ags_iteration, "AGSIteration");
   for (unsigned int iter = 0; iter < max_iterations_; ++iter)
   {
+    CALI_CXX_MARK_LOOP_ITERATION(ags_iteration, iter);
+
     num_iterations = iter + 1;
     for (auto& solver : wgs_solvers_)
     {
@@ -107,6 +112,7 @@ AGSLinearSolver::Solve()
     else
       phi_old_ = lbs_problem_.GetPhiNewLocal();
   }
+  CALI_CXX_MARK_LOOP_END(ags_iteration);
 
   const auto inner_status = failed
                               ? IterationStatus::FAILED
@@ -118,7 +124,8 @@ AGSLinearSolver::Solve()
   last_solve_.metric_name =
     lbs_problem_.GetOptions().ags_pointwise_convergence ? "pw_change" : "l2_change";
   last_solve_.metric_value = last_error;
-  if (print_ags_stats and not converged)
+  if (print_ags_stats and (last_solve_.status == IterationStatus::FAILED or
+                           last_solve_.status == IterationStatus::LIMIT))
     log.Log() << program_timer.GetTimeString() << " " << FormatIterationSummary("AGS", last_solve_);
 
   for (const auto& solver : wgs_solvers_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
@@ -12,8 +12,10 @@
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "framework/math/linear_solver/linear_solver.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
+#include "caliper/cali.h"
 #include <memory>
 
 namespace opensn
@@ -39,6 +41,10 @@ ClassicRichardson::SyncLaggedStateToLatestIterate(WGSContext& gs_context)
 void
 ClassicRichardson::Solve()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_wgs("WGS", CaliperWGSScopeDepth());
+  CALI_CXX_MARK_SCOPE("ClassicRichardson");
+
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   gs_context_ptr->PreSetupCallback();
   gs_context_ptr->PreSolveCallback();
@@ -54,17 +60,25 @@ ClassicRichardson::Solve()
   double last_pw_phi_change = 0.0;
   bool converged = false;
   unsigned int num_iterations = 0;
+  CALI_CXX_MARK_LOOP_BEGIN(wgs_iteration, "WGSIteration");
   for (unsigned int k = 0; k < groupset.max_iterations; ++k)
   {
+    CALI_CXX_MARK_LOOP_ITERATION(wgs_iteration, k);
+
     num_iterations = k + 1;
     do_problem.SetQMomentsFrom(saved_q_moments_local_);
-    gs_context_ptr->set_source_function(
-      groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    {
+      CALI_CXX_MARK_SCOPE("Source");
+      gs_context_ptr->set_source_function(
+        groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    }
     gs_context_ptr->ApplyInverseTransportOperator(scope);
 
     // Apply WGDSA
     if (groupset.apply_wgdsa)
     {
+      CALI_CXX_MARK_SCOPE("Acceleration/WGDSA");
+
       std::vector<double> delta_phi;
       WGDSA::AssembleDeltaPhiVector(
         do_problem, groupset, do_problem.GetPhiNewLocal() - do_problem.GetPhiOldLocal(), delta_phi);
@@ -77,6 +91,8 @@ ClassicRichardson::Solve()
     // Apply TGDSA
     if (groupset.apply_tgdsa)
     {
+      CALI_CXX_MARK_SCOPE("Acceleration/TGDSA");
+
       std::vector<double> delta_phi;
       TGDSA::AssembleDeltaPhiVector(
         do_problem, groupset, do_problem.GetPhiNewLocal() - do_problem.GetPhiOldLocal(), delta_phi);
@@ -124,6 +140,7 @@ ClassicRichardson::Solve()
       break;
     }
   }
+  CALI_CXX_MARK_LOOP_END(wgs_iteration);
 
   gs_context_ptr->last_solve.num_iterations = num_iterations;
   gs_context_ptr->last_solve.status = IterationStatusFromSolve(converged, true);
@@ -131,7 +148,8 @@ ClassicRichardson::Solve()
   gs_context_ptr->last_solve.metric_name = "phi_change";
   gs_context_ptr->last_solve.metric_value = last_pw_phi_change;
 
-  if (verbose_ and not converged)
+  if (verbose_ and (gs_context_ptr->last_solve.status == IterationStatus::FAILED or
+                    gs_context_ptr->last_solve.status == IterationStatus::LIMIT))
     log.Log() << program_timer.GetTimeString() << " "
               << FormatIterationSummary("WGS groups [" + std::to_string(groupset.first_group) +
                                           "-" + std::to_string(groupset.last_group) + "]",

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_residual_func.cc
@@ -8,7 +8,9 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbs_shell_operations.h"
+#include "framework/utils/caliper_scopes.h"
 
+#include "caliper/cali.h"
 #include <petscsnes.h>
 
 namespace opensn
@@ -31,6 +33,8 @@ GetLocalGroupsetVectorSize(const LBSProblem& lbs_problem, const LBSGroupset& gro
 PetscErrorCode
 NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
 {
+  CALI_CXX_MARK_SCOPE("Residual");
+
   auto& function_context = *static_cast<KResidualFunctionContext*>(ctx);
 
   NLKEigenAGSContext* nl_context_ptr = nullptr;
@@ -61,39 +65,49 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   // Compute 1/k F phi
   lbs_problem->ZeroQMoments();
   for (const auto& groupset : lbs_problem->GetGroupsets())
+  {
+    CALI_CXX_MARK_SCOPE("Source");
     active_set_source_function(groupset,
                                lbs_problem->GetQMomentsLocal(),
                                lbs_problem->GetPhiOldLocal(),
                                APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+  }
 
   const double k_eff = ComputeFissionProduction(*lbs_problem, lbs_problem->GetPhiOldLocal());
   lbs_problem->ScaleQMoments(1.0 / k_eff);
 
-  // Now add MS phi
-  for (const auto& groupset : lbs_problem->GetGroupsets())
   {
-    auto& wgs_context = do_problem->GetWGSContext(groupset.id);
-    const bool supress_wgs = wgs_context.lhs_src_scope & SUPPRESS_WG_SCATTER;
-    SourceFlags source_flags = APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES;
-    if (supress_wgs)
-      source_flags |= SUPPRESS_WG_SCATTER;
-    active_set_source_function(
-      groupset, lbs_problem->GetQMomentsLocal(), lbs_problem->GetPhiOldLocal(), source_flags);
-  }
+    CALI_CXX_MARK_SCOPE("LinearSolve");
 
-  // Sweep all the groupsets
-  // After this phi_new = DLinv(MSD phi + 1/k FD phi)
-  offset = 0;
-  for (const auto groupset_id : groupset_ids)
-  {
-    const auto& groupset = lbs_problem->GetGroupsets().at(groupset_id);
-    auto& wgs_context = do_problem->GetWGSContext(groupset.id);
-    LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(
-      *lbs_problem, groupset, phi, PhiSTLOption::PHI_OLD, offset);
-    wgs_context.ApplyInverseTransportOperator(SourceFlags());
-    LBSVecOps::SetGSPETScVecFromPrimarySTLvector(
-      *lbs_problem, groupset, r, PhiSTLOption::PHI_NEW, offset);
-    offset += GetLocalGroupsetVectorSize(*lbs_problem, groupset);
+    // Now add MS phi
+    for (const auto& groupset : lbs_problem->GetGroupsets())
+    {
+      auto& wgs_context = do_problem->GetWGSContext(groupset.id);
+      const bool supress_wgs = wgs_context.lhs_src_scope & SUPPRESS_WG_SCATTER;
+      SourceFlags source_flags = APPLY_AGS_SCATTER_SOURCES | APPLY_WGS_SCATTER_SOURCES;
+      if (supress_wgs)
+        source_flags |= SUPPRESS_WG_SCATTER;
+      {
+        CALI_CXX_MARK_SCOPE("Source");
+        active_set_source_function(
+          groupset, lbs_problem->GetQMomentsLocal(), lbs_problem->GetPhiOldLocal(), source_flags);
+      }
+    }
+
+    // Sweep all the groupsets
+    // After this phi_new = DLinv(MSD phi + 1/k FD phi)
+    offset = 0;
+    for (const auto groupset_id : groupset_ids)
+    {
+      const auto& groupset = lbs_problem->GetGroupsets().at(groupset_id);
+      auto& wgs_context = do_problem->GetWGSContext(groupset.id);
+      LBSVecOps::SetPrimarySTLvectorFromGSPETScVec(
+        *lbs_problem, groupset, phi, PhiSTLOption::PHI_OLD, offset);
+      wgs_context.ApplyInverseTransportOperator(SourceFlags());
+      LBSVecOps::SetGSPETScVecFromPrimarySTLvector(
+        *lbs_problem, groupset, r, PhiSTLOption::PHI_NEW, offset);
+      offset += GetLocalGroupsetVectorSize(*lbs_problem, groupset);
+    }
   }
 
   ierr = VecAXPY(r, -1.0, phi);
@@ -104,7 +118,10 @@ NLKEigenResidualFunction(SNES snes, Vec phi, Vec r, void* ctx)
   {
     auto& wgs_context = do_problem->GetWGSContext(groupset.id);
     if (groupset.apply_wgdsa or groupset.apply_tgdsa)
+    {
+      CALI_CXX_MARK_SCOPE("Acceleration");
       WGDSA_TGDSA_PreConditionerMult2(wgs_context, r, r);
+    }
   }
 
   // Assign k to the context so monitors can work

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
@@ -10,7 +10,9 @@
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
+#include "caliper/cali.h"
 #include <petscsnes.h>
 
 namespace opensn
@@ -30,6 +32,13 @@ GetNLKAGSContextPtr(const std::shared_ptr<NonLinearSolverContext>& context,
 }
 
 } // namespace
+
+void
+NLKEigenvalueAGSSolver::Solve()
+{
+  CaliperRegionScope cali_nl_method(options_.nl_method.c_str(), CaliperNLKEMethodScopeDepth());
+  PETScNonLinearSolver::Solve();
+}
 
 void
 NLKEigenvalueAGSSolver::PreSetupCallback()

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.h
@@ -19,6 +19,8 @@ public:
 
   ~NLKEigenvalueAGSSolver() override = default;
 
+  void Solve() override;
+
 protected:
   void PreSetupCallback() override;
   void SetMonitor() override;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
@@ -10,7 +10,9 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
+#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -21,6 +23,9 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
                            unsigned int max_iterations,
                            double& k_eff)
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_pi("PI", CaliperPIScopeDepth());
+
   const std::string fname = "PowerIterationKEigenSolver";
   auto* do_problem = dynamic_cast<DiscreteOrdinatesProblem*>(&lbs_problem);
   if (not do_problem)
@@ -56,14 +61,20 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
   ags_solver->SetVerbosity(print_ags_iters);
   unsigned int nit = 0;
   bool converged = false;
+  CALI_CXX_MARK_LOOP_BEGIN(pi_iteration, "PIIteration");
   while (nit < max_iterations)
   {
+    CALI_CXX_MARK_LOOP_ITERATION(pi_iteration, nit);
+
     lbs_problem.ZeroQMoments();
     for (const auto& groupset : groupsets)
+    {
+      CALI_CXX_MARK_SCOPE("Source");
       active_set_source_function(groupset,
                                  lbs_problem.GetQMomentsLocal(),
                                  phi_old_local,
                                  APPLY_AGS_FISSION_SOURCES | APPLY_WGS_FISSION_SOURCES);
+    }
 
     lbs_problem.ScaleQMoments(1.0 / k_eff);
 
@@ -118,6 +129,7 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
     if (converged)
       break;
   } // for k iterations
+  CALI_CXX_MARK_LOOP_END(pi_iteration);
 
   // Print summary
   size_t total_sweeps = 0;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -9,6 +9,7 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/utils/timer.h"
+#include "framework/utils/caliper_scopes.h"
 #include "caliper/cali.h"
 #include <petscksp.h>
 
@@ -63,10 +64,16 @@ void
 SweepWGSContext::RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term,
                                                     bool zero_incoming_delayed_psi)
 {
+  CALI_CXX_MARK_SCOPE("AngularFluxReconstruction");
+
   auto scope = lhs_src_scope | rhs_src_scope;
   if (zero_incoming_delayed_psi)
     scope |= ZERO_INCOMING_DELAYED_PSI;
-  set_source_function(groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+  {
+    CALI_CXX_MARK_SCOPE("Source");
+    set_source_function(
+      groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+  }
 
   sweep_chunk->IncludeRHSTimeTerm(include_rhs_time_term);
   ApplyInverseTransportOperator(scope);
@@ -77,7 +84,6 @@ SweepWGSContext::RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term,
 void
 SweepWGSContext::SetPreconditioner(KSP& solver)
 {
-  CALI_CXX_MARK_SCOPE("SweepWGSContext::SetPreconditioner");
 
   auto& ksp = solver;
 
@@ -98,7 +104,6 @@ SweepWGSContext::SetPreconditioner(KSP& solver)
 std::pair<int64_t, int64_t>
 SweepWGSContext::GetSystemSize()
 {
-  CALI_CXX_MARK_SCOPE("SweepWGSContext::SystemSize");
 
   const size_t local_node_count = do_problem.GetLocalNodeCount();
   const auto global_node_count = do_problem.GetGlobalNodeCount();
@@ -135,7 +140,7 @@ SweepWGSContext::PreSolveCallback()
 void
 SweepWGSContext::ApplyInverseTransportOperator(SourceFlags scope)
 {
-  CALI_CXX_MARK_SCOPE("SweepWGSContext::ApplyInverseTransportOperator");
+  CaliperRegionScope cali_sweep_region("Sweep", CaliperSweepScopeDepth());
 
   ++counter_applications_of_inv_op;
 
@@ -159,7 +164,6 @@ SweepWGSContext::ApplyInverseTransportOperator(SourceFlags scope)
 void
 SweepWGSContext::PostSolveCallback()
 {
-  CALI_CXX_MARK_SCOPE("SweepWGSContext::PostSolveCallback");
 
   // Perform final sweep with converged phi and delayed psi dofs. This step is necessary for
   // Krylov methods to recover the actual solution (this includes all of the PETSc methods

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_context.cc
@@ -31,7 +31,7 @@ WGSContext::WGSContext(DiscreteOrdinatesProblem& do_problem,
 int
 WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
 {
-  CALI_CXX_MARK_SCOPE("WGSContext::MatrixAction");
+  CALI_CXX_MARK_SCOPE("MatrixAction");
 
   WGSContext* gs_context_ptr = nullptr;
   OpenSnPETScCall(MatShellGetContext(matrix, static_cast<void*>(&gs_context_ptr)));
@@ -42,8 +42,11 @@ WGSContext::MatrixAction(Mat& matrix, Vec& action_vector, Vec& action)
 
   // Setting the source using updated phi_old
   do_problem.ZeroQMoments();
-  set_source_function(
-    groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), lhs_src_scope);
+  {
+    CALI_CXX_MARK_SCOPE("Source");
+    set_source_function(
+      groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), lhs_src_scope);
+  }
 
   // Disable RHS time term in Krylov operator
   if (auto* sweep_ctx = dynamic_cast<SweepWGSContext*>(gs_context_ptr))

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
@@ -9,7 +9,6 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -19,8 +18,6 @@ PetscErrorCode
 GSConvergenceTest(
   KSP ksp, PetscInt n, PetscReal rnorm, KSPConvergedReason* convergedReason, void* /*unused*/)
 {
-  CALI_CXX_MARK_FUNCTION;
-
   // Get data context
   WGSContext* context = nullptr;
   PetscErrorCode ierr = KSPGetApplicationContext(ksp, static_cast<void*>(&context));

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
@@ -8,6 +8,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
 #include "framework/math/petsc_utils/petsc_utils.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
 #include <petscksp.h>
@@ -16,6 +17,27 @@
 
 namespace opensn
 {
+
+namespace
+{
+
+const char*
+WGSMethodName(LinearSystemSolver::IterativeMethod method)
+{
+  switch (method)
+  {
+    case LinearSystemSolver::IterativeMethod::PETSC_RICHARDSON:
+      return "Richardson";
+    case LinearSystemSolver::IterativeMethod::PETSC_GMRES:
+      return "GMRES";
+    case LinearSystemSolver::IterativeMethod::PETSC_BICGSTAB:
+      return "BiCGSTAB";
+    default:
+      return "WGSIteration";
+  }
+}
+
+} // namespace
 
 WGSLinearSolver::WGSLinearSolver(const std::shared_ptr<WGSContext>& gs_context_ptr)
   : PETScLinearSolver(gs_context_ptr->groupset.iterative_method, gs_context_ptr),
@@ -31,6 +53,15 @@ WGSLinearSolver::WGSLinearSolver(const std::shared_ptr<WGSContext>& gs_context_p
 WGSLinearSolver::~WGSLinearSolver()
 {
   OpenSnPETScCall(VecDestroy(&rhs_preconditioned_work_));
+}
+
+void
+WGSLinearSolver::Solve()
+{
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_wgs("WGS", CaliperWGSScopeDepth());
+  CaliperRegionScope cali_method(WGSMethodName(method_), CaliperWGSMethodScopeDepth());
+  PETScLinearSolver::Solve();
 }
 
 void
@@ -140,7 +171,7 @@ WGSLinearSolver::SetInitialGuess()
 void
 WGSLinearSolver::SetRHS()
 {
-  CALI_CXX_MARK_SCOPE("WGSLinearSolver::SetRHS");
+  CALI_CXX_MARK_SCOPE("SetRHS");
 
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   auto& groupset = gs_context_ptr->groupset;
@@ -156,8 +187,11 @@ WGSLinearSolver::SetRHS()
   if (not single_richardson)
   {
     const auto scope = gs_context_ptr->rhs_src_scope | ZERO_INCOMING_DELAYED_PSI;
-    gs_context_ptr->set_source_function(
-      groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    {
+      CALI_CXX_MARK_SCOPE("Source");
+      gs_context_ptr->set_source_function(
+        groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    }
 
     // Enable RHS time (tau*psi^n)
     auto sweep_ctx = std::dynamic_pointer_cast<SweepWGSContext>(gs_context_ptr);
@@ -187,8 +221,11 @@ WGSLinearSolver::SetRHS()
   else
   {
     const auto scope = gs_context_ptr->rhs_src_scope | gs_context_ptr->lhs_src_scope;
-    gs_context_ptr->set_source_function(
-      groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    {
+      CALI_CXX_MARK_SCOPE("Source");
+      gs_context_ptr->set_source_function(
+        groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
+    }
 
     // Apply transport operator
     gs_context_ptr->ApplyInverseTransportOperator(scope);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.h
@@ -24,6 +24,8 @@ public:
 
   ~WGSLinearSolver() override;
 
+  void Solve() override;
+
 protected:
   void PreSetupCallback() override;
   void SetConvergenceTest() override;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbs_dsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbs_dsa_preconditioner.cc
@@ -9,6 +9,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
+#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -35,6 +36,8 @@ WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   // Apply WGDSA
   if (groupset.apply_wgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/WGDSA");
+
     std::vector<double> delta_phi_local;
     WGDSA::AssembleDeltaPhiVector(do_problem, groupset, phi_new_local, delta_phi_local);
 
@@ -46,6 +49,8 @@ WGDSA_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   // Apply TGDSA
   if (groupset.apply_tgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/TGDSA");
+
     std::vector<double> delta_phi_local;
     TGDSA::AssembleDeltaPhiVector(do_problem, groupset, phi_new_local, delta_phi_local);
 
@@ -77,6 +82,8 @@ WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec p
   // Apply WGDSA
   if (groupset.apply_wgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/WGDSA");
+
     std::vector<double> delta_phi_local;
     WGDSA::AssembleDeltaPhiVector(do_problem, groupset, phi_new_local, delta_phi_local);
 
@@ -88,6 +95,8 @@ WGDSA_TGDSA_PreConditionerMult2(WGSContext& gs_context_ptr, Vec phi_input, Vec p
   // Apply TGDSA
   if (groupset.apply_tgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/TGDSA");
+
     std::vector<double> delta_phi_local;
     TGDSA::AssembleDeltaPhiVector(do_problem, groupset, phi_new_local, delta_phi_local);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
@@ -7,6 +7,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
+#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -32,6 +33,8 @@ MIP_TGDSA_PreConditionerMult(PC pc, Vec phi_input, Vec pc_output)
   // Apply TGDSA
   if (groupset.apply_tgdsa)
   {
+    CALI_CXX_MARK_SCOPE("Acceleration/TGDSA");
+
     // DSA dsa(solver);
     std::vector<double> delta_phi_local;
     TGDSA::AssembleDeltaPhiVector(solver, groupset, phi_delta, delta_phi_local);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/nl_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/nl_keigen_solver.cc
@@ -9,8 +9,10 @@
 #include "framework/object_factory.h"
 #include "framework/logging/log.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
+#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -82,6 +84,10 @@ NonLinearKEigenSolver::NonLinearKEigenSolver(const InputParameters& params)
 void
 NonLinearKEigenSolver::Initialize()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_nlke("NLKE", CaliperNLKEScopeDepth());
+  CALI_CXX_MARK_SCOPE("Initialize");
+
   log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
 
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
@@ -93,6 +99,9 @@ NonLinearKEigenSolver::Initialize()
 void
 NonLinearKEigenSolver::Execute()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_nlke("NLKE", CaliperNLKEScopeDepth());
+
   log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
 
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
@@ -103,6 +112,8 @@ NonLinearKEigenSolver::Execute()
   double initial_k_eff = 1.0;
   if (num_initial_power_its_ > 0)
   {
+    CALI_CXX_MARK_SCOPE("InitialPowerIteration");
+
     PowerIterationKEigenSolver(*do_problem_,
                                nl_solver_.GetToleranceOptions().nl_abs_tol,
                                num_initial_power_its_,
@@ -116,7 +127,10 @@ NonLinearKEigenSolver::Execute()
   LBSVecOps::ScalePhiVector(*do_problem_, PhiSTLOption::PHI_OLD, normalization);
   LBSVecOps::ScalePhiVector(*do_problem_, PhiSTLOption::PHI_NEW, normalization);
 
-  nl_solver_.Setup();
+  {
+    CALI_CXX_MARK_SCOPE("Setup");
+    nl_solver_.Setup();
+  }
   nl_solver_.Solve();
 
   if (do_problem_->GetOptions().use_precursors)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
@@ -8,6 +8,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/iterative_methods/iteration_logging.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/timer.h"
 #include "framework/utils/hdf_utils.h"
 #include "framework/utils/error.h"
@@ -15,6 +16,7 @@
 #include "framework/runtime.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
+#include "caliper/cali.h"
 #include <cmath>
 #include <iomanip>
 
@@ -67,6 +69,10 @@ PowerIterationKEigenSolver::PowerIterationKEigenSolver(const InputParameters& pa
 void
 PowerIterationKEigenSolver::Initialize()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_pi("PI", CaliperPIScopeDepth());
+  CALI_CXX_MARK_SCOPE("Initialize");
+
   log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
 
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
@@ -104,19 +110,28 @@ PowerIterationKEigenSolver::Initialize()
   F_prev_ = ComputeFissionProduction(*do_problem_, phi_old_local_);
 
   if (acceleration_)
+  {
+    CALI_CXX_MARK_SCOPE("Acceleration");
     acceleration_->Initialize(*this);
+  }
   initialized_ = true;
 }
 
 void
 PowerIterationKEigenSolver::Execute()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_pi("PI", CaliperPIScopeDepth());
+
   log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
 
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   if (acceleration_)
+  {
+    CALI_CXX_MARK_SCOPE("Acceleration");
     acceleration_->PreExecute();
+  }
 
   const auto& options = do_problem_->GetOptions();
   double k_eff_prev = 1.0;
@@ -125,17 +140,26 @@ PowerIterationKEigenSolver::Execute()
   // Start power iterations
   unsigned int nit = 0;
   bool converged = false;
+  CALI_CXX_MARK_LOOP_BEGIN(pi_iteration, "PIIteration");
   while (nit < max_iters_)
   {
+    CALI_CXX_MARK_LOOP_ITERATION(pi_iteration, nit);
+
     OpenSnLogicalErrorIf(k_eff_ <= 0.0 or not std::isfinite(k_eff_),
                          GetName() + ": invalid k_eff encountered: " + std::to_string(k_eff_));
 
     // Set the fission source
-    SetLBSFissionSource(phi_old_local_, false);
+    {
+      CALI_CXX_MARK_SCOPE("Source");
+      SetLBSFissionSource(phi_old_local_, false);
+    }
     do_problem_->ScaleQMoments(1.0 / k_eff_);
 
     if (acceleration_)
+    {
+      CALI_CXX_MARK_SCOPE("Acceleration");
       acceleration_->PrePowerIteration();
+    }
 
     // This solves the inners for transport
     auto ags_solver = do_problem_->GetAGSSolver();
@@ -145,6 +169,7 @@ PowerIterationKEigenSolver::Execute()
     // Get k-eigenvalue from the acceleration method
     if (acceleration_)
     {
+      CALI_CXX_MARK_SCOPE("Acceleration");
       k_eff_ = acceleration_->PostPowerIteration();
     }
     // Recompute k-eigenvalue
@@ -207,6 +232,7 @@ PowerIterationKEigenSolver::Execute()
     if (converged)
       break;
   } // for k iterations
+  CALI_CXX_MARK_LOOP_END(pi_iteration);
 
   // If restarts are enabled, always write a restart dump upon convergence or
   // when we reach the iteration limit

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
@@ -8,6 +8,7 @@
 #include "framework/logging/log.h"
 #include "framework/object_factory.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
 #include <memory>
@@ -47,7 +48,9 @@ SteadyStateSourceSolver::SteadyStateSourceSolver(const InputParameters& params)
 void
 SteadyStateSourceSolver::Initialize()
 {
-  CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Initialize");
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_steady_state("SteadyState", CaliperSteadyStateScopeDepth());
+  CALI_CXX_MARK_SCOPE("Initialize");
   log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
 
   OpenSnInvalidArgumentIf(do_problem_->IsTimeDependent(),
@@ -62,7 +65,8 @@ SteadyStateSourceSolver::Initialize()
 void
 SteadyStateSourceSolver::Execute()
 {
-  CALI_CXX_MARK_SCOPE("SteadyStateSourceSolver::Execute");
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_steady_state("SteadyState", CaliperSteadyStateScopeDepth());
   log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
 
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
@@ -9,8 +9,10 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "framework/logging/log.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/hdf_utils.h"
 #include "framework/runtime.h"
+#include "caliper/cali.h"
 #include <iomanip>
 #include <limits>
 #include <utility>
@@ -96,6 +98,10 @@ TransientSolver::TransientSolver(const InputParameters& params)
 void
 TransientSolver::Initialize()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_transient("Transient", CaliperTransientScopeDepth());
+  CALI_CXX_MARK_SCOPE("Initialize");
+
   log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
   enforce_stop_time_ = false;
 
@@ -162,6 +168,9 @@ TransientSolver::Initialize()
 void
 TransientSolver::Execute()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_transient("Transient", CaliperTransientScopeDepth());
+
   log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
@@ -176,6 +185,8 @@ TransientSolver::Execute()
     64.0 * std::numeric_limits<double>::epsilon() * std::max({1.0, std::abs(tf), std::abs(t0)});
 
   enforce_stop_time_ = true;
+  CALI_CXX_MARK_LOOP_BEGIN(time_step, "TimeStep");
+  bool time_step_loop_open = true;
   try
   {
     while (true)
@@ -188,6 +199,8 @@ TransientSolver::Execute()
         do_problem_->SetTime(current_time_);
         break;
       }
+
+      CALI_CXX_MARK_LOOP_ITERATION(time_step, step_);
 
       if (pre_advance_callback_)
         pre_advance_callback_();
@@ -215,10 +228,14 @@ TransientSolver::Execute()
   }
   catch (...)
   {
+    if (time_step_loop_open)
+      CALI_CXX_MARK_LOOP_END(time_step);
     do_problem_->SetTimeStep(dt_nominal);
     enforce_stop_time_ = false;
     throw;
   }
+  CALI_CXX_MARK_LOOP_END(time_step);
+  time_step_loop_open = false;
 
   do_problem_->SetTimeStep(dt_nominal);
   enforce_stop_time_ = false;
@@ -232,6 +249,10 @@ TransientSolver::Execute()
 void
 TransientSolver::Advance()
 {
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_transient("Transient", CaliperTransientScopeDepth());
+  CALI_CXX_MARK_SCOPE("Advance");
+
   const auto& options = do_problem_->GetOptions();
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Advance.");
   if (enforce_stop_time_ and stop_time_ <= current_time_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/source_functions/source_function.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/source_functions/source_function.cc
@@ -6,7 +6,6 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -21,8 +20,6 @@ SourceFunction::operator()(const LBSGroupset& groupset,
                            const std::vector<double>& phi,
                            const SourceFlags source_flags)
 {
-  CALI_CXX_MARK_SCOPE("SourceFunction::operator");
-
   if (source_flags.Empty())
     return;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_aggregation/angle_aggregation.cc
@@ -32,7 +32,6 @@ AngleAggregation::AngleAggregation(const LBSGroupset& groupset,
 void
 AngleAggregation::ZeroOutgoingDelayedPsi()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::ZeroOutgoingDelayedPsi");
 
   for (auto& angset : angle_set_groups_)
     for (auto& delayed_data : angset->GetFLUDS().DelayedPrelocIOutgoingPsi())
@@ -47,7 +46,6 @@ AngleAggregation::ZeroOutgoingDelayedPsi()
 void
 AngleAggregation::ZeroIncomingDelayedPsi()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::ZeroIncomingDelayedPsi");
 
   // Opposing reflecting bndries
   for (const auto& [bid, bndry] : boundaries_)
@@ -91,7 +89,7 @@ AngleAggregation::ResetAngleSetDependencies()
 void
 AngleAggregation::SetupAngleSetDependencies()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetupAngleSetDependencies");
+  CALI_CXX_MARK_SCOPE("AngleSetDependencies");
 
   ResetAngleSetDependencies();
 
@@ -141,7 +139,6 @@ AngleAggregation::SetupAngleSetDependencies()
 std::pair<size_t, size_t>
 AngleAggregation::GetNumDelayedAngularDOFs()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::GetNumDelayedAngularDOFs");
 
   // Check if this is already developed
   if (num_ang_unknowns_avail_)
@@ -174,7 +171,6 @@ AngleAggregation::GetNumDelayedAngularDOFs()
 void
 AngleAggregation::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* x_ref)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::AppendNewDelayedAngularDOFsToArray");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->AppendNewDelayedAngularDOFsToArray(groupset_id_, index, x_ref);
@@ -200,7 +196,6 @@ AngleAggregation::AppendNewDelayedAngularDOFsToArray(int64_t& index, double* x_r
 void
 AngleAggregation::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* x_ref)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::AppendOldDelayedAngularDOFsToArray");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->AppendOldDelayedAngularDOFsToArray(groupset_id_, index, x_ref);
@@ -226,7 +221,6 @@ AngleAggregation::AppendOldDelayedAngularDOFsToArray(int64_t& index, double* x_r
 void
 AngleAggregation::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double* x_ref)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetOldDelayedAngularDOFsFromArray");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->SetOldDelayedAngularDOFsFromArray(groupset_id_, index, x_ref);
@@ -252,7 +246,6 @@ AngleAggregation::SetOldDelayedAngularDOFsFromArray(int64_t& index, const double
 void
 AngleAggregation::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double* x_ref)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetNewDelayedAngularDOFsFromArray");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->SetNewDelayedAngularDOFsFromArray(groupset_id_, index, x_ref);
@@ -278,7 +271,6 @@ AngleAggregation::SetNewDelayedAngularDOFsFromArray(int64_t& index, const double
 std::vector<double>
 AngleAggregation::GetNewDelayedAngularDOFsAsSTLVector()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::GetNewDelayedAngularDOFsAsSTLVector");
 
   std::vector<double> psi_vector;
 
@@ -305,7 +297,6 @@ AngleAggregation::GetNewDelayedAngularDOFsAsSTLVector()
 void
 AngleAggregation::SetNewDelayedAngularDOFsFromSTLVector(const std::vector<double>& stl_vector)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetNewDelayedAngularDOFsFromSTLVector");
 
   auto psi_size = GetNumDelayedAngularDOFs();
   size_t stl_size = stl_vector.size();
@@ -334,7 +325,6 @@ AngleAggregation::SetNewDelayedAngularDOFsFromSTLVector(const std::vector<double
 std::vector<double>
 AngleAggregation::GetOldDelayedAngularDOFsAsSTLVector()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::GetOldDelayedAngularDOFsAsSTLVector");
 
   std::vector<double> psi_vector;
 
@@ -361,7 +351,6 @@ AngleAggregation::GetOldDelayedAngularDOFsAsSTLVector()
 void
 AngleAggregation::SetOldDelayedAngularDOFsFromSTLVector(const std::vector<double>& stl_vector)
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetOldDelayedAngularDOFsFromSTLVector");
 
   auto psi_size = GetNumDelayedAngularDOFs();
   size_t stl_size = stl_vector.size();
@@ -390,7 +379,6 @@ AngleAggregation::SetOldDelayedAngularDOFsFromSTLVector(const std::vector<double
 void
 AngleAggregation::SetDelayedPsiOld2New()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetDelayedPsiOld2New");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->CopyDelayedAngularFluxOldToNew(groupset_id_);
@@ -407,7 +395,6 @@ AngleAggregation::SetDelayedPsiOld2New()
 void
 AngleAggregation::SetDelayedPsiNew2Old()
 {
-  CALI_CXX_MARK_SCOPE("AngleAggregation::SetDelayedPsiNew2Old");
 
   for (auto& [bid, bndry] : boundaries_)
     bndry->CopyDelayedAngularFluxNewToOld(groupset_id_);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aah_angle_set.cc
@@ -5,7 +5,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/sweep_chunk.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -32,8 +31,6 @@ AAH_AngleSet::InitializeDelayedUpstreamData()
 AngleSetStatus
 AAH_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission)
 {
-  CALI_CXX_MARK_SCOPE("AAH_AngleSet::AngleSetAdvance");
-
   if (executed_)
   {
     if (not async_comm_.DoneSending())

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.cu
@@ -4,7 +4,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/aahd_angle_set.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aahd_sweep_chunk.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h"
-#include "caliper/cali.h"
 #include <algorithm>
 
 namespace opensn
@@ -64,8 +63,6 @@ AAHD_AngleSet::IsReady()
 AngleSetStatus
 AAHD_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission)
 {
-  CALI_CXX_MARK_SCOPE("AAHD_AngleSet::AngleSetAdvance");
-
   if (executed_)
     return AngleSetStatus::FINISHED;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
@@ -9,7 +9,6 @@
 #include "framework/data_types/range.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -36,8 +35,6 @@ CBC_AngleSet::GetCommunicator()
 AngleSetStatus
 CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission)
 {
-  CALI_CXX_MARK_SCOPE("CBC_AngleSet::AngleSetAdvance");
-
   if (executed_)
     return AngleSetStatus::FINISHED;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbcd_angle_set.cu
@@ -10,7 +10,6 @@
 #include "framework/data_types/range.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicate_location_dependencies.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicate_location_dependencies.cc
@@ -4,7 +4,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -13,7 +12,6 @@ void
 CommunicateLocationDependencies(const std::vector<int>& location_dependencies,
                                 std::vector<std::vector<int>>& global_dependencies)
 {
-  CALI_CXX_MARK_FUNCTION;
 
   int P = opensn::mpi_comm.size();
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aah_async_comm.cc
@@ -7,7 +7,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <algorithm>
 #include <cassert>
 #include <functional>
@@ -78,7 +77,6 @@ AAH_ASynchronousCommunicator::Reset()
 void
 AAH_ASynchronousCommunicator::BuildMessageStructure()
 {
-  CALI_CXX_MARK_SCOPE("AAH_ASynchronousCommunicator::BuildMessageStructure");
   const auto& spds = fluds_.GetSPDS();
   auto* aah_fluds = dynamic_cast<AAH_FLUDS*>(&fluds_);
   if (aah_fluds == nullptr)
@@ -134,7 +132,6 @@ AAH_ASynchronousCommunicator::InitializeDelayedUpstreamData()
 bool
 AAH_ASynchronousCommunicator::ReceiveDelayedData(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAH_ASynchronousCommunicator::ReceiveDelayedData");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& comm = comm_set_.LocICommunicator(opensn::mpi_comm.rank());
@@ -169,7 +166,6 @@ AAH_ASynchronousCommunicator::ReceiveDelayedData(int angle_set_num)
 AngleSetStatus
 AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAH_ASynchronousCommunicator::ReceiveUpstreamPsi");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& comm = comm_set_.LocICommunicator(opensn::mpi_comm.rank());
@@ -214,7 +210,6 @@ AAH_ASynchronousCommunicator::ReceiveUpstreamPsi(int angle_set_num)
 void
 AAH_ASynchronousCommunicator::SendDownstreamPsi(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAH_ASynchronousCommunicator::SendDownstreamPsi");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& location_successors = spds.GetLocationSuccessors();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aahd_async_comm.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aahd_async_comm.cu
@@ -4,7 +4,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/aahd_async_comm.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h"
-#include "caliper/cali.h"
 #include <functional>
 #include <numeric>
 
@@ -38,7 +37,6 @@ AAHD_ASynchronousCommunicator::AAHD_ASynchronousCommunicator(FLUDS& fluds,
 void
 AAHD_ASynchronousCommunicator::BuildMessageStructure()
 {
-  CALI_CXX_MARK_SCOPE("AAHD_ASynchronousCommunicator::BuildMessageStructure");
   const auto& spds = fluds_.GetSPDS();
   auto* aahd_fluds = dynamic_cast<AAHD_FLUDS*>(&fluds_);
   if (aahd_fluds == nullptr)
@@ -81,7 +79,6 @@ AAHD_ASynchronousCommunicator::BuildMessageStructure()
 void
 AAHD_ASynchronousCommunicator::PrepostReceiveUpstreamPsi(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAHD_ASynchronousCommunicator::PrepostReceiveUpstreamPsi");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& comm = comm_set_.LocICommunicator(opensn::mpi_comm.rank());
@@ -115,7 +112,6 @@ AAHD_ASynchronousCommunicator::WaitForUpstreamPsi()
 void
 AAHD_ASynchronousCommunicator::PrepostReceiveDelayedData(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAH_ASynchronousCommunicator::PrepostReceiveDelayedData");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& comm = comm_set_.LocICommunicator(opensn::mpi_comm.rank());
@@ -143,7 +139,6 @@ AAHD_ASynchronousCommunicator::WaitForDelayedIncomingPsi()
 void
 AAHD_ASynchronousCommunicator::SendDownstreamPsi(int angle_set_num)
 {
-  CALI_CXX_MARK_SCOPE("AAHD_ASynchronousCommunicator::SendDownstreamPsi");
 
   const auto& spds = fluds_.GetSPDS();
   const auto& location_successors = spds.GetLocationSuccessors();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/cbc_async_comm.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/cbc_async_comm.cc
@@ -8,7 +8,6 @@
 #include "framework/mpi/mpi_comm_set.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <memory>
 
 namespace opensn
@@ -31,7 +30,6 @@ CBC_AsynchronousCommunicator::InitGetDownwindMessageData(int location_id,
 bool
 CBC_AsynchronousCommunicator::SendData()
 {
-  CALI_CXX_MARK_SCOPE("CBC_AsynchronousCommunicator::SendData");
 
   // First we convert any new outgoing messages from the queue into
   // buffer messages. We aggregate these messages per location-id
@@ -92,7 +90,6 @@ CBC_AsynchronousCommunicator::SendData()
 std::vector<uint64_t>
 CBC_AsynchronousCommunicator::ReceiveData()
 {
-  CALI_CXX_MARK_SCOPE("CBC_AsynchronousCommunicator::ReceiveData");
 
   using CellFaceKey = std::pair<uint64_t, unsigned int>; // cell_gid + face_id
   std::map<CellFaceKey, std::vector<double>> received_messages;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
@@ -5,7 +5,6 @@
 #include "framework/logging/log.h"
 #include "framework/math/math.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <utility>
 
 namespace opensn
@@ -34,7 +33,6 @@ AAH_FLUDS::AAH_FLUDS(unsigned int num_groups,
     delayed_local_psi_Gn_block_strideG_(common_data_.delayed_local_psi_Gn_block_stride_ *
                                         num_groups_)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDS::AAH_FLUDS");
 
   // Adjusting for different group aggregate
   for (const auto& val : common_data_.local_psi_n_block_stride_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
@@ -7,7 +7,6 @@
 #include "framework/mesh/mesh_continuum/grid_face_histogram.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <algorithm>
 #include <utility>
 
@@ -30,7 +29,6 @@ void
 AAH_FLUDSCommonData::InitializeAlphaElements(const SPDS& spds,
                                              const GridFaceHistogram& grid_face_histogram)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::InitializeAlphaElements");
 
   const auto grid = spds.GetGrid();
   const auto& spls = spds.GetLocalSubgrid();
@@ -124,7 +122,6 @@ AAH_FLUDSCommonData::SlotDynamics(
   std::vector<std::vector<std::pair<std::optional<uint64_t>, short>>>& lock_boxes,
   std::vector<std::pair<std::optional<uint64_t>, short>>& delayed_lock_box)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::SlotDynamics");
 
   const auto& grid_ptr = spds.GetGrid();
 
@@ -287,7 +284,6 @@ AAH_FLUDSCommonData::AddFaceViewToDepLocI(int deplocI,
                                           uint64_t face_slot,
                                           const CellFace& face)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::AddFaceViewToDepLocI");
 
   // Check if cell is already there
   bool cell_already_there = false;
@@ -317,7 +313,6 @@ AAH_FLUDSCommonData::LocalIncidentMapping(const Cell& cell,
                                           const SPDS& spds,
                                           std::vector<uint64_t>& local_so_cell_mapping)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::LocalIncidentMapping");
 
   const auto grid = spds.GetGrid();
   const auto& cell_nodal_mapping = grid_nodal_mappings_[cell.local_id];
@@ -380,7 +375,6 @@ AAH_FLUDSCommonData::LocalIncidentMapping(const Cell& cell,
 void
 AAH_FLUDSCommonData::InitializeBetaElements(const SPDS& spds, int tag_index /*=0*/)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::InitializeBetaElements");
 
   const auto grid = spds.GetGrid();
   const auto& spls = spds.GetLocalSubgrid();
@@ -522,7 +516,6 @@ AAH_FLUDSCommonData::SerializeCellInfo(std::vector<CompactCellView>& cell_views,
                                        std::vector<int64_t>& face_indices,
                                        uint64_t num_face_dofs)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::SerializeCellInfo");
 
   const size_t num_cells = cell_views.size();
 
@@ -566,7 +559,6 @@ AAH_FLUDSCommonData::DeSerializeCellInfo(std::vector<CompactCellView>& cell_view
                                          std::vector<int64_t>* face_indices,
                                          int64_t& num_face_dofs)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::DeSerializeCellInfo");
 
   num_face_dofs = (*face_indices)[0];
   auto num_cells = (*face_indices)[1];
@@ -618,7 +610,6 @@ AAH_FLUDSCommonData::DeSerializeCellInfo(std::vector<CompactCellView>& cell_view
 void
 AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
 {
-  CALI_CXX_MARK_SCOPE("AAH_FLUDSCommonData::NonLocalIncidentMapping");
 
   const auto grid = spds.GetGrid();
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds.cc
@@ -5,7 +5,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h"
 #include "framework/math/spatial_discretization/spatial_discretization.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cc
@@ -9,7 +9,6 @@
 #include "framework/math/quadratures/angular/curvilinear_product_quadrature.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <algorithm>
 #include <unordered_map>
 
@@ -54,8 +53,6 @@ SweepScheduler::SweepScheduler(SchedulingAlgorithm scheduler_type,
                                SweepChunk& sweep_chunk)
   : scheduler_type_(scheduler_type), angle_agg_(angle_agg), sweep_chunk_(sweep_chunk)
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::SweepScheduler");
-
   if (scheduler_type_ == SchedulingAlgorithm::DEPTH_OF_GRAPH)
     InitializeAlgoDOG();
 
@@ -100,8 +97,6 @@ SweepScheduler::SweepScheduler(SchedulingAlgorithm scheduler_type,
 void
 SweepScheduler::InitializeAlgoDOG()
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::InitializeAlgoDOG");
-
   const bool is_cylindrical = angle_agg_.GetQuadrature()->GetDimension() == 2 &&
                               angle_agg_.GetCoordinateSystem() == CoordinateSystemType::CYLINDRICAL;
 
@@ -172,8 +167,6 @@ SweepScheduler::InitializeAlgoDOG()
 void
 SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoDOG");
-
   // Reset dependency counter
   for (auto& angle_set : angle_agg_)
     angle_set->ResetDependencyCounter();
@@ -216,8 +209,6 @@ SweepScheduler::ScheduleAlgoDOG(SweepChunk& sweep_chunk)
 void
 SweepScheduler::ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoFIFO");
-
   // Reset dependency counter
   for (auto& angle_set : angle_agg_)
     angle_set->ResetDependencyCounter();
@@ -279,8 +270,6 @@ SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
 void
 SweepScheduler::Sweep()
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::Sweep");
-
   if (scheduler_type_ == SchedulingAlgorithm::ASYNC_FIFO)
     ScheduleAlgoAsyncFIFO(sweep_chunk_);
   else if (scheduler_type_ == SchedulingAlgorithm::FIRST_IN_FIRST_OUT)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/sweep_scheduler.cu
@@ -9,7 +9,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbcd_sweep_chunk.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "caribou/main.hpp"
-#include "caliper/cali.h"
 #include <thread>
 #include <vector>
 
@@ -19,8 +18,6 @@ namespace opensn
 void
 SweepScheduler::ScheduleAlgoAAO(SweepChunk& sweep_chunk)
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoAAO");
-
   // copy phi and src moments to device
   auto aah_sweep_chunk = static_cast<AAHDSweepChunk&>(sweep_chunk);
   int groupset_id = angle_agg_.GetGroupsetID();
@@ -85,8 +82,6 @@ SweepScheduler::ScheduleAlgoAAO(SweepChunk& sweep_chunk)
 void
 SweepScheduler::ScheduleAlgoAsyncFIFO(SweepChunk& sweep_chunk)
 {
-  CALI_CXX_MARK_SCOPE("SweepScheduler::ScheduleAlgoAsyncFIFO");
-
   // Reset dependency counter
   for (auto& angle_set : angle_agg_)
     angle_set->ResetDependencyCounter();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
@@ -6,7 +6,6 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <boost/graph/topological_sort.hpp>
 #include <algorithm>
 
@@ -20,7 +19,6 @@ AAH_SPDS::AAH_SPDS(int id,
                    bool use_gpus)
   : SPDS(omega, grid), id_(id), allow_cycles_(allow_cycles)
 {
-  CALI_CXX_MARK_SCOPE("AAH_SPDS::AAH_SPDS");
 
   // Populate Cell Relationships
   size_t num_loc_cells = grid->local_cells.size();
@@ -99,8 +97,6 @@ AAH_SPDS::BuildGlobalSweepFAS()
 {
   assert(not global_dependencies_.empty());
 
-  CALI_CXX_MARK_SCOPE("AAH_SPDS::BuildGlobalSweepFAS");
-
   // Create global sweep graph
   const int comm_size = opensn::mpi_comm.size();
   Graph global_tdg(comm_size);
@@ -136,7 +132,6 @@ AAH_SPDS::BuildGlobalSweepFAS()
 std::vector<double>
 AAH_SPDS::ComputeLocalLocationEdgeWeights() const
 {
-  CALI_CXX_MARK_SCOPE("AAH_SPDS::ComputeLocalLocationEdgeWeights");
 
   const int comm_size = opensn::mpi_comm.size();
   std::vector<double> row(comm_size, 0.0);
@@ -170,7 +165,6 @@ AAH_SPDS::ComputeLocalLocationEdgeWeights() const
 void
 AAH_SPDS::BuildGlobalSweepTDG()
 {
-  CALI_CXX_MARK_SCOPE("AAH_SPDS::BuildGlobalSweepTDG");
 
   // Create graph
   Graph global_tdg(opensn::mpi_comm.size());

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
@@ -6,7 +6,6 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <boost/graph/topological_sort.hpp>
 
 namespace opensn
@@ -17,7 +16,6 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
                    bool allow_cycles)
   : SPDS(omega, grid)
 {
-  CALI_CXX_MARK_SCOPE("CBC_SPDS::CBC_SPDS");
 
   size_t num_loc_cells = grid->local_cells.size();
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
@@ -6,7 +6,6 @@
 #include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/strong_components.hpp>
 #include <algorithm>
@@ -334,7 +333,6 @@ SPDS::RemoveCyclicDependencies(Graph& g)
 int
 SPDS::MapLocJToPrelocI(int locJ) const
 {
-  CALI_CXX_MARK_SCOPE("SPDS::MapLocJToPrelocI");
 
   for (int i = 0; i < location_dependencies_.size(); ++i)
   {
@@ -359,7 +357,6 @@ SPDS::MapLocJToPrelocI(int locJ) const
 int
 SPDS::MapLocJToDeplocI(int locJ) const
 {
-  CALI_CXX_MARK_SCOPE("SPDS::MapLocJToDeploc");
 
   for (int i = 0; i < location_successors_.size(); ++i)
   {
@@ -380,7 +377,6 @@ SPDS::PopulateCellRelationships(
   std::set<int>& location_successors,
   std::vector<std::set<std::pair<std::uint32_t, double>>>& cell_successors)
 {
-  CALI_CXX_MARK_SCOPE("SPDS::PopulateCellRelationships");
 
   constexpr double tolerance = 1.0e-16;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
@@ -6,7 +6,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/utils/error.h"
-#include "caliper/cali.h"
 #include <algorithm>
 #include <array>
 #include <vector>
@@ -223,8 +222,6 @@ void
 AAH_Sweep_FixedN(AAHSweepData& data, AngleSet& angle_set)
 {
   static_assert(NumNodes >= 1 and NumNodes <= 8);
-
-  CALI_CXX_MARK_SCOPE("AAH_Sweep_FixedN");
 
   const auto& groupset = data.groupset;
   const auto gs_size = groupset.GetNumGroups();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk.cc
@@ -6,7 +6,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "caliper/cali.h"
 
 #include "framework/logging/log.h"
 #include "framework/runtime.h"

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.cc
@@ -6,7 +6,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_chunk_td.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_sweep_kernels.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "caliper/cali.h"
 #include <stdexcept>
 
 namespace opensn
@@ -84,8 +83,6 @@ AAHSweepChunkTD::Sweep(AngleSet& angle_set)
 void
 AAHSweepChunkTD::Sweep_Generic(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("AAHSweepChunkTD::Sweep");
-
   AAHSweepData data{grid_,
                     discretization_,
                     unit_cell_matrices_,
@@ -115,8 +112,6 @@ template <int NumNodes>
 void
 AAHSweepChunkTD::Sweep_FixedN(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("AAHSweepChunkTD::Sweep_FixedN");
-
   AAHSweepData data{grid_,
                     discretization_,
                     unit_cell_matrices_,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
@@ -8,7 +8,6 @@
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/mesh/cell/cell.h"
 #include "framework/logging/log.h"
-#include "caliper/cali.h"
 
 namespace opensn
 {
@@ -47,8 +46,6 @@ CBCSweepChunk::CBCSweepChunk(DiscreteOrdinatesProblem& problem, LBSGroupset& gro
 void
 CBCSweepChunk::SetAngleSet(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CbcSweepChunk::SetAngleSet");
-
   fluds_ = &dynamic_cast<CBC_FLUDS&>(angle_set.GetFLUDS());
 
   gs_size_ = groupset_.GetNumGroups();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbcd_sweep_chunk.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbcd_sweep_chunk.cu
@@ -6,7 +6,6 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/gpu_kernel/round_up.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/device_vector_mirror.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/carrier/mesh_carrier.h"
-#include "caliper/cali.h"
 #include <algorithm>
 
 namespace opensn
@@ -51,8 +50,6 @@ CBCDSweepChunk::CBCDSweepChunk(DiscreteOrdinatesProblem& problem, LBSGroupset& g
 void
 CBCDSweepChunk::Sweep(const std::vector<std::uint32_t>& cell_local_ids, size_t angle_set_id)
 {
-  CALI_CXX_MARK_SCOPE("CBCDSweepChunk::Sweep");
-
   auto* fluds = fluds_list_[angle_set_id];
   auto* device_saved_psi = fluds->GetSavedAngularFluxDevicePointer();
   auto& stream = streams_list_[angle_set_id];

--- a/modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.cc
@@ -4,7 +4,6 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/compute/lbs_compute.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include <cassert>
 
 namespace opensn
@@ -13,7 +12,6 @@ namespace opensn
 double
 ComputeFissionProduction(const LBSProblem& lbs_problem, const std::vector<double>& phi)
 {
-  CALI_CXX_MARK_SCOPE("ComputeFissionProduction");
 
   const auto& grid = lbs_problem.GetGrid();
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
@@ -74,7 +72,6 @@ ComputeFissionProduction(const LBSProblem& lbs_problem, const std::vector<double
 double
 ComputeFissionRate(const LBSProblem& lbs_problem, const std::vector<double>& phi)
 {
-  CALI_CXX_MARK_SCOPE("ComputeFissionRate");
 
   const auto& grid = lbs_problem.GetGrid();
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
@@ -122,7 +119,6 @@ ComputeFissionRate(const LBSProblem& lbs_problem, const std::vector<double>& phi
 void
 ComputePrecursors(LBSProblem& lbs_problem)
 {
-  CALI_CXX_MARK_SCOPE("ComputePrecursors");
 
   const auto J = lbs_problem.GetMaxPrecursorsPerMaterial();
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -13,6 +13,7 @@
 #include "framework/runtime.h"
 #include "framework/data_types/allowable_range.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 #include "caliper/cali.h"
 #include <algorithm>
 #include <iomanip>
@@ -732,8 +733,6 @@ LBSProblem::WriteProblemRestartData(hid_t /*file_id*/) const
 void
 LBSProblem::BuildRuntime()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::BuildRuntime");
-
   PrintSimHeader();
   mpi_comm.barrier();
 
@@ -899,7 +898,8 @@ LBSProblem::InitializeXSMap(const InputParameters& params)
 void
 LBSProblem::InitializeMaterials()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::InitializeMaterials");
+  CaliperPhaseScope cali_setup_phase("Setup", CaliperSetupPhaseDepth());
+  CALI_CXX_MARK_SCOPE("Materials");
 
   log.Log0Verbose1() << "Initializing Materials";
 
@@ -1003,7 +1003,7 @@ LBSProblem::InitializeMaterials()
 void
 LBSProblem::InitializeSpatialDiscretization()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::InitializeSpatialDiscretization");
+  CALI_CXX_MARK_SCOPE("SpatialDiscretization");
 
   OpenSnLogicalErrorIf(not discretization_,
                        GetName() + ": Missing spatial discretization. Construct the problem "
@@ -1016,7 +1016,7 @@ LBSProblem::InitializeSpatialDiscretization()
 void
 LBSProblem::ComputeUnitIntegrals()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::ComputeUnitIntegrals");
+  CALI_CXX_MARK_SCOPE("UnitIntegrals");
 
   log.Log() << "Computing unit integrals.\n";
   const auto& sdm = *discretization_;
@@ -1049,7 +1049,7 @@ LBSProblem::ComputeUnitIntegrals()
 void
 LBSProblem::InitializeParrays()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::InitializeParrays");
+  CALI_CXX_MARK_SCOPE("ParallelArrays");
 
   log.Log() << "Initializing parallel arrays."
             << " G=" << num_groups_ << " M=" << num_moments_ << std::endl;
@@ -1196,7 +1196,7 @@ LBSProblem::CheckCapableDevices()
 std::vector<double>
 LBSProblem::MakeSourceMomentsFromPhi()
 {
-  CALI_CXX_MARK_SCOPE("LBSProblem::MakeSourceMomentsFromPhi");
+  CALI_CXX_MARK_SCOPE("Source/MomentsFromPhi");
 
   auto num_local_dofs = discretization_->GetNumLocalDOFs(flux_moments_uk_man_);
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.cc
@@ -15,7 +15,6 @@ LBSVecOps::GroupsetScopedCopy(LBSProblem& lbs_problem,
                               unsigned int gss,
                               Functor func)
 {
-  CALI_CXX_MARK_SCOPE("LBSVecOps::GroupsetScopedCopy");
 
   const auto& grid = lbs_problem.GetGrid();
   const auto& cell_transport_views = lbs_problem.GetCellTransportViews();
@@ -45,7 +44,6 @@ LBSVecOps::GroupsetScopedCopy(LBSProblem& lbs_problem,
 void
 LBSVecOps::SetPhiVectorScalarValues(LBSProblem& lbs_problem, PhiSTLOption phi_opt, double value)
 {
-  CALI_CXX_MARK_SCOPE("LBSVecOps::SetPhiVectorScalarValues");
 
   auto& phi = (phi_opt == PhiSTLOption::PHI_NEW) ? lbs_problem.GetPhiNewLocal()
                                                  : lbs_problem.GetPhiOldLocal();
@@ -72,7 +70,6 @@ LBSVecOps::SetPhiVectorScalarValues(LBSProblem& lbs_problem, PhiSTLOption phi_op
 void
 LBSVecOps::ScalePhiVector(LBSProblem& lbs_problem, PhiSTLOption phi_opt, double value)
 {
-  CALI_CXX_MARK_SCOPE("LBSVecOps::ScalePhiVector");
 
   const auto& groupsets = lbs_problem.GetGroupsets();
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h
@@ -5,7 +5,6 @@
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
-#include "caliper/cali.h"
 #include <petscksp.h>
 #include <cstdint>
 #include <vector>

--- a/python/lib/py_app.cc
+++ b/python/lib/py_app.cc
@@ -8,7 +8,6 @@
 #include "framework/utils/utils.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
-#include "caliper/cali.h"
 #include "cxxopts/cxxopts.h"
 #include <string>
 
@@ -98,6 +97,9 @@ PyApp::Run(int argc, char** argv)
   }
   else
     return EXIT_FAILURE;
+
+  if (opensn::use_caliper and opensn::mpi_comm.rank() == 0)
+    std::cout << std::endl;
 
   cali_mgr.flush();
   return EXIT_SUCCESS;


### PR DESCRIPTION
Here is an example of the new `caliper` output (hopefully much more user friendly than a bunch of C++ method names):
```
Path                                    Min time/rank Max time/rank Avg time/rank Time %
OpenSn                                      34.195814     34.202005     34.200024 99.999439
  Setup                                     12.952149     12.952987     12.952578 37.872796
    Materials                                0.000049      0.000050      0.000050  0.000146
    SpatialDiscretization                    9.410114      9.410122      9.410116 27.514786
      UnitIntegrals                          9.410098      9.410106      9.410100 27.514738
    ParallelArrays                           0.102612      0.102617      0.102614  0.300038
    Boundaries                               0.000222      0.000231      0.000229  0.000668
    SweepDataStructures                      3.435861      3.436940      3.436193 10.047284
    FluxDataStructures                       0.000093      0.001195      0.000822  0.002402
    AngleSetDependencies                     0.000005      0.000007      0.000005  0.000016
  Solve                                     20.171846     20.172697     20.172265 58.982859
    SteadyState                             20.171836     20.172689     20.172256 58.982832
      Initialize                             0.000004      0.000012      0.000006  0.000019
      AGS                                   20.171791     20.172641     20.172204 58.982682
        AGSIteration                        20.170797     20.171590     20.171295 58.980022
          WGS                               20.118230     20.119185     20.118664 58.826131
            GMRES                           20.118220     20.119172     20.118653 58.826101
              SetRHS                         1.671496      1.671542      1.671520  4.887453
                Source                       0.019331      0.019797      0.019547  0.057154
                Sweep                        1.647859      1.648404      1.648144  4.819105
              MatrixAction                  16.600455     16.605219     16.602655 48.545470
                Source                       0.015306      0.016824      0.015862  0.046381
                Sweep                       16.551619     16.558368     16.555293 48.406983
              AngularFluxReconstruction      1.672131      1.672504      1.672388  4.889993
                Source                       0.018676      0.019637      0.019227  0.056218
                Sweep                        1.651919      1.652842      1.652351  4.831404
```