### PR TITLE
Update scaling tests

### DIFF
--- a/tools/scaling/generate_scaling_study.py
+++ b/tools/scaling/generate_scaling_study.py
@@ -19,6 +19,9 @@ gmsh_binary = "gmsh"
 opensn_binary = base_dir.parents[1] / "build/python/opensn"
 """Path to the OpenSn binary. Default is '../../../build/python/opensn'."""
 
+suffix = ""
+"""Suffix appended to the output folder to distincguish between different binary versions."""
+
 strong_divisor = 39
 """Divisor for Gmsh to control mesh resolution for strong scaling study (default: 39)."""
 
@@ -32,7 +35,7 @@ weak_divisors = [15, 19, 24, 31, 39, 49, 62, 78, 98, 124]
 nodes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 """List of node counts to generate job files for."""
 
-ncores = 64
+ncores = 0
 """
 Number of CPU cores available per node.
 
@@ -63,6 +66,9 @@ extra_data = {
     "name": "dane",
     "description": "LLNL Dane (64 rpn)"
 }
+"""
+Extra data describing the run in history file.
+"""
 
 if __name__ == "__main__":
 
@@ -90,6 +96,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    if ncores == 0:
+        raise ValueError("Please specify the number of CPU cores per node.")
     if args.processor == "gpu" and ngpus == 0:
         raise ValueError("Please specify the number of GPUs per node.")
 
@@ -100,6 +108,7 @@ if __name__ == "__main__":
 
     inputs = {
         "opensn_binary": opensn_binary,
+        "suffix": suffix,
         "gmsh_binary": gmsh_binary,
         "geo_filename": geo_filename,
         "ncores": ncores,

--- a/tools/scaling/lib/__init__.py
+++ b/tools/scaling/lib/__init__.py
@@ -94,7 +94,12 @@ def generate_strong_scaling(nodes, **kwargs):
     # copy necessary files to output directory
     processor = kwargs["processor"]
     engine = kwargs["engine"]
-    out_dir = base_dir.parent / "output" / f"strong_{processor}"
+    suffix = kwargs["suffix"]
+    if suffix:
+        out_name = f"strong_{processor}_{suffix}"
+    else:
+        out_name = f"strong_{processor}"
+    out_dir = base_dir.parent / "output" / out_name
     os.makedirs(out_dir, exist_ok=True)
     shutil.copyfile(
         base_dir / "xs_168g.xs",
@@ -151,7 +156,12 @@ def generate_weak_scaling(nodes, divisors, **kwargs):
     # copy necessary files to output directory
     processor = kwargs["processor"]
     engine = kwargs["engine"]
-    out_dir = base_dir.parent / "output" / f"weak_{processor}"
+    suffix = kwargs["suffix"]
+    if suffix:
+        out_name = f"weak_{processor}_{suffix}"
+    else:
+        out_name = f"weak_{processor}"
+    out_dir = base_dir.parent / "output" / out_name
     os.makedirs(out_dir, exist_ok=True)
     shutil.copyfile(
         base_dir / "xs_168g.xs",

--- a/tools/scaling/lib/flux_template.txt
+++ b/tools/scaling/lib/flux_template.txt
@@ -10,5 +10,6 @@
 {{gpu_options}}
 {% endif %}
 cd {{outdir}}
+export OPENSN_NUM_THREADS={{n_cores}}
 flux run -n {{n_nodes * n_tasks}} -c {{n_cores}} {{opensn_binary}} -i {{input_script}}
 

--- a/tools/scaling/lib/pbs_template.txt
+++ b/tools/scaling/lib/pbs_template.txt
@@ -13,6 +13,7 @@
 {{environment}}
 {% endif -%}
 cd {{outdir}}
+export OPENSN_NUM_THREADS={{n_cores}}
 mpiexec -n {{n_nodes * n_tasks}} \
 {% if processor == "gpu" -%}
   --ppn {{n_tasks}} \

--- a/tools/scaling/lib/slurm_template.txt
+++ b/tools/scaling/lib/slurm_template.txt
@@ -10,5 +10,6 @@
 {{gpu_options}}
 {% endif %}
 cd {{outdir}}
+export OPENSN_NUM_THREADS={{n_cores}}
 srun -n {{n_nodes * n_tasks}} -c {{n_cores}} {{opensn_binary}} -i {{input_script}}
 


### PR DESCRIPTION
This PR adds `export OPENSN_NUM_THREADS=` into the launch script for correctly handle threadpool.

It also adds `suffix` into the input generating script so user can launch in parallel multiple versions of the opensn binary.

Example:

```
# build main
>>> git checkout main
>>> cmake -S . -B build-main
opensn_binary = base_dir.parents[1] / "build-main/python/opensn"
suffix = "main"  # scaling inputs written to strong_cpu_main

# build test
>>> git checkout test
>>> cmake -S . -B build-test
opensn_binary = base_dir.parents[1] / "build-test/python/opensn"
suffix = "test"  # scaling inputs written to strong_cpu_test
```

## PR Checklist

- [x] I have updated the user guide and/or Python API documentation if necessary.
