### PR TITLE
Adding support for steady-state solve -> restart dump -> transient solve workflow

### DIFF
--- a/doc/source/userguide/discrete_ordinates_problems.rst
+++ b/doc/source/userguide/discrete_ordinates_problems.rst
@@ -212,6 +212,33 @@ The most important options for everyday use are:
 There are also restart, precursor, and message-size options for more
 specialized workflows.
 
+Restart-related options include:
+
+* ``restart_writes_enabled``: enable restart dump writes.
+* ``write_restart_path``: file stem used when writing restart dumps. OpenSn
+  appends the MPI rank and ``.restart.h5``.
+* ``read_restart_path``: file stem used when reading a full restart. This is
+  for continuing the same type of solve from restart state.
+* ``read_initial_condition_path``: file stem used when reading restart data as
+  an initial condition. :py:class:`pyopensn.solver.TransientSolver` can use a
+  steady-state restart this way, then switch the problem to time-dependent mode.
+* ``write_angular_flux_to_restart``: include stored angular fluxes in restart
+  dumps when ``save_angular_flux=True``. This is required for full transient
+  continuation restarts, but optional when a steady-state restart is used only
+  as a transient initial condition.
+* ``write_delayed_psi_to_restart``: include delayed sweep angular-flux buffers.
+  Full continuation restarts require these buffers whenever the problem has
+  delayed sweep angular state, including partitioned parallel,
+  reflected-boundary, and cyclic-sweep cases. These buffers are optional for
+  the steady-state-restart-as-transient-initial-condition workflow.
+
+.. warning::
+
+   Restart files are rank-layout specific. A restart written with one MPI rank
+   count should be read with the same rank count and a compatible problem
+   definition. Changing from serial to parallel, or from one partition count to
+   another, is not a supported restart workflow.
+
 .. note::
 
    Problem options are where users should look for global transport behavior.
@@ -437,6 +464,11 @@ These are useful for:
 * restart-like workflows,
 * response studies,
 * source-driven workflows that reuse previously computed fields.
+
+For restartable solver state, prefer the restart options documented above over
+manual angular-flux files. Manual angular-flux files are useful when the
+workflow explicitly wants to manage angular fluxes, but restart dumps also carry
+flux moments, time metadata, precursor state, and solver-specific restart data.
 
 Updating the Problem In Place
 =============================

--- a/doc/source/userguide/example_problems.rst
+++ b/doc/source/userguide/example_problems.rst
@@ -741,6 +741,106 @@ This is useful when:
    practice, that means the mesh, group structure, discretization, and related
    state layout must match the restart data being read.
 
+.. warning::
+
+   Restart files are rank-layout specific. A restart written with ``mpirun -np
+   4`` should be read with ``mpirun -np 4`` and the same compatible problem
+   layout. Reading a serial restart with a parallel run, or changing the MPI
+   rank count, is not a supported workflow.
+
+Example 14: Starting a Transient from a Steady-State Restart
+============================================================
+
+A common production workflow is to converge a steady-state problem, write a
+restart dump, and later use that steady-state solution as the initial condition
+for a transient calculation. Use ``read_initial_condition_path`` for this
+workflow.
+
+The steady-state input writes the restart. The angular-flux payloads are
+optional for this specific workflow because the transient initialization can
+reconstruct angular state from the flux moments:
+
+.. code-block:: python
+
+   # steady_input.py
+   from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
+
+   phys = DiscreteOrdinatesProblem(
+       mesh=mesh,
+       num_groups=num_groups,
+       groupsets=groupsets,
+       xs_map=xs_map,
+       volumetric_sources=[steady_source],
+       boundary_conditions=boundary_conditions,
+       options={
+           "save_angular_flux": True,
+           "restart_writes_enabled": True,
+           "write_restart_path": "restart_data/steady_ic",
+           "write_angular_flux_to_restart": False,
+           "write_delayed_psi_to_restart": False,
+       },
+   )
+
+   steady = SteadyStateSourceSolver(problem=phys)
+   steady.Initialize()
+   steady.Execute()
+
+This writes rank-local restart files named like
+``restart_data/steady_ic0.restart.h5``,
+``restart_data/steady_ic1.restart.h5``, and so on.
+
+The transient input builds a compatible problem, points
+``read_initial_condition_path`` at the same file stem, and lets
+:py:class:`pyopensn.solver.TransientSolver` switch the problem into
+time-dependent mode during initialization:
+
+.. code-block:: python
+
+   # transient_input.py
+   from pyopensn.solver import DiscreteOrdinatesProblem, TransientSolver
+
+   phys = DiscreteOrdinatesProblem(
+       mesh=mesh,
+       num_groups=num_groups,
+       groupsets=groupsets,
+       xs_map=xs_map,
+       volumetric_sources=[transient_source],
+       boundary_conditions=boundary_conditions,
+       options={
+           "save_angular_flux": True,
+           "read_initial_condition_path": "restart_data/steady_ic",
+       },
+   )
+
+   transient = TransientSolver(
+       problem=phys,
+       dt=1.0e-3,
+       theta=1.0,
+       stop_time=1.0e-1,
+       initial_state="existing",
+   )
+   transient.Initialize()
+   transient.Execute()
+
+Important points:
+
+* The transient problem should not be constructed with ``time_dependent=True``
+  when using ``read_initial_condition_path``. The transient solver reads the
+  initial condition first, then switches the problem to time-dependent mode.
+* ``save_angular_flux=True`` is still required on the transient problem because
+  time-dependent transport stores angular fluxes.
+* Full transient continuation restarts are different. If a transient run will
+  later be continued with ``read_restart_path``, keep
+  ``write_angular_flux_to_restart=True`` so the restart contains the angular
+  flux state required for continuation. If the problem has delayed sweep
+  angular state, including partitioned parallel, reflected-boundary, or
+  cyclic-sweep cases, ``write_delayed_psi_to_restart=True`` is also required so
+  delayed sweep buffers are carried into the continuation run.
+* Reflected-boundary and delayed-neutron precursor cases are supported by this
+  workflow. If the steady restart omits angular-flux payloads, the transient
+  initialization reconstructs the needed angular state before the first time
+  step.
+
 Choosing a Template
 ===================
 
@@ -753,5 +853,7 @@ As a practical guide:
 * use Example 6 only when the nonlinear eigenvalue solve is specifically
   needed,
 * use Example 13 when a workflow needs restartable transport state across runs,
