### PR TITLE
Performance improvements for WGDSA/TGDSA.

### DIFF
--- a/doc/source/userguide/cmfd_acceleration.rst
+++ b/doc/source/userguide/cmfd_acceleration.rst
@@ -198,9 +198,9 @@ defaults.
   CMFD corrections can be noisy; if it is too tight, coarse-solve work can
   dominate runtime.
 
-``coarse_solver_policy`` and ``direct_coarse_solve_threshold``
+``coarse_solver_policy`` and ``coarse_direct_solve_threshold``
   PETSc coarse-solver selection controls. ``"auto"`` uses a direct PETSc LU
-  solve for coarse systems below ``direct_coarse_solve_threshold`` global
+  solve for coarse systems below ``coarse_direct_solve_threshold`` global
   unknowns and an iterative GMRES/Jacobi solve otherwise. The default threshold
   is ``20000`` global unknowns. Force ``"direct"`` only for small or moderate
   coarse systems that fit comfortably in host memory. Use ``"iterative"`` when

--- a/doc/source/userguide/groupsets.rst
+++ b/doc/source/userguide/groupsets.rst
@@ -37,11 +37,15 @@ The main groupset fields exposed in the Python API are:
 * ``wgdsa_l_max_its``
 * ``wgdsa_verbose``
 * ``wgdsa_petsc_options``
+* ``wgdsa_solver_policy``
+* ``wgdsa_direct_solve_threshold``
 * ``apply_tgdsa``
 * ``tgdsa_l_abs_tol``
 * ``tgdsa_l_max_its``
 * ``tgdsa_verbose``
 * ``tgdsa_petsc_options``
+* ``tgdsa_solver_policy``
+* ``tgdsa_direct_solve_threshold``
 
 The simplest valid pattern is one groupset covering all groups:
 
@@ -303,10 +307,14 @@ with associated controls:
 * ``wgdsa_l_max_its``
 * ``wgdsa_verbose``
 * ``wgdsa_petsc_options``
+* ``wgdsa_solver_policy``
+* ``wgdsa_direct_solve_threshold``
 * ``tgdsa_l_abs_tol``
 * ``tgdsa_l_max_its``
 * ``tgdsa_verbose``
 * ``tgdsa_petsc_options``
+* ``tgdsa_solver_policy``
+* ``tgdsa_direct_solve_threshold``
 
 ``apply_wgdsa``
 ~~~~~~~~~~~~~~~
@@ -329,6 +337,15 @@ The main WGDSA controls are:
 * ``wgdsa_l_max_its``
 * ``wgdsa_verbose``
 * ``wgdsa_petsc_options``
+* ``wgdsa_solver_policy``
+* ``wgdsa_direct_solve_threshold``
+
+``wgdsa_solver_policy`` controls the PETSc solver setup for the WGDSA diffusion
+correction. ``"auto"`` uses a direct PETSc LU solve when the global WGDSA
+diffusion unknown count is at or below ``wgdsa_direct_solve_threshold`` and an
+iterative solve otherwise. ``"direct"`` and ``"iterative"`` force those paths,
+and ``"petsc_options"`` lets ``wgdsa_petsc_options`` define the KSP/PC setup.
+The default threshold is ``20000`` global unknowns.
 
 ``apply_tgdsa``
 ~~~~~~~~~~~~~~~
@@ -349,6 +366,12 @@ The main TGDSA controls are:
 * ``tgdsa_l_max_its``
 * ``tgdsa_verbose``
 * ``tgdsa_petsc_options``
+* ``tgdsa_solver_policy``
+* ``tgdsa_direct_solve_threshold``
+
+``tgdsa_solver_policy`` and ``tgdsa_direct_solve_threshold`` have the same
+meaning for the TGDSA diffusion correction solve that the corresponding WGDSA
+options have for WGDSA. The default threshold is ``20000`` global unknowns.
 
 When to think about DSA
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/userguide/iterative_methods.rst
+++ b/doc/source/userguide/iterative_methods.rst
@@ -78,11 +78,15 @@ These are specified inside each entry of ``groupsets=[...]``:
 - ``wgdsa_l_max_its``
 - ``wgdsa_verbose``
 - ``wgdsa_petsc_options``
+- ``wgdsa_solver_policy``
+- ``wgdsa_direct_solve_threshold``
 - ``apply_tgdsa``
 - ``tgdsa_l_abs_tol``
 - ``tgdsa_l_max_its``
 - ``tgdsa_verbose``
 - ``tgdsa_petsc_options``
+- ``tgdsa_solver_policy``
+- ``tgdsa_direct_solve_threshold``
 
 These settings control the solve performed within a single groupset.
 
@@ -497,10 +501,14 @@ with associated controls:
 - ``wgdsa_l_max_its``
 - ``wgdsa_verbose``
 - ``wgdsa_petsc_options``
+- ``wgdsa_solver_policy``
+- ``wgdsa_direct_solve_threshold``
 - ``tgdsa_l_abs_tol``
 - ``tgdsa_l_max_its``
 - ``tgdsa_verbose``
 - ``tgdsa_petsc_options``
+- ``tgdsa_solver_policy``
+- ``tgdsa_direct_solve_threshold``
 
 WGDSA
 -----
@@ -520,6 +528,13 @@ WGDSA controls:
 
 - ``wgdsa_l_abs_tol``: stopping tolerance for the diffusion correction solve
 - ``wgdsa_l_max_its``: hard cap on WGDSA iterations
