### PR TITLE
Pull solver scheme construction out of DiscreteOrdinatesProblem.

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -18,14 +18,13 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk_td.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "framework/math/functions/function.h"
 #include "framework/data_types/allowable_range.h"
-#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.h"
-#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/source_functions/source_function.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/source_functions/transient_source_function.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
@@ -641,24 +640,17 @@ DiscreteOrdinatesProblem::RebuildBoundaryRuntimeData()
 void
 DiscreteOrdinatesProblem::InitializeSolverSchemes()
 {
-  ags_solver_.reset();
-  wgs_solvers_.clear();
-  wgs_contexts_.clear();
-  InitializeWGSContexts();
-  InitializeWGSSolvers();
-
-  ags_solver_ = std::make_shared<AGSLinearSolver>(*this, wgs_solvers_);
-  if (groupsets_.size() == 1)
-  {
-    ags_solver_->SetMaxIterations(1);
-    ags_solver_->SetVerbosity(false);
-  }
-  else
-  {
-    ags_solver_->SetMaxIterations(options_.max_ags_iterations);
-    ags_solver_->SetVerbosity(options_.verbose_inner_iterations);
-  }
-  ags_solver_->SetTolerance(options_.ags_tolerance);
+  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeSolverSchemes");
+  auto solver_scheme =
+    BuildSolvers(*this,
+                 active_set_source_function_,
+                 [this](LBSGroupset& groupset) { return SetSweepChunk(groupset); });
+  ags_solver_ = std::move(solver_scheme.ags_solver);
+  wgs_contexts_ = std::move(solver_scheme.wgs_contexts);
+  wgs_solvers_ = std::move(solver_scheme.wgs_solvers);
+  max_groupset_size_ = solver_scheme.max_groupset_size;
+  max_level_size_ = solver_scheme.max_level_size;
+  max_angleset_size_ = solver_scheme.max_angleset_size;
 }
 
 void
@@ -1092,74 +1084,9 @@ DiscreteOrdinatesProblem::InitializeBoundaries()
 }
 
 void
