### PR TITLE
Cleaning up iteration logs.

### DIFF
--- a/framework/logging/log_stream.h
+++ b/framework/logging/log_stream.h
@@ -13,6 +13,20 @@
 namespace opensn
 {
 
+inline int
+NoWrapStreamIndex()
+{
+  static const int index = std::ios_base::xalloc();
+  return index;
+}
+
+inline std::ostream&
+no_wrap(std::ostream& stream)
+{
+  stream.iword(NoWrapStreamIndex()) = 1;
+  return stream;
+}
+
 /// Log stream for adding header information to a string stream.
 class LogStream : public std::stringstream
 {
@@ -58,8 +72,14 @@ public:
       std::string line;
       std::string oline;
       std::string reset_str = use_color_ ? StringStreamColor(StringStreamColorCode::RESET) : "";
+      const bool wrap_lines = this->iword(NoWrapStreamIndex()) == 0;
       while (std::getline(iss, line))
-        AppendWrappedLine(oline, line, reset_str);
+      {
+        if (wrap_lines)
+          AppendWrappedLine(oline, line, reset_str);
+        else
+          AppendUnwrappedLine(oline, line, reset_str);
+      }
 
       if (!oline.empty())
         *log_stream_ << oline << std::flush;
@@ -94,6 +114,18 @@ private:
       text.remove_prefix(1);
 
     return text;
+  }
+
+  void AppendUnwrappedLine(std::string& output,
+                           std::string_view line,
+                           const std::string& reset_str) const
+  {
+    output += header_.prefix;
+    output += header_.color;
+    output += header_.label;
+    output += line;
+    output += reset_str;
+    output += "\n";
   }
 
   void

--- a/framework/math/petsc_utils/petsc_utils.cc
+++ b/framework/math/petsc_utils/petsc_utils.cc
@@ -258,7 +258,7 @@ KSPMonitorRelativeToRHS(KSP ksp, PetscInt n, PetscReal rnorm, void* /* context *
   buff << program_timer.GetTimeString() << " " << ksp_name << " iteration = " << n;
   AppendNumericField(buff, "residual", rnorm / rhs_norm, Scientific(6));
 
-  log.Log() << buff.str();
+  log.Log() << no_wrap << buff.str();
 
   return PETSC_SUCCESS;
 }

--- a/modules/diffusion/diffusion.cc
+++ b/modules/diffusion/diffusion.cc
@@ -26,7 +26,7 @@ LogDiffusionSolveStart(const std::string& name, Vec rhs)
   std::ostringstream out;
   out << name << " solve";
   AppendNumericField(out, "rhs_norm", rhs_norm, Scientific(6));
-  log.Log() << program_timer.GetTimeString() << " " << out.str();
+  log.Log() << no_wrap << program_timer.GetTimeString() << " " << out.str();
 }
 
 void
@@ -48,7 +48,7 @@ LogDiffusionSolveFinal(const std::string& name, KSP ksp, Vec x)
   AppendNumericField(out, "solution_norm", solution_norm, Scientific(6));
   if (log.GetVerbosity() >= 2)
     out << ", detail = " << GetPETScConvergedReasonstring(reason);
-  log.Log() << program_timer.GetTimeString() << " " << out.str();
+  log.Log() << no_wrap << program_timer.GetTimeString() << " " << out.str();
 }
 
 } // namespace

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/nl_keigen_acc_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/nl_keigen_acc_solver.cc
@@ -129,7 +129,7 @@ NLKEigenDiffSolver::PostSolveCallback()
       summary, "function_evaluations", static_cast<std::size_t>(number_of_func_evals));
     if (log.GetVerbosity() >= 2)
       summary << ", detail = " << GetPETScConvergedReasonstring(reason);
-    log.Log() << program_timer.GetTimeString() << " " << summary.str();
+    log.Log() << no_wrap << program_timer.GetTimeString() << " " << summary.str();
   }
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
@@ -224,7 +224,7 @@ SCDSAAcceleration::PostPowerIteration()
       AppendNumericField(out, "lambda_change", lambda_change, Scientific(6));
       if (status != IterationStatus::NONE)
         out << ", status = " << IterationStatusName(status);
-      log.Log() << program_timer.GetTimeString() << " " << out.str();
+      log.Log() << no_wrap << program_timer.GetTimeString() << " " << out.str();
     }
 
     if (converged)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
@@ -221,7 +221,7 @@ SMMAcceleration::PostPowerIteration()
       AppendNumericField(out, "lambda_change", lambda_change, Scientific(6));
       if (status != IterationStatus::NONE)
         out << ", status = " << IterationStatusName(status);
-      log.Log() << program_timer.GetTimeString() << " " << out.str();
+      log.Log() << no_wrap << program_timer.GetTimeString() << " " << out.str();
     }
 
     if (converged_this_iteration)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -578,7 +578,8 @@ DiscreteOrdinatesProblem::BuildRuntime()
     TGDSA::Init(*this, groupset);
   }
 
-  log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
+  if (options_.verbose_inner_iterations)
+    log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
 
   // Initialize runtime boundary data
   RebuildBoundaryRuntimeData();
@@ -1946,9 +1947,6 @@ DiscreteOrdinatesProblem::InitFluxDataStructures(LBSGroupset& groupset)
   } // for so_grouping
 
   groupset.angle_agg->BuildDirnumToAnglesetMap();
-
-  if (options_.verbose_inner_iterations)
-    log.Log() << program_timer.GetTimeString() << " Initialized angle aggregation.";
 
   opensn::mpi_comm.barrier();
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/ags_linear_solver.cc
@@ -92,7 +92,7 @@ AGSLinearSolver::Solve()
     iter_stats << FormatNestedStatusCounts("WGS", wgs_summaries);
 
     if (print_ags_stats)
-      log.Log() << iter_stats.str();
+      log.Log() << no_wrap << iter_stats.str();
 
     // Restore qmoms
     lbs_problem_.SetQMomentsFrom(saved_qmoms);
@@ -126,7 +126,8 @@ AGSLinearSolver::Solve()
   last_solve_.metric_value = last_error;
   if (print_ags_stats and (last_solve_.status == IterationStatus::FAILED or
                            last_solve_.status == IterationStatus::LIMIT))
-    log.Log() << program_timer.GetTimeString() << " " << FormatIterationSummary("AGS", last_solve_);
+    log.Log() << no_wrap << program_timer.GetTimeString() << " "
+              << FormatIterationSummary("AGS", last_solve_);
 
   for (const auto& solver : wgs_solvers_)
   {
@@ -163,14 +164,14 @@ AGSLinearSolver::Solve()
     AppendNumericField(
       sweep_timing, "sweep_time_per_unknown", sweep_time_per_unknown, Scientific(6));
     sweep_timing << " ns";
-    log.Log() << program_timer.GetTimeString() << " " << sweep_timing.str();
+    log.Log() << no_wrap << program_timer.GetTimeString() << " " << sweep_timing.str();
 
     std::stringstream sweep_work;
     sweep_work << label;
     AppendNumericField(sweep_work, "unknowns", num_unknowns, false);
     AppendNumericField(sweep_work, "lagged_unknowns", num_delayed_unknowns);
     AppendNumericField(sweep_work, "lagged_pct", delayed_unknown_percent, Fixed(2));
-    log.Log() << program_timer.GetTimeString() << " " << sweep_work.str();
+    log.Log() << no_wrap << program_timer.GetTimeString() << " " << sweep_work.str();
 
     sweep_context->ResetAccumulatedSweepStats();
   }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
@@ -131,7 +131,7 @@ ClassicRichardson::Solve()
 
       if (converged)
         iter_stats << ", status = " << IterationStatusName(IterationStatus::CONVERGED);
-      log.Log() << iter_stats.str();
+      log.Log() << no_wrap << iter_stats.str();
     }
 
     if (converged)
@@ -150,7 +150,7 @@ ClassicRichardson::Solve()
 
   if (verbose_ and (gs_context_ptr->last_solve.status == IterationStatus::FAILED or
                     gs_context_ptr->last_solve.status == IterationStatus::LIMIT))
-    log.Log() << program_timer.GetTimeString() << " "
+    log.Log() << no_wrap << program_timer.GetTimeString() << " "
               << FormatIterationSummary("WGS groups [" + std::to_string(groupset.first_group) +
                                           "-" + std::to_string(groupset.last_group) + "]",
                                         gs_context_ptr->last_solve);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/nonlinear_keigen_ags_solver.cc
@@ -155,7 +155,7 @@ NLKEigenvalueAGSSolver::PostSolveCallback()
                                       PETScSolverStatusToIterationStatus(status));
   if (log.GetVerbosity() >= 2)
     summary << ", detail = " << GetPETScConvergedReasonstring(reason);
-  log.Log() << program_timer.GetTimeString() << " " << summary.str();
+  log.Log() << no_wrap << program_timer.GetTimeString() << " " << summary.str();
 }
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/power_iteration_keigen.cc
@@ -115,7 +115,7 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
         MostSevereIterationStatus(ags_status, MostSevereIterationStatus(wgs_summaries));
       const auto outer_status =
         IterationStatusFromSolve(converged, nit >= max_iterations, inner_status);
-      log.Log() << program_timer.GetTimeString() << " "
+      log.Log() << no_wrap << program_timer.GetTimeString() << " "
                 << FormatKEigenOuterIteration("PI",
                                               nit,
                                               k_eff,
@@ -141,7 +141,7 @@ PowerIterationKEigenSolver(LBSProblem& lbs_problem,
       total_sweeps += wgs_context->counter_applications_of_inv_op;
   }
 
-  log.Log() << program_timer.GetTimeString() << " "
+  log.Log() << no_wrap << program_timer.GetTimeString() << " "
             << FormatKEigenFinalSummary("PI",
                                         k_eff,
                                         k_eff_change,

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/snes_k_monitor.cc
@@ -38,7 +38,7 @@ KEigenSNESMonitor(SNES snes, PetscInt iter, PetscReal rnorm, void* ctx)
     if (log.GetVerbosity() >= 2)
       out << ", detail = " << GetPETScConvergedReasonstring(linear_reason);
   }
-  log.Log() << program_timer.GetTimeString() << " " << out.str();
+  log.Log() << no_wrap << program_timer.GetTimeString() << " " << out.str();
 
   return 0;
 }
@@ -52,7 +52,7 @@ KEigenKSPMonitor(KSP /*ksp*/, PetscInt iter, PetscReal rnorm, void* ctx)
   iter_info << program_timer.GetTimeString() << " NLKE inner"
             << " iteration = " << iter;
   AppendNumericField(iter_info, "residual", rnorm, Scientific(6));
-  log.Log() << iter_info.str();
+  log.Log() << no_wrap << iter_info.str();
 
   return 0;
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/sweep_wgs_context.cc
@@ -115,19 +115,6 @@ SweepWGSContext::GetSystemSize()
     local_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.first;
   const auto global_size =
     global_node_count * num_moments * groupset_numgrps + num_delayed_psi_info.second;
-  const size_t num_angles = groupset.quadrature->GetNumAngles();
-  const size_t num_psi_global = global_node_count * num_angles * groupset.GetNumGroups();
-  const size_t num_delayed_psi_global = num_delayed_psi_info.second;
-
-  if (log_info)
-  {
-    log.Log() << "Total number of angular unknowns: " << num_psi_global << "\n"
-              << "Number of lagged angular unknowns: " << num_delayed_psi_global << "("
-              << std::setprecision(2)
-              << static_cast<double>(num_delayed_psi_global) * 100 /
-                   static_cast<double>(num_psi_global)
-              << "%)";
-  }
 
   return {static_cast<int64_t>(local_size), static_cast<int64_t>(global_size)};
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_convergence_test.cc
@@ -68,7 +68,7 @@ GSConvergenceTest(
   }
 
   if (context->log_info)
-    log.Log() << iter_info.str();
+    log.Log() << no_wrap << iter_info.str();
 
   return PETSC_SUCCESS;
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
@@ -260,7 +260,7 @@ WGSLinearSolver::PostSolveCallback()
     if (report_nonfatal and (gs_context_ptr->last_solve.status == IterationStatus::FAILED or
                              gs_context_ptr->last_solve.status == IterationStatus::LIMIT))
     {
-      log.Log() << program_timer.GetTimeString() << " "
+      log.Log() << no_wrap << program_timer.GetTimeString() << " "
                 << FormatIterationSummary("WGS groups [" + std::to_string(groupset.first_group) +
                                             "-" + std::to_string(groupset.last_group) + "]",
                                           gs_context_ptr->last_solve);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/wgs_linear_solver.cc
@@ -137,14 +137,6 @@ WGSLinearSolver::PreSolveCallback()
 {
   auto gs_context_ptr = std::dynamic_pointer_cast<WGSContext>(context_ptr_);
   gs_context_ptr->last_solve = {};
-  auto& groupset = gs_context_ptr->groupset;
-  auto& do_problem = gs_context_ptr->do_problem;
-  if (do_problem.GetOptions().verbose_inner_iterations)
-  {
-    log.Log() << "Solving groupset " << groupset.id << " with " << this->GetIterativeMethodName()
-              << " (groups " << groupset.first_group << "-" << groupset.last_group << ", "
-              << groupset.quadrature->GetNumAngles() << " angles)\n";
-  }
   gs_context_ptr->PreSolveCallback();
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/solvers/pi_keigen_solver.cc
@@ -215,7 +215,7 @@ PowerIterationKEigenSolver::Execute()
         MostSevereIterationStatus(ags_status, MostSevereIterationStatus(wgs_summaries));
       const auto outer_status =
         IterationStatusFromSolve(converged, nit >= max_iters_, inner_status);
-      log.Log() << program_timer.GetTimeString() << " "
+      log.Log() << no_wrap << program_timer.GetTimeString() << " "
                 << FormatKEigenOuterIteration("PI",
                                               nit,
                                               k_eff_,
@@ -250,7 +250,7 @@ PowerIterationKEigenSolver::Execute()
     total_num_sweeps += wgs_context->counter_applications_of_inv_op;
   }
 
-  log.Log() << program_timer.GetTimeString() << " "
+  log.Log() << no_wrap << program_timer.GetTimeString() << " "
             << FormatKEigenFinalSummary("PI",
                                         k_eff_,
                                         k_eff_change,

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -14,6 +14,7 @@
 #include "framework/data_types/allowable_range.h"
 #include "framework/utils/error.h"
 #include "framework/utils/caliper_scopes.h"
+#include "framework/utils/timer.h"
 #include "caliper/cali.h"
 #include <algorithm>
 #include <iomanip>
@@ -1008,7 +1009,7 @@ LBSProblem::InitializeSpatialDiscretization()
   OpenSnLogicalErrorIf(not discretization_,
                        GetName() + ": Missing spatial discretization. Construct the problem "
                                    "through its factory Create(...) entry point.");
-  log.Log() << "Initializing spatial discretization metadata.\n";
+  log.Log() << program_timer.GetTimeString() << " Initializing spatial discretization metadata.\n";
 
   ComputeUnitIntegrals();
 }
@@ -1018,7 +1019,7 @@ LBSProblem::ComputeUnitIntegrals()
 {
   CALI_CXX_MARK_SCOPE("UnitIntegrals");
 
-  log.Log() << "Computing unit integrals.\n";
+  log.Log() << program_timer.GetTimeString() << " Computing unit integrals.\n";
   const auto& sdm = *discretization_;
 
   const size_t num_local_cells = grid_->local_cells.size();
@@ -1041,9 +1042,9 @@ LBSProblem::ComputeUnitIntegrals()
   mpi_comm.all_reduce(num_local_ucms.data(), 2, num_global_ucms.data(), mpi::op::sum<size_t>());
 
   opensn::mpi_comm.barrier();
-  log.Log() << "Ghost cell unit cell-matrix ratio: "
+  log.Log() << program_timer.GetTimeString() << " Ghost cell unit cell-matrix ratio: "
             << (double)num_global_ucms[1] * 100 / (double)num_global_ucms[0] << "%";
-  log.Log() << "Cell matrices computed.";
+  log.Log() << program_timer.GetTimeString() << " Cell matrices computed.";
 }
 
 void
@@ -1051,7 +1052,7 @@ LBSProblem::InitializeParrays()
 {
   CALI_CXX_MARK_SCOPE("ParallelArrays");
 
-  log.Log() << "Initializing parallel arrays."
+  log.Log() << program_timer.GetTimeString() << " Initializing parallel arrays."
             << " G=" << num_groups_ << " M=" << num_moments_ << std::endl;
 
   // Initialize unknown
@@ -1173,7 +1174,7 @@ LBSProblem::InitializeParrays()
   grid_local_comm_set_ = grid_->MakeMPILocalCommunicatorSet();
 
   opensn::mpi_comm.barrier();
-  log.Log() << "Done with parallel arrays." << std::endl;
+  log.Log() << program_timer.GetTimeString() << " Done with parallel arrays." << std::endl;
 }
 
 #ifndef __OPENSN_WITH_GPU__


### PR DESCRIPTION
Adding `no_wrap` stream operator for log streams. This allows us to tell the logger not to auto wrap some output, making it easier to parse.