+* use Example 14 when a transient should start from a separately computed
+  steady-state restart,
 * add the post-processing patterns only after the solve itself is behaving
   correctly.

--- a/doc/source/userguide/solvers.rst
+++ b/doc/source/userguide/solvers.rst
@@ -161,7 +161,9 @@ Problem options available in Python include:
 * ``max_mpi_message_size``
 * ``restart_writes_enabled``
 * ``write_delayed_psi_to_restart``
+* ``write_angular_flux_to_restart``
 * ``read_restart_path``
+* ``read_initial_condition_path``
 * ``write_restart_path``
 * ``write_restart_time_interval``
 * ``use_precursors``
@@ -181,7 +183,21 @@ active for the problem. The default is ``True``. This should usually stay
 enabled for transient and k-eigen workflows unless you explicitly want a
 prompt-only model.
 
-The setting is treated as user intent and persists across later
+``read_restart_path`` reads a full restart for continuing a compatible solve.
+``read_initial_condition_path`` reads restart data as an initial condition; this
+is the option to use when a :py:class:`pyopensn.solver.TransientSolver` should
+start from a separately written steady-state restart. Full transient
+continuation restarts require angular flux state. If the problem has delayed
+sweep angular state, including partitioned parallel, reflected-boundary, or
+cyclic-sweep cases, continuation also requires delayed sweep angular-flux
+buffers in the restart. The steady-state initial-condition path can reconstruct
+angular state from flux moments if ``write_angular_flux_to_restart`` or
+``write_delayed_psi_to_restart`` were disabled in the steady run.
+
+Restart files are rank-layout specific. Read restart files with the same MPI
+rank count and compatible problem definition used when writing them.
+
+The ``use_precursors`` setting is treated as user intent and persists across later
 :py:meth:`SetXSMap` calls, even if the current cross-section map temporarily has
 no precursor-bearing material. If cross sections are swapped, existing
 precursor concentrations are remapped by local cell and precursor-family index;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -729,7 +729,7 @@ DiscreteOrdinatesProblem::ResetMode(SweepChunkMode target_mode)
         // Keep source moments and scalar flux fixed at converged steady-state values.
         GetQMomentsLocal() = q_moments_ref;
         GetPhiOldLocal() = phi_new_ref;
-        wgs_context->RebuildAngularFluxFromConvergedPhi(false);
+        wgs_context->RebuildAngularFluxFromConvergedPhi(false, pass == 0);
 
         const auto delayed_psi_new =
           wgs_context->groupset.angle_agg->GetNewDelayedAngularDOFsAsSTLVector();
@@ -2065,9 +2065,11 @@ DiscreteOrdinatesProblem::UpdatePsiOld()
 }
 
 bool