-DiscreteOrdinatesProblem::InitializeWGSContexts()
-{
-
-  // Determine max size and number of matrices along sweep front
-  max_groupset_size_ = 0;
-  max_level_size_ = 0;
-  max_angleset_size_ = 0;
-  for (auto& groupset : groupsets_)
-  {
-    // Max groupset size
-    max_groupset_size_ = std::max(max_groupset_size_, groupset.GetNumGroups());
-
-    for (auto& angleset : *(groupset.angle_agg))
-    {
-      // Max level size
-      const auto& spds = angleset->GetSPDS();
-      const auto& levelized_spls = spds.GetLevelizedLocalSubgrid();
-      for (const auto& level : levelized_spls)
-        max_level_size_ = std::max(max_level_size_, level.size());
-
-      // Max angleset size
-      max_angleset_size_ = std::max(max_angleset_size_, angleset->GetAngleIndices().size());
-    }
-  }
-
-  wgs_contexts_.clear();
-  for (auto& groupset : groupsets_)
-  {
-    std::shared_ptr<SweepChunk> sweep_chunk = SetSweepChunk(groupset);
-    auto sweep_wgs_context_ptr = std::make_shared<SweepWGSContext>(
-      *this,
-      groupset,
-      active_set_source_function_,
-      APPLY_WGS_SCATTER_SOURCES | APPLY_WGS_FISSION_SOURCES,
-      APPLY_FIXED_SOURCES | APPLY_AGS_SCATTER_SOURCES | APPLY_AGS_FISSION_SOURCES,
-      options_.verbose_inner_iterations,
-      sweep_chunk);
-    wgs_contexts_.push_back(sweep_wgs_context_ptr);
-  }
-}
-
-void
-DiscreteOrdinatesProblem::InitializeWGSSolvers()
-{
-
-  OpenSnLogicalErrorIf(wgs_contexts_.empty(),
-                       GetName() + ": Cannot initialize WGS solvers before WGS contexts.");
-  OpenSnLogicalErrorIf(wgs_contexts_.size() != groupsets_.size(),
-                       GetName() + ": WGS context count does not match groupset count.");
-
-  for (size_t gsid = 0; gsid < groupsets_.size(); ++gsid)
-  {
-    auto& groupset = groupsets_[gsid];
-    const auto& sweep_wgs_context_ptr = wgs_contexts_[gsid];
-    OpenSnLogicalErrorIf(not sweep_wgs_context_ptr, GetName() + ": Null WGS context.");
-    if (groupset.iterative_method == LinearSystemSolver::IterativeMethod::CLASSIC_RICHARDSON)
-    {
-      wgs_solvers_.push_back(std::make_shared<ClassicRichardson>(
-        sweep_wgs_context_ptr, options_.verbose_inner_iterations));
-    }
-    else
-      wgs_solvers_.push_back(std::make_shared<WGSLinearSolver>(sweep_wgs_context_ptr));
-  }
-}
-
-void
 DiscreteOrdinatesProblem::ReorientAdjointSolution()
 {
+  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ReorientAdjointSolution");
 
   for (const auto& groupset : groupsets_)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h
@@ -192,11 +192,6 @@ protected:
   void ResetSweepChunkMode() { sweep_chunk_mode_.reset(); }
   void ResetMode(SweepChunkMode target_mode);
 
-  void InitializeWGSContexts();
-
-  /// Initializes Within-GroupSet solvers.
-  void InitializeWGSSolvers();
-
   void InitializeBoundaryCarrier();
 
   /**
@@ -229,11 +224,6 @@ protected:
 
   /// Sets up the sweep chunk for the given discretization method.
   virtual std::shared_ptr<SweepChunk> SetSweepChunk(LBSGroupset& groupset);
-
-  std::shared_ptr<SweepChunk> CreateSweepChunk(LBSGroupset& groupset)
-  {
-    return SetSweepChunk(groupset);
-  }
   /** @} */
 
   /**

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.cc
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/angle_set.h"
+#include "modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h"
+#include "framework/utils/error.h"
+#include <algorithm>
+
+namespace opensn
+{
+
+namespace
+{
+
+void
+UpdateSweepWorkLimits(SolverScheme& scheme, LBSGroupset& groupset)
+{
+  scheme.max_groupset_size = std::max(scheme.max_groupset_size, groupset.GetNumGroups());
+
+  for (auto& angleset : *groupset.angle_agg)
+  {
+    const auto& spds = angleset->GetSPDS();
+    const auto& levelized_spls = spds.GetLevelizedLocalSubgrid();
+    for (const auto& level : levelized_spls)
+      scheme.max_level_size = std::max(scheme.max_level_size, level.size());
+
+    scheme.max_angleset_size =
+      std::max(scheme.max_angleset_size, angleset->GetAngleIndices().size());
+  }
+}
+
+std::shared_ptr<WGSContext>
+MakeWGSContext(DiscreteOrdinatesProblem& problem,
+               LBSGroupset& groupset,
+               const SetSourceFunction& set_source_function,
+               const SweepChunkFactory& sweep_chunk_factory)
+{
+  const auto& options = problem.GetOptions();
+  return std::make_shared<SweepWGSContext>(problem,
+                                           groupset,
+                                           set_source_function,
+                                           APPLY_WGS_SCATTER_SOURCES | APPLY_WGS_FISSION_SOURCES,
+                                           APPLY_FIXED_SOURCES | APPLY_AGS_SCATTER_SOURCES |
+                                             APPLY_AGS_FISSION_SOURCES,
+                                           options.verbose_inner_iterations,
+                                           sweep_chunk_factory(groupset));
+}
+
+std::shared_ptr<LinearSolver>
+MakeWGSSolver(LBSGroupset& groupset,
+              const std::shared_ptr<WGSContext>& wgs_context,
+              bool verbose_inner_iterations)
+{
+  if (groupset.iterative_method == LinearSystemSolver::IterativeMethod::CLASSIC_RICHARDSON)
+    return std::make_shared<ClassicRichardson>(wgs_context, verbose_inner_iterations);
+
+  return std::make_shared<WGSLinearSolver>(wgs_context);
+}
+
+std::shared_ptr<AGSLinearSolver>
+MakeAGSSolver(DiscreteOrdinatesProblem& problem,
+              const std::vector<std::shared_ptr<LinearSolver>>& wgs_solvers)
+{
+  const auto& options = problem.GetOptions();
+  auto ags_solver = std::make_shared<AGSLinearSolver>(problem, wgs_solvers);
+  if (problem.GetNumGroupsets() == 1)
+  {
+    ags_solver->SetMaxIterations(1);
+    ags_solver->SetVerbosity(false);
+  }
+  else
+  {
+    ags_solver->SetMaxIterations(options.max_ags_iterations);
+    ags_solver->SetVerbosity(options.verbose_inner_iterations);
+  }
+  ags_solver->SetTolerance(options.ags_tolerance);
+
+  return ags_solver;
+}
+
+} // namespace
+
+SolverScheme
+BuildSolvers(DiscreteOrdinatesProblem& problem,
+             const SetSourceFunction& set_source_function,
+             const SweepChunkFactory& sweep_chunk_factory)
+{
+  SolverScheme result;
+  const auto& options = problem.GetOptions();
+
+  for (size_t gsid = 0; gsid < problem.GetNumGroupsets(); ++gsid)
+  {
+    auto& groupset = problem.GetGroupset(gsid);
+    UpdateSweepWorkLimits(result, groupset);
+    result.wgs_contexts.push_back(
+      MakeWGSContext(problem, groupset, set_source_function, sweep_chunk_factory));
+  }
+
+  OpenSnLogicalErrorIf(result.wgs_contexts.empty(),
+                       problem.GetName() + ": Cannot initialize WGS solvers before WGS contexts.");
+  OpenSnLogicalErrorIf(result.wgs_contexts.size() != problem.GetNumGroupsets(),
+                       problem.GetName() + ": WGS context count does not match groupset count.");
+
+  for (size_t gsid = 0; gsid < problem.GetNumGroupsets(); ++gsid)
+  {
+    auto& groupset = problem.GetGroupset(gsid);
+    const auto& wgs_context = result.wgs_contexts[gsid];
+    OpenSnLogicalErrorIf(not wgs_context, problem.GetName() + ": Null WGS context.");
+    result.wgs_solvers.push_back(
+      MakeWGSSolver(groupset, wgs_context, options.verbose_inner_iterations));
+  }
+
+  result.ags_solver = MakeAGSSolver(problem, result.wgs_solvers);
+  return result;
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/solver_scheme.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "modules/linear_boltzmann_solvers/lbs_problem/source_functions/source_flags.h"
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace opensn
+{
+
+class AGSLinearSolver;
+class DiscreteOrdinatesProblem;
+class LBSGroupset;
+class LinearSolver;
+class SweepChunk;
+struct WGSContext;
+
+using SweepChunkFactory = std::function<std::shared_ptr<SweepChunk>(LBSGroupset&)>;
+
+struct SolverScheme
+{
+  std::shared_ptr<AGSLinearSolver> ags_solver;
+  std::vector<std::shared_ptr<WGSContext>> wgs_contexts;
+  std::vector<std::shared_ptr<LinearSolver>> wgs_solvers;
+  unsigned int max_groupset_size = 0;
+  std::size_t max_level_size = 0;
+  std::size_t max_angleset_size = 0;
+};
+
+SolverScheme BuildSolvers(DiscreteOrdinatesProblem& problem,
+                          const SetSourceFunction& set_source_function,
+                          const SweepChunkFactory& sweep_chunk_factory);
+
+} // namespace opensn


### PR DESCRIPTION
This PR starts a refactor of `DiscreteOrdinatesProblem` by pulling the building of solver schemes into an external routine.
