### PR TITLE
Fix `DiscreteOrdinatesProblem` solver/context destruction order

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -291,6 +291,9 @@ DiscreteOrdinatesProblem::DiscreteOrdinatesProblem(const InputParameters& params
 
 DiscreteOrdinatesProblem::~DiscreteOrdinatesProblem()
 {
+  ags_solver_.reset();
+  wgs_solvers_.clear();
+  wgs_contexts_.clear();
 
   ResetBoundaryCarrier();
 


### PR DESCRIPTION
Destroy AGS/WGS solvers before WGS contexts so PETSc pointers do not outlive contexts during Python cleanup.
