### PR TITLE
Fix SPMD_ThreadPool::ExecuteBatch to wake up worker threads

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/spmd_threadpool.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/scheduler/spmd_threadpool.h
@@ -96,6 +96,7 @@ public:
       for (std::size_t i = 0; i < n; ++i)
         ++epoch_states_[i].request;
     }
+    cv_start_.notify_all();
     WaitAll();
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.

This PR patches `SPMD_ThreadPool::ExecuteBatch` to wake up worker threads that depend upon `cv_start_`.