### PR TITLE
Performance improvements for initializing sweep data structures.

### DIFF
--- a/framework/mesh/cell/cell.h
+++ b/framework/mesh/cell/cell.h
@@ -94,6 +94,9 @@ public:
     return value_ != std::numeric_limits<std::uint64_t>::max();
   }
 
+  /// Return the packed 64-bit value (cell|face|node) for hashing.
+  constexpr std::uint64_t GetValue() const { return value_; }
+
 private:
   /// Core value.
   std::uint64_t value_ = std::numeric_limits<std::uint64_t>::max();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -1317,16 +1317,12 @@ DiscreteOrdinatesProblem::InitializeSweepDataStructures()
 {
   CALI_CXX_MARK_SCOPE("SweepDataStructures");
 
-  log.Log() << program_timer.GetTimeString() << " Initializing sweep datastructures.\n";
-
   auto sweep_runtime = BuildSweepRuntime(
     GetName(), groupsets_, grid_, sweep_type_, use_gpus_, *discretization_, grid_nodal_mappings_);
 
   quadrature_unq_so_grouping_map_ = std::move(sweep_runtime.quadrature_unq_so_grouping_map);
   quadrature_spds_map_ = std::move(sweep_runtime.quadrature_spds_map);
   quadrature_fluds_commondata_map_ = std::move(sweep_runtime.quadrature_fluds_commondata_map);
-
-  log.Log() << program_timer.GetTimeString() << " Done initializing sweep datastructures.\n";
 }
 
 #ifndef __OPENSN_WITH_GPU__

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/io/discrete_ordinates_problem_io.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "hdf5.h"
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicate_location_dependencies.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicate_location_dependencies.cc
@@ -39,4 +39,65 @@ CommunicateLocationDependencies(const std::vector<int>& location_dependencies,
   }
 }
 
+std::vector<std::vector<std::vector<int>>>
+BatchCommunicateLocationDependencies(const std::vector<std::vector<int>>& local_deps)
+{
+  const int num_ranks = opensn::mpi_comm.size();
+  const int num_spds = static_cast<int>(local_deps.size());
+  const auto num_spds_size = static_cast<size_t>(num_spds);
+
+  std::vector<std::vector<std::vector<int>>> result(num_spds,
+                                                    std::vector<std::vector<int>>(num_ranks));
+
+  if (num_spds == 0)
+    return result;
+
+  // All-gather dependency counts for every SPDS
+  std::vector<int> local_counts(num_spds);
+  for (int s = 0; s < num_spds; ++s)
+    local_counts[s] = static_cast<int>(local_deps[s].size());
+
+  std::vector<int> all_counts(static_cast<size_t>(num_ranks) * num_spds_size);
+  mpi_comm.all_gather(local_counts.data(), num_spds, all_counts.data(), num_spds);
+
+  // Concatenate all local dependency vectors in a single flat send buffer
+  std::vector<int> flat_deps;
+  int total = 0;
+  for (int s = 0; s < num_spds; ++s)
+    total += local_counts[s];
+  flat_deps.reserve(total);
+  for (int s = 0; s < num_spds; ++s)
+    flat_deps.insert(flat_deps.end(), local_deps[s].begin(), local_deps[s].end());
+
+  // Compute per-rank receive counts and displacements for all_gatherv
+  std::vector<int> recv_counts(num_ranks), recv_displs(num_ranks, 0);
+  for (int r = 0; r < num_ranks; ++r)
+  {
+    int sz = 0;
+    for (int s = 0; s < num_spds; ++s)
+      sz += all_counts[static_cast<size_t>(r) * num_spds_size + static_cast<size_t>(s)];
+    recv_counts[r] = sz;
+  }
+  for (int r = 1; r < num_ranks; ++r)
+    recv_displs[r] = recv_displs[r - 1] + recv_counts[r - 1];
+
+  const int total_recv = recv_displs[num_ranks - 1] + recv_counts[num_ranks - 1];
+  std::vector<int> all_flat_deps(total_recv);
+  mpi_comm.all_gather(flat_deps, all_flat_deps, recv_counts, recv_displs);
+
+  // Unpack result[s][r] into dependencies for SPDS s on rank r
+  for (int r = 0; r < num_ranks; ++r)
+  {
+    int offset = recv_displs[r];
+    for (int s = 0; s < num_spds; ++s)
+    {
+      const int cnt = all_counts[static_cast<size_t>(r) * num_spds_size + static_cast<size_t>(s)];
+      result[s][r].assign(all_flat_deps.begin() + offset, all_flat_deps.begin() + offset + cnt);
+      offset += cnt;
+    }
+  }
+
+  return result;
+}
+
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds.cc
@@ -30,9 +30,13 @@ AAH_FLUDS::AAH_FLUDS(unsigned int num_groups,
                      const AAH_FLUDSCommonData& common_data)
   : FLUDS(num_groups, num_angles, common_data.GetSPDS()),
     common_data_(common_data),
