### PR TITLE
Automatically wrap and indent logger output.

### DIFF
--- a/framework/logging/log.cc
+++ b/framework/logging/log.cc
@@ -16,12 +16,18 @@ LogStream
 Logger::Log(LOG_LVL level)
 {
   int rank = opensn::mpi_comm.rank();
-  std::string header;
+  const auto prefix = "[" + std::to_string(rank) + "]  ";
+  LogStream::Header header;
   std::ostream* stream = nullptr;
   bool use_dummy = false;
   bool use_color = false;
   auto color = [this](StringStreamColorCode code)
   { return color_enabled_ ? StringStreamColor(code) : std::string{}; };
+  auto set_header = [&](std::string label = "", std::string color_code = std::string{})
+  {
+    header = {prefix, std::move(label), std::move(color_code)};
+    use_color = color_enabled_ and not header.color.empty();
+  };
 
   switch (level)
   {
@@ -30,7 +36,7 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0)
       {
-        header = "[" + std::to_string(rank) + "]  ";
+        set_header();
         stream = &std::cout;
       }
       else
@@ -41,8 +47,7 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_YELLOW) + "*** WARNING ***  ";
-        use_color = color_enabled_;
+        set_header("*** WARNING ***  ", color(FG_YELLOW));
         stream = &std::cout;
       }
       else
@@ -53,8 +58,7 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_RED) + "**** ERROR ****  ";
-        use_color = color_enabled_;
+        set_header("**** ERROR ****  ", color(FG_RED));
         stream = &std::cerr;
       }
       else
@@ -65,8 +69,7 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0 and verbosity_ >= 1)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_CYAN);
-        use_color = color_enabled_;
+        set_header("", color(FG_CYAN));
         stream = &std::cout;
       }
       else
@@ -77,8 +80,7 @@ Logger::Log(LOG_LVL level)
     {
       if (rank == 0 and verbosity_ >= 2)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_MAGENTA);
-        use_color = color_enabled_;
+        set_header("", color(FG_MAGENTA));
         stream = &std::cout;
       }
       else
@@ -88,21 +90,19 @@ Logger::Log(LOG_LVL level)
     case LOG_ALL:
     case LOG_ALLVERBOSE_0:
     {
-      header = "[" + std::to_string(rank) + "]  ";
+      set_header();
       stream = &std::cout;
       break;
     }
     case LOG_ALLWARNING:
     {
-      header = "[" + std::to_string(rank) + "]  " + color(FG_YELLOW) + "*** WARNING ***  ";
-      use_color = color_enabled_;
+      set_header("*** WARNING ***  ", color(FG_YELLOW));
       stream = &std::cout;
       break;
     }
     case LOG_ALLERROR:
     {
-      header = "[" + std::to_string(rank) + "]  " + color(FG_RED) + "**** ERROR ****  ";
-      use_color = color_enabled_;
+      set_header("**** ERROR ****  ", color(FG_RED));
       stream = &std::cerr;
       break;
     }
@@ -110,8 +110,7 @@ Logger::Log(LOG_LVL level)
     {
       if (verbosity_ >= 1)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_CYAN);
-        use_color = color_enabled_;
+        set_header("", color(FG_CYAN));
         stream = &std::cout;
       }
       else
@@ -122,8 +121,7 @@ Logger::Log(LOG_LVL level)
     {
       if (verbosity_ >= 2)
       {
-        header = "[" + std::to_string(rank) + "]  " + color(FG_MAGENTA);
-        use_color = color_enabled_;
+        set_header("", color(FG_MAGENTA));
         stream = &std::cout;
       }
       else

--- a/framework/logging/log_stream.h
+++ b/framework/logging/log_stream.h
@@ -5,6 +5,9 @@
 
 #include <iostream>
 #include <sstream>
+#include <string_view>
+#include <cctype>
+#include <utility>
 #include "stringstream_color.h"
 
 namespace opensn
@@ -14,14 +17,26 @@ namespace opensn
 class LogStream : public std::stringstream
 {
 public:
+  struct Header
+  {
+    std::string prefix;
+    std::string label;
+    std::string color;
+  };
+
   LogStream(std::ostream* output_stream,
-            std::string header,
+            Header header,
             bool dummy_flag = false,
             bool use_color = false)
     : log_stream_(output_stream),
-      log_header_(std::move(header)),
+      header_(std::move(header)),
       dummy_(dummy_flag),
       use_color_(use_color)
+  {
+  }
+
+  LogStream(std::ostream* output_stream, std::string header, bool dummy_flag = false)
+    : LogStream(output_stream, Header{std::move(header), "", ""}, dummy_flag, false)
   {
   }
 
@@ -44,12 +59,7 @@ public:
       std::string oline;
       std::string reset_str = use_color_ ? StringStreamColor(StringStreamColorCode::RESET) : "";
       while (std::getline(iss, line))
-      {
-        oline += log_header_;
-        oline += line;
-        oline += reset_str;
-        oline += "\n";
-      }
+        AppendWrappedLine(oline, line, reset_str);
 
       if (!oline.empty())
         *log_stream_ << oline << std::flush;
@@ -61,8 +71,67 @@ public:
   }
 
 private:
+  static constexpr std::size_t LINE_WRAP_WIDTH = 100;
+  static constexpr std::size_t CONTINUATION_INDENT = 4;
+
+  static std::size_t FindWrapPosition(std::string_view text, std::size_t max_width)
+  {
+    if (text.size() <= max_width)
+      return std::string_view::npos;
+
+    for (std::size_t i = max_width; i < text.size(); ++i)
+    {
+      if (std::isspace(static_cast<unsigned char>(text[i])))
+        return i;
+    }
+
+    return max_width;
+  }
+
+  static std::string_view TrimLeadingSpaces(std::string_view text)
+  {
+    while (not text.empty() and std::isspace(static_cast<unsigned char>(text.front())))
+      text.remove_prefix(1);
+
+    return text;
+  }
+
+  void
+  AppendWrappedLine(std::string& output, std::string_view line, const std::string& reset_str) const
+  {
+    bool first_piece = true;
+
+    bool line_remaining = true;
+    while (line_remaining)
+    {
+      const auto header_width = first_piece ? header_.prefix.size() + header_.label.size()
+                                            : header_.prefix.size() + CONTINUATION_INDENT;
+      const auto content_width =
+        header_width < LINE_WRAP_WIDTH ? LINE_WRAP_WIDTH - header_width : LINE_WRAP_WIDTH;
+      const auto wrap_pos = FindWrapPosition(line, content_width);
+      const auto piece = wrap_pos == std::string_view::npos ? line : line.substr(0, wrap_pos);
+
+      output += header_.prefix;
+      output += header_.color;
+      if (first_piece)
+        output += header_.label;
+      else
+        output += std::string(CONTINUATION_INDENT, ' ');
+
+      output += piece;
+      output += reset_str;
+      output += "\n";
+
+      first_piece = false;
+      line_remaining = wrap_pos != std::string_view::npos;
+
+      if (line_remaining)
+        line = TrimLeadingSpaces(line.substr(wrap_pos));
+    }
+  }
+
   std::ostream* log_stream_;
-  std::string log_header_;
+  Header header_;
   const bool dummy_;
   bool use_color_;
 };


### PR DESCRIPTION
Current line length before wrapping is 100 characters (logger will split at first space after 100 characters). Color output is maintained for split lines and child lines are indented by 4 spaces.
