### PR TITLE
Moving AAH sweep restriction for PI acceleration into SMM and SCDSA.

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.cc
@@ -55,6 +55,18 @@ DiscreteOrdinatesKEigenAcceleration::DiscreteOrdinatesKEigenAcceleration(
     solver_(nullptr),
     name_(params.GetParamValue<std::string>("name"))
 {
+}
+
+void
+DiscreteOrdinatesKEigenAcceleration::Initialize(PowerIterationKEigenSolver& solver)
+{
+  solver_ = &solver;
+  Initialize();
+}
+
+void
+DiscreteOrdinatesKEigenAcceleration::CheckAAHSingleSweepStability() const
+{
   // If using the AAH solver with one sweep, a few iterations need to be done
   // to get rid of the junk in the unconverged lagged angular fluxes.  Five
   // sweeps is a guess at how many initial sweeps are necessary.
@@ -64,13 +76,6 @@ DiscreteOrdinatesKEigenAcceleration::DiscreteOrdinatesKEigenAcceleration(
                              "the presence of lagged angular fluxes.  Multiple sweeps are "
                              "allowed, however, the number of sweeps required to get sensible "
                              "results is not well studied and problem dependent.");
-}
-
-void
-DiscreteOrdinatesKEigenAcceleration::Initialize(PowerIterationKEigenSolver& solver)
-{
-  solver_ = &solver;
-  Initialize();
 }
 
 std::vector<uint64_t>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/discrete_ordinates_keigen_acceleration.h
@@ -102,6 +102,9 @@ protected:
   /// Copies back only the scalar moments to a lbs primary flux vector.
   void ProjectBackPhi0(const std::vector<double>& input, std::vector<double>& output) const;
 
+  /// Guard used by acceleration methods that are not stable with one AAH sweep.
+  void CheckAAHSingleSweepStability() const;
+
   /// The associated DiscreteOrdinatesProblem problem
   DiscreteOrdinatesProblem& do_problem_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/scdsa_acceleration.cc
@@ -51,6 +51,8 @@ SCDSAAcceleration::SCDSAAcceleration(const InputParameters& params)
 void
 SCDSAAcceleration::Initialize()
 {
+  CheckAAHSingleSweepStability();
+
   front_wgs_solver_ = do_problem_.GetWGSSolver(front_gs_.id);
   front_wgs_context_ = std::dynamic_pointer_cast<WGSContext>(front_wgs_solver_->GetContext());
   OpenSnLogicalErrorIf(not front_wgs_context_, ": Casting failed");

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/smm_acceleration.cc
@@ -64,6 +64,8 @@ SMMAcceleration::SMMAcceleration(const InputParameters& params)
 void
 SMMAcceleration::Initialize()
 {
+  CheckAAHSingleSweepStability();
+
   const auto& sdm = do_problem_.GetSpatialDiscretization();
   const auto num_groups = do_problem_.GetNumGroups();
   const auto num_gs_groups = front_gs_.GetNumGroups();


### PR DESCRIPTION
This sweep restriction doesn't apply to CMFD.