-DiscreteOrdinatesProblem::ReadProblemRestartData(hid_t file_id)
+DiscreteOrdinatesProblem::ReadProblemRestartData(hid_t file_id,
+                                                 bool allow_transient_initialization_from_steady)
 {
-  return DiscreteOrdinatesProblemIO::ReadRestartData(*this, file_id);
+  return DiscreteOrdinatesProblemIO::ReadRestartData(
+    *this, file_id, allow_transient_initialization_from_steady);
 }
 
 bool

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -241,7 +241,8 @@ protected:
    * @{
    */
 
-  bool ReadProblemRestartData(hid_t file_id) override;
+  bool ReadProblemRestartData(hid_t file_id,
+                              bool allow_transient_initialization_from_steady) override;
   bool WriteProblemRestartData(hid_t file_id) const override;
   void ResetDerivedSolutionVectors() override;
   void UpdateBoundaryDefinition(const InputParameters& params);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
@@ -17,7 +17,9 @@ class DiscreteOrdinatesProblem;
 class DiscreteOrdinatesProblemIO
 {
 public:
-  static bool ReadRestartData(DiscreteOrdinatesProblem& do_problem, hid_t file_id);
+  static bool ReadRestartData(DiscreteOrdinatesProblem& do_problem,
+                              hid_t file_id,
+                              bool allow_transient_initialization_from_steady);
 
   static bool WriteRestartData(const DiscreteOrdinatesProblem& do_problem, hid_t file_id);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/restart_io.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/restart_io.cc
@@ -8,9 +8,35 @@
 
 namespace opensn
 {
+namespace
+{
 
 bool
-DiscreteOrdinatesProblemIO::ReadRestartData(DiscreteOrdinatesProblem& do_problem, hid_t file_id)
+ReadSizedDoubleVector(hid_t file_id,
+                      const std::string& dataset_name,
+                      std::vector<double>& destination,
+                      size_t expected_size,
+                      const std::string& problem_name)
+{
+  std::vector<double> values;
+  const bool success = H5ReadDataset1D<double>(file_id, dataset_name, values);
+  if (success)
+  {
+    OpenSnInvalidArgumentIf(values.size() != expected_size,
+                            problem_name + ": restart dataset `" + dataset_name + "` has size " +
+                              std::to_string(values.size()) + " but expected " +
+                              std::to_string(expected_size) + ".");
+    destination = std::move(values);
+  }
+  return success;
+}
+
+} // namespace
+
+bool
+DiscreteOrdinatesProblemIO::ReadRestartData(DiscreteOrdinatesProblem& do_problem,
+                                            hid_t file_id,
+                                            bool allow_transient_initialization_from_steady)
 {
   bool success = true;
 
@@ -18,21 +44,34 @@ DiscreteOrdinatesProblemIO::ReadRestartData(DiscreteOrdinatesProblem& do_problem
   if (H5Aexists(file_id, "time_dependent") > 0)
     success &= H5ReadAttribute<bool>(file_id, "time_dependent", file_time_dependent);
 
-  OpenSnInvalidArgumentIf(file_time_dependent != do_problem.IsTimeDependent(),
+  const bool steady_to_transient_initial_condition = allow_transient_initialization_from_steady and
+                                                     do_problem.IsTimeDependent() and
+                                                     (not file_time_dependent);
+
+  OpenSnInvalidArgumentIf(file_time_dependent != do_problem.IsTimeDependent() and
+                            not steady_to_transient_initial_condition,
                           do_problem.GetName() +
                             ": restart time-dependent mode does not match the configured "
                             "problem mode.");
 
   int gs_id = 0;
+  const bool full_time_dependent_restart =
+    do_problem.IsTimeDependent() and not steady_to_transient_initial_condition;
   for (const auto& gs : do_problem.GetGroupsets())
   {
     if (gs.angle_agg)
     {
       const auto delayed_name = "delayed_psi_old_gs" + std::to_string(gs_id);
+      const size_t expected_delayed_size = gs.angle_agg->GetNumDelayedAngularDOFs().first;
+      OpenSnInvalidArgumentIf(full_time_dependent_restart and expected_delayed_size > 0 and
+                                not H5Has(file_id, delayed_name),
+                              do_problem.GetName() + ": time-dependent restart requires `" +
+                                delayed_name + ".");
       if (H5Has(file_id, delayed_name))
       {
         std::vector<double> psi;
-        success &= H5ReadDataset1D<double>(file_id, delayed_name, psi);
+        success &= ReadSizedDoubleVector(
+          file_id, delayed_name, psi, expected_delayed_size, do_problem.GetName());
         if (success)
           gs.angle_agg->SetOldDelayedAngularDOFsFromSTLVector(psi);
       }
@@ -42,34 +81,54 @@ DiscreteOrdinatesProblemIO::ReadRestartData(DiscreteOrdinatesProblem& do_problem
 
   if (do_problem.IsTimeDependent())
   {
-    const bool has_psi_old = do_problem.GetGroupsets().empty() or H5Has(file_id, "psi_old_gs0");
-    OpenSnInvalidArgumentIf(not has_psi_old,
-                            do_problem.GetName() +
-                              ": time-dependent restart requires saved angular flux state in the "
-                              "restart file.");
-
-    auto& psi_old_local = do_problem.GetPsiOldLocal();
-    auto& psi_new_local = do_problem.GetPsiNewLocal();
-    psi_old_local.clear();
-    psi_new_local.clear();
-    psi_old_local.reserve(do_problem.GetGroupsets().size());
-    psi_new_local.reserve(do_problem.GetGroupsets().size());
-
-    for (size_t gsid = 0; gsid < do_problem.GetGroupsets().size(); ++gsid)
+    if (not steady_to_transient_initial_condition)
     {
-      std::vector<double> psi_old;
-      std::vector<double> psi_new;
-      const auto old_name = "psi_old_gs" + std::to_string(gsid);
-      const auto new_name = "psi_new_gs" + std::to_string(gsid);
+      auto& psi_old_local = do_problem.GetPsiOldLocal();
+      auto& psi_new_local = do_problem.GetPsiNewLocal();
+      std::vector<size_t> expected_psi_old_sizes;
+      std::vector<size_t> expected_psi_new_sizes;
+      expected_psi_old_sizes.reserve(psi_old_local.size());
+      expected_psi_new_sizes.reserve(psi_new_local.size());
+      for (const auto& psi : psi_old_local)
+        expected_psi_old_sizes.push_back(psi.size());
+      for (const auto& psi : psi_new_local)
+        expected_psi_new_sizes.push_back(psi.size());
+      psi_old_local.clear();
+      psi_new_local.clear();
+      psi_old_local.reserve(do_problem.GetGroupsets().size());
+      psi_new_local.reserve(do_problem.GetGroupsets().size());
 
-      success &= H5ReadDataset1D<double>(file_id, old_name, psi_old);
-      if (H5Has(file_id, new_name))
-        success &= H5ReadDataset1D<double>(file_id, new_name, psi_new);
-      else
-        psi_new = psi_old;
+      for (size_t gsid = 0; gsid < do_problem.GetGroupsets().size(); ++gsid)
+      {
+        std::vector<double> psi_old;
+        std::vector<double> psi_new;
+        const auto old_name = "psi_old_gs" + std::to_string(gsid);
+        const auto new_name = "psi_new_gs" + std::to_string(gsid);
+        const bool has_psi_old = H5Has(file_id, old_name);
+        const bool has_psi_new = H5Has(file_id, new_name);
+        const size_t expected_old_size = expected_psi_old_sizes.at(gsid);
+        const size_t expected_new_size = expected_psi_new_sizes.at(gsid);
 
-      psi_old_local.push_back(std::move(psi_old));
-      psi_new_local.push_back(std::move(psi_new));
+        OpenSnInvalidArgumentIf(
+          not has_psi_old and not has_psi_new,
+          do_problem.GetName() +
+            ": time-dependent restart requires saved angular flux state for groupset " +
+            std::to_string(gsid) + ".");
+
+        if (has_psi_old)
+          success &= ReadSizedDoubleVector(
+            file_id, old_name, psi_old, expected_old_size, do_problem.GetName());
+        if (has_psi_new)
+          success &= ReadSizedDoubleVector(
+            file_id, new_name, psi_new, expected_new_size, do_problem.GetName());
+        else
+          psi_new = psi_old;
+        if (psi_old.empty())
+          psi_old = psi_new;
+
+        psi_old_local.push_back(std::move(psi_old));
+        psi_new_local.push_back(std::move(psi_new));
+      }
     }
   }
 
@@ -100,7 +159,8 @@ DiscreteOrdinatesProblemIO::WriteRestartData(const DiscreteOrdinatesProblem& do_
     }
   }
 
-  if (do_problem.GetOptions().save_angular_flux)
+  if (do_problem.GetOptions().save_angular_flux and
+      do_problem.GetOptions().restart.write_angular_flux)
   {
     const auto& psi_old_local = do_problem.GetPsiOldLocal();
     const auto& psi_new_local = do_problem.GetPsiNewLocal();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -60,9 +60,12 @@ SweepWGSContext::SweepWGSContext(DiscreteOrdinatesProblem& do_problem,
 }
 
 void
-SweepWGSContext::RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term)
+SweepWGSContext::RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term,
+                                                    bool zero_incoming_delayed_psi)
 {
-  const auto scope = lhs_src_scope | rhs_src_scope;
+  auto scope = lhs_src_scope | rhs_src_scope;
+  if (zero_incoming_delayed_psi)
+    scope |= ZERO_INCOMING_DELAYED_PSI;
   set_source_function(groupset, do_problem.GetQMomentsLocal(), do_problem.GetPhiOldLocal(), scope);
 
   sweep_chunk->IncludeRHSTimeTerm(include_rhs_time_term);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h
@@ -36,7 +36,8 @@ struct SweepWGSContext : public WGSContext
   void ApplyInverseTransportOperator(SourceFlags scope) override;
 
   void PostSolveCallback() override;
-  void RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term);
+  void RebuildAngularFluxFromConvergedPhi(bool include_rhs_time_term,
+                                          bool zero_incoming_delayed_psi = false);
   SweepStats GetAccumulatedSweepStats() const { return sweep_stats_; }
   void ResetAccumulatedSweepStats() { sweep_stats_ = {}; }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/steady_state_solver.cc
@@ -72,11 +72,11 @@ SteadyStateSourceSolver::Execute()
   auto& ags_solver = *do_problem_->GetAGSSolver();
   ags_solver.Solve();
 
-  if (options.restart.writes_enabled)
-    do_problem_->WriteRestartData();
-
   if (options.use_precursors)
     ComputePrecursors(*do_problem_);
+
+  if (options.restart.writes_enabled)
+    do_problem_->WriteRestartData();
 
   if (options.adjoint)
     do_problem_->ReorientAdjointSolution();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.cc
@@ -101,6 +101,7 @@ TransientSolver::Initialize()
 
   const auto& options = do_problem_->GetOptions();
   bool restart_successful = false;
+  bool initial_condition_successful = false;
   do_problem_->SetTime(current_time_);
 
   const std::string& init_state = initial_state_;
@@ -111,17 +112,19 @@ TransientSolver::Initialize()
                        GetName() + ": Problem must be fully constructed before "
                                    "TransientSolver initialization.");
 
+  if (not options.restart.read_path.empty())
+    restart_successful = ReadRestartData();
+  else if (not options.restart.read_initial_condition_path.empty())
+    initial_condition_successful = ReadInitialConditionData();
+
   OpenSnInvalidArgumentIf(not do_problem_->IsTimeDependent(),
                           GetName() + ": Problem is in steady-state mode. Call problem."
                                       "SetTimeDependentMode() before initializing this solver.");
 
-  if (not options.restart.read_path.empty())
-    restart_successful = ReadRestartData();
-
-  if (not restart_successful)
+  if (not restart_successful and not initial_condition_successful)
     do_problem_->SetTime(current_time_);
 
-  if (initial_state_ == "zero" and not restart_successful)
+  if (initial_state_ == "zero" and not restart_successful and not initial_condition_successful)
   {
     do_problem_->ZeroPhi();
     do_problem_->ZeroPrecursors();
@@ -379,6 +382,34 @@ TransientSolver::StepPrecursors()
   for (size_t i = 0; i < precursor_new_local.size(); ++i)
     precursor_new_local[i] =
       inv_theta * (precursor_new_local[i] + (theta - 1.0) * precursor_prev_local_[i]);
+}
+
+bool
+TransientSolver::ReadInitialConditionData()
+{
+  OpenSnInvalidArgumentIf(
+    do_problem_->IsTimeDependent(),
+    GetName() +
+      ": `read_initial_condition_path` must be used with a problem that has not already been "
+      "placed in time-dependent mode. The transient solver loads the initial condition and "
+      "then switches the problem to time-dependent mode.");
+
+  const double requested_dt = do_problem_->GetTimeStep();
+  const double requested_theta = do_problem_->GetTheta();
+
+  bool success = do_problem_->ReadRestartData(
+    {}, do_problem_->GetOptions().restart.read_initial_condition_path, true);
+  OpenSnInvalidArgumentIf(
+    not success, GetName() + ": failed to read transient initial condition from restart data.");
+
+  do_problem_->SetTimeStep(requested_dt);
+  do_problem_->SetTheta(requested_theta);
+  current_time_ = do_problem_->GetTime();
+  step_ = 0;
+
+  do_problem_->SetTimeDependentMode();
+
+  return success;
 }
 
 bool

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/transient_solver.h
@@ -39,6 +39,7 @@ public:
 
 private:
   bool ReadRestartData();
+  bool ReadInitialConditionData();
   bool WriteRestartData();
 
   std::shared_ptr<DiscreteOrdinatesProblem> do_problem_;

--- a/modules/linear_boltzmann_solvers/lbs_problem/io/lbs_problem_io.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/io/lbs_problem_io.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <vector>
 #include <functional>
+#include <filesystem>
 
 namespace opensn
 {
@@ -18,7 +19,9 @@ class LBSSolverIO
 {
 public:
   static bool ReadRestartData(LBSProblem& lbs_problem,
-                              const std::function<bool(hid_t)>& extra_reader = {});
+                              const std::function<bool(hid_t)>& extra_reader = {},
+                              const std::filesystem::path& read_path = {},
+                              bool allow_transient_initialization_from_steady = false);
 
   static bool WriteRestartData(LBSProblem& lbs_problem,
                                const std::function<bool(hid_t)>& extra_writer = {});

--- a/modules/linear_boltzmann_solvers/lbs_problem/io/restart_io.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/io/restart_io.cc
@@ -7,30 +7,137 @@
 #include "framework/utils/hdf_utils.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include <algorithm>
 #include <iostream>
 
 namespace opensn
 {
+namespace
+{
 
 bool
-LBSProblem::ReadRestartData(const RestartDataHook& extra_reader)
+ReadSizedDoubleVector(hid_t file_id,
+                      const std::string& dataset_name,
+                      std::vector<double>& destination,
+                      size_t expected_size,
+                      const std::string& problem_name)
 {
-  const auto& fname = GetOptions().restart.read_path;
+  std::vector<double> values;
+  const bool success = H5ReadDataset1D<double>(file_id, dataset_name, values);
+  if (success)
+  {
+    OpenSnInvalidArgumentIf(values.size() != expected_size,
+                            problem_name + ": restart dataset `" + dataset_name + "` has size " +
+                              std::to_string(values.size()) + " but expected " +
+                              std::to_string(expected_size) + ".");
+    destination = std::move(values);
+  }
+  return success;
+}
+
+bool
+ReadPrecursorVector(hid_t file_id,
+                    std::vector<double>& destination,
+                    size_t expected_size,
+                    const LBSProblem& problem,
+                    bool allow_size_remap)
+{
+  std::vector<double> values;
+  const bool success = H5ReadDataset1D<double>(file_id, "precursors_new", values);
+  if (not success)
+    return false;
+
+  if (values.size() == expected_size)
+  {
+    destination = std::move(values);
+    return true;
+  }
+
+  OpenSnInvalidArgumentIf(not allow_size_remap,
+                          problem.GetName() + ": restart dataset `precursors_new` has size " +
+                            std::to_string(values.size()) + " but expected " +
+                            std::to_string(expected_size) + ".");
+
+  const auto& grid = problem.GetGrid();
+  const size_t num_local_cells = grid->local_cells.size();
+  OpenSnInvalidArgumentIf(num_local_cells == 0,
+                          problem.GetName() +
+                            ": cannot remap restart precursor data without local cells.");
+  OpenSnInvalidArgumentIf(
+    values.size() % num_local_cells != 0 or expected_size % num_local_cells != 0,
+    problem.GetName() + ": restart dataset `precursors_new` cannot be remapped from size " +
+      std::to_string(values.size()) + " to " + std::to_string(expected_size) + " for " +
+      std::to_string(num_local_cells) + " local cells.");
+
+  const size_t old_stride = values.size() / num_local_cells;
+  const size_t new_stride = expected_size / num_local_cells;
+  const size_t copy_stride = std::min(old_stride, new_stride);
+
+  std::vector<double> remapped(expected_size, 0.0);
+  for (const auto& cell : grid->local_cells)
+  {
+    const size_t old_base = cell.local_id * old_stride;
+    const size_t new_base = cell.local_id * new_stride;
+    for (size_t j = 0; j < copy_stride; ++j)
+      remapped[new_base + j] = values[old_base + j];
+  }
+
+  destination = std::move(remapped);
+  return true;
+}
+
+} // namespace
+
+bool
+LBSProblem::ReadRestartData(const RestartDataHook& extra_reader,
+                            const std::filesystem::path& read_path,
+                            bool allow_transient_initialization_from_steady)
+{
+  const auto& fname = read_path.empty() ? GetOptions().restart.read_path : read_path;
   OpenSnInvalidArgumentIf(fname.empty(), GetName() + ": restart read path is empty.");
 
   const H5FileHandle file(H5Fopen(fname.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT));
   bool success = (file.Id() >= 0);
   if (file.Id() >= 0)
   {
-    success &= H5ReadDataset1D<double>(file.Id(), "phi_old", phi_old_local_);
+    const size_t expected_phi_size = phi_old_local_.size();
+    const size_t expected_precursor_size = precursor_new_local_.size();
+
+    if (H5Aexists(file.Id(), "mpi_size") > 0)
+    {
+      int restart_mpi_size = 0;
+      success &= H5ReadAttribute<int>(file.Id(), "mpi_size", restart_mpi_size);
+      OpenSnInvalidArgumentIf(restart_mpi_size != opensn::mpi_comm.size(),
+                              GetName() + ": restart was written with " +
+                                std::to_string(restart_mpi_size) + " MPI ranks but this run uses " +
+                                std::to_string(opensn::mpi_comm.size()) + ".");
+    }
+
+    if (H5Aexists(file.Id(), "mpi_rank") > 0)
+    {
+      int restart_mpi_rank = -1;
+      success &= H5ReadAttribute<int>(file.Id(), "mpi_rank", restart_mpi_rank);
+      OpenSnInvalidArgumentIf(restart_mpi_rank != opensn::mpi_comm.rank(),
+                              GetName() + ": restart file rank metadata is " +
+                                std::to_string(restart_mpi_rank) + " but this process rank is " +
+                                std::to_string(opensn::mpi_comm.rank()) + ".");
+    }
+
+    success &=
+      ReadSizedDoubleVector(file.Id(), "phi_old", phi_old_local_, expected_phi_size, GetName());
 
     if (H5Has(file.Id(), "phi_new"))
-      success &= H5ReadDataset1D<double>(file.Id(), "phi_new", phi_new_local_);
+      success &=
+        ReadSizedDoubleVector(file.Id(), "phi_new", phi_new_local_, expected_phi_size, GetName());
     else
       phi_new_local_ = phi_old_local_;
 
     if (H5Has(file.Id(), "precursors_new"))
-      success &= H5ReadDataset1D<double>(file.Id(), "precursors_new", precursor_new_local_);
+      success &= ReadPrecursorVector(file.Id(),
+                                     precursor_new_local_,
+                                     expected_precursor_size,
+                                     *this,
+                                     allow_transient_initialization_from_steady);
 
     double time = GetTime();
     double dt = GetTimeStep();
@@ -56,7 +163,7 @@ LBSProblem::ReadRestartData(const RestartDataHook& extra_reader)
       SetTheta(theta);
     }
 
-    success &= ReadProblemRestartData(file.Id());
+    success &= ReadProblemRestartData(file.Id(), allow_transient_initialization_from_steady);
     if (extra_reader)
       success &= extra_reader(file.Id());
   }
@@ -83,6 +190,8 @@ LBSProblem::WriteRestartData(const RestartDataHook& extra_writer)
 
     success &=
       H5CreateAttribute<unsigned int>(file.Id(), "restart_format_version", restart_format_version);
+    success &= H5CreateAttribute<int>(file.Id(), "mpi_size", opensn::mpi_comm.size());
+    success &= H5CreateAttribute<int>(file.Id(), "mpi_rank", opensn::mpi_comm.rank());
     success &= H5CreateAttribute<double>(file.Id(), "time", GetTime());
     success &= H5CreateAttribute<double>(file.Id(), "dt", GetTimeStep());
     success &= H5CreateAttribute<double>(file.Id(), "theta", GetTheta());
@@ -112,9 +221,12 @@ LBSProblem::WriteRestartData(const RestartDataHook& extra_writer)
 
 bool
 LBSSolverIO::ReadRestartData(LBSProblem& lbs_problem,
-                             const std::function<bool(hid_t)>& extra_reader)
+                             const std::function<bool(hid_t)>& extra_reader,
+                             const std::filesystem::path& read_path,
+                             bool allow_transient_initialization_from_steady)
 {
-  return lbs_problem.ReadRestartData(extra_reader);
+  return lbs_problem.ReadRestartData(
+    extra_reader, read_path, allow_transient_initialization_from_steady);
 }
 
 bool

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -501,8 +501,16 @@ LBSProblem::GetOptionsBlock()
   params.AddOptionalParameter("write_delayed_psi_to_restart",
                               true,
                               "Flag that controls writing of delayed angular fluxes to restarts.");
+  params.AddOptionalParameter("write_angular_flux_to_restart",
+                              true,
+                              "Flag that controls writing angular fluxes to restart dumps when "
+                              "`save_angular_flux` is enabled.");
   params.AddOptionalParameter(
     "read_restart_path", "", "Full path for reading restart dumps including file stem.");
+  params.AddOptionalParameter(
+    "read_initial_condition_path",
+    "",
+    "Full path for reading restart data as an initial condition, including file stem.");
   params.AddOptionalParameter(
     "write_restart_path", "", "Full path for writing restart dumps including file stem.");
   params.AddOptionalParameter("write_restart_time_interval",
@@ -593,9 +601,18 @@ LBSProblem::ParseOptions(const InputParameters& input)
     {"write_delayed_psi_to_restart",
      [this](const ParameterBlock& spec)
      { options_.restart.write_delayed_psi = spec.GetValue<bool>(); }},
+    {"write_angular_flux_to_restart",
+     [this](const ParameterBlock& spec)
+     { options_.restart.write_angular_flux = spec.GetValue<bool>(); }},
     {"read_restart_path",
      [this](const ParameterBlock& spec)
      { options_.restart.read_path = BuildRestartPath(spec.GetValue<std::string>()); }},
+    {"read_initial_condition_path",
+     [this](const ParameterBlock& spec)
+     {
+       options_.restart.read_initial_condition_path =
+         BuildRestartPath(spec.GetValue<std::string>());
+     }},
     {"write_restart_path",
      [this](const ParameterBlock& spec)
      { options_.restart.write_path = BuildRestartPath(spec.GetValue<std::string>()); }},
@@ -694,7 +711,8 @@ LBSProblem::BuildRestartPath(const std::string& path_stem)
 }
 
 bool
-LBSProblem::ReadProblemRestartData(hid_t /*file_id*/)
+LBSProblem::ReadProblemRestartData(hid_t /*file_id*/,
+                                   bool /*allow_transient_initialization_from_steady*/)
 {
   return true;
 }

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h
@@ -286,7 +286,9 @@ public:
   std::shared_ptr<FieldFunctionGridBased> CreateFieldFunction(
     const std::string& name, const std::string& xs_name, double power_normalization_target = -1.0);
 
-  bool ReadRestartData(const RestartDataHook& extra_reader = {});
+  bool ReadRestartData(const RestartDataHook& extra_reader = {},
+                       const std::filesystem::path& read_path = {},
+                       bool allow_transient_initialization_from_steady = false);
   bool WriteRestartData(const RestartDataHook& extra_writer = {});
 
   bool TriggerRestartDump() const { return options_.restart.IsWriteDue(); }
@@ -329,7 +331,8 @@ protected:
   void UpdateDerivedFieldFunction(FieldFunctionGridBased& ff,
                                   const std::string& xs_name,
                                   double power_normalization_target);
-  virtual bool ReadProblemRestartData(hid_t file_id);
+  virtual bool ReadProblemRestartData(hid_t file_id,
+                                      bool allow_transient_initialization_from_steady);
   virtual bool WriteProblemRestartData(hid_t file_id) const;
 
   LBSOptions options_;

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_structs.h
@@ -34,7 +34,9 @@ struct LBSRestartOptions
 {
   bool writes_enabled = false;
   bool write_delayed_psi = true;
+  bool write_angular_flux = true;
   std::filesystem::path read_path;
+  std::filesystem::path read_initial_condition_path;
   std::filesystem::path write_path;
   std::chrono::time_point<std::chrono::system_clock> last_write_time;
   std::chrono::seconds write_time_interval = std::chrono::seconds(0);

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -772,9 +772,27 @@ WrapLBS(py::module& slv)
         A block of optional configuration parameters, including:
           - max_mpi_message_size: int, default=32768
           - restart_writes_enabled: bool, default=False
+              Enable restart dump writes for solvers that support restart output.
           - write_delayed_psi_to_restart: bool, default=True
+              Include delayed sweep angular-flux buffers. Full continuation restarts require
+              these buffers whenever the problem has delayed sweep angular state, including
+              partitioned parallel, reflected-boundary, and cyclic-sweep cases. These buffers
+              are optional when a steady-state restart is used only as a transient initial
+              condition because the transient initialization can reconstruct angular state
+              from the flux moments.
+          - write_angular_flux_to_restart: bool, default=True
+              Include stored angular fluxes in restart dumps when ``save_angular_flux=True``.
+              This is required for continuing a time-dependent restart, but optional when a
+              steady-state restart is used only as a transient initial condition.
           - read_restart_path: str, default=''
+              File stem for reading a full restart. The number of MPI ranks and partitioned
+              state layout must match the run that wrote the restart files.
+          - read_initial_condition_path: str, default=''
+              File stem for reading restart data as an initial condition. A steady-state
+              restart may be used by ``TransientSolver`` through this option.
           - write_restart_path: str, default=''
+              File stem for restart dump writes. OpenSn appends the MPI rank and
+              ``.restart.h5`` to this stem.
           - write_restart_time_interval: int, default=0
             (must be 0 or >=30)
           - use_precursors: bool, default=True
@@ -1238,9 +1256,27 @@ WrapLBS(py::module& slv)
         A block of optional configuration parameters applied at problem creation, including:
           - max_mpi_message_size: int, default=32768
           - restart_writes_enabled: bool, default=False
+              Enable restart dump writes for solvers that support restart output.
           - write_delayed_psi_to_restart: bool, default=True
+              Include delayed sweep angular-flux buffers. Full continuation restarts require
+              these buffers whenever the problem has delayed sweep angular state, including
+              partitioned parallel, reflected-boundary, and cyclic-sweep cases. These buffers
+              are optional when a steady-state restart is used only as a transient initial
+              condition because the transient initialization can reconstruct angular state
+              from the flux moments.
+          - write_angular_flux_to_restart: bool, default=True
+              Include stored angular fluxes in restart dumps when ``save_angular_flux=True``.
+              This is required for continuing a time-dependent restart, but optional when a
+              steady-state restart is used only as a transient initial condition.
           - read_restart_path: str, default=''
+              File stem for reading a full restart. The number of MPI ranks and partitioned
+              state layout must match the run that wrote the restart files.
+          - read_initial_condition_path: str, default=''
+              File stem for reading restart data as an initial condition. A steady-state
+              restart may be used by ``TransientSolver`` through this option.
           - write_restart_path: str, default=''
+              File stem for restart dump writes. OpenSn appends the MPI rank and
+              ``.restart.h5`` to this stem.
           - write_restart_time_interval: int, default=0
           - use_precursors: bool, default=True
             Enable delayed-neutron precursor treatment. This remains active across later
@@ -1327,6 +1363,10 @@ WrapSteadyState(py::module& slv)
     restart data is read during :meth:`Initialize`. If it was constructed with
     ``options={'restart_writes_enabled': True, ...}``, a restart dump is written
     after :meth:`Execute` completes.
+
+    Restart files are rank-layout specific. A restart written with ``N`` MPI
+    ranks must be read with the same rank count and a compatible problem
+    definition.
     )"
   );
   steady_state_solver.def(
@@ -1436,9 +1476,26 @@ WrapTransient(py::module& slv)
 
     If the problem was constructed with ``options={'read_restart_path': ...}``,
     restart data is read during :meth:`Initialize`. If it was constructed with
+    ``options={'read_initial_condition_path': ...}``, restart data is read as a
+    transient initial condition during :meth:`Initialize`, then the problem is
+    switched to time-dependent mode; a steady-state restart may be used in this
+    mode. In this initial-condition path, stored angular fluxes and delayed
+    sweep angular-flux buffers are optional in the steady-state restart; the
+    transient solver reconstructs angular state from the loaded flux moments.
+    If it was constructed with
     ``options={'restart_writes_enabled': True, ...}``, timed restart dumps may
     be written during :meth:`Execute` and a final restart dump is written when
     execution completes.
+
+    A full transient continuation restart read with ``read_restart_path`` is
+    different from a steady-state initial-condition restart read with
+    ``read_initial_condition_path``. Full transient continuation restarts require
+    angular flux state in the restart file; if the problem has delayed sweep
+    angular state, including partitioned parallel, reflected-boundary, or
+    cyclic-sweep cases, continuation also requires delayed sweep angular-flux
+    buffers in the restart. Restart files are rank-layout specific: use the same MPI rank
+    count and compatible problem definition when reading files written by a
+    previous run.
     )"
   );
   transient_solver.def(

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/tests.json
@@ -175,6 +175,34 @@
     ]
   },
   {
+    "file": "transient_init_from_steady_restart.py",
+    "comment": "Transient initial condition loaded directly from a steady-state restart",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "STEADY_RESTART_IC_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
+    "file": "transient_precursors_from_steady_restart.py",
+    "comment": "Delayed precursor transient initialized from a steady-state restart",
+    "num_procs": 4,
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "PRECURSOR_RESTART_IC_PASS",
+        "wordnum": 1,
+        "gold": 1,
+        "abs_tol": 1e-12
+      }
+    ]
+  },
+  {
     "file": "transient_keigen_1d_theta_precursor_scaling.py",
     "comment": "1D delayed fission source scales with theta (TransientSourceFunction check)",
     "num_procs": 4,

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_from_steady_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_init_from_steady_restart.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import numpy as np
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.source import VolumetricSource
+    from pyopensn.aquad import GLProductQuadrature1DSlab
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver, TransientSolver
+
+
+def build_problem_options(grid, xs, source, quadrature, options, time_dependent=False):
+    return {
+        "mesh": grid,
+        "num_groups": 1,
+        "groupsets": [
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quadrature,
+                "inner_linear_method": "petsc_gmres",
+                "l_abs_tol": 1.0e-10,
+                "l_max_its": 200,
+                "gmres_restart_interval": 30,
+            }
+        ],
+        "xs_map": [{"block_ids": [0], "xs": xs}],
+        "volumetric_sources": [source],
+        "boundary_conditions": [
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
+        "options": options,
+        "time_dependent": time_dependent,
+    }
+
+
+def evolve_transient(phys, dt, num_steps):
+    solver = TransientSolver(
+        problem=phys,
+        dt=dt,
+        theta=1.0,
+        stop_time=dt * num_steps,
+        initial_state="existing",
+        verbose=False,
+    )
+    solver.Initialize()
+    solver.Execute()
+
+    return (
+        np.array(phys.GetPhiNewLocal(), copy=True),
+        [np.array(psi, copy=True) for psi in phys.GetPsi()],
+    )
+
+
+if __name__ == "__main__":
+    meshgen = OrthogonalMeshGenerator(node_sets=[np.linspace(0.0, 1.0, 11).tolist()])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    xs = MultiGroupXS()
+    xs.CreateSimpleOneGroup(1.0, 0.0, 1.0)
+    source0 = VolumetricSource(block_ids=[0], group_strength=[2.0], start_time=0.0, end_time=10.0)
+    quadrature = GLProductQuadrature1DSlab(n_polar=4, scattering_order=0)
+
+    dt = 0.01
+    num_steps = 5
+
+    common_options = {
+        "save_angular_flux": True,
+        "use_precursors": False,
+        "verbose_inner_iterations": False,
+        "verbose_outer_iterations": False,
+    }
+
+    phys_continuous = DiscreteOrdinatesProblem(
+        **build_problem_options(grid, xs, source0, quadrature, dict(common_options))
+    )
+    steady_continuous = SteadyStateSourceSolver(problem=phys_continuous)
+    steady_continuous.Initialize()
+    steady_continuous.Execute()
+    phys_continuous.SetTimeDependentMode()
+    phi_continuous, psi_continuous = evolve_transient(phys_continuous, dt, num_steps)
+
+    for write_angular_flux in (False, True):
+        for write_delayed_psi in (False, True):
+            restart_base = f"steady_ic_af{int(write_angular_flux)}_dpsi{int(write_delayed_psi)}"
+            steady_options = {
+                **common_options,
+                "restart_writes_enabled": True,
+                "write_angular_flux_to_restart": write_angular_flux,
+                "write_delayed_psi_to_restart": write_delayed_psi,
+                "write_restart_path": restart_base,
+            }
+            phys_steady = DiscreteOrdinatesProblem(
+                **build_problem_options(grid, xs, source0, quadrature, steady_options)
+            )
+            steady_solver = SteadyStateSourceSolver(problem=phys_steady)
+            steady_solver.Initialize()
+            steady_solver.Execute()
+
+            transient_options = {
+                **common_options,
+                "read_initial_condition_path": restart_base,
+            }
+            phys_transient = DiscreteOrdinatesProblem(
+                **build_problem_options(grid, xs, source0, quadrature, transient_options)
+            )
+            phi_split, psi_split = evolve_transient(phys_transient, dt, num_steps)
+
+            local_ok = np.allclose(phi_continuous, phi_split, rtol=1.0e-10, atol=1.0e-12)
+            phi_diff = np.max(np.abs(phi_continuous - phi_split))
+            psi_diff = 0.0
+            local_ok = local_ok and len(psi_continuous) == len(psi_split)
+            for arr_continuous, arr_split in zip(psi_continuous, psi_split):
+                psi_diff = max(psi_diff, np.max(np.abs(arr_continuous - arr_split)))
+                local_ok = local_ok and np.allclose(
+                    arr_continuous, arr_split, rtol=1.0e-10, atol=1.0e-12
+                )
+
+            global_ok = MPIAllReduce(float(local_ok))
+            if global_ok != size:
+                if rank == 0:
+                    print(f"STEADY_RESTART_IC_WRITE_PSI {int(write_angular_flux)}")
+                    print(f"STEADY_RESTART_IC_WRITE_DELAYED_PSI {int(write_delayed_psi)}")
+                    print(f"STEADY_RESTART_IC_PHI_DIFF {phi_diff:.12e}")
+                    print(f"STEADY_RESTART_IC_PSI_DIFF {psi_diff:.12e}")
+                    sys.stdout.flush()
+                raise ValueError("steady restart initial condition mismatch")
+
+            restart_file = f"{restart_base}{rank}.restart.h5"
+            if os.path.exists(restart_file):
+                os.remove(restart_file)
+
+    if rank == 0:
+        print("STEADY_RESTART_IC_PASS 1")

--- a/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_precursors_from_steady_restart.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_transient/transient_precursors_from_steady_restart.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import numpy as np
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.source import VolumetricSource
+    from pyopensn.aquad import GLProductQuadrature1DSlab
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver, TransientSolver
+
+
+def build_problem(grid, xs, sources, quadrature, options, time_dependent=False):
+    return DiscreteOrdinatesProblem(
+        mesh=grid,
+        num_groups=1,
+        groupsets=[
+            {
+                "groups_from_to": (0, 0),
+                "angular_quadrature": quadrature,
+                "inner_linear_method": "petsc_richardson",
+                "l_abs_tol": 1.0e-8,
+                "l_max_its": 200,
+            }
+        ],
+        xs_map=[{"block_ids": [0], "xs": xs}],
+        volumetric_sources=sources,
+        boundary_conditions=[
+            {"name": "zmin", "type": "reflecting"},
+            {"name": "zmax", "type": "reflecting"},
+        ],
+        options=options,
+        time_dependent=time_dependent,
+    )
+
+
+def run_decay_transient(phys, dt):
+    solver = TransientSolver(
+        problem=phys, dt=dt, theta=1.0, stop_time=dt, initial_state="existing", verbose=False
+    )
+    solver.Initialize()
+    solver.Execute()
+    return (
+        np.array(phys.GetPhiNewLocal(), copy=True),
+        [np.array(psi, copy=True) for psi in phys.GetPsi()],
+    )
+
+
+if __name__ == "__main__":
+    dx = 1.0 / 10
+    nodes = [i * dx for i in range(10 + 1)]
+    meshgen = OrthogonalMeshGenerator(node_sets=[nodes])
+    grid = meshgen.Execute()
+    grid.SetUniformBlockID(0)
+
+    dt = 0.05
+    xs = MultiGroupXS()
+    xs.LoadFromOpenSn(os.path.join(os.path.dirname(__file__), "xs1g_delayed_crit_1p.cxs"))
+
+    source = VolumetricSource(block_ids=[0], group_strength=[0.5], start_time=0.0, end_time=10.0)
+    quadrature = GLProductQuadrature1DSlab(n_polar=4, scattering_order=0)
+
+    common_options = {
+        "save_angular_flux": True,
+        "use_precursors": True,
+        "verbose_inner_iterations": False,
+        "verbose_outer_iterations": False,
+    }
+
+    phys_continuous = build_problem(grid, xs, [source], quadrature, dict(common_options))
+    steady_continuous = SteadyStateSourceSolver(problem=phys_continuous)
+    steady_continuous.Initialize()
+    steady_continuous.Execute()
+    phys_continuous.SetVolumetricSources(clear_volumetric_sources=True)
+    phys_continuous.SetTimeDependentMode()
+    phi_continuous, psi_continuous = run_decay_transient(phys_continuous, dt)
+
+    for write_angular_flux in (False, True):
+        for write_delayed_psi in (False, True):
+            restart_base = (
+                f"steady_precursor_ic_af{int(write_angular_flux)}_dpsi{int(write_delayed_psi)}"
+            )
+            steady_options = {
+                **common_options,
+                "restart_writes_enabled": True,
+                "write_angular_flux_to_restart": write_angular_flux,
+                "write_delayed_psi_to_restart": write_delayed_psi,
+                "write_restart_path": restart_base,
+            }
+            phys_steady = build_problem(grid, xs, [source], quadrature, steady_options)
+            steady_solver = SteadyStateSourceSolver(problem=phys_steady)
+            steady_solver.Initialize()
+            steady_solver.Execute()
+
+            transient_options = {
+                **common_options,
+                "read_initial_condition_path": restart_base,
+            }
+            phys_split = build_problem(grid, xs, [], quadrature, transient_options)
+            phi_split, psi_split = run_decay_transient(phys_split, dt)
+
+            local_ok = np.allclose(phi_continuous, phi_split, rtol=1.0e-10, atol=1.0e-12)
+            local_ok = local_ok and len(psi_continuous) == len(psi_split)
+            for arr_continuous, arr_split in zip(psi_continuous, psi_split):
+                local_ok = local_ok and np.allclose(
+                    arr_continuous, arr_split, rtol=1.0e-10, atol=1.0e-12
+                )
+
+            global_ok = MPIAllReduce(float(local_ok))
+            if global_ok != size:
+                raise ValueError("precursor steady restart transient mismatch")
+
+            restart_file = f"{restart_base}{rank}.restart.h5"
+            if os.path.exists(restart_file):
+                os.remove(restart_file)
+
+    if rank == 0:
+        print("PRECURSOR_RESTART_IC_PASS 1")


### PR DESCRIPTION
This PR allows the use of a steady-steady restart dump as the initial condition for a new transient problem. 

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.
