### PR TITLE
Refactoring logger global out of runtime.

### DIFF
--- a/framework/logging/log.cc
+++ b/framework/logging/log.cc
@@ -10,6 +10,8 @@
 namespace opensn
 {
 
+Logger& log = Logger::GetInstance();
+
 LogStream
 Logger::Log(LOG_LVL level)
 {
@@ -18,6 +20,8 @@ Logger::Log(LOG_LVL level)
   std::ostream* stream = nullptr;
   bool use_dummy = false;
   bool use_color = false;
+  auto color = [this](StringStreamColorCode code)
+  { return color_enabled_ ? StringStreamColor(code) : std::string{}; };
 
   switch (level)
   {
@@ -37,9 +41,8 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0)
       {
-        header =
-          "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_YELLOW) + "*** WARNING ***  ";
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_YELLOW) + "*** WARNING ***  ";
+        use_color = color_enabled_;
         stream = &std::cout;
       }
       else
@@ -50,9 +53,8 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0)
       {
-        header =
-          "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_RED) + "**** ERROR ****  ";
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_RED) + "**** ERROR ****  ";
+        use_color = color_enabled_;
         stream = &std::cerr;
       }
       else
@@ -63,8 +65,8 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0 and verbosity_ >= 1)
       {
-        header = "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_CYAN);
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_CYAN);
+        use_color = color_enabled_;
         stream = &std::cout;
       }
       else
@@ -75,8 +77,8 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0 and verbosity_ >= 2)
       {
-        header = "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_MAGENTA);
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_MAGENTA);
+        use_color = color_enabled_;
         stream = &std::cout;
       }
       else
@@ -92,16 +94,15 @@ Logger::Log(LOG_LVL level)
     }
     case LOG_ALLWARNING:
     {
-      header =
-        "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_YELLOW) + "*** WARNING ***  ";
-      use_color = true;
+      header = "[" + std::to_string(rank) + "]  " + color(FG_YELLOW) + "*** WARNING ***  ";
+      use_color = color_enabled_;
       stream = &std::cout;
       break;
     }
     case LOG_ALLERROR:
     {
-      header = "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_RED) + "**** ERROR ****  ";
-      use_color = true;
+      header = "[" + std::to_string(rank) + "]  " + color(FG_RED) + "**** ERROR ****  ";
+      use_color = color_enabled_;
       stream = &std::cerr;
       break;
     }
@@ -109,8 +110,8 @@ Logger::Log(LOG_LVL level)
     {
       if (verbosity_ >= 1)
       {
-        header = "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_CYAN);
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_CYAN);
+        use_color = color_enabled_;
         stream = &std::cout;
       }
       else
@@ -121,8 +122,8 @@ Logger::Log(LOG_LVL level)
     {
       if (verbosity_ >= 2)
       {
-        header = "[" + std::to_string(rank) + "]  " + StringStreamColor(FG_MAGENTA);
-        use_color = true;
+        header = "[" + std::to_string(rank) + "]  " + color(FG_MAGENTA);
+        use_color = color_enabled_;
         stream = &std::cout;
       }
       else

--- a/framework/logging/log.h
+++ b/framework/logging/log.h
@@ -42,13 +42,11 @@ namespace opensn
  *  - LOG_ALLVERBOSE_1,     Used only if verbosity level equals 1
  *  - LOG_ALLVERBOSE_2,     Used only if verbosity level equals 2
  *
- * A log can be made by first connecting code with the logger. This is done
- * by including the log header and then defining an extern reference to the
- * global object.
+ * The logging facility can be accessed by including the log header and using
+ * the global logger.
  *
  * \code
  * #include "framework/logging/log.h"
- * extern Logger& opensn::log;
  * \endcode
  *
  * A log is then written inside a piece of code as follows:
@@ -93,6 +91,8 @@ public:
 
   void SetVerbosity(unsigned int level) { verbosity_ = std::min(level, 2U); }
   unsigned int GetVerbosity() const { return verbosity_; }
+  void SetColorEnabled(bool enabled) { color_enabled_ = enabled; }
+  bool IsColorEnabled() const { return color_enabled_; }
   LogStream Log(LOG_LVL level = LOG_0);
   LogStream Log0() { return Log(LOG_0); }
   LogStream Log0Warning() { return Log(LOG_0WARNING); }
@@ -112,6 +112,7 @@ private:
 
   DummyStream dummy_stream_;
   unsigned int verbosity_{0};
+  bool color_enabled_{true};
 
 public:
   static Logger& GetInstance() noexcept
@@ -120,5 +121,7 @@ public:
     return instance;
   }
 };
+
+extern Logger& log;
 
 } // namespace opensn