+- ``wgdsa_solver_policy``: PETSc solver setup policy for the WGDSA diffusion
+  solve. ``"auto"`` uses direct PETSc LU for systems at or below
+  ``wgdsa_direct_solve_threshold`` global unknowns and an iterative solve
+  otherwise. ``"direct"``, ``"iterative"``, and ``"petsc_options"`` force a
+  specific path.
+- ``wgdsa_direct_solve_threshold``: maximum global WGDSA diffusion unknown count
+  for the automatic direct solve. The default is ``20000``.
 
 Reasonable values:
 
@@ -541,6 +556,10 @@ TGDSA controls:
 
 - ``tgdsa_l_abs_tol``: stopping tolerance for the two-grid diffusion solve
 - ``tgdsa_l_max_its``: hard cap on TGDSA iterations
+- ``tgdsa_solver_policy``: PETSc solver setup policy for the TGDSA diffusion
+  solve, with the same choices and behavior as ``wgdsa_solver_policy``.
+- ``tgdsa_direct_solve_threshold``: maximum global TGDSA diffusion unknown count
+  for the automatic direct solve. The default is ``20000``.
 
 Reasonable values:
 

--- a/modules/diffusion/diffusion.cc
+++ b/modules/diffusion/diffusion.cc
@@ -9,6 +9,7 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include "framework/utils/timer.h"
+#include "framework/utils/error.h"
 #include <sstream>
 
 namespace opensn
@@ -84,6 +85,7 @@ DiffusionSolver::~DiffusionSolver()
 {
   OpenSnPETScCall(MatDestroy(&A_));
   OpenSnPETScCall(VecDestroy(&rhs_));
+  OpenSnPETScCall(VecDestroy(&x_));
   OpenSnPETScCall(KSPDestroy(&ksp_));
 }
 
@@ -187,10 +189,11 @@ DiffusionSolver::Initialize()
   log.Log() << "Done vector creation";
   opensn::mpi_comm.barrier();
 
+  OpenSnPETScCall(VecDuplicate(rhs_, &x_));
+
   // Create KSP
   OpenSnPETScCall(KSPCreate(opensn::mpi_comm, &ksp_));
   OpenSnPETScCall(KSPSetOptionsPrefix(ksp_, name_.c_str()));
-  OpenSnPETScCall(KSPSetType(ksp_, KSPCG));
 
   OpenSnPETScCall(
     KSPSetTolerances(ksp_, 1.0e-50, options.residual_tolerance, 1.0e50, options.max_iters));
@@ -198,25 +201,42 @@ DiffusionSolver::Initialize()
   // Set Pre-conditioner
   PC pc = nullptr;
   OpenSnPETScCall(KSPGetPC(ksp_, &pc));
-  //  PCSetType(pc, PCGAMG);
-  OpenSnPETScCall(PCSetType(pc, PCHYPRE));
+  const bool petsc_options_policy = options.solver_policy == "petsc_options";
+  const bool direct_policy = options.solver_policy == "direct" or
+                             (options.solver_policy == "auto" and opensn::mpi_comm.size() == 1 and
+                              num_global_dofs_ <= options.direct_solve_threshold);
+  OpenSnInvalidArgumentIf(options.solver_policy != "auto" and options.solver_policy != "direct" and
+                            options.solver_policy != "iterative" and not petsc_options_policy,
+                          "Unsupported diffusion solver policy \"" + options.solver_policy +
+                            "\". Valid values are auto, direct, iterative, and petsc_options.");
 
-  OpenSnPETScCall(PCHYPRESetType(pc, "boomeramg"));
-  std::vector<std::string> pc_options = {"pc_hypre_boomeramg_agg_nl 1",
-                                         "pc_hypre_boomeramg_P_max 4",
-                                         "pc_hypre_boomeramg_grid_sweeps_coarse 1",
-                                         "pc_hypre_boomeramg_max_levels 25",
-                                         "pc_hypre_boomeramg_relax_type_all symmetric-SOR/Jacobi",
-                                         "pc_hypre_boomeramg_coarsen_type HMIS",
-                                         "pc_hypre_boomeramg_interp_type ext+i"};
+  if (not petsc_options_policy and direct_policy)
+  {
+    OpenSnPETScCall(KSPSetType(ksp_, KSPPREONLY));
+    OpenSnPETScCall(PCSetType(pc, PCLU));
+  }
+  else if (not petsc_options_policy)
+  {
+    OpenSnPETScCall(KSPSetType(ksp_, KSPCG));
+    OpenSnPETScCall(PCSetType(pc, PCHYPRE));
 
-  if (grid_->GetDimension() == 2)
-    pc_options.emplace_back("pc_hypre_boomeramg_strong_threshold 0.6");
-  else if (grid_->GetDimension() == 3)
-    pc_options.emplace_back("pc_hypre_boomeramg_strong_threshold 0.8");
+    OpenSnPETScCall(PCHYPRESetType(pc, "boomeramg"));
+    std::vector<std::string> pc_options = {"pc_hypre_boomeramg_agg_nl 1",
+                                           "pc_hypre_boomeramg_P_max 4",
+                                           "pc_hypre_boomeramg_grid_sweeps_coarse 1",
+                                           "pc_hypre_boomeramg_max_levels 25",
+                                           "pc_hypre_boomeramg_relax_type_all symmetric-SOR/Jacobi",
+                                           "pc_hypre_boomeramg_coarsen_type HMIS",
+                                           "pc_hypre_boomeramg_interp_type ext+i"};
 
-  for (const auto& option : pc_options)
-    OpenSnPETScCall(PetscOptionsInsertString(nullptr, ("-" + name_ + option).c_str()));
+    if (grid_->GetDimension() == 2)
+      pc_options.emplace_back("pc_hypre_boomeramg_strong_threshold 0.6");
+    else if (grid_->GetDimension() == 3)
+      pc_options.emplace_back("pc_hypre_boomeramg_strong_threshold 0.8");
+
+    for (const auto& option : pc_options)
+      OpenSnPETScCall(PetscOptionsInsertString(nullptr, ("-" + name_ + option).c_str()));
+  }
 
   OpenSnPETScCall(PetscOptionsInsertString(nullptr, options.additional_options_string.c_str()));
 
