### PR TITLE
Fix conflict between libstdc++'s format and clang UBsan

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_definition.h"
-#include <format>
 #include <map>
+#include <sstream>
 
 namespace opensn
 {
@@ -16,6 +16,40 @@ std::map<std::string, LBSBoundaryType> type_map = {{"vacuum", LBSBoundaryType::V
                                                    {"reflecting", LBSBoundaryType::REFLECTING},
                                                    {"arbitrary", LBSBoundaryType::ARBITRARY}};
 
+std::string
+UnsupportedParameterMessage(const std::string& boundary_name,
+                            const std::string& boundary_type,
+                            const std::string& param_name)
+{
+  std::ostringstream message;
+  message << "Boundary '" << boundary_name << "' of type=\"" << boundary_type
+          << "\" does not support \"" << param_name << "\".";
+  return message.str();
+}
+
+std::string
+MissingParameterMessage(const std::string& boundary_name,
+                        const std::string& boundary_type,
+                        const std::string& param_name)
+{
+  std::ostringstream message;
+  message << "Boundary '" << boundary_name << "' of type=\"" << boundary_type << "\" requires \""
+          << param_name << "\".";
+  return message.str();
+}
+
+std::string
+MissingEitherParameterMessage(const std::string& boundary_name,
+                              const std::string& boundary_type,
+                              const std::string& param_name1,
+                              const std::string& param_name2)
+{
+  std::ostringstream message;
+  message << "Boundary '" << boundary_name << "' of type=\"" << boundary_type
+          << "\" requires either \"" << param_name1 << "\" or \"" << param_name2 << "\".";
+  return message.str();
+}
+
 void
 CheckForbiddenParams(const InputParameters& params,
                      const std::string& boundary_name,
@@ -23,10 +57,7 @@ CheckForbiddenParams(const InputParameters& params,
                      const std::string& param_name)
 {
   if (params.IsParameterValid(param_name))
-    throw std::runtime_error(std::format(R"(Boundary '{}' of type="{}" does not support "{}".)",
-                                         boundary_name,
-                                         boundary_type,
-                                         param_name));
+    throw std::runtime_error(UnsupportedParameterMessage(boundary_name, boundary_type, param_name));
 }
 
 void
@@ -36,8 +67,7 @@ CheckRequiredParams(const InputParameters& params,
                     const std::string& param_name)
 {
   if (not params.IsParameterValid(param_name))
-    throw std::runtime_error(std::format(
-      R"(Boundary '{}' of type="{}" requires "{}".)", boundary_name, boundary_type, param_name));
+    throw std::runtime_error(MissingParameterMessage(boundary_name, boundary_type, param_name));
 }
 
 void
@@ -50,11 +80,7 @@ CheckRequiredParams(const InputParameters& params,
   bool is_valid = (params.IsParameterValid(param_name1) xor params.IsParameterValid(param_name2));
   if (not is_valid)
     throw std::runtime_error(
-      std::format(R"(Boundary '{}' of type="{}" requires either "{}" or "{}".)",
-                  boundary_name,
-                  boundary_type,
-                  param_name1,
-                  param_name2));
+      MissingEitherParameterMessage(boundary_name, boundary_type, param_name1, param_name2));
 }
 
 } // namespace
@@ -81,24 +107,28 @@ BoundaryDefinition::BoundaryDefinition(const InputParameters& params, unsigned i
       params.RequireParameterBlockTypeIs("group_strength", ParameterBlockType::ARRAY);
       auto param_group_strength = params.GetParamVectorValue<double>("group_strength");
       if (param_group_strength.size() != num_groups)
-        throw std::runtime_error(std::format(
-          "Boundary '{}' with type=\"isotropic\" expected \"group_strength\" to contain "
-          "{} entries, one for each solver group, but received {}.",
-          boundary_name,
-          num_groups,
-          param_group_strength.size()));
+      {
+        std::ostringstream message;
+        message << "Boundary '" << boundary_name
+                << R"(' with type="isotropic" expected "group_strength" to contain )" << num_groups
+                << " entries, one for each solver group, but received "
+                << param_group_strength.size() << ".";
+        throw std::runtime_error(message.str());
+      }
       group_strength = std::move(param_group_strength);
       if (params.IsParameterValid("start_time"))
         start_time = params.GetParamValue<double>("start_time");
       if (params.IsParameterValid("end_time"))
         end_time = params.GetParamValue<double>("end_time");
       if (not(start_time <= end_time))
-        throw std::runtime_error(std::format(
-          "Boundary '{}' with type=\"isotropic\" expected \"start_time\" to be less than or "
-          "equal to \"end_time\", but received start_time={} and end_time={}.",
-          boundary_name,
-          start_time,
-          end_time));
+      {
+        std::ostringstream message;
+        message << "Boundary '" << boundary_name
+                << "' with type=\"isotropic\" expected \"start_time\" to be less than or "
+                   "equal to \"end_time\", but received start_time="
+                << start_time << " and end_time=" << end_time << ".";
+        throw std::runtime_error(message.str());
+      }
       break;
     }
     case LBSBoundaryType::ARBITRARY:
@@ -112,10 +142,13 @@ BoundaryDefinition::BoundaryDefinition(const InputParameters& params, unsigned i
         auto param_angular_flux_function =
           params.GetSharedPtrParam<AngularFluxFunction>("function", false);
         if (not param_angular_flux_function)
-          throw std::runtime_error(std::format(
-            "Boundary '{}' with type=\"arbitrary\" expected parameter \"function\" to hold a "
-            "non-null AngularFluxFunction.",
-            boundary_name));
+        {
+          std::ostringstream message;
+          message << "Boundary '" << boundary_name
+                  << "' with type=\"arbitrary\" expected parameter \"function\" to hold a "
+                     "non-null AngularFluxFunction.";
+          throw std::runtime_error(message.str());
+        }
         time_angular_flux_function = std::make_shared<AngularFluxTimeFunction>(
           [angular_flux_function =
              std::move(param_angular_flux_function)](int group, int direction, double time)
@@ -126,10 +159,13 @@ BoundaryDefinition::BoundaryDefinition(const InputParameters& params, unsigned i
         auto param_angular_flux_function =
           params.GetSharedPtrParam<AngularFluxTimeFunction>("time_function", false);
         if (not param_angular_flux_function)
-          throw std::runtime_error(std::format(
-            "Boundary '{}' with type=\"arbitrary\" expected parameter \"time_function\" to hold a "
-            "non-null AngularFluxFunction.",
-            boundary_name));
+        {
+          std::ostringstream message;
+          message << "Boundary '" << boundary_name
+                  << "' with type=\"arbitrary\" expected parameter \"time_function\" to hold a "
+                     "non-null AngularFluxFunction.";
+          throw std::runtime_error(message.str());
+        }
         time_angular_flux_function = std::move(param_angular_flux_function);
       }
       break;


### PR DESCRIPTION
libstdc++'s `std::format` implementation internally uses a sentinel value like -1, then converts it to `size_t`. This mismatch makes Clang’s implicit-conversion sanitizer (UBsan) flag the conversion as undefined/suspicious behavior.

This PR replaces the use of `std::format` in `BoundaryDefinition`'s exceptions with `std::ostringstream`.

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.