--- a/framework/logging/stringstream_color.cc
+++ b/framework/logging/stringstream_color.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/logging/stringstream_color.h"
-#include "framework/runtime.h"
 
 namespace opensn
 {
@@ -10,8 +9,6 @@ namespace opensn
 std::string
 StringStreamColor(StringStreamColorCode code)
 {
-  if (suppress_color)
-    return {};
   return "\033[" + std::to_string(static_cast<int>(code)) + "m";
 }
 

--- a/framework/object_factory.cc
+++ b/framework/object_factory.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/object_factory.h"
-#include "framework/runtime.h"
 #include "framework/logging/log.h"
 
 namespace opensn

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -4,7 +4,6 @@
 #include "framework/runtime.h"
 #include "framework/math/math.h"
 #include "framework/object_factory.h"
-#include "framework/logging/log.h"
 #include "framework/utils/timer.h"
 #include "config.h"
 #include "caliper/cali.h"
@@ -15,13 +14,11 @@ namespace opensn
 {
 
 // Global variables
-Logger& log = Logger::GetInstance();
 mpi::Communicator mpi_comm;
 bool use_caliper = false;
 std::string cali_config("runtime-report(calc.inclusive=true),max_column_width=80");
 cali::ConfigManager cali_mgr;
 Timer program_timer;
-bool suppress_color = false;
 std::filesystem::path input_path;
 
 int

--- a/framework/runtime.h
+++ b/framework/runtime.h
@@ -20,15 +20,12 @@ namespace opensn
 static const std::string program = "OpenSn";
 
 class Timer;
-class Logger;
 
 extern mpi::Communicator mpi_comm;
-extern Logger& log;
 extern Timer program_timer;
 extern bool use_caliper;
 extern std::string cali_config;
 extern cali::ConfigManager cali_mgr;
-extern bool suppress_color;
 extern std::filesystem::path input_path;
 
 /// Initializes all necessary items

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 #include "framework/object_factory.h"
+#include "framework/logging/log.h"
 #include "framework/data_types/vector_ghost_communicator/vector_ghost_communicator.h"
 #include "framework/math/spatial_discretization/finite_element/piecewise_linear/piecewise_linear_continuous.h"
 #include "framework/runtime.h"

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The OpenSn Authors <https://open-sn.github.io/opensn/>
 // SPDX-License-Identifier: MIT
 #include "framework/object_factory.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/utils/timer.h"
 #include "framework/data_types/parallel_vector/ghosted_parallel_stl_vector.h"

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.cc
@@ -5,6 +5,7 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "caliper/cali.h"
 #include <algorithm>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/angular_flux_io.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/angular_flux_io.cc
@@ -3,6 +3,7 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/utils/hdf_utils.h"

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/compute/discrete_ordinates_compute.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
+#include "framework/logging/log.h"
 #include "framework/object_factory.h"
 #include "framework/utils/error.h"
 #include "framework/runtime.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/io/flux_moments_io.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/io/flux_moments_io.cc
@@ -3,6 +3,7 @@
 
 #include "modules/linear_boltzmann_solvers/lbs_problem/io/lbs_problem_io.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/utils/hdf_utils.h"

--- a/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/volumetric_source/volumetric_source.cc
@@ -7,6 +7,7 @@
 #include "framework/mesh/cell/cell.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/mesh/logical_volume/logical_volume.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/object_factory.h"
 #include <memory>

--- a/modules/problem.cc
+++ b/modules/problem.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/problem.h"
-#include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/object_factory.h"
 

--- a/modules/solver.cc
+++ b/modules/solver.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/solver.h"
-#include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/object_factory.h"
 

--- a/pyopensn/py_env.cc
+++ b/pyopensn/py_env.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "python/lib/py_env.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/utils/timer.h"
 #include "mpi4py/mpi4py.h"
@@ -40,7 +41,7 @@ PyEnv::PyEnv()
   ::PetscOptionsSetValue(NULL, "-options_left", "0");
   ::PetscOptionsInsertString(nullptr, "-no_signal_handler");
   ::PetscInitialize(nullptr, nullptr, nullptr, nullptr);
-  opensn::suppress_color = true;
+  log.SetColorEnabled(false);
   Initialize();
 }
 

--- a/python/lib/context.cc
+++ b/python/lib/context.cc
@@ -78,7 +78,7 @@ WrapSettings(py::module& context)
     "UseColor",
     [](bool cfg)
     {
-      suppress_color = (!cfg);
+      log.SetColorEnabled(cfg);
     },
     "Enable/disable color output. Default is True.",
     py::arg("config") = true
@@ -161,7 +161,7 @@ WrapSysArgv(py::module& context)
         // color
         if (arg == "-c" || arg == "--suppress-color")
         {
-          suppress_color = true;
+          log.SetColorEnabled(false);
           continue;
         }
         // verbosity

--- a/python/lib/mesh.cc
+++ b/python/lib/mesh.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "python/lib/py_wrappers.h"
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/graphs/graph_partitioner.h"
 #include "framework/graphs/kba_graph_partitioner.h"

--- a/python/lib/py_app.cc
+++ b/python/lib/py_app.cc
@@ -137,7 +137,7 @@ PyApp::ProcessArguments(int argc, char** argv)
     }
 
     if (result.count("suppress-color"))
-      opensn::suppress_color = true;
+      opensn::log.SetColorEnabled(false);
 
     if (result.count("caliper"))
     {

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -3,6 +3,7 @@
 
 #include "python/lib/py_wrappers.h"
 #include <pybind11/functional.h>
+#include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/field_functions/field_function_grid_based.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h"


### PR DESCRIPTION
Move the global logger declaration and definition out of runtime.h and into the logging class. This lets callers use logging by simply including `framework/logging/log.h`.