@@ -228,9 +248,7 @@ void
 DiffusionSolver::Solve(std::vector<double>& solution, bool use_initial_guess)
 {
   const std::string fname = "acceleration::DiffusionMIPSolver::Solve";
-  Vec x = nullptr;
-  OpenSnPETScCall(VecDuplicate(rhs_, &x));
-  OpenSnPETScCall(VecSet(x, 0.0));
+  OpenSnPETScCall(VecSet(x_, 0.0));
 
   if (not use_initial_guess)
     OpenSnPETScCall(KSPSetInitialGuessNonzero(ksp_, PETSC_FALSE));
@@ -257,40 +275,35 @@ DiffusionSolver::Solve(std::vector<double>& solution, bool use_initial_guess)
   if (use_initial_guess)
   {
     PetscScalar* x_raw = nullptr;
-    OpenSnPETScCall(VecGetArray(x, &x_raw));
+    OpenSnPETScCall(VecGetArray(x_, &x_raw));
     size_t k = 0;
     for (const auto& value : solution)
       x_raw[k++] = value;
-    OpenSnPETScCall(VecRestoreArray(x, &x_raw));
+    OpenSnPETScCall(VecRestoreArray(x_, &x_raw));
   }
 
   // Solve
-  OpenSnPETScCall(KSPSolve(ksp_, rhs_, x));
+  OpenSnPETScCall(KSPSolve(ksp_, rhs_, x_));
 
   // Print convergence info
   if (options.verbose)
-    LogDiffusionSolveFinal(name_, ksp_, x);
+    LogDiffusionSolveFinal(name_, ksp_, x_);
 
   // Transfer petsc solution to vector
   if (requires_ghosts_)
   {
-    CommunicateGhostEntries(x);
-    sdm_.LocalizePETScVectorWithGhosts(x, solution, uk_man_);
+    CommunicateGhostEntries(x_);
+    sdm_.LocalizePETScVectorWithGhosts(x_, solution, uk_man_);
   }
   else
-    sdm_.LocalizePETScVector(x, solution, uk_man_);
-
-  // Cleanup x
-  OpenSnPETScCall(VecDestroy(&x));
+    sdm_.LocalizePETScVector(x_, solution, uk_man_);
 }
 
 void
 DiffusionSolver::Solve(Vec petsc_solution, bool use_initial_guess)
 {
   const std::string fname = "acceleration::DiffusionMIPSolver::Solve";
-  Vec x = nullptr;
-  OpenSnPETScCall(VecDuplicate(rhs_, &x));
-  OpenSnPETScCall(VecSet(x, 0.0));
+  OpenSnPETScCall(VecSet(x_, 0.0));
 
   if (not use_initial_guess)
     OpenSnPETScCall(KSPSetInitialGuessNonzero(ksp_, PETSC_FALSE));
@@ -316,21 +329,18 @@ DiffusionSolver::Solve(Vec petsc_solution, bool use_initial_guess)
 
   if (use_initial_guess)
   {
-    OpenSnPETScCall(VecCopy(petsc_solution, x));
+    OpenSnPETScCall(VecCopy(petsc_solution, x_));
   }
 
   // Solve
-  OpenSnPETScCall(KSPSolve(ksp_, rhs_, x));
+  OpenSnPETScCall(KSPSolve(ksp_, rhs_, x_));
 
   // Print convergence info
   if (options.verbose)
-    LogDiffusionSolveFinal(name_, ksp_, x);
+    LogDiffusionSolveFinal(name_, ksp_, x_);
 
   // Transfer petsc solution to vector
-  OpenSnPETScCall(VecCopy(x, petsc_solution));
-
-  // Cleanup x
-  OpenSnPETScCall(VecDestroy(&x));
+  OpenSnPETScCall(VecCopy(x_, petsc_solution));
 }
 
 } // namespace opensn

--- a/modules/diffusion/diffusion.h
+++ b/modules/diffusion/diffusion.h
@@ -33,6 +33,8 @@ public:
     bool verbose = false;
     /// For debugging only (very expensive)
     bool perform_symmetry_check = false;
+    std::string solver_policy = "auto";
+    PetscInt direct_solve_threshold = 20000;
     std::string additional_options_string;
     double penalty_factor = 4.0;
   } options;
@@ -122,6 +124,7 @@ protected:
 
   Mat A_ = nullptr;
   Vec rhs_ = nullptr;
+  Vec x_ = nullptr;
   KSP ksp_ = nullptr;
 
   const bool requires_ghosts_;

--- a/modules/diffusion/diffusion_mip_solver.cc
+++ b/modules/diffusion/diffusion_mip_solver.cc
@@ -612,6 +612,7 @@ DiffusionMIPSolver::AssembleAand_b(const std::vector<double>& q_vector)
     DenseMatrix<double> cell_A(num_nodes, num_nodes);
     Vector<double> cell_rhs(num_nodes);
     Vector<PetscInt> cell_idxs(num_nodes);
