### PR TITLE
Factor SIMD

### DIFF
--- a/framework/simd/simd.h
+++ b/framework/simd/simd.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __AVX512F__
+#include "framework/simd/simd_avx512.h"
+#elif defined(__AVX__) || defined(__AVX2__)
+#include "framework/simd/simd_avx.h"
+#elif defined(__SSE2__) || defined(_M_X64) || defined(_M_AMD64) ||                                 \
+  (defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
+#include "framework/simd/simd_sse2.h"
+#elif (defined(__ARM_NEON) && (!defined(__ARM_ARCH) || (__ARM_ARCH >= 7))) ||                      \
+  defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#include "framework/simd/simd_neon.h"
+#else
+#include "framework/simd/simd_scalar.h"
+#endif

--- a/framework/simd/simd_avx.h
+++ b/framework/simd/simd_avx.h
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <immintrin.h>
+
+// NOLINTBEGIN(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)
+namespace opensn
+{
+
+struct SimdTraits
+{
+  using register_type = __m256d;
+  using index_type = __m256i;
+  static constexpr std::size_t size = 4;
+  static constexpr std::size_t register_alignment = alignof(register_type);
+  static constexpr std::size_t index_alignment = alignof(index_type);
+};
+
+} // namespace opensn
+
+#include "framework/simd/simd_impl.h"
+
+namespace opensn
+{
+
+inline SimdIndex::SimdIndex(const value_type* src)
+  : value_(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)))
+{
+}
+
+inline SimdIndex::register_type
+SimdIndex::native() const
+{
+  return value_;
+}
+
+inline Simd::Simd() : value_(_mm256_setzero_pd())
+{
+}
+
+inline Simd::Simd(double value) : value_(_mm256_set1_pd(value))
+{
+}
+
+inline Simd::Simd(const double* src) : value_(_mm256_loadu_pd(src))
+{
+}
+
+inline void
+Simd::LoadUnaligned(const double* src)
+{
+  value_ = _mm256_loadu_pd(src);
+}
+
+inline void
+Simd::StoreUnaligned(double* dst) const
+{
+  _mm256_storeu_pd(dst, value_);
+}
+
+inline Simd
+Simd::Gather(const double* src, const SimdIndex& index)
+{
+#if defined(__AVX2__)
+  Simd result;
+  result.value_ = _mm256_i64gather_pd(src, index.value_, static_cast<int>(sizeof(double)));
+  return result;
+#else
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(indices), index.value_);
+  for (std::size_t i = 0; i < size; ++i)
+    values[i] = src[indices[i]];
+  return Simd(values);
+#endif
+}
+
+inline void
+Simd::Scatter(double* dst, const SimdIndex& index) const
+{
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(indices), index.value_);
+  _mm256_storeu_pd(values, value_);
+  for (std::size_t i = 0; i < size; ++i)
+    dst[indices[i]] = values[i];
+}
+
+inline Simd::register_type
+Simd::native() const
+{
+  return value_;
+}
+
+inline Simd&
+Simd::operator+=(const Simd& other)
+{
+  value_ = _mm256_add_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator-=(const Simd& other)
+{
+  value_ = _mm256_sub_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator*=(const Simd& other)
+{
+  value_ = _mm256_mul_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator/=(const Simd& other)
+{
+  value_ = _mm256_div_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd
+Simd::Fma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+#if defined(__FMA__)
+  result.value_ = _mm256_fmadd_pd(a.value_, b.value_, c.value_);
+#else
+  result.value_ = _mm256_add_pd(_mm256_mul_pd(a.value_, b.value_), c.value_);
+#endif
+  return result;
+}
+
+inline Simd
+Simd::Fnma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+#if defined(__FMA__)
+  result.value_ = _mm256_fnmadd_pd(a.value_, b.value_, c.value_);
+#else
+  result.value_ = _mm256_sub_pd(c.value_, _mm256_mul_pd(a.value_, b.value_));
+#endif
+  return result;
+}
+
+} // namespace opensn
+// NOLINTEND(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)

--- a/framework/simd/simd_avx512.h
+++ b/framework/simd/simd_avx512.h
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <immintrin.h>
+
+// NOLINTBEGIN(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)
+namespace opensn
+{
+
+struct SimdTraits
+{
+  using register_type = __m512d;
+  using index_type = __m512i;
+  static constexpr std::size_t size = 8;
+  static constexpr std::size_t register_alignment = alignof(register_type);
+  static constexpr std::size_t index_alignment = alignof(index_type);
+};
+
+} // namespace opensn
+
+#include "framework/simd/simd_impl.h"
+
+namespace opensn
+{
+
+inline SimdIndex::SimdIndex(const value_type* src) : value_(_mm512_loadu_si512(src))
+{
+}
+
+inline SimdIndex::register_type
+SimdIndex::native() const
+{
+  return value_;
+}
+
+inline Simd::Simd() : value_(_mm512_setzero_pd())
+{
+}
+
+inline Simd::Simd(double value) : value_(_mm512_set1_pd(value))
+{
+}
+
+inline Simd::Simd(const double* src) : value_(_mm512_loadu_pd(src))
+{
+}
+
+inline void
+Simd::LoadUnaligned(const double* src)
+{
+  value_ = _mm512_loadu_pd(src);
+}
+
+inline void
+Simd::StoreUnaligned(double* dst) const
+{
+  _mm512_storeu_pd(dst, value_);
+}
+
+inline Simd
+Simd::Gather(const double* src, const SimdIndex& index)
+{
+  Simd result;
+  result.value_ = _mm512_i64gather_pd(index.value_, src, static_cast<int>(sizeof(double)));
+  return result;
+}
+
+inline void
+Simd::Scatter(double* dst, const SimdIndex& index) const
+{
+  _mm512_i64scatter_pd(dst, index.value_, value_, static_cast<int>(sizeof(double)));
+}
+
+inline Simd::register_type
+Simd::native() const
+{
+  return value_;
+}
+
+inline Simd&
+Simd::operator+=(const Simd& other)
+{
+  value_ = _mm512_add_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator-=(const Simd& other)
+{
+  value_ = _mm512_sub_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator*=(const Simd& other)
+{
+  value_ = _mm512_mul_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator/=(const Simd& other)
+{
+  value_ = _mm512_div_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd
+Simd::Fma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+  result.value_ = _mm512_fmadd_pd(a.value_, b.value_, c.value_);
+  return result;
+}
+
+inline Simd
+Simd::Fnma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+  result.value_ = _mm512_fnmadd_pd(a.value_, b.value_, c.value_);
+  return result;
+}
+
+} // namespace opensn
+// NOLINTEND(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)

--- a/framework/simd/simd_impl.h
+++ b/framework/simd/simd_impl.h
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace opensn
+{
+
+/// Wrapper around a target-dependent SIMD integer register used for indexed memory operations.
+struct SimdIndex
+{
+  using value_type = std::int64_t;
+  using register_type = SimdTraits::index_type;
+
+  static constexpr std::size_t size = SimdTraits::size;
+  static constexpr std::size_t alignment = SimdTraits::index_alignment;
+
+  /// Load lane indices from an unaligned integer buffer.
+  explicit SimdIndex(const value_type* src);
+
+  register_type native() const;
+
+private:
+  friend class Simd;
+
+  register_type value_;
+};
+
+/// Wrapper around a target-dependent SIMD register or scalar fallback value for ``double``.
+class Simd
+{
+public:
+  using value_type = double;
+  using register_type = SimdTraits::register_type;
+
+  static constexpr std::size_t size = SimdTraits::size;
+  static constexpr std::size_t alignment = SimdTraits::register_alignment;
+
+  Simd();
+  explicit Simd(value_type value);
+  explicit Simd(const value_type* src);
+
+  void LoadUnaligned(const value_type* src);
+  void StoreUnaligned(value_type* dst) const;
+  static Simd Gather(const value_type* src, const SimdIndex& index);
+  void Scatter(value_type* dst, const SimdIndex& index) const;
+
+  static Simd Fma(const Simd& a, const Simd& b, const Simd& c);
+  static Simd Fnma(const Simd& a, const Simd& b, const Simd& c);
+
+  register_type native() const;
+
+  Simd& operator+=(const Simd& other);
+  Simd& operator-=(const Simd& other);
+  Simd& operator*=(const Simd& other);
+  Simd& operator/=(const Simd& other);
+
+private:
+  register_type value_;
+};
+
+inline Simd
+operator+(Simd lhs, const Simd& rhs)
+{
+  lhs += rhs;
+  return lhs;
+}
+
+inline Simd
+operator-(Simd lhs, const Simd& rhs)
+{
+  lhs -= rhs;
+  return lhs;
+}
+
+inline Simd
+operator*(Simd lhs, const Simd& rhs)
+{
+  lhs *= rhs;
+  return lhs;
+}
+
+inline Simd
+operator/(Simd lhs, const Simd& rhs)
+{
+  lhs /= rhs;
+  return lhs;
+}
+
+} // namespace opensn

--- a/framework/simd/simd_neon.h
+++ b/framework/simd/simd_neon.h
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <arm_neon.h>
+#include <cstddef>
+#include <cstdint>
+
+// NOLINTBEGIN(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)
+namespace opensn
+{
+
+struct SimdTraits
+{
+  using register_type = float64x2_t;
+  using index_type = int64x2_t;
+  static constexpr std::size_t size = 2;
+  static constexpr std::size_t register_alignment = alignof(register_type);
+  static constexpr std::size_t index_alignment = alignof(index_type);
+};
+
+} // namespace opensn
+
+#include "framework/simd/simd_impl.h"
+
+namespace opensn
+{
+
+inline SimdIndex::SimdIndex(const value_type* src) : value_(vld1q_s64(src))
+{
+}
+
+inline SimdIndex::register_type
+SimdIndex::native() const
+{
+  return value_;
+}
+
+inline Simd::Simd() : value_(vdupq_n_f64(0.0))
+{
+}
+
+inline Simd::Simd(double value) : value_(vdupq_n_f64(value))
+{
+}
+
+inline Simd::Simd(const double* src) : value_(vld1q_f64(src))
+{
+}
+
+inline void
+Simd::LoadUnaligned(const double* src)
+{
+  value_ = vld1q_f64(src);
+}
+
+inline void
+Simd::StoreUnaligned(double* dst) const
+{
+  vst1q_f64(dst, value_);
+}
+
+inline Simd
+Simd::Gather(const double* src, const SimdIndex& index)
+{
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  vst1q_s64(indices, index.value_);
+  for (std::size_t i = 0; i < size; ++i)
+    values[i] = src[indices[i]];
+  return Simd(values);
+}
+
+inline void
+Simd::Scatter(double* dst, const SimdIndex& index) const
+{
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  vst1q_s64(indices, index.value_);
+  vst1q_f64(values, value_);
+  for (std::size_t i = 0; i < size; ++i)
+    dst[indices[i]] = values[i];
+}
+
+inline Simd::register_type
+Simd::native() const
+{
+  return value_;
+}
+
+inline Simd&
+Simd::operator+=(const Simd& other)
+{
+  value_ = vaddq_f64(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator-=(const Simd& other)
+{
+  value_ = vsubq_f64(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator*=(const Simd& other)
+{
+  value_ = vmulq_f64(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator/=(const Simd& other)
+{
+  value_ = vdivq_f64(value_, other.value_);
+  return *this;
+}
+
+inline Simd
+Simd::Fma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+  result.value_ = vfmaq_f64(c.value_, a.value_, b.value_);
+#else
+  result.value_ = vaddq_f64(vmulq_f64(a.value_, b.value_), c.value_);
+#endif
+  return result;
+}
+
+inline Simd
+Simd::Fnma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+  result.value_ = vfmsq_f64(c.value_, a.value_, b.value_);
+#else
+  result.value_ = vsubq_f64(c.value_, vmulq_f64(a.value_, b.value_));
+#endif
+  return result;
+}
+
+} // namespace opensn
+// NOLINTEND(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)

--- a/framework/simd/simd_scalar.h
+++ b/framework/simd/simd_scalar.h
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+
+namespace opensn
+{
+
+struct SimdTraits
+{
+  using register_type = double;
+  using index_type = std::size_t;
+  static constexpr std::size_t size = 1;
+  static constexpr std::size_t register_alignment = alignof(register_type);
+  static constexpr std::size_t index_alignment = alignof(index_type);
+};
+
+} // namespace opensn
+
+#include "framework/simd/simd_impl.h"
+
+namespace opensn
+{
+
+inline SimdIndex::SimdIndex(const value_type* src) : value_(static_cast<register_type>(*src))
+{
+}
+
+inline SimdIndex::register_type
+SimdIndex::native() const
+{
+  return value_;
+}
+
+inline Simd::Simd() : value_(0.0)
+{
+}
+
+inline Simd::Simd(double value) : value_(value)
+{
+}
+
+inline Simd::Simd(const double* src) : value_(*src)
+{
+}
+
+inline void
+Simd::LoadUnaligned(const double* src)
+{
+  value_ = *src;
+}
+
+inline void
+Simd::StoreUnaligned(double* dst) const
+{
+  *dst = value_;
+}
+
+inline Simd
+Simd::Gather(const double* src, const SimdIndex& index)
+{
+  return Simd(src[index.value_]);
+}
+
+inline void
+Simd::Scatter(double* dst, const SimdIndex& index) const
+{
+  dst[index.value_] = value_;
+}
+
+inline Simd::register_type
+Simd::native() const
+{
+  return value_;
+}
+
+inline Simd&
+Simd::operator+=(const Simd& other)
+{
+  value_ += other.value_;
+  return *this;
+}
+
+inline Simd&
+Simd::operator-=(const Simd& other)
+{
+  value_ -= other.value_;
+  return *this;
+}
+
+inline Simd&
+Simd::operator*=(const Simd& other)
+{
+  value_ *= other.value_;
+  return *this;
+}
+
+inline Simd&
+Simd::operator/=(const Simd& other)
+{
+  value_ /= other.value_;
+  return *this;
+}
+
+inline Simd
+Simd::Fma(const Simd& a, const Simd& b, const Simd& c)
+{
+  return Simd(std::fma(a.value_, b.value_, c.value_));
+}
+
+inline Simd
+Simd::Fnma(const Simd& a, const Simd& b, const Simd& c)
+{
+  return Simd(std::fma(-a.value_, b.value_, c.value_));
+}
+
+} // namespace opensn

--- a/framework/simd/simd_sse2.h
+++ b/framework/simd/simd_sse2.h
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <emmintrin.h>
+
+// NOLINTBEGIN(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)
+namespace opensn
+{
+
+struct SimdTraits
+{
+  using register_type = __m128d;
+  using index_type = __m128i;
+  static constexpr std::size_t size = 2;
+  static constexpr std::size_t register_alignment = alignof(register_type);
+  static constexpr std::size_t index_alignment = alignof(index_type);
+};
+
+} // namespace opensn
+
+#include "framework/simd/simd_impl.h"
+
+namespace opensn
+{
+
+inline SimdIndex::SimdIndex(const value_type* src)
+  : value_(_mm_loadu_si128(reinterpret_cast<const __m128i*>(src)))
+{
+}
+
+inline SimdIndex::register_type
+SimdIndex::native() const
+{
+  return value_;
+}
+
+inline Simd::Simd() : value_(_mm_setzero_pd())
+{
+}
+
+inline Simd::Simd(double value) : value_(_mm_set1_pd(value))
+{
+}
+
+inline Simd::Simd(const double* src) : value_(_mm_loadu_pd(src))
+{
+}
+
+inline void
+Simd::LoadUnaligned(const double* src)
+{
+  value_ = _mm_loadu_pd(src);
+}
+
+inline void
+Simd::StoreUnaligned(double* dst) const
+{
+  _mm_storeu_pd(dst, value_);
+}
+
+inline Simd
+Simd::Gather(const double* src, const SimdIndex& index)
+{
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(indices), index.value_);
+  for (std::size_t i = 0; i < size; ++i)
+    values[i] = src[indices[i]];
+  return Simd(values);
+}
+
+inline void
+Simd::Scatter(double* dst, const SimdIndex& index) const
+{
+  alignas(SimdTraits::index_alignment) std::int64_t indices[size];
+  alignas(SimdTraits::register_alignment) double values[size];
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(indices), index.value_);
+  _mm_storeu_pd(values, value_);
+  for (std::size_t i = 0; i < size; ++i)
+    dst[indices[i]] = values[i];
+}
+
+inline Simd::register_type
+Simd::native() const
+{
+  return value_;
+}
+
+inline Simd&
+Simd::operator+=(const Simd& other)
+{
+  value_ = _mm_add_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator-=(const Simd& other)
+{
+  value_ = _mm_sub_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator*=(const Simd& other)
+{
+  value_ = _mm_mul_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd&
+Simd::operator/=(const Simd& other)
+{
+  value_ = _mm_div_pd(value_, other.value_);
+  return *this;
+}
+
+inline Simd
+Simd::Fma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+  result.value_ = _mm_add_pd(_mm_mul_pd(a.value_, b.value_), c.value_);
+  return result;
+}
+
+inline Simd
+Simd::Fnma(const Simd& a, const Simd& b, const Simd& c)
+{
+  Simd result;
+  result.value_ = _mm_sub_pd(c.value_, _mm_mul_pd(a.value_, b.value_));
+  return result;
+}
+
+} // namespace opensn
+// NOLINTEND(portability-simd-intrinsics,cppcoreguidelines-pro-type-reinterpret-cast)

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/aah_avx_sweep_chunk.cc
@@ -246,15 +246,9 @@ AAH_Sweep_FixedN(AAHSweepData& data, AngleSet& angle_set)
 
         size_t k = 0;
 
-#if __AVX512F__
-        for (; k + simd_width <= block_len; k += simd_width)
-          detail::SimdBatchSolve<detail::AVX512Ops, NumNodes>(
+        for (; k + Simd::size <= block_len; k += Simd::size)
+          detail::SimdBatchSolve<NumNodes>(
             Amat.data(), mass_matrix.data(), &sigma_block[k], &b[(g0 + k) * NumNodes]);
-#elif __AVX2__
-        for (; k + simd_width <= block_len; k += simd_width)
-          detail::SimdBatchSolve<detail::AVX2Ops, NumNodes>(
-            Amat.data(), mass_matrix.data(), &sigma_block[k], &b[(g0 + k) * NumNodes]);
-#endif
 
         for (; k < block_len; ++k)
         {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/avx_sweep_chunk_utils.h
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/avx_sweep_chunk_utils.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
+#include "framework/simd/simd.h"
+
 #include <algorithm>
 #include <cstddef>
-
-#if __AVX512F__ || __AVX2__
-#include <immintrin.h>
-#endif
+#include <cstdint>
 
 #if __clang__ || __INTEL_COMPILER
 #define PRAGMA_UNROLL _Pragma("unroll")
@@ -21,214 +20,91 @@
 namespace opensn
 {
 
-static constexpr size_t simd_width =
-#if __AVX512F__
-  8; // 8 lanes (512-bit, doubles)
-#elif __AVX2__
-  4; // 4 lanes (256-bit, doubles)
-#else
-  1; // scalar
-#endif
-
 inline size_t
 ComputeGroupBlockSize(size_t gs_size)
 {
-  if (gs_size <= simd_width)
+  if (gs_size <= Simd::size)
     return gs_size;
 
   size_t target = 0;
-  if (gs_size >= 16 * simd_width)
-    target = 4 * simd_width;
-  else if (gs_size >= 4 * simd_width)
-    target = 2 * simd_width;
+  if (gs_size >= 16 * Simd::size)
+    target = 4 * Simd::size;
+  else if (gs_size >= 4 * Simd::size)
+    target = 2 * Simd::size;
   else
-    target = 1 * simd_width;
+    target = 1 * Simd::size;
 
   target = std::min(target, gs_size);
-  if (target >= simd_width)
-    target = (target / simd_width) * simd_width;
+  if (target >= Simd::size)
+    target = (target / Simd::size) * Simd::size;
   return target;
 }
 
 namespace detail
 {
 
-#if __AVX512F__
-struct AVX512Ops
-{
-  using avx_vec = __m512d;
-  using avx_index = __m512i;
-
-  static inline avx_vec LoadSigma(const double* sigma) { return _mm512_loadu_pd(sigma); }
-  static inline avx_vec Set1(double x) { return _mm512_set1_pd(x); }
-  static inline avx_vec Add(const avx_vec& a, const avx_vec& b) { return _mm512_add_pd(a, b); }
-  static inline avx_vec Sub(const avx_vec& a, const avx_vec& b) { return _mm512_sub_pd(a, b); }
-  static inline avx_vec Mul(const avx_vec& a, const avx_vec& b) { return _mm512_mul_pd(a, b); }
-  static inline avx_vec Div(const avx_vec& a, const avx_vec& b) { return _mm512_div_pd(a, b); }
-  static inline avx_vec Fmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    // a + b * c
-    return _mm512_fmadd_pd(b, c, a);
-  }
-  static inline avx_vec Fnmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    // c - a * b
-    return _mm512_fnmadd_pd(a, b, c);
-  }
-  static inline avx_vec Reciprocal(const avx_vec& v) { return Div(Set1(1.0), v); }
-  static inline avx_vec Gather(const avx_index& idx, const double* base)
-  {
-    return _mm512_i64gather_pd(idx, base, sizeof(double));
-  }
-  static inline void Scatter(const avx_index& idx, double* base, const avx_vec& value)
-  {
-    _mm512_i64scatter_pd(base, idx, value, sizeof(double));
-  }
-};
-#elif __AVX2__
-struct AVX2Ops
-{
-  using avx_vec = __m256d;
-  using avx_index = __m128i;
-
-  static inline avx_vec LoadSigma(const double* sigma) { return _mm256_loadu_pd(sigma); }
-  static inline avx_vec Set1(double x) { return _mm256_set1_pd(x); }
-  static inline avx_vec Add(const avx_vec& a, const avx_vec& b) { return _mm256_add_pd(a, b); }
-  static inline avx_vec Sub(const avx_vec& a, const avx_vec& b) { return _mm256_sub_pd(a, b); }
-  static inline avx_vec Mul(const avx_vec& a, const avx_vec& b) { return _mm256_mul_pd(a, b); }
-  static inline avx_vec Div(const avx_vec& a, const avx_vec& b) { return _mm256_div_pd(a, b); }
-
-#if __FMA__
-  static inline avx_vec Fmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    return _mm256_fmadd_pd(b, c, a);
-  }
-  static inline avx_vec Fnmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    return _mm256_fnmadd_pd(a, b, c);
-  }
-#else
-  static inline avx_vec Fmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    return Add(a, Mul(b, c));
-  }
-  static inline avx_vec Fnmadd(const avx_vec& a, const avx_vec& b, const avx_vec& c)
-  {
-    return Sub(c, Mul(a, b));
-  }
-#endif
-
-  static inline avx_vec Reciprocal(const avx_vec& v) { return Div(Set1(1.0), v); }
-  static inline avx_vec Gather(const avx_index& idx, const double* base)
-  {
-    return _mm256_i32gather_pd(base, idx, sizeof(double));
-  }
-  static inline void Scatter(const avx_index& idx, double* base, const avx_vec& value)
-  {
-    alignas(32) double buffer[simd_width];
-    _mm256_store_pd(buffer, value);
-    alignas(16) int offsets[simd_width];
-    _mm_store_si128(reinterpret_cast<__m128i*>(offsets), idx);
-    for (int lane = 0; lane < simd_width; ++lane)
-      base[offsets[lane]] = buffer[lane];
-  }
-};
-#endif
-
-template <class Ops, int N>
-struct GatherIndexBuilder
-{
-  static Ops::avx_index Build(int row) = delete;
-};
-
-#if __AVX512F__
 template <int N>
-struct GatherIndexBuilder<AVX512Ops, N>
-{
-  static AVX512Ops::avx_index Build(int row)
-  {
-    long long vals[simd_width];
-    for (int lane = 0; lane < simd_width; ++lane)
-      vals[lane] = static_cast<long long>(lane * N + row);
-    return _mm512_setr_epi64(
-      vals[0], vals[1], vals[2], vals[3], vals[4], vals[5], vals[6], vals[7]);
-  }
-};
-#elif __AVX2__
-template <int N>
-struct GatherIndexBuilder<AVX2Ops, N>
-{
-  static AVX2Ops::avx_index Build(int row)
-  {
-    int vals[simd_width];
-    for (int lane = 0; lane < simd_width; ++lane)
-      vals[lane] = lane * N + row;
-    return _mm_setr_epi32(vals[0], vals[1], vals[2], vals[3]);
-  }
-};
-#endif
-
-template <class Ops, int N>
-inline Ops::avx_index
+inline SimdIndex
 MakeGatherIndex(int row)
 {
-  return GatherIndexBuilder<Ops, N>::Build(row);
+  alignas(SimdIndex::alignment) std::int64_t indices[Simd::size];
+  for (std::size_t lane = 0; lane < Simd::size; ++lane)
+    indices[lane] = static_cast<std::int64_t>(lane * N + row);
+  return SimdIndex(indices);
 }
 
-template <class Ops, int N>
+template <int N>
 inline void
 SimdBatchSolve(const double* Am, const double* Mm, const double* sigma_t, double* __restrict b)
 {
-  using avx_vec = Ops::avx_vec;
-
-  avx_vec rhs[N];
+  Simd rhs[N];
   PRAGMA_UNROLL
   for (int row = 0; row < N; ++row)
-    rhs[row] = Ops::Gather(MakeGatherIndex<Ops, N>(row), b);
+    rhs[row] = Simd::Gather(b, MakeGatherIndex<N>(row));
 
-  const avx_vec sigma = Ops::LoadSigma(sigma_t);
-  avx_vec A[N * N];
+  const Simd sigma(sigma_t);
+  Simd A[N * N];
   PRAGMA_UNROLL
   for (int i = 0; i < N; ++i)
   {
     PRAGMA_UNROLL
     for (int j = 0; j < N; ++j)
     {
-      const avx_vec Amij = Ops::Set1(Am[i * N + j]);
-      const avx_vec Mmij = Ops::Set1(Mm[i * N + j]);
-      A[i * N + j] = Ops::Fmadd(Amij, sigma, Mmij);
+      const Simd Amij(Am[i * N + j]);
+      const Simd Mmij(Mm[i * N + j]);
+      A[i * N + j] = Simd::Fma(sigma, Mmij, Amij);
     }
   }
 
-  auto entry = [&](int i, int j) -> avx_vec& { return A[i * N + j]; };
+  auto entry = [&](int i, int j) -> Simd& { return A[i * N + j]; };
   PRAGMA_UNROLL
   for (int pivot = 0; pivot < N; ++pivot)
   {
-    const avx_vec inv = Ops::Reciprocal(entry(pivot, pivot));
+    const Simd inv = Simd(1.0) / entry(pivot, pivot);
     PRAGMA_UNROLL
     for (int row = pivot + 1; row < N; ++row)
     {
-      const avx_vec factor = Ops::Mul(entry(row, pivot), inv);
-      rhs[row] = Ops::Fnmadd(factor, rhs[pivot], rhs[row]);
+      const Simd factor = entry(row, pivot) * inv;
+      rhs[row] = Simd::Fnma(factor, rhs[pivot], rhs[row]);
       PRAGMA_UNROLL
       for (int col = pivot + 1; col < N; ++col)
-        entry(row, col) = Ops::Fnmadd(factor, entry(pivot, col), entry(row, col));
+        entry(row, col) = Simd::Fnma(factor, entry(pivot, col), entry(row, col));
     }
   }
 
   PRAGMA_UNROLL
   for (int pivot = N - 1; pivot >= 0; --pivot)
   {
-    avx_vec rhs_vec = rhs[pivot];
+    Simd rhs_vec = rhs[pivot];
     PRAGMA_UNROLL
     for (int col = pivot + 1; col < N; ++col)
-      rhs_vec = Ops::Fnmadd(entry(pivot, col), rhs[col], rhs_vec);
-    rhs[pivot] = Ops::Mul(rhs_vec, Ops::Reciprocal(entry(pivot, pivot)));
+      rhs_vec = Simd::Fnma(entry(pivot, col), rhs[col], rhs_vec);
+    rhs[pivot] = rhs_vec * (Simd(1.0) / entry(pivot, pivot));
   }
 
   PRAGMA_UNROLL
   for (int row = 0; row < N; ++row)
-    Ops::Scatter(MakeGatherIndex<Ops, N>(row), b, rhs[row]);
+    rhs[row].Scatter(b, MakeGatherIndex<N>(row));
 }
 
 } // namespace detail

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_avx_sweep_chunk.cc
@@ -241,15 +241,9 @@ CBC_Sweep_FixedN(SweepChunkT& sweep_chunk, AngleSet& angle_set)
 
       std::size_t k = 0;
 
-#if __AVX512F__
-      for (; k + simd_width <= block_len; k += simd_width)
-        detail::SimdBatchSolve<detail::AVX512Ops, NumNodes>(
+      for (; k + Simd::size <= block_len; k += Simd::size)
+        detail::SimdBatchSolve<NumNodes>(
           Amat.data(), mass_matrix.data(), &sigma_block[k], &b[(g0 + k) * NumNodes]);
-#elif __AVX2__
-      for (; k + simd_width <= block_len; k += simd_width)
-        detail::SimdBatchSolve<detail::AVX2Ops, NumNodes>(
-          Amat.data(), mass_matrix.data(), &sigma_block[k], &b[(g0 + k) * NumNodes]);
-#endif
 
       for (; k < block_len; ++k)
       {


### PR DESCRIPTION
This PR extracts SIMD instructions into `framework/simd` and exposes them through a unified `Simd` and `SimdIndex` API.

This allows to remove architecture-specific macro checks in the AAH/CBC AVX sweep-chunk implementations. All macro checks are confined only to `framework/simd`.

In addition, this PR adds Neon64 support for ARM CPUs, including macOS on Apple Silicon, as well as SSE-only implementations.