-    delayed_local_psi_Gn_block_strideG_(common_data_.delayed_local_psi_Gn_block_stride_ *
-                                        num_groups_)
+    delayed_local_psi_Gn_block_strideG_(0)
 {
+  if (not common_data_.IsFinalized())
+    throw std::logic_error("AAH FLUDS common data must be finalized before use");
+
+  delayed_local_psi_Gn_block_strideG_ =
+    common_data_.delayed_local_psi_Gn_block_stride_ * num_groups_;
 
   // Adjusting for different group aggregate
   for (const auto& val : common_data_.local_psi_n_block_stride_)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.cc
@@ -8,12 +8,23 @@
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
 #include <algorithm>
+#include <memory>
+#include <unordered_set>
 #include <utility>
 
 namespace opensn
 {
 
 using LockBox = std::vector<std::pair<std::optional<uint64_t>, short>>;
+
+std::unique_ptr<AAH_FLUDSCommonData>
+AAH_FLUDSCommonData::MakeAlpha(const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,
+                               const SPDS& spds,
+                               const GridFaceHistogram& grid_face_histogram)
+{
+  return std::unique_ptr<AAH_FLUDSCommonData>(
+    new AAH_FLUDSCommonData(grid_nodal_mappings, spds, grid_face_histogram));
+}
 
 AAH_FLUDSCommonData::AAH_FLUDSCommonData(
   const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,
@@ -22,7 +33,15 @@ AAH_FLUDSCommonData::AAH_FLUDSCommonData(
   : FLUDSCommonData(spds, grid_nodal_mappings)
 {
   this->InitializeAlphaElements(spds, grid_face_histogram);
+}
+
+void
+AAH_FLUDSCommonData::FinalizeBeta(const SPDS& spds)
+{
+  if (finalized_)
+    throw std::logic_error("AAH FLUDS common data has already been finalized");
   this->InitializeBetaElements(spds); // NOLINT
+  finalized_ = true;
 }
 
 void
@@ -45,8 +64,9 @@ AAH_FLUDSCommonData::InitializeAlphaElements(const SPDS& spds,
   size_t num_of_deplocs = spds.GetLocationSuccessors().size();
   deplocI_face_dof_count_.resize(num_of_deplocs, 0);
   deplocI_cell_views_.resize(num_of_deplocs);
+  deploc_i_cell_idx_.resize(num_of_deplocs);
 
-  // PERFORM SLOT DYNAMICS
+  // Perform slot dynamics
   // Loop over cells in sweep order
 
   // Given a local cell index, gives the so index
@@ -74,7 +94,6 @@ AAH_FLUDSCommonData::InitializeAlphaElements(const SPDS& spds,
   } // for csoi
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Done with Slot Dynamics.";
-  opensn::mpi_comm.barrier();
 
   // PERFORM INCIDENT MAPPING
   // Loop over cells in sweep order
@@ -101,7 +120,6 @@ AAH_FLUDSCommonData::InitializeAlphaElements(const SPDS& spds,
   delayed_local_psi_Gn_block_strideG_ = delayed_local_psi_Gn_block_stride_ * /*G=*/1;
 
   log.Log(Logger::LOG_LVL::LOG_0VERBOSE_2) << "Done with Local Incidence mapping.";
-  opensn::mpi_comm.barrier();
 
   // Clean up
   so_cell_outb_face_slot_indices_.shrink_to_fit();
@@ -284,27 +302,20 @@ AAH_FLUDSCommonData::AddFaceViewToDepLocI(int deplocI,
                                           uint64_t face_slot,
                                           const CellFace& face)
 {
-
-  // Check if cell is already there
-  bool cell_already_there = false;
-  for (auto& cell_view : deplocI_cell_views_[deplocI])
+  auto& idx_map = deploc_i_cell_idx_[deplocI];
+  auto it = idx_map.find(cell_g_index);
+  if (it != idx_map.end())
   {
-    if (cell_view.first == cell_g_index)
-    {
-      cell_already_there = true;
-      cell_view.second.emplace_back(face_slot, face.vertex_ids);
-      break;
-    }
+    deplocI_cell_views_[deplocI][it->second].second.emplace_back(face_slot, face.vertex_ids);
   }
-
-  // If the cell is not there yet
-  if (not cell_already_there)
+  else
   {
+    const size_t pos = deplocI_cell_views_[deplocI].size();
     CompactCellView new_cell_view;
     new_cell_view.first = cell_g_index;
     new_cell_view.second.emplace_back(face_slot, face.vertex_ids);
-
-    deplocI_cell_views_[deplocI].push_back(new_cell_view);
+    deplocI_cell_views_[deplocI].push_back(std::move(new_cell_view));
+    idx_map.emplace(cell_g_index, pos);
   }
 }
 
@@ -478,21 +489,30 @@ AAH_FLUDSCommonData::InitializeBetaElements(const SPDS& spds, int tag_index /*=0
   multi_face_indices.clear();
   multi_face_indices.shrink_to_fit();
 
-  // In the next process we loop over cells in the sweep order and perform
-  // the non-local face mappings. This is dependent on having the compact
-  // cellviews on the partition interfaces.
+  // Map each cell id directly to its entry in the incoming cell views
+  std::vector<std::unordered_map<uint64_t, size_t>> preloc_i_idx(prelocI_cell_views_.size());
+  for (size_t pi = 0; pi < prelocI_cell_views_.size(); ++pi)
+    for (size_t c = 0; c < prelocI_cell_views_[pi].size(); ++c)
+      preloc_i_idx[pi].emplace(prelocI_cell_views_[pi][c].first, c);
 
-  // Loop over cells in sorder
+  std::vector<std::unordered_map<uint64_t, size_t>> dpreloc_i_idx(
+    delayed_prelocI_cell_views_.size());
+  for (size_t pi = 0; pi < delayed_prelocI_cell_views_.size(); ++pi)
+    for (size_t c = 0; c < delayed_prelocI_cell_views_[pi].size(); ++c)
+      dpreloc_i_idx[pi].emplace(delayed_prelocI_cell_views_[pi][c].first, c);
+
   for (auto csoi = 0; csoi < spls.size(); ++csoi)
   {
     auto cell_local_index = spls[csoi];
     const auto& cell = grid->local_cells[cell_local_index];
 
-    NonLocalIncidentMapping(cell, spds);
-  } // for csoi
+    NonLocalIncidentMapping(cell, spds, preloc_i_idx, dpreloc_i_idx);
+  }
 
   deplocI_cell_views_.clear();
   deplocI_cell_views_.shrink_to_fit();
+  deploc_i_cell_idx_.clear();
+  deploc_i_cell_idx_.shrink_to_fit();
 
   prelocI_cell_views_.clear();
   prelocI_cell_views_.shrink_to_fit();
@@ -500,7 +520,7 @@ AAH_FLUDSCommonData::InitializeBetaElements(const SPDS& spds, int tag_index /*=0
   delayed_prelocI_cell_views_.clear();
   delayed_prelocI_cell_views_.shrink_to_fit();
 
-  // Clear unneccesary data
+  // Clear unnecessary data
   auto empty_vector = std::vector<std::vector<CompactCellView>>(0);
   deplocI_cell_views_.swap(empty_vector);
 
@@ -609,7 +629,11 @@ AAH_FLUDSCommonData::DeSerializeCellInfo(std::vector<CompactCellView>& cell_view
 }
 
 void
-AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
+AAH_FLUDSCommonData::NonLocalIncidentMapping(
+  const Cell& cell,
+  const SPDS& spds,
+  const std::vector<std::unordered_map<uint64_t, size_t>>& preloc_i_idx,
+  const std::vector<std::unordered_map<uint64_t, size_t>>& dpreloc_i_idx)
 {
 
   const auto grid = spds.GetGrid();
@@ -629,19 +653,15 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
         auto locJ = face.GetNeighborPartitionID(grid.get());
         auto prelocI = spds.MapLocJToPrelocI(locJ);
 
+        // Build vertex set once per face. It is reused in both the prelocI and delayed branches.
+        const std::unordered_set<uint64_t> cfvid_set(face.vertex_ids.begin(),
+                                                     face.vertex_ids.end());
+
         if (prelocI >= 0)
         {
-          // Find the cell in prelocI cell views
-          int adj_cell = -1;
-          for (auto c = 0; c < prelocI_cell_views_[prelocI].size(); ++c)
-          {
-            if (std::cmp_equal(prelocI_cell_views_[prelocI][c].first, face.neighbor_id))
-            {
-              adj_cell = c;
-              break;
-            }
-          }
-          if (adj_cell < 0)
+          // Find the cell in prelocI cell views via hash lookup
+          const auto cell_it = preloc_i_idx[prelocI].find(face.neighbor_id);
+          if (cell_it == preloc_i_idx[prelocI].end())
           {
             std::ostringstream oss;
             oss << "AAH_FLUDSCommonData: Required predecessor cell not found in call to "
@@ -650,22 +670,25 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
                 << ")";
             throw std::runtime_error(oss.str());
           }
+          const size_t adj_cell = cell_it->second;
 
-          // Find associated face
-          std::set<uint64_t> cfvids(face.vertex_ids.begin(), face.vertex_ids.end());
+          // Find associated face via vertex-set membership
           CompactCellView* adj_cell_view = &prelocI_cell_views_[prelocI][adj_cell];
           int adj_face_idx = -1, af = -1;
-          for (auto& adj_face : adj_cell_view->second)
+          for (const auto& adj_face : adj_cell_view->second)
           {
             ++af;
-            bool face_matches = true;
-
-            std::set<uint64_t> afvids(adj_face.second.begin(), adj_face.second.end());
-
-            if (cfvids != afvids)
-              face_matches = false;
-
-            if (face_matches)
+            const auto& afvids = adj_face.second;
+            if (afvids.size() != face.vertex_ids.size())
+              continue;
+            bool match = true;
+            for (uint64_t vid : afvids)
+              if (!cfvid_set.count(vid))
+              {
+                match = false;
+                break;
+              }
+            if (match)
             {
               adj_face_idx = af;
               break;
@@ -712,17 +735,9 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
         else
         {
           int delayed_preLocI = abs(prelocI) - 1;
-          // Find the cell in prelocI cell views
-          int ass_cell = -1;
-          for (auto c = 0; c < delayed_prelocI_cell_views_[delayed_preLocI].size(); ++c)
-          {
-            if (delayed_prelocI_cell_views_[delayed_preLocI][c].first == face.neighbor_id)
-            {
-              ass_cell = c;
-              break;
-            }
-          }
-          if (ass_cell < 0)
+          // Find the cell via hash lookup
+          const auto dcell_it = dpreloc_i_idx[delayed_preLocI].find(face.neighbor_id);
+          if (dcell_it == dpreloc_i_idx[delayed_preLocI].end())
           {
             std::ostringstream oss;
             oss << "AAH_FLUDSCommonData: Required predecessor cell not located in call to "
@@ -731,35 +746,26 @@ AAH_FLUDSCommonData::NonLocalIncidentMapping(const Cell& cell, const SPDS& spds)
                 << ", cell = " << face.neighbor_id << ")";
             throw std::runtime_error(oss.str());
           }
+          const size_t ass_cell = dcell_it->second;
 
-          // Find associated face
+          // Find associated face via vertex-set membership (same cfvid_set built above)
           CompactCellView* adj_cell_view = &delayed_prelocI_cell_views_[delayed_preLocI][ass_cell];
           int adj_face_idx = -1;
-          for (auto af = 0; af < adj_cell_view->second.size(); ++af)
+          for (size_t af = 0; af < adj_cell_view->second.size(); ++af)
           {
-            bool face_matches = true;
-            for (auto afv = 0; afv < adj_cell_view->second[af].second.size(); ++afv)
-            {
-              bool match_found = false;
-              for (auto fv = 0; fv < face.vertex_ids.size(); ++fv)
+            const auto& afvids = adj_cell_view->second[af].second;
+            if (afvids.size() != face.vertex_ids.size())
+              continue;
+            bool match = true;
+            for (uint64_t vid : afvids)
+              if (!cfvid_set.count(vid))
               {
-                if (adj_cell_view->second[af].second[afv] == face.vertex_ids[fv])
-                {
-                  match_found = true;
-                  break;
-                }
-              }
-
-              if (not match_found)
-              {
-                face_matches = false;
+                match = false;
                 break;
               }
-            }
-
-            if (face_matches)
+            if (match)
             {
-              adj_face_idx = af;
+              adj_face_idx = static_cast<int>(af);
               break;
             }
           }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aah_fluds_common_data.h
@@ -5,8 +5,10 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/fluds_common_data.h"
 #include <set>
+#include <unordered_map>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 namespace opensn
@@ -27,6 +29,13 @@ class SPDS;
 class AAH_FLUDSCommonData : public FLUDSCommonData
 {
 public:
+  /// Construct alpha phase only (local work, no MPI). Call FinalizeBeta() afterwards.
+  /// MakeAlpha() prevents us from holding an unfinalized object.
+  static std::unique_ptr<AAH_FLUDSCommonData>
+  MakeAlpha(const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,
+            const SPDS& spds,
+            const GridFaceHistogram& grid_face_histogram);
+
   struct INCOMING_FACE_INFO
   {
     int slot_address = 0;
@@ -41,10 +50,17 @@ public:
 
     ~INCOMING_FACE_INFO() = default;
   }; // TODO: Make common
-public:
+private:
   explicit AAH_FLUDSCommonData(const std::vector<CellFaceNodalMapping>& grid_nodal_mappings,
                                const SPDS& spds,
                                const GridFaceHistogram& grid_face_histogram);
+
+public:
+  /// Complete SPDS construction. Exchange inter-rank face data via MPI. This routine must be
+  /// called sequentially across all SPDS in the same order on all ranks after the constructor.
+  void FinalizeBeta(const SPDS& spds);
+
+  bool IsFinalized() const { return finalized_; }
 
 protected:
   friend class AAH_FLUDS;
@@ -87,6 +103,8 @@ protected:
    * Cleared after beta-pass.
    */
   std::vector<std::vector<CompactCellView>> deplocI_cell_views_;
+  std::vector<std::unordered_map<uint64_t, size_t>> deploc_i_cell_idx_;
+  bool finalized_ = false;
 
   /**
    * This is a vector [cell_sweep_order_index][outgoing_face_count] which holds the slot address in
@@ -135,7 +153,11 @@ private:
 
   void InitializeBetaElements(const SPDS& spds, int tag_index = 0);
 
-  void NonLocalIncidentMapping(const Cell& cell, const SPDS& spds);
+  void
+  NonLocalIncidentMapping(const Cell& cell,
+                          const SPDS& spds,
+                          const std::vector<std::unordered_map<uint64_t, size_t>>& preloc_i_idx,
+                          const std::vector<std::unordered_map<uint64_t, size_t>>& dpreloc_i_idx);
 
   std::vector<std::vector<INCOMING_FACE_INFO>> so_cell_inco_face_dof_indices_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <queue>
 #include <set>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,23 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonDelayedLocalFaces(const SpatialDiscr
   const MeshContinuum& grid = *(spds_.GetGrid());
   std::vector<AAHD_DirectedEdgeNode> local_node_stack;
   std::queue<std::uint64_t> idle_slots;
+
+  // Store the stack slots that provide incoming data to each downstream cell. This lets us find a
+  // cell's incoming slots directly instead of searching the entire stack. A slot remains valid
+  // until its downstream cell is processed, because that is the only time the slot is released.
+  std::unordered_map<std::uint32_t, std::vector<std::uint64_t>> downwind_index;
+  downwind_index.reserve(grid.local_cells.size());
+
+  // Place a directed edge node at the stack_index and register it in downwind_index.
+  auto RegisterNode = [&](std::uint64_t stack_index, const AAHD_DirectedEdgeNode& new_node)
+  {
+    downwind_index[new_node.downwind_node.GetCellIndex()].push_back(stack_index);
+    node_tracker_.emplace(new_node.upwind_node,
+                          AAHD_NodeIndex(stack_index, true, false, true, false));
+    node_tracker_.emplace(new_node.downwind_node,
+                          AAHD_NodeIndex(stack_index, false, false, true, false));
+  };
+
   for (const std::vector<std::uint32_t>& level : topological_levels)
   {
     std::queue<std::uint64_t> level_idle_slots;
@@ -49,34 +67,33 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonDelayedLocalFaces(const SpatialDiscr
     for (const auto& cell_local_idx : level)
     {
       std::queue<std::uint64_t> cell_idle_slots;
-      // push incoming face nodes in the cell's queue of idle slots
-      for (std::uint32_t i_node = 0; i_node < local_node_stack.size(); ++i_node)
+      // Collect idle slots for this cell
+      auto it = downwind_index.find(cell_local_idx);
+      if (it != downwind_index.end())
       {
-        AAHD_DirectedEdgeNode& node = local_node_stack[i_node];
-        if (node.IsInitialized() && node.downwind_node.GetCellIndex() == cell_local_idx)
+        for (std::uint64_t pos : it->second)
         {
-          cell_idle_slots.push(i_node);
-          node = AAHD_DirectedEdgeNode();
+          cell_idle_slots.push(pos);
+          local_node_stack[pos] = AAHD_DirectedEdgeNode();
         }
+        it->second.clear();
       }
-      // build a list of outgoing nodes for the current cell
+      // Build a list of outgoing nodes for the current cell
       const Cell& cell = grid.local_cells[cell_local_idx];
       std::vector<AAHD_DirectedEdgeNode> new_outgoing_nodes;
       for (std::uint32_t f = 0; f < cell.faces.size(); ++f)
       {
-        // get data of the face
         const CellFace& face = cell.faces[f];
         const FaceOrientation& orientation = spds_.GetCellFaceOrientations()[cell_local_idx][f];
         const FaceNodalMapping& face_nodal_mapping = grid_nodal_mappings_[cell_local_idx][f];
-        // skip if the face is not outgoing face or the neighbor cell is not a local one
+        // Skip if the face is not outgoing or its neighbor is not local
         if (orientation != FaceOrientation::OUTGOING || !(face.IsNeighborLocal(&grid)))
           continue;
-        // check if the face is not in the FAS
+        // Check if the face is not in the FAS
         std::uint32_t neighbor_local_idx = face.GetNeighborLocalID(&grid);
         if (fas_edges.contains(
               std::pair<std::uint32_t, std::uint32_t>(cell_local_idx, neighbor_local_idx)))
           continue;
-        // for each node on the face, initialize face node
         std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
         for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
         {
@@ -88,45 +105,35 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonDelayedLocalFaces(const SpatialDiscr
           new_outgoing_nodes.push_back(new_node);
         }
       }
-      // insert new outgoing nodes into the stack
+      // Insert new outgoing nodes into the stack
       for (const AAHD_DirectedEdgeNode& new_node : new_outgoing_nodes)
       {
         std::uint64_t stack_index = std::numeric_limits<std::uint64_t>::max();
-        // check for cell idle slots first
         if (!cell_idle_slots.empty())
         {
           stack_index = cell_idle_slots.front();
           cell_idle_slots.pop();
           local_node_stack[stack_index] = new_node;
         }
-        // then check for idle slots
         else if (!idle_slots.empty())
         {
           stack_index = idle_slots.front();
           idle_slots.pop();
           local_node_stack[stack_index] = new_node;
         }
-        // otherwise, expand the stack
         else
         {
           stack_index = local_node_stack.size();
           local_node_stack.push_back(new_node);
         }
-        // record the stack index
-        node_tracker_.emplace(new_node.upwind_node,
-                              AAHD_NodeIndex(stack_index, true, false, true, false));
-        node_tracker_.emplace(new_node.downwind_node,
-                              AAHD_NodeIndex(stack_index, false, false, true, false));
-        ++stack_index;
+        RegisterNode(stack_index, new_node);
       }
-      // merge cell idle slots to level idle slots
       while (!cell_idle_slots.empty())
       {
         level_idle_slots.push(cell_idle_slots.front());
         cell_idle_slots.pop();
       }
     }
-    // merge level idle slots to idle slots
     while (!level_idle_slots.empty())
     {
       idle_slots.push(level_idle_slots.front());
@@ -181,28 +188,27 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForDelayedLocalFaces(const SpatialDiscreti
 void
 AAHD_FLUDSCommonData::ComputeNodeIndexForNonLocalFaces(const SpatialDiscretization& sdm)
 {
-  // get reference to the mesh
   const MeshContinuum& grid = *(spds_.GetGrid());
-  // initialize index for boundary nodes and banks for tracking non-local nodes for each location
-  std::vector<std::set<AAHD_NonLocalFaceNode>> incoming_bank, delayed_incoming_bank, outgoing_bank;
+  // Sort each bank before assigning node indices so that index ordering is deterministic. Face
+  // nodes are unique, so the banks do not require duplicate removal.
+  std::vector<std::vector<AAHD_NonLocalFaceNode>> incoming_bank, delayed_incoming_bank,
+    outgoing_bank;
   incoming_bank.resize(spds_.GetLocationDependencies().size());
   delayed_incoming_bank.resize(spds_.GetDelayedLocationDependencies().size());
   outgoing_bank.resize(spds_.GetLocationSuccessors().size());
-  std::uint64_t incremental_boundary_index = 0;
-  // loop for each cell and isolate the non-local neighbor or boundary faces
+  // Loop over cells and isolate the non-local neighbor or boundary faces
   for (const Cell& cell : grid.local_cells)
   {
     for (std::uint32_t f = 0; f < cell.faces.size(); ++f)
     {
-      // get face data
       const CellFace& face = cell.faces[f];
       const FaceOrientation& orientation = spds_.GetCellFaceOrientations()[cell.local_id][f];
       const FaceNodalMapping& face_nodal_mapping = grid_nodal_mappings_[cell.local_id][f];
       std::uint32_t num_face_nodes = sdm.GetCellMapping(cell).GetNumFaceNodes(f);
-      // skip for local face and boundary face
+      // Skip for local face and boundary face
       if (face.IsNeighborLocal(&grid) or not face.has_neighbor)
         continue;
-      // store non-local face nodes to the banks
+      // Store non-local face nodes
       std::vector<AAHD_NonLocalFaceNode> nl_en_vec(num_face_nodes);
       for (std::uint32_t fnode = 0; fnode < num_face_nodes; ++fnode)
       {
@@ -214,33 +220,41 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonLocalFaces(const SpatialDiscretizati
                                                  face_nodal_mapping.associated_face_,
                                                  face_nodal_mapping.face_node_mapping_.at(fnode));
       }
-      // get neighbor partition ID
       int loc = face.GetNeighborPartitionID(&grid);
-      // append to incoming bank
       if (orientation == FaceOrientation::INCOMING)
       {
         int preloc = spds_.MapLocJToPrelocI(loc);
-        // non-delayed incoming
+        // Non-delayed incoming
         if (preloc >= 0)
         {
-          incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
+          incoming_bank[preloc].insert(
+            incoming_bank[preloc].end(), nl_en_vec.begin(), nl_en_vec.end());
         }
-        // delayed incoming
+        // Delayed incoming
         else
         {
           preloc = -preloc - 1;
-          delayed_incoming_bank[preloc].insert(nl_en_vec.begin(), nl_en_vec.end());
+          delayed_incoming_bank[preloc].insert(
+            delayed_incoming_bank[preloc].end(), nl_en_vec.begin(), nl_en_vec.end());
         }
       }
-      // append to outgoing bank
+      // Append to outgoing bank
       else if (orientation == FaceOrientation::OUTGOING)
       {
         int deploc = spds_.MapLocJToDeplocI(loc);
-        outgoing_bank[deploc].insert(nl_en_vec.begin(), nl_en_vec.end());
+        outgoing_bank[deploc].insert(
+          outgoing_bank[deploc].end(), nl_en_vec.begin(), nl_en_vec.end());
       }
     }
   }
-  // for each bank, loop in lexicographic order and retrieve the index
+  // Sort each bank
+  for (auto& bank : incoming_bank)
+    std::sort(bank.begin(), bank.end());
+  for (auto& bank : delayed_incoming_bank)
+    std::sort(bank.begin(), bank.end());
+  for (auto& bank : outgoing_bank)
+    std::sort(bank.begin(), bank.end());
+  // For each bank, loop in lexicographic order and retrieve the index
   std::uint64_t node_index = 0;
   for (std::uint32_t loc_idx = 0; loc_idx < incoming_bank.size(); ++loc_idx)
   {
@@ -268,29 +282,29 @@ AAHD_FLUDSCommonData::ComputeNodeIndexForNonLocalFaces(const SpatialDiscretizati
       node_index++;
     }
   }
-  // store size
+  // Store size
   std::size_t cumulative_offset = 0;
   nonlocal_incoming_node_offsets_ = {0};
-  for (const std::set<AAHD_NonLocalFaceNode>& nl_en_set : incoming_bank)
+  for (const auto& bank : incoming_bank)
   {
-    nonlocal_incoming_node_sizes_.push_back(nl_en_set.size());
-    cumulative_offset += nl_en_set.size();
+    nonlocal_incoming_node_sizes_.push_back(bank.size());
+    cumulative_offset += bank.size();
     nonlocal_incoming_node_offsets_.push_back(cumulative_offset);
   }
   cumulative_offset = 0;
   nonlocal_delayed_incoming_node_offsets_ = {0};
-  for (const std::set<AAHD_NonLocalFaceNode>& nl_en_set : delayed_incoming_bank)
+  for (const auto& bank : delayed_incoming_bank)
   {
-    nonlocal_delayed_incoming_node_sizes_.push_back(nl_en_set.size());
-    cumulative_offset += nl_en_set.size();
+    nonlocal_delayed_incoming_node_sizes_.push_back(bank.size());
+    cumulative_offset += bank.size();
     nonlocal_delayed_incoming_node_offsets_.push_back(cumulative_offset);
   }
   cumulative_offset = 0;
   nonlocal_outgoing_node_offsets_ = {0};
-  for (const std::set<AAHD_NonLocalFaceNode>& nl_en_set : outgoing_bank)
+  for (const auto& bank : outgoing_bank)
   {
-    nonlocal_outgoing_node_sizes_.push_back(nl_en_set.size());
-    cumulative_offset += nl_en_set.size();
+    nonlocal_outgoing_node_sizes_.push_back(bank.size());
+    cumulative_offset += bank.size();
     nonlocal_outgoing_node_offsets_.push_back(cumulative_offset);
   }
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <limits>
 #include <map>
+#include <unordered_map>
 #include <stdexcept>
 
 namespace opensn
@@ -18,6 +19,14 @@ namespace opensn
 class AAHD_AngleSet;
 class SpatialDiscretization;
 class SweepBoundary;
+
+struct FaceNodeHash
+{
+  std::size_t operator()(const FaceNode& fn) const noexcept
+  {
+    return std::hash<std::uint64_t>{}(fn.GetValue());
+  }
+};
 
 /**
  * Random-access stack based FLUDS.
@@ -35,7 +44,10 @@ public:
                        const SpatialDiscretization& sdm);
 
   /// Get constant reference to the face node tracker map.
-  const std::map<FaceNode, AAHD_NodeIndex>& GetNodeTracker() const { return node_tracker_; }
+  const std::unordered_map<FaceNode, AAHD_NodeIndex, FaceNodeHash>& GetNodeTracker() const
+  {
+    return node_tracker_;
+  }
 
   /// \name Size getters
   /// \{
@@ -91,7 +103,7 @@ public:
 
 protected:
   /// Map face node to its associated index in the corresponding bank.
-  std::map<FaceNode, AAHD_NodeIndex> node_tracker_;
+  std::unordered_map<FaceNode, AAHD_NodeIndex, FaceNodeHash> node_tracker_;
   /// List of anglesets associated to this sweep ordering.
   mutable std::vector<AAHD_AngleSet*> associated_anglesets_;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.cc
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <limits>
 #include <map>
+#include <memory>
 
 namespace opensn
 {
@@ -24,9 +25,16 @@ constexpr std::size_t FACE_SLOT_RECORD_SIZE = 3;
 
 } // namespace
 
+std::unique_ptr<CBC_FLUDSCommonData>
+CBC_FLUDSCommonData::MakeAlpha(const SPDS& spds,
+                               const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
+{
+  return std::unique_ptr<CBC_FLUDSCommonData>(new CBC_FLUDSCommonData(spds, grid_nodal_mappings));
+}
+
 CBC_FLUDSCommonData::CBC_FLUDSCommonData(
   const SPDS& spds, const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
-  : FLUDSCommonData(spds, grid_nodal_mappings), num_incoming_faces_(0)
+  : FLUDSCommonData(spds, grid_nodal_mappings), num_incoming_faces_(0), num_outgoing_faces_(0)
 {
   const auto& grid = *spds.GetGrid();
   const auto& face_orientations = spds.GetCellFaceOrientations();
@@ -34,7 +42,6 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
 
   std::size_t num_local_faces = 0;
   std::size_t num_incoming_faces = 0;
-  std::size_t num_outgoing_faces = 0;
   for (const auto& cell : grid.local_cells)
   {
     assert(cell.local_id < face_offsets_.size());
@@ -51,7 +58,7 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
       if (orientation == FaceOrientation::INCOMING)
         ++num_incoming_faces;
       else if (orientation == FaceOrientation::OUTGOING)
-        ++num_outgoing_faces;
+        ++num_outgoing_faces_;
     }
   }
 
@@ -60,13 +67,6 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
   outgoing_face_slots_.assign(num_local_faces, INVALID_FACE_SLOT);
   outgoing_peer_indices_.assign(num_local_faces, INVALID_PEER_INDEX);
 
-  boost::unordered_flat_map<int, std::size_t> outgoing_peer_index_by_location;
-  const auto& location_successors = spds.GetLocationSuccessors();
-  outgoing_peer_index_by_location.reserve(location_successors.size());
-  for (std::size_t i = 0; i < location_successors.size(); ++i)
-    outgoing_peer_index_by_location.emplace(location_successors[i], i);
-
-  std::map<int, std::vector<std::uint64_t>> incoming_slot_records_by_upstream_location;
   for (const auto& cell : grid.local_cells)
   {
     const auto face_offset = face_offsets_[cell.local_id];
@@ -84,7 +84,7 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
         incoming_face_slots_[face_offset + f] = slot;
         incoming_face_cells_.push_back(cell.local_id);
         auto& records =
-          incoming_slot_records_by_upstream_location[face.GetNeighborPartitionID(&grid)];
+          incoming_slot_records_by_upstream_location_[face.GetNeighborPartitionID(&grid)];
         records.push_back(cell.global_id);
         records.push_back(static_cast<std::uint64_t>(f));
         records.push_back(static_cast<std::uint64_t>(slot));
@@ -92,11 +92,26 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
       }
     }
   }
+}
 
-  const auto downstream_slot_records = MapAllToAll(incoming_slot_records_by_upstream_location);
+void
+CBC_FLUDSCommonData::FinalizeBeta()
+{
+  if (finalized_)
+    throw std::logic_error("CBC FLUDS common data has already been finalized");
+  const auto& grid = *spds_.GetGrid();
+  const auto& face_orientations = spds_.GetCellFaceOrientations();
+  boost::unordered_flat_map<int, std::size_t> outgoing_peer_index_by_location;
+  const auto& location_successors = spds_.GetLocationSuccessors();
+  outgoing_peer_index_by_location.reserve(location_successors.size());
+  for (std::size_t i = 0; i < location_successors.size(); ++i)
+    outgoing_peer_index_by_location.emplace(location_successors[i], i);
+
+  const auto downstream_slot_records = MapAllToAll(incoming_slot_records_by_upstream_location_);
+  incoming_slot_records_by_upstream_location_.clear();
   boost::unordered_flat_map<CellFaceKey, std::size_t, std::hash<CellFaceKey>>
     downstream_slot_by_face;
-  downstream_slot_by_face.reserve(num_outgoing_faces);
+  downstream_slot_by_face.reserve(num_outgoing_faces_);
   for (const auto& location_records : downstream_slot_records)
   {
     const auto& records = location_records.second;
@@ -146,11 +161,13 @@ CBC_FLUDSCommonData::CBC_FLUDSCommonData(
       outgoing_peer_indices_[face_offset + f] = peer_it->second;
     }
   }
+  finalized_ = true;
 }
 
 std::size_t
 CBC_FLUDSCommonData::IncomingFaceSlot(std::uint32_t cell_local_id, unsigned int face_id) const
 {
+  CheckFinalized();
   const auto slot_offset = face_offsets_[cell_local_id] + face_id;
   return incoming_face_slots_[slot_offset];
 }
@@ -158,6 +175,7 @@ CBC_FLUDSCommonData::IncomingFaceSlot(std::uint32_t cell_local_id, unsigned int 
 std::size_t
 CBC_FLUDSCommonData::OutgoingFaceSlot(std::uint32_t cell_local_id, unsigned int face_id) const
 {
+  CheckFinalized();
   const auto slot_offset = face_offsets_[cell_local_id] + face_id;
   return outgoing_face_slots_[slot_offset];
 }
@@ -165,6 +183,7 @@ CBC_FLUDSCommonData::OutgoingFaceSlot(std::uint32_t cell_local_id, unsigned int 
 std::size_t
 CBC_FLUDSCommonData::OutgoingPeerIndex(std::uint32_t cell_local_id, unsigned int face_id) const
 {
+  CheckFinalized();
   const auto slot_offset = face_offsets_[cell_local_id] + face_id;
   return outgoing_peer_indices_[slot_offset];
 }
@@ -172,6 +191,7 @@ CBC_FLUDSCommonData::OutgoingPeerIndex(std::uint32_t cell_local_id, unsigned int
 std::uint32_t
 CBC_FLUDSCommonData::IncomingFaceCell(std::size_t incoming_face_slot) const
 {
+  CheckFinalized();
   return incoming_face_cells_[incoming_face_slot];
 }
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbc_fluds_common_data.h
@@ -7,6 +7,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <map>
+#include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace opensn
@@ -16,8 +19,13 @@ namespace opensn
 class CBC_FLUDSCommonData : public FLUDSCommonData
 {
 public:
-  CBC_FLUDSCommonData(const SPDS& spds,
-                      const std::vector<CellFaceNodalMapping>& grid_nodal_mappings);
+  /// Construct alpha phase only (local work, no MPI). Call FinalizeBeta() afterwards.
+  /// MakeAlpha() prevents us from holding an unfinalized object.
+  static std::unique_ptr<CBC_FLUDSCommonData>
+  MakeAlpha(const SPDS& spds, const std::vector<CellFaceNodalMapping>& grid_nodal_mappings);
+
+  /// Exchange nonlocal face slots after parallel local construction.
+  void FinalizeBeta();
 
   std::size_t NumIncomingFaces() const { return num_incoming_faces_; }
 
@@ -63,7 +71,18 @@ public:
   static constexpr std::size_t INVALID_PEER_INDEX = std::numeric_limits<std::size_t>::max();
 
 private:
+  CBC_FLUDSCommonData(const SPDS& spds,
+                      const std::vector<CellFaceNodalMapping>& grid_nodal_mappings);
+
+  void CheckFinalized() const
+  {
+    if (not finalized_)
+      throw std::logic_error("CBC FLUDS common data must be finalized before use");
+  }
+
   std::size_t num_incoming_faces_;
+  std::size_t num_outgoing_faces_;
+  bool finalized_ = false;
   /// Prefix offsets into local-face-indexed slot arrays.
   std::vector<std::size_t> face_offsets_;
   /// Local-face-indexed incoming slots.
@@ -74,6 +93,8 @@ private:
   std::vector<std::size_t> outgoing_face_slots_;
   /// Local-face-indexed SPDS-successor peer indices.
   std::vector<std::size_t> outgoing_peer_indices_;
+  /// Incoming face-slot records grouped by upstream location.
+  std::map<int, std::vector<std::uint64_t>> incoming_slot_records_by_upstream_location_;
 };
 
 } // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.cc
@@ -15,26 +15,23 @@ namespace opensn
 AAH_SPDS::AAH_SPDS(int id,
                    const Vector3& omega,
                    const std::shared_ptr<MeshContinuum> grid,
+                   const SPDSFaceNeighborInfoVec& face_neighbor_info,
                    bool allow_cycles,
                    bool use_gpus)
   : SPDS(omega, grid), id_(id), allow_cycles_(allow_cycles)
 {
 
-  // Populate Cell Relationships
+  // Populate cell relationships
   size_t num_loc_cells = grid->local_cells.size();
-  std::vector<std::set<std::pair<std::uint32_t, double>>> cell_successors(num_loc_cells);
-  std::set<int> location_successors;
-  std::set<int> location_dependencies;
+  std::vector<std::vector<std::pair<std::uint32_t, double>>> cell_successors(num_loc_cells);
+  std::vector<int> location_successors;
+  std::vector<int> location_dependencies;
 
-  PopulateCellRelationships(omega, location_dependencies, location_successors, cell_successors);
+  PopulateCellRelationships(
+    omega, face_neighbor_info, location_dependencies, location_successors, cell_successors);
 
-  location_successors_.reserve(location_successors.size());
-  for (auto v : location_successors)
-    location_successors_.push_back(v);
-
-  location_dependencies_.reserve(location_dependencies.size());
-  for (auto v : location_dependencies)
-    location_dependencies_.push_back(v);
+  location_successors_ = std::move(location_successors);
+  location_dependencies_ = std::move(location_dependencies);
 
   // Create local cell graph
   Graph local_cell_graph(num_loc_cells);
@@ -82,10 +79,6 @@ AAH_SPDS::AAH_SPDS(int id,
   for (auto& level : levelized_spls_)
     for (auto& cell : level)
       spls_.push_back(cell);
-
-  // Generate location-to-location dependencies
-  global_dependencies_.resize(opensn::mpi_comm.size());
-  CommunicateLocationDependencies(location_dependencies_, global_dependencies_);
 
   // Copy levelized spls data to GPU
   if (use_gpus)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/aah.h
@@ -18,17 +18,22 @@ public:
    * \param id The unique identifier for this SPDS.
    * \param omega The angular direction for the sweep operation.
    * \param grid The grid on which the sweep is performed.
-   * \param allow_cycles Whether cycles are allowed in the local and global swepp dependency graphs.
+   * \param face_neighbor_info Cached neighbor information for every local cell face.
+   * \param allow_cycles Whether cycles are allowed in the local and global sweep dependency graphs.
    * \param use_gpus Whether to allocate device memory for GPU acceleration.
    */
   AAH_SPDS(int id,
            const Vector3& omega,
            std::shared_ptr<MeshContinuum> grid,
+           const SPDSFaceNeighborInfoVec& face_neighbor_info,
            bool allow_cycles,
            bool use_gpus = false);
 
   /// Returns the id of this SPDS.
   int GetId() const { return id_; }
+
+  /// Returns true if this SPDS is allowed to remove local and global sweep cycles.
+  bool AllowCycles() const { return allow_cycles_; }
 
   /// Return the levelized global sweep TDG.
   const std::vector<STDG>& GetGlobalSweepPlanes() const { return global_sweep_planes_; }
@@ -67,6 +72,12 @@ public:
   void SetGlobalEdgeWeights(std::vector<double> weights)
   {
     global_edge_weights_ = std::move(weights);
+  }
+
+  /// Sets the global location-to-location dependencies (result of BatchCommunicateLocationDeps).
+  void SetGlobalDependencies(std::vector<std::vector<int>> deps)
+  {
+    global_dependencies_ = std::move(deps);
   }
 
   /// Destructor.

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.cc
@@ -14,6 +14,7 @@ namespace opensn
 
 CBC_SPDS::CBC_SPDS(const Vector3& omega,
                    const std::shared_ptr<MeshContinuum>& grid,
+                   const SPDSFaceNeighborInfoVec& face_neighbor_info,
                    bool allow_cycles)
   : SPDS(omega, grid)
 {
@@ -21,20 +22,15 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
   const auto num_loc_cells = grid->local_cells.size();
 
   // Populate cell relationships
-  std::vector<std::set<std::pair<std::uint32_t, double>>> cell_successors(num_loc_cells);
-  std::set<int> location_successors;
-  std::set<int> location_dependencies;
+  std::vector<std::vector<std::pair<std::uint32_t, double>>> cell_successors(num_loc_cells);
+  std::vector<int> location_successors;
+  std::vector<int> location_dependencies;
 
-  PopulateCellRelationships(omega, location_dependencies, location_successors, cell_successors);
+  PopulateCellRelationships(
+    omega, face_neighbor_info, location_dependencies, location_successors, cell_successors);
 
-  location_successors_.reserve(location_successors.size());
-  location_dependencies_.reserve(location_dependencies.size());
-
-  for (const auto location : location_successors)
-    location_successors_.push_back(location);
-
-  for (const auto location : location_dependencies)
-    location_dependencies_.push_back(location);
+  location_successors_ = std::move(location_successors);
+  location_dependencies_ = std::move(location_dependencies);
 
   // Build local cell graph
   Graph local_DG(num_loc_cells);
@@ -62,9 +58,6 @@ CBC_SPDS::CBC_SPDS(const Vector3& omega,
   }
 
   // Create task list
-  std::vector<std::vector<int>> global_dependencies(opensn::mpi_comm.size());
-  CommunicateLocationDependencies(location_dependencies_, global_dependencies);
-
   constexpr auto INCOMING = FaceOrientation::INCOMING;
   constexpr auto OUTGOING = FaceOrientation::OUTGOING;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/cbc.h
@@ -18,9 +18,13 @@ public:
    *
    * \param omega The angular direction vector.
    * \param grid Reference to the grid.
+   * \param face_neighbor_info Cached neighbor information for every local cell face.
    * \param allow_cycles Whether cycles are allowed in the local sweep dependency graph.
    */
-  CBC_SPDS(const Vector3& omega, const std::shared_ptr<MeshContinuum>& grid, bool allow_cycles);
+  CBC_SPDS(const Vector3& omega,
+           const std::shared_ptr<MeshContinuum>& grid,
+           const SPDSFaceNeighborInfoVec& face_neighbor_info,
+           bool allow_cycles);
 
   const std::vector<Task>& GetTaskList() const;
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.cc
@@ -16,25 +16,10 @@
 namespace opensn
 {
 
-namespace
+SPDSFaceNeighborInfoVec
+BuildSPDSFaceNeighborInfo(const MeshContinuum& grid)
 {
-
-struct FaceNeighborInfo
-{
-  bool has_neighbor = false;
-  bool neighbor_local = false;
-  bool owns_face = true;
-  std::uint32_t neighbor_local_id = 0;
-  int neighbor_partition_id = -1;
-  unsigned int neighbor_adj_face = 0;
-};
-
-using FaceNeighborInfoVec = std::vector<std::vector<FaceNeighborInfo>>;
-
-FaceNeighborInfoVec
-GetFaceNeighborInfo(const MeshContinuum& grid)
-{
-  FaceNeighborInfoVec info;
+  SPDSFaceNeighborInfoVec info;
   info.resize(grid.local_cells.size());
   for (const auto& cell : grid.local_cells)
   {
@@ -67,8 +52,6 @@ GetFaceNeighborInfo(const MeshContinuum& grid)
 
   return info;
 }
-
-} // namespace
 
 std::vector<std::pair<Vertex, Vertex>>
 SPDS::FindApproxMinimumFAS(Graph& g, std::vector<Vertex>& scc_vertices)
@@ -373,9 +356,10 @@ SPDS::MapLocJToDeplocI(int locJ) const
 void
 SPDS::PopulateCellRelationships(
   const Vector3& omega,
-  std::set<int>& location_dependencies,
-  std::set<int>& location_successors,
-  std::vector<std::set<std::pair<std::uint32_t, double>>>& cell_successors)
+  const SPDSFaceNeighborInfoVec& face_info,
+  std::vector<int>& location_dependencies,
+  std::vector<int>& location_successors,
+  std::vector<std::vector<std::pair<std::uint32_t, double>>>& cell_successors)
 {
 
   constexpr double tolerance = FACE_ORIENTATION_TOLERANCE;
@@ -387,8 +371,6 @@ SPDS::PopulateCellRelationships(
   cell_face_orientations_.assign(grid_->local_cells.size(), {});
   for (auto& cell : grid_->local_cells)
     cell_face_orientations_[cell.local_id].assign(cell.faces.size(), FOPARALLEL);
-
-  const auto& face_info = GetFaceNeighborInfo(*grid_);
 
   for (auto& cell : grid_->local_cells)
   {
@@ -481,11 +463,10 @@ SPDS::PopulateCellRelationships(
           if (face_info[cell.local_id][f].neighbor_local)
           {
             const auto weight = mu * face.area;
-            cell_successors[c].insert(
-              std::make_pair(face_info[cell.local_id][f].neighbor_local_id, weight));
+            cell_successors[c].emplace_back(face_info[cell.local_id][f].neighbor_local_id, weight);
           }
           else
-            location_successors.insert(face_info[cell.local_id][f].neighbor_partition_id);
+            location_successors.push_back(face_info[cell.local_id][f].neighbor_partition_id);
         }
       }
       // If not outgoing determine what it is dependent on
@@ -494,11 +475,22 @@ SPDS::PopulateCellRelationships(
         // if it is a cell and not bndry
         if (face_info[cell.local_id][f].has_neighbor and
             not face_info[cell.local_id][f].neighbor_local)
-          location_dependencies.insert(face_info[cell.local_id][f].neighbor_partition_id);
+          location_dependencies.push_back(face_info[cell.local_id][f].neighbor_partition_id);
       }
       ++f;
     } // for face
   } // for cell
+
+  auto SortUnique = [](auto& values)
+  {
+    std::sort(values.begin(), values.end());
+    values.erase(std::unique(values.begin(), values.end()), values.end());
+  };
+
+  SortUnique(location_dependencies);
+  SortUnique(location_successors);
+  for (auto& successors : cell_successors)
+    SortUnique(successors);
 }
 
 void

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/spds/spds.h
@@ -7,6 +7,7 @@
 #include "framework/mesh/logical_volume/logical_volume.h"
 #include "framework/data_types/vector3.h"
 #include <boost/graph/directed_graph.hpp>
+#include <cstdint>
 #include <memory>
 #include <stack>
 
@@ -24,6 +25,20 @@ using Graph = boost::adjacency_list<boost::vecS,
                                     opensn::VertexProperties,
                                     boost::property<boost::edge_weight_t, double>>;
 using Vertex = boost::graph_traits<Graph>::vertex_descriptor;
+
+struct SPDSFaceNeighborInfo
+{
+  bool has_neighbor = false;
+  bool neighbor_local = false;
+  bool owns_face = true;
+  std::uint32_t neighbor_local_id = 0;
+  int neighbor_partition_id = -1;
+  unsigned int neighbor_adj_face = 0;
+};
+
+using SPDSFaceNeighborInfoVec = std::vector<std::vector<SPDSFaceNeighborInfo>>;
+
+SPDSFaceNeighborInfoVec BuildSPDSFaceNeighborInfo(const MeshContinuum& grid);
 
 class SPDS
 {
@@ -119,9 +134,10 @@ protected:
    */
   void PopulateCellRelationships(
     const Vector3& omega,
-    std::set<int>& location_dependencies,
-    std::set<int>& location_successors,
-    std::vector<std::set<std::pair<std::uint32_t, double>>>& cell_successors);
+    const SPDSFaceNeighborInfoVec& face_info,
+    std::vector<int>& location_dependencies,
+    std::vector<int>& location_successors,
+    std::vector<std::vector<std::pair<std::uint32_t, double>>>& cell_successors);
 
   /// Find bi-, tri-, and n-connected strongly connected components (SCCs) in the given graph.
   std::vector<std::vector<Vertex>> FindSCCs(Graph& g);

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep.h
@@ -55,6 +55,11 @@ struct STDG
 void CommunicateLocationDependencies(const std::vector<int>& location_dependencies,
                                      std::vector<std::vector<int>>& global_dependencies);
 
+/// Batched variant of CommunicateLocationDependencies. Gathers dependencies for all N SPDS in 2
+/// MPI collectives instead of 2*N. Returns global_deps[s][rank] for each SPDS s and MPI rank.
+std::vector<std::vector<std::vector<int>>>
+BatchCommunicateLocationDependencies(const std::vector<std::vector<int>>& local_deps);
+
 /// Print a sweep ordering to file.
 void PrintSweepOrdering(SPDS* sweep_order, std::shared_ptr<MeshContinuum> vol_continuum);
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_parallel_for.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_parallel_for.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <exception>
+#include <thread>
+#include <vector>
+
+namespace opensn
+{
+
+/// Run `function(i)` for i in [0, count) across `num_threads` threads, strided.
+/// Exceptions thrown by any worker are propagated to the caller (first wins).
+template <typename Function>
+void
+ParallelFor(size_t count, size_t num_threads, Function function)
+{
+  std::vector<std::exception_ptr> exceptions(num_threads);
+  {
+    std::vector<std::jthread> workers;
+    workers.reserve(num_threads);
+    for (size_t thread_id = 0; thread_id < num_threads; ++thread_id)
+      workers.emplace_back(
+        [&, thread_id]()
+        {
+          try
+          {
+            for (size_t i = thread_id; i < count; i += num_threads)
+              function(i);
+          }
+          catch (...)
+          {
+            exceptions[thread_id] = std::current_exception();
+          }
+        });
+  }
+
+  for (const auto& exception : exceptions)
+    if (exception)
+      std::rethrow_exception(exception);
+}
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_runtime_builder.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_runtime_builder.cc
@@ -12,6 +12,7 @@
 #include "framework/mesh/mesh_continuum/grid_face_histogram.h"
 #include "framework/mesh/mesh_continuum/mesh_continuum.h"
 #include "framework/runtime.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_parallel_for.h"
 #include "framework/utils/error.h"
 #include "framework/utils/timer.h"
 #include <cmath>
@@ -245,51 +246,90 @@ template <typename CreateSPDS>
 void
 BuildSPDSForSweepOrderings(SweepRuntime& runtime, CreateSPDS create_spds)
 {
+  struct WorkItem
+  {
+    std::shared_ptr<AngularQuadrature> quadrature;
+    size_t sweep_ordering_id = 0;
+    Vector3 omega;
+  };
+  std::vector<WorkItem> work;
   for (const auto& [quadrature, info] : runtime.quadrature_unq_so_grouping_map)
   {
-    auto& spds_list = runtime.quadrature_spds_map[quadrature];
     const auto& unique_so_groupings = info.first;
+    size_t sweep_ordering_id = 0;
     for (const auto& so_grouping : unique_so_groupings)
-    {
-      const size_t master_dir_id = so_grouping.front();
-      const auto& omega = quadrature->GetOmega(master_dir_id);
-      spds_list.push_back(create_spds(quadrature, spds_list.size(), omega));
-    }
+      work.push_back({quadrature, sweep_ordering_id++, quadrature->GetOmega(so_grouping.front())});
   }
+
+  for (auto& [quadrature, spds_list] : runtime.quadrature_spds_map)
+    spds_list.clear();
+  if (work.empty())
+    return;
+  std::vector<std::shared_ptr<SPDS>> result(work.size());
+  const size_t nthreads = std::min<size_t>(std::max(1U, opensn_num_threads), work.size());
+  log.Log() << program_timer.GetTimeString() << " SPDS construction: " << work.size() << " angles ("
+            << nthreads << " threads(s)).";
+  ParallelFor(
+    work.size(),
+    nthreads,
+    [&](size_t i)
+    { result[i] = create_spds(work[i].quadrature, work[i].sweep_ordering_id, work[i].omega); });
+  for (size_t i = 0; i < work.size(); ++i)
+    runtime.quadrature_spds_map[work[i].quadrature].push_back(std::move(result[i]));
+  log.Log() << program_timer.GetTimeString() << " SPDS construction done.";
 }
+
+std::vector<std::shared_ptr<AAH_SPDS>> GetAAHSPDSList(const SweepRuntime& runtime);
 
 void
 BuildAAHSPDS(SweepRuntime& runtime,
              const std::shared_ptr<MeshContinuum>& grid,
+             const SPDSFaceNeighborInfoVec& face_neighbor_info,
              const std::map<std::shared_ptr<AngularQuadrature>, bool>& allow_cycles_map,
              bool use_gpus)
 {
-  log.Log0Verbose1() << program_timer.GetTimeString() << " Initializing AAH SPDS.";
-  BuildSPDSForSweepOrderings(
-    runtime,
-    [&grid, &allow_cycles_map, use_gpus](const std::shared_ptr<AngularQuadrature>& quadrature,
-                                         size_t sweep_ordering_id,
-                                         const Vector3& omega) -> std::shared_ptr<SPDS>
-    {
-      return std::make_shared<AAH_SPDS>(static_cast<int>(sweep_ordering_id),
-                                        omega,
-                                        grid,
-                                        allow_cycles_map.at(quadrature),
-                                        use_gpus);
-    });
+  BuildSPDSForSweepOrderings(runtime,
+                             [&grid, &face_neighbor_info, &allow_cycles_map](
+                               const std::shared_ptr<AngularQuadrature>& quadrature,
+                               size_t sweep_ordering_id,
+                               const Vector3& omega) -> std::shared_ptr<SPDS>
+                             {
+                               return std::make_shared<AAH_SPDS>(
+                                 static_cast<int>(sweep_ordering_id),
+                                 omega,
+                                 grid,
+                                 face_neighbor_info,
+                                 allow_cycles_map.at(quadrature),
+                                 false);
+                             });
+
+  const auto spds_list = GetAAHSPDSList(runtime);
+  if (use_gpus)
+    for (const auto& spds : spds_list)
+      spds->CopySPLSDataOnDevice();
+  std::vector<std::vector<int>> local_dependencies(spds_list.size());
+  for (size_t i = 0; i < spds_list.size(); ++i)
+    local_dependencies[i] = spds_list[i]->GetLocationDependencies();
+  auto global_dependencies = BatchCommunicateLocationDependencies(local_dependencies);
+  for (size_t i = 0; i < spds_list.size(); ++i)
+    spds_list[i]->SetGlobalDependencies(std::move(global_dependencies[i]));
 }
 
 void
 BuildCBCSPDS(SweepRuntime& runtime,
              const std::shared_ptr<MeshContinuum>& grid,
+             const SPDSFaceNeighborInfoVec& face_neighbor_info,
              const std::map<std::shared_ptr<AngularQuadrature>, bool>& allow_cycles_map)
 {
-  BuildSPDSForSweepOrderings(
-    runtime,
-    [&grid, &allow_cycles_map](const std::shared_ptr<AngularQuadrature>& quadrature,
+  BuildSPDSForSweepOrderings(runtime,
+                             [&grid, &face_neighbor_info, &allow_cycles_map](
+                               const std::shared_ptr<AngularQuadrature>& quadrature,
                                size_t,
                                const Vector3& omega) -> std::shared_ptr<SPDS>
-    { return std::make_shared<CBC_SPDS>(omega, grid, allow_cycles_map.at(quadrature)); });
+                             {
+                               return std::make_shared<CBC_SPDS>(
+                                 omega, grid, face_neighbor_info, allow_cycles_map.at(quadrature));
+                             });
 }
 
 std::vector<std::shared_ptr<AAH_SPDS>>
@@ -410,9 +450,13 @@ ApplyAAHSweepFAS(const std::vector<std::shared_ptr<AAH_SPDS>>& spds_list,
 void
 BuildAAHSweepTDGs(const std::vector<std::shared_ptr<AAH_SPDS>>& spds_list)
 {
-  log.Log0Verbose1() << program_timer.GetTimeString() << " Build global sweep TDGs.";
-  for (const auto& spds : spds_list)
-    spds->BuildGlobalSweepTDG();
+  if (spds_list.empty())
+    return;
+  const size_t nthreads = std::min<size_t>(std::max(1U, opensn_num_threads), spds_list.size());
+  log.Log() << program_timer.GetTimeString() << " TDG build: " << spds_list.size() << " angles ("
+            << nthreads << " threads(s)).";
+  ParallelFor(spds_list.size(), nthreads, [&](size_t i) { spds_list[i]->BuildGlobalSweepTDG(); });
+  log.Log() << program_timer.GetTimeString() << " TDG build done.";
 }
 
 void
@@ -443,21 +487,68 @@ BuildAAHCPUFludsCommonData(SweepRuntime& runtime,
                            const std::shared_ptr<MeshContinuum>& grid,
                            const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
 {
-  const auto grid_face_histogram = grid->MakeGridFaceHistogram();
+  struct WorkItem
+  {
+    std::shared_ptr<AngularQuadrature> quadrature;
+    std::shared_ptr<SPDS> spds;
+  };
+  std::vector<WorkItem> work;
   for (const auto& [quadrature, spds_list] : runtime.quadrature_spds_map)
     for (const auto& spds : spds_list)
-      runtime.quadrature_fluds_commondata_map[quadrature].push_back(
-        std::make_unique<AAH_FLUDSCommonData>(grid_nodal_mappings, *spds, *grid_face_histogram));
+      work.push_back({quadrature, spds});
+  if (work.empty())
+    return;
+
+  const auto grid_face_histogram = grid->MakeGridFaceHistogram();
+  const size_t nthreads = std::min<size_t>(std::max(1U, opensn_num_threads), work.size());
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction: " << work.size()
+            << " angles (" << nthreads << " threads(s)).";
+  std::vector<std::unique_ptr<AAH_FLUDSCommonData>> result(work.size());
+  ParallelFor(work.size(),
+              nthreads,
+              [&](size_t i)
+              {
+                result[i] = AAH_FLUDSCommonData::MakeAlpha(
+                  grid_nodal_mappings, *work[i].spds, *grid_face_histogram);
+              });
+
+  // Inter-rank face exchange must retain identical ordering on every rank.
+  for (size_t i = 0; i < work.size(); ++i)
+    result[i]->FinalizeBeta(*work[i].spds);
+  for (size_t i = 0; i < work.size(); ++i)
+    runtime.quadrature_fluds_commondata_map[work[i].quadrature].push_back(std::move(result[i]));
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction done.";
 }
 
 void
 BuildCBCCPUFludsCommonData(SweepRuntime& runtime,
                            const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
 {
+  struct WorkItem
+  {
+    std::shared_ptr<AngularQuadrature> quadrature;
+    std::shared_ptr<SPDS> spds;
+  };
+  std::vector<WorkItem> work;
   for (const auto& [quadrature, spds_list] : runtime.quadrature_spds_map)
     for (const auto& spds : spds_list)
-      runtime.quadrature_fluds_commondata_map[quadrature].push_back(
-        std::make_unique<CBC_FLUDSCommonData>(*spds, grid_nodal_mappings));
+      work.push_back({quadrature, spds});
+  if (work.empty())
+    return;
+
+  const size_t nthreads = std::min<size_t>(std::max(1U, opensn_num_threads), work.size());
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction: " << work.size()
+            << " angles (" << nthreads << " threads(s)).";
+  std::vector<std::unique_ptr<CBC_FLUDSCommonData>> result(work.size());
+  ParallelFor(work.size(),
+              nthreads,
+              [&](size_t i)
+              { result[i] = CBC_FLUDSCommonData::MakeAlpha(*work[i].spds, grid_nodal_mappings); });
+  for (auto& fluds : result)
+    fluds->FinalizeBeta();
+  for (size_t i = 0; i < work.size(); ++i)
+    runtime.quadrature_fluds_commondata_map[work[i].quadrature].push_back(std::move(result[i]));
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction done.";
 }
 
 } // namespace
@@ -477,14 +568,15 @@ BuildSweepRuntime(const std::string& problem_name,
   const auto geometry_type = grid->GetGeometryType();
   BuildSweepOrderingGroups(
     runtime, problem_name, groupsets, grid, geometry_type, quadrature_allow_cycles_map);
+  const auto face_neighbor_info = BuildSPDSFaceNeighborInfo(*grid);
 
   if (sweep_type == "AAH")
   {
-    BuildAAHSPDS(runtime, grid, quadrature_allow_cycles_map, use_gpus);
+    BuildAAHSPDS(runtime, grid, face_neighbor_info, quadrature_allow_cycles_map, use_gpus);
     BuildAAHGlobalSweepGraph(runtime);
   }
   else if (sweep_type == "CBC")
-    BuildCBCSPDS(runtime, grid, quadrature_allow_cycles_map);
+    BuildCBCSPDS(runtime, grid, face_neighbor_info, quadrature_allow_cycles_map);
   else
     OpenSnInvalidArgument("Unsupported sweep type \"" + sweep_type + "\"");
 

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_runtime_builder.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_runtime_builder.cu
@@ -5,6 +5,10 @@
 
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds_common_data.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/cbcd_fluds_common_data.h"
+#include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/sweep_parallel_for.h"
+#include "framework/logging/log.h"
+#include "framework/runtime.h"
+#include "framework/utils/timer.h"
 
 namespace opensn::detail
 {
@@ -14,10 +18,32 @@ BuildAAHGPUFludsCommonData(SweepRuntime& runtime,
                            const SpatialDiscretization& discretization,
                            const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
 {
+  struct WorkItem
+  {
+    std::shared_ptr<AngularQuadrature> quadrature;
+    std::shared_ptr<SPDS> spds;
+  };
+  std::vector<WorkItem> work;
   for (const auto& [quadrature, spds_list] : runtime.quadrature_spds_map)
     for (const auto& spds : spds_list)
-      runtime.quadrature_fluds_commondata_map[quadrature].push_back(
-        std::make_unique<AAHD_FLUDSCommonData>(*spds, grid_nodal_mappings, discretization));
+      work.push_back({quadrature, spds});
+  if (work.empty())
+    return;
+
+  const size_t nthreads = std::min<size_t>(std::max(1U, opensn_num_threads), work.size());
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction: " << work.size()
+            << " angles (" << nthreads << " threads(s)).";
+  std::vector<std::unique_ptr<AAHD_FLUDSCommonData>> result(work.size());
+  opensn::ParallelFor(work.size(),
+                      nthreads,
+                      [&](size_t i)
+                      {
+                        result[i] = std::make_unique<AAHD_FLUDSCommonData>(
+                          *work[i].spds, grid_nodal_mappings, discretization);
+                      });
+  for (size_t i = 0; i < work.size(); ++i)
+    runtime.quadrature_fluds_commondata_map[work[i].quadrature].push_back(std::move(result[i]));
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction done.";
 }
 
 void
@@ -25,10 +51,28 @@ BuildCBCGPUFludsCommonData(SweepRuntime& runtime,
                            const SpatialDiscretization& discretization,
                            const std::vector<CellFaceNodalMapping>& grid_nodal_mappings)
 {
+  struct WorkItem
+  {
+    std::shared_ptr<AngularQuadrature> quadrature;
+    std::shared_ptr<SPDS> spds;
+  };
+  std::vector<WorkItem> work;
   for (const auto& [quadrature, spds_list] : runtime.quadrature_spds_map)
     for (const auto& spds : spds_list)
-      runtime.quadrature_fluds_commondata_map[quadrature].push_back(
-        std::make_unique<CBCD_FLUDSCommonData>(*spds, grid_nodal_mappings, discretization));
+      work.push_back({quadrature, spds});
+  if (work.empty())
+    return;
+
+  constexpr size_t nthreads = 1;
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction: " << work.size()
+            << " angles (" << nthreads << " threads(s)).";
+  std::vector<std::unique_ptr<CBCD_FLUDSCommonData>> result(work.size());
+  for (size_t i = 0; i < work.size(); ++i)
+    result[i] =
+      std::make_unique<CBCD_FLUDSCommonData>(*work[i].spds, grid_nodal_mappings, discretization);
+  for (size_t i = 0; i < work.size(); ++i)
+    runtime.quadrature_fluds_commondata_map[work[i].quadrature].push_back(std::move(result[i]));
+  log.Log() << program_timer.GetTimeString() << " FLUDS construction done.";
 }
 
 } // namespace opensn::detail

--- a/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/groupset/lbs_groupset.cc
@@ -125,7 +125,7 @@ LBSGroupset::Init(int aid)
   residual_tolerance = 1.0e-6;
   max_iterations = 200;
   gmres_restart_intvl = 30;
-  allow_cycles = false;
+  allow_cycles = true;
   apply_wgdsa = false;
   apply_tgdsa = false;
   wgdsa_max_iters = 30;


### PR DESCRIPTION
Initialization of sweep data structures has been simplified and uses threads where possible (honoring OPENSN_NUM_THREADS). This can provide a significant performance improvement when running problems with large meshes and high angle counts on a small number of ranks (i.e. runs using GPUs).