+    std::vector<double> qg(num_nodes, 0.0);
     for (unsigned int g = 0; g < num_groups; ++g)
     {
       cell_A.Set(0.);
@@ -623,7 +624,6 @@ DiffusionMIPSolver::AssembleAand_b(const std::vector<double>& q_vector)
       const double Dg = xs.Dg[g];
       const double sigr_g = xs.sigR[g];
 
-      std::vector<double> qg(num_nodes, 0.0);
       for (size_t j = 0; j < num_nodes; ++j)
         qg[j] = q_vector[sdm_.MapDOFLocal(cell, j, uk_man_, 0, g)];
 
@@ -905,6 +905,7 @@ DiffusionMIPSolver::Assemble_b(const std::vector<double>& q_vector)
 
     Vector<double> cell_rhs(num_nodes);
     Vector<PetscInt> cell_idxs(num_nodes);
+    std::vector<double> qg(num_nodes, 0.0);
     for (unsigned int g = 0; g < num_groups; ++g)
     {
       cell_rhs.Set(0.);
@@ -914,7 +915,6 @@ DiffusionMIPSolver::Assemble_b(const std::vector<double>& q_vector)
       // Get coefficient and nodal src
       const double Dg = xs.Dg[g];
 
-      std::vector<double> qg(num_nodes, 0.0);
       for (size_t j = 0; j < num_nodes; ++j)
         qg[j] = q_vector[sdm_.MapDOFLocal(cell, j, uk_man_, 0, g)];
 
@@ -1059,6 +1059,7 @@ DiffusionMIPSolver::Assemble_b(Vec petsc_q_vector)
 
     Vector<double> cell_rhs(num_nodes);
     Vector<PetscInt> cell_idxs(num_nodes);
+    std::vector<double> qg(num_nodes, 0.0);
     for (unsigned int g = 0; g < num_groups; ++g)
     {
       cell_rhs.Set(0.);
@@ -1068,7 +1069,6 @@ DiffusionMIPSolver::Assemble_b(Vec petsc_q_vector)
       // Get coefficient and nodal src
       const double Dg = xs.Dg[g];
 
-      std::vector<double> qg(num_nodes, 0.0);
       for (size_t j = 0; j < num_nodes; ++j)
         qg[j] = q_vector[sdm_.MapDOFLocal(cell, j, uk_man_, 0, g)];
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/cmfd_acceleration.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/cmfd_acceleration.cc
@@ -196,10 +196,10 @@ CMFDAcceleration::GetInputParameters()
     "coarse_solver_policy",
     "auto",
     "[developer/debug] CMFD coarse solver policy. auto chooses direct PETSc LU below "
-    "direct_coarse_solve_threshold global unknowns and iterative GMRES/Jacobi otherwise. "
+    "coarse_direct_solve_threshold global unknowns and iterative GMRES/Jacobi otherwise. "
     "direct, iterative, and petsc_options force a specific path. CMFD corrections from "
     "unconverged coarse linear solves are always skipped.");
-  params.AddOptionalParameter("direct_coarse_solve_threshold",
+  params.AddOptionalParameter("coarse_direct_solve_threshold",
                               20000,
                               "[developer/debug] Maximum global CMFD unknown count for using the "
                               "direct PETSc LU path when coarse_solver_policy is auto. Larger "
@@ -223,7 +223,7 @@ CMFDAcceleration::GetInputParameters()
   params.ConstrainParameterRange("update_wgs_max_its", AllowableRangeLowLimit::New(1));
   params.ConstrainParameterRange("update_wgs_abs_tol", AllowableRangeLowLimit::New(1.0e-18));
   params.ConstrainParameterRange("balance_residual_tolerance", AllowableRangeLowLimit::New(0.0));
-  params.ConstrainParameterRange("direct_coarse_solve_threshold", AllowableRangeLowLimit::New(1));
+  params.ConstrainParameterRange("coarse_direct_solve_threshold", AllowableRangeLowLimit::New(1));
   params.ChangeExistingParamToOptional("name", "CMFDAcceleration");
   params.ChangeExistingParamToOptional(
     "l_abs_tol", 1.0e-7, "[developer/debug] Absolute residual tolerance for CMFD coarse solves.");
@@ -274,8 +274,8 @@ CMFDAcceleration::CMFDAcceleration(const InputParameters& params)
     update_wgs_abs_tol_(params.GetParamValue<double>("update_wgs_abs_tol")),
     balance_residual_tolerance_(params.GetParamValue<double>("balance_residual_tolerance")),
     coarse_solver_policy_(params.GetParamValue<std::string>("coarse_solver_policy")),
-    direct_coarse_solve_threshold_(
-      static_cast<std::size_t>(params.GetParamValue<int>("direct_coarse_solve_threshold"))),
+    coarse_direct_solve_threshold_(
+      static_cast<std::size_t>(params.GetParamValue<int>("coarse_direct_solve_threshold"))),
     num_groups_(do_problem_.GetNumGroups()),
     num_coarse_groups_((num_groups_ + group_aggregation_size_ - 1) / group_aggregation_size_),
     current_closure_blend_(current_closure_ == "partial" ? 1.0 : 0.0)
@@ -672,7 +672,7 @@ CMFDAcceleration::PostPowerIteration()
     k_eff = transport_k_eff;
     const bool can_switch_to_direct = coarse_solver_policy_ == "auto" and
                                       not using_direct_coarse_solver_ and
-                                      GlobalUnknownCount() <= direct_coarse_solve_threshold_;
+                                      GlobalUnknownCount() <= coarse_direct_solve_threshold_;
     if (can_switch_to_direct)
     {
       ConfigureCoarseLinearSolver(true);
@@ -996,7 +996,7 @@ CMFDAcceleration::InitializeLinearSystem()
   const bool petsc_options_policy = coarse_solver_policy_ == "petsc_options";
   using_direct_coarse_solver_ =
     coarse_solver_policy_ == "direct" or
-    (coarse_solver_policy_ == "auto" and GlobalUnknownCount() <= direct_coarse_solve_threshold_);
+    (coarse_solver_policy_ == "auto" and GlobalUnknownCount() <= coarse_direct_solve_threshold_);
   if (not petsc_options_policy)
     ConfigureCoarseLinearSolver(using_direct_coarse_solver_);
   OpenSnPETScCall(KSPSetTolerances(ksp_, l_abs_tol_, PETSC_DEFAULT, PETSC_DEFAULT, max_iters_));

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/cmfd_acceleration.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/cmfd_acceleration.h
@@ -143,7 +143,7 @@ private:
   const double update_wgs_abs_tol_;
   const double balance_residual_tolerance_;
   const std::string coarse_solver_policy_;
-  const std::size_t direct_coarse_solve_threshold_;
+  const std::size_t coarse_direct_solve_threshold_;
   const unsigned int first_group_ = 0;
   const unsigned int num_groups_;
   const unsigned int num_coarse_groups_;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/tgdsa.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/tgdsa.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "caliper/cali.h"
+#include <algorithm>
 
 namespace opensn
 {
@@ -62,6 +63,8 @@ TGDSA::Init(DiscreteOrdinatesProblem& do_problem, LBSGroupset& groupset)
 
     solver->options.residual_tolerance = groupset.tgdsa_tol;
     solver->options.max_iters = groupset.tgdsa_max_iters;
+    solver->options.solver_policy = groupset.tgdsa_solver_policy;
+    solver->options.direct_solve_threshold = groupset.tgdsa_direct_solve_threshold;
     solver->options.verbose = groupset.tgdsa_verbose;
     solver->options.additional_options_string = groupset.tgdsa_string;
 
@@ -91,8 +94,10 @@ TGDSA::AssembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
   const auto gss = groupset.GetNumGroups();
 
   auto local_node_count = do_problem.GetLocalNodeCount();
-  delta_phi_local.clear();
-  delta_phi_local.assign(local_node_count, 0.0);
+  if (delta_phi_local.size() != local_node_count)
+    delta_phi_local.assign(local_node_count, 0.0);
+  else
+    std::fill(delta_phi_local.begin(), delta_phi_local.end(), 0.0);
 
   for (const auto& cell : grid->local_cells)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/acceleration/wgdsa.cc
@@ -5,6 +5,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "caliper/cali.h"
+#include <algorithm>
 
 namespace opensn
 {
@@ -47,6 +48,8 @@ WGDSA::Init(DiscreteOrdinatesProblem& do_problem,
 
     solver->options.residual_tolerance = groupset.wgdsa_tol;
     solver->options.max_iters = groupset.wgdsa_max_iters;
+    solver->options.solver_policy = groupset.wgdsa_solver_policy;
+    solver->options.direct_solve_threshold = groupset.wgdsa_direct_solve_threshold;
     solver->options.verbose = groupset.wgdsa_verbose;
     solver->options.additional_options_string = groupset.wgdsa_string;
 
@@ -76,8 +79,11 @@ WGDSA::AssembleDeltaPhiVector(DiscreteOrdinatesProblem& do_problem,
   const auto gsi = groupset.first_group;
   const auto gss = groupset.GetNumGroups();
 
-  delta_phi_local.clear();
-  delta_phi_local.assign(sdm.GetNumLocalDOFs(dphi_uk_man), 0.0);
+  const auto num_delta_phi_dofs = sdm.GetNumLocalDOFs(dphi_uk_man);
+  if (delta_phi_local.size() != num_delta_phi_dofs)
+    delta_phi_local.assign(num_delta_phi_dofs, 0.0);
+  else
+    std::fill(delta_phi_local.begin(), delta_phi_local.end(), 0.0);
 
   for (const auto& cell : grid->local_cells)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/iterative_methods/classic_richardson.cc
@@ -18,6 +18,7 @@
 #include "framework/runtime.h"
 #include "caliper/cali.h"
 #include <memory>
+#include <vector>
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbs_dsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbs_dsa_preconditioner.cc
@@ -10,6 +10,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/vecops/lbs_vecops.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "caliper/cali.h"
+#include <vector>
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/preconditioning/lbsmip_tgdsa_preconditioner.cc
@@ -8,6 +8,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/diffusion/diffusion_mip_solver.h"
 #include "caliper/cali.h"
+#include <vector>
 
 namespace opensn
 {

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
@@ -58,6 +58,16 @@ LBSGroupset::GetInputParameters()
   params.AddOptionalParameter(
     "wgdsa_l_abs_tol", 1.0e-4, "Within-group DSA linear absolute tolerance");
   params.AddOptionalParameter("wgdsa_l_max_its", 30, "Within-group DSA linear maximum iterations");
+  params.AddOptionalParameter("wgdsa_solver_policy",
+                              "auto",
+                              "Within-group DSA diffusion solver policy. auto uses a serial "
+                              "direct PETSc LU solve below wgdsa_direct_solve_threshold global "
+                              "unknowns and iterative CG/BoomerAMG otherwise. direct, iterative, "
+                              "and petsc_options force a specific path.");
+  params.AddOptionalParameter("wgdsa_direct_solve_threshold",
+                              20000,
+                              "Maximum global unknown count for the automatic WGDSA direct PETSc "
+                              "LU path.");
   params.AddOptionalParameter(
     "wgdsa_verbose", false, "If true, WGDSA routines will print verbosely");
   params.AddOptionalParameter("wgdsa_petsc_options", "", "PETSc options to pass to WGDSA solver");
@@ -67,6 +77,16 @@ LBSGroupset::GetInputParameters()
     "apply_tgdsa", false, "Flag to turn on Two-Grid Acceleration for this groupset");
   params.AddOptionalParameter("tgdsa_l_abs_tol", 1.0e-4, "Two-Grid DSA linear absolute tolerance");
   params.AddOptionalParameter("tgdsa_l_max_its", 30, "Two-Grid DSA linear maximum iterations");
+  params.AddOptionalParameter("tgdsa_solver_policy",
+                              "auto",
+                              "Two-grid DSA diffusion solver policy. auto uses a serial direct "
+                              "PETSc LU solve below tgdsa_direct_solve_threshold global unknowns "
+                              "and iterative CG/BoomerAMG otherwise. direct, iterative, and "
+                              "petsc_options force a specific path.");
+  params.AddOptionalParameter("tgdsa_direct_solve_threshold",
+                              20000,
+                              "Maximum global unknown count for the automatic TGDSA direct PETSc "
+                              "LU path.");
   params.AddOptionalParameter(
     "tgdsa_verbose", false, "If true, TGDSA routines will print verbosely");
   params.AddOptionalParameter("tgdsa_petsc_options", "", "PETSc options to pass to TGDSA solver");
@@ -82,6 +102,14 @@ LBSGroupset::GetInputParameters()
   params.ConstrainParameterRange("l_abs_tol", AllowableRangeLowLimit::New(1.0e-18));
   params.ConstrainParameterRange("l_max_its", AllowableRangeLowLimit::New(0));
   params.ConstrainParameterRange("gmres_restart_interval", AllowableRangeLowLimit::New(1));
+  params.ConstrainParameterRange(
+    "wgdsa_solver_policy",
+    AllowableRangeList::New({"auto", "direct", "iterative", "petsc_options"}));
+  params.ConstrainParameterRange(
+    "tgdsa_solver_policy",
+    AllowableRangeList::New({"auto", "direct", "iterative", "petsc_options"}));
+  params.ConstrainParameterRange("wgdsa_direct_solve_threshold", AllowableRangeLowLimit::New(1));
+  params.ConstrainParameterRange("tgdsa_direct_solve_threshold", AllowableRangeLowLimit::New(1));
 
   return params;
 }
@@ -111,6 +139,10 @@ LBSGroupset::Init(int aid)
   tgdsa_max_iters = 30;
   wgdsa_tol = 1.0e-4;
   tgdsa_tol = 1.0e-4;
+  wgdsa_solver_policy = "auto";
+  tgdsa_solver_policy = "auto";
+  wgdsa_direct_solve_threshold = 20000;
+  tgdsa_direct_solve_threshold = 20000;
   wgdsa_verbose = false;
   tgdsa_verbose = false;
   wgdsa_solver = nullptr;
@@ -184,6 +216,11 @@ LBSGroupset::LBSGroupset( // NOLINT(cppcoreguidelines-pro-type-member-init)
 
   wgdsa_max_iters = params.GetParamValue<unsigned int>("wgdsa_l_max_its");
   tgdsa_max_iters = params.GetParamValue<unsigned int>("tgdsa_l_max_its");
+
+  wgdsa_solver_policy = params.GetParamValue<std::string>("wgdsa_solver_policy");
+  tgdsa_solver_policy = params.GetParamValue<std::string>("tgdsa_solver_policy");
+  wgdsa_direct_solve_threshold = params.GetParamValue<unsigned int>("wgdsa_direct_solve_threshold");
+  tgdsa_direct_solve_threshold = params.GetParamValue<unsigned int>("tgdsa_direct_solve_threshold");
 
   wgdsa_verbose = params.GetParamValue<bool>("wgdsa_verbose");
   tgdsa_verbose = params.GetParamValue<bool>("tgdsa_verbose");

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.h
@@ -83,6 +83,10 @@ public:
   unsigned int tgdsa_max_iters;
   double wgdsa_tol;
   double tgdsa_tol;
+  std::string wgdsa_solver_policy;
+  std::string tgdsa_solver_policy;
+  unsigned int wgdsa_direct_solve_threshold;
+  unsigned int tgdsa_direct_solve_threshold;
   bool wgdsa_verbose;
   bool tgdsa_verbose;
   std::string wgdsa_string;

--- a/python/lib/solver.cc
+++ b/python/lib/solver.cc
@@ -727,6 +727,13 @@ WrapLBS(py::module& slv)
               Verbose WGDSA output.
           - wgdsa_petsc_options: str, default=''
               PETSc options string for the WGDSA solver.
+          - wgdsa_solver_policy: {'auto', 'direct', 'iterative', 'petsc_options'}, default='auto'
+              WGDSA diffusion solver policy. ``auto`` uses a direct PETSc LU solve below
+              ``wgdsa_direct_solve_threshold`` global unknowns and an iterative solve
+              otherwise. ``petsc_options`` lets ``wgdsa_petsc_options`` control the
+              PETSc KSP/PC setup.
+          - wgdsa_direct_solve_threshold: int, default=20000
+              Maximum global WGDSA diffusion unknown count for the automatic direct solve.
           - apply_tgdsa: bool, default=False
               Enable two-grid DSA for this groupset.
           - tgdsa_l_abs_tol: float, default=1.0e-4
@@ -737,6 +744,13 @@ WrapLBS(py::module& slv)
               Verbose TGDSA output.
           - tgdsa_petsc_options: str, default=''
               PETSc options string for the TGDSA solver.
+          - tgdsa_solver_policy: {'auto', 'direct', 'iterative', 'petsc_options'}, default='auto'
+              TGDSA diffusion solver policy. ``auto`` uses a direct PETSc LU solve below
+              ``tgdsa_direct_solve_threshold`` global unknowns and an iterative solve
+              otherwise. ``petsc_options`` lets ``tgdsa_petsc_options`` control the
+              PETSc KSP/PC setup.
+          - tgdsa_direct_solve_threshold: int, default=20000
+              Maximum global TGDSA diffusion unknown count for the automatic direct solve.
     xs_map : List[Dict], default=[]
         A list of mappings from block ids to cross-section definitions. Each dictionary supports:
           - block_ids: List[int] (required)
@@ -1214,6 +1228,13 @@ WrapLBS(py::module& slv)
               Verbose WGDSA output.
           - wgdsa_petsc_options: str, default=''
               PETSc options string for the WGDSA solver.
+          - wgdsa_solver_policy: {'auto', 'direct', 'iterative', 'petsc_options'}, default='auto'
+              WGDSA diffusion solver policy. ``auto`` uses a direct PETSc LU solve below
+              ``wgdsa_direct_solve_threshold`` global unknowns and an iterative solve
+              otherwise. ``petsc_options`` lets ``wgdsa_petsc_options`` control the
+              PETSc KSP/PC setup.
+          - wgdsa_direct_solve_threshold: int, default=20000
+              Maximum global WGDSA diffusion unknown count for the automatic direct solve.
           - apply_tgdsa: bool, default=False
               Enable two-grid DSA for this groupset.
           - tgdsa_l_abs_tol: float, default=1.0e-4
@@ -1223,6 +1244,14 @@ WrapLBS(py::module& slv)
           - tgdsa_verbose: bool, default=False
               Verbose TGDSA output.
           - tgdsa_petsc_options: str, default=''
+              PETSc options string for the TGDSA solver.
+          - tgdsa_solver_policy: {'auto', 'direct', 'iterative', 'petsc_options'}, default='auto'
+              TGDSA diffusion solver policy. ``auto`` uses a direct PETSc LU solve below
+              ``tgdsa_direct_solve_threshold`` global unknowns and an iterative solve
+              otherwise. ``petsc_options`` lets ``tgdsa_petsc_options`` control the
+              PETSc KSP/PC setup.
+          - tgdsa_direct_solve_threshold: int, default=20000
+              Maximum global TGDSA diffusion unknown count for the automatic direct solve.
     xs_map : list of dict
         A list of mappings from block ids to cross-section definitions. Each dictionary supports:
           - block_ids: List[int] (required)
@@ -2135,7 +2164,7 @@ WrapDiscreteOrdinatesKEigenAcceleration(py::module& slv)
         iterations.
     coarse_solver_policy: str, default="auto"
         Developer/debug. Coarse solver policy. Valid choices are:
-            - 'auto' : PETSc preonly+LU below ``direct_coarse_solve_threshold``
+            - 'auto' : PETSc preonly+LU below ``coarse_direct_solve_threshold``
               global unknowns, GMRES+Jacobi otherwise
             - 'direct' : PETSc preonly+LU
             - 'iterative' : GMRES+Jacobi
@@ -2144,7 +2173,7 @@ WrapDiscreteOrdinatesKEigenAcceleration(py::module& slv)
         The skipped correction uses the unaccelerated transport update for that power
         iteration; after repeated skipped corrections, CMFD returns the raw transport
         k update so that power iteration can continue to move.
-    direct_coarse_solve_threshold: int, default=20000
+    coarse_direct_solve_threshold: int, default=20000
         Developer/debug. Maximum global CMFD unknown count for automatic direct coarse
         solves when ``coarse_solver_policy="auto"``. Larger values make ``"auto"`` use
         direct solves for larger coarse systems; choose values based on available host

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/tests.json
@@ -1255,28 +1255,21 @@
     "checks": [
       {
         "type": "StrCompare",
-        "key": "WGS groups [0-62] iteration = 22",
-        "wordnum": 18,
-        "gold": "converged"
+        "key": "AGS iteration = 52",
+        "wordnum": 16,
+        "gold": "converged;"
       },
       {
         "type": "StrCompare",
-        "key": "WGS groups [63-167] iteration = 59",
-        "wordnum": 18,
+        "key": "AGS iteration = 52",
+        "wordnum": 20,
         "gold": "converged"
       },
       {
         "type": "FloatCompare",
-        "key": "WGS groups [0-62] iteration = 22",
-        "wordnum": 13,
-        "gold": 9.6079e-08,
-        "abs_tol": 1e-09
-      },
-      {
-        "type": "FloatCompare",
-        "key": "WGS groups [63-167] iteration = 59",
-        "wordnum": 13,
-        "gold": 4.73732e-07,
+        "key": "AGS iteration = 52",
+        "wordnum": 11,
+        "gold": 9.454622e-07,
         "abs_tol": 1e-09
       }
     ]
@@ -1554,6 +1547,38 @@
         "key": "BOUNDARY_MUTATION_MAX_DIFF=",
         "goldvalue": 0.0,
         "abs_tol": 5.0e-8
+      }
+    ]
+  },
+  {
+    "file": "transport_2d_dsa_compare.py",
+    "comment": "Compare WGDSA/TGDSA accelerated fixed-source solutions against unaccelerated transport",
+    "num_procs": 4,
+    "weight_class": "intermediate",
+    "checks": [
+      {
+        "type": "KeyValuePair",
+        "key": "WGDSA_DIFF_G39=",
+        "goldvalue": 0.0,
+        "abs_tol": 1.0e-6
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "WGDSA_DIFF_G120=",
+        "goldvalue": 0.0,
+        "abs_tol": 1.0e-6
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "WGDSA_TGDSA_DIFF_G39=",
+        "goldvalue": 0.0,
+        "abs_tol": 1.0e-6
+      },
+      {
+        "type": "KeyValuePair",
+        "key": "WGDSA_TGDSA_DIFF_G120=",
+        "goldvalue": 0.0,
+        "abs_tol": 1.0e-6
       }
     ]
   }

--- a/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_dsa_compare.py
+++ b/test/python/modules/linear_boltzmann_solvers/transport_steady/transport_2d_dsa_compare.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+if "opensn_console" not in globals():
+    from mpi4py import MPI
+
+    size = MPI.COMM_WORLD.size
+    rank = MPI.COMM_WORLD.rank
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../")))
+    from pyopensn.mesh import OrthogonalMeshGenerator
+    from pyopensn.xs import MultiGroupXS
+    from pyopensn.source import VolumetricSource
+    from pyopensn.aquad import GLCProductQuadrature2DXY
+    from pyopensn.solver import DiscreteOrdinatesProblem, SteadyStateSourceSolver
+    from pyopensn.logvol import RPPLogicalVolume
+    from pyopensn.fieldfunc import FieldFunctionInterpolationVolume
+
+
+def make_grid():
+    n = 8
+    length = 100.0
+    xmin = -0.5 * length
+    dx = length / n
+    nodes = [xmin + i * dx for i in range(n + 1)]
+    grid = OrthogonalMeshGenerator(node_sets=[nodes, nodes]).Execute()
+    grid.SetUniformBlockID(0)
+    cavity = RPPLogicalVolume(xmin=-10.0, xmax=10.0, ymin=-10.0, ymax=10.0, infz=True)
+    grid.SetBlockIDFromLogicalVolume(cavity, 1, True)
+    return grid
+
+
+def solve(mode):
+    num_groups = 168
+    use_wgdsa = mode in ("wgdsa", "wgdsa_tgdsa")
+    use_tgdsa = mode == "wgdsa_tgdsa"
+
+    xs_graphite = MultiGroupXS()
+    xs_graphite.LoadFromOpenSn("../../../../assets/xs/xs_graphite_pure.xs")
+    xs_air = MultiGroupXS()
+    xs_air.LoadFromOpenSn("../../../../assets/xs/xs_air50RH.xs")
+
+    graphite_source = [0.0] * num_groups
+    graphite_source[0] = 1.0
+    air_source = [0.0] * num_groups
+
+    quad = GLCProductQuadrature2DXY(n_polar=2, n_azimuthal=4, scattering_order=1)
+    common = {
+        "angular_quadrature": quad,
+        "angle_aggregation_num_subsets": 1,
+        "inner_linear_method": "petsc_gmres",
+        "l_abs_tol": 1.0e-8,
+        "l_max_its": 1000,
+        "gmres_restart_interval": 30,
+        "apply_wgdsa": use_wgdsa,
+        "wgdsa_l_abs_tol": 1.0e-8,
+        "wgdsa_l_max_its": 200,
+        "wgdsa_solver_policy": "auto",
+    }
+
+    problem = DiscreteOrdinatesProblem(
+        mesh=make_grid(),
+        num_groups=num_groups,
+        groupsets=[
+            dict(common, **{"groups_from_to": [0, 62]}),
+            dict(
+                common,
+                **{
+                    "groups_from_to": [63, num_groups - 1],
+                    "apply_tgdsa": use_tgdsa,
+                    "tgdsa_l_abs_tol": 1.0e-8,
+                    "tgdsa_l_max_its": 200,
+                    "tgdsa_solver_policy": "auto",
+                },
+            ),
+        ],
+        xs_map=[
+            {"block_ids": [0], "xs": xs_graphite},
+            {"block_ids": [1], "xs": xs_air},
+        ],
+        volumetric_sources=[
+            VolumetricSource(block_ids=[0], group_strength=graphite_source),
+            VolumetricSource(block_ids=[1], group_strength=air_source),
+        ],
+        options={
+            "max_ags_iterations": 100,
+            "ags_tolerance": 1.0e-8,
+            "ags_convergence_check": "pointwise",
+            "verbose_inner_iterations": False,
+        },
+    )
+
+    solver = SteadyStateSourceSolver(problem=problem)
+    solver.Initialize()
+    solver.Execute()
+
+    volume = RPPLogicalVolume(infx=True, infy=True, infz=True)
+    fields = problem.GetScalarFluxFieldFunction()
+    values = []
+    for group in (39, 120):
+        interp = FieldFunctionInterpolationVolume()
+        interp.SetOperationType("max")
+        interp.SetLogicalVolume(volume)
+        interp.SetFieldFunction(fields[group])
+        interp.Execute()
+        value = interp.GetValue()
+        values.append(value)
+    return values
+
+
+if __name__ == "__main__":
+    if size != 4:
+        sys.exit(f"Expected 4 ranks, got {size}.")
+
+    reference = solve("none")
+    wgdsa = solve("wgdsa")
+    wgdsa_tgdsa = solve("wgdsa_tgdsa")
+
+    if rank == 0:
+        for i, group in enumerate((39, 120)):
+            print(f"WGDSA_DIFF_G{group}={abs(wgdsa[i] - reference[i]):.12e}")
+            print(f"WGDSA_TGDSA_DIFF_G{group}={abs(wgdsa_tgdsa[i] - reference[i]):.12e}")


### PR DESCRIPTION
This PR adds WGDSA/TGDSA solver options with automatic direct/iterative selection. This is analogous to the solver option for CMFD. The user can now choose between direct or iterative solvers or set the unknown threshold for `auto` to automatically switch between the two.  In addition, this PR adds reuse of the diffusion solver vectors and correction storage to reduce the overall number of accelerator allocations.

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.
