### PR TITLE
Sweep bugfixes

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
@@ -563,7 +563,8 @@ AAH_FLUDSCommonData::DeSerializeCellInfo(std::vector<CompactCellView>& cell_view
   num_face_dofs = (*face_indices)[0];
   auto num_cells = (*face_indices)[1];
 
-  cell_views.resize(num_cells);
+  cell_views.clear();
+  cell_views.reserve(num_cells);
 
   int k = 2;
   int64_t last_cell = -1;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
@@ -136,7 +136,7 @@ AAH_SPDS::ComputeLocalLocationEdgeWeights() const
   const int comm_size = opensn::mpi_comm.size();
   std::vector<double> row(comm_size, 0.0);
 
-  constexpr double tolerance = 1.0e-16;
+  constexpr double tolerance = FACE_ORIENTATION_TOLERANCE;
 
   for (const auto& cell : grid_->local_cells)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
@@ -378,7 +378,7 @@ SPDS::PopulateCellRelationships(
   std::vector<std::set<std::pair<std::uint32_t, double>>>& cell_successors)
 {
 
-  constexpr double tolerance = 1.0e-16;
+  constexpr double tolerance = FACE_ORIENTATION_TOLERANCE;
 
   constexpr auto FOPARALLEL = FaceOrientation::PARALLEL;
   constexpr auto FOINCOMING = FaceOrientation::INCOMING;
@@ -504,7 +504,7 @@ SPDS::PopulateCellRelationships(
 void
 SPDS::PrintGhostedGraph() const
 {
-  constexpr double tolerance = 1.0e-16;
+  constexpr double tolerance = FACE_ORIENTATION_TOLERANCE;
 
   for (int p = 0; p < opensn::mpi_comm.size(); ++p)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
@@ -15,6 +15,8 @@ class Cell;
 class SPDS;
 class MeshContinuum;
 
+inline constexpr double FACE_ORIENTATION_TOLERANCE = 1.0e-12;
+
 enum class FaceOrientation : short
 {
   PARALLEL = -1,


### PR DESCRIPTION
This PR fixes two minor sweep bugs:
1. The tolerance used to classify face orientation was too tight. A value of 1.0e-16 is near double-precision roundoff and small differences in dot-product calculations could classify faces differently on different ranks or in different code paths. Relaxing the tolerance to 1.0e-12.
2. Fixing a minor issue with vector sizing in cell serialization.