### PR TITLE
Minor fixes for caliper paths. Adding maximum memory usage output.

### DIFF
--- a/framework/materials/multi_group_xs/xsfile.cc
+++ b/framework/materials/multi_group_xs/xsfile.cc
@@ -5,6 +5,7 @@
 #include "framework/utils/utils.h"
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
+#include "framework/utils/caliper_scopes.h"
 
 #include <cmath>
 #include <unordered_set>
@@ -27,6 +28,8 @@ XSFile::XSFile(const std::string& file_name)
 void
 XSFile::Read()
 {
+  CaliperRegionScope cali_xs_read_scope("CrossSectionRead", CaliperCrossSectionReadScopeDepth());
+
   std::string word, line;
   size_t line_number = 0;
   bool read_num_groups = false;

--- a/framework/mesh/io/vtk_io.cc
+++ b/framework/mesh/io/vtk_io.cc
@@ -6,6 +6,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/utils/utils.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/mesh/mesh_continuum/grid_vtk_utils.h"
 #include <vtkCell.h>
 #include <vtkPolygon.h>
@@ -1221,6 +1222,8 @@ MeshIO::ToExodusII(const std::shared_ptr<MeshContinuum>& grid,
 void
 MeshIO::ToPVTU(const std::shared_ptr<MeshContinuum>& grid, const std::string& file_base_name)
 {
+  CaliperRegionScope cali_output_scope("Output", CaliperOutputScopeDepth());
+
   log.Log() << "Exporting mesh to VTK files with base " << file_base_name;
 
   auto ugrid = PrepareVtkUnstructuredGrid(grid, false);

--- a/framework/mesh/mesh_generator/mesh_generator.cc
+++ b/framework/mesh/mesh_generator/mesh_generator.cc
@@ -9,6 +9,7 @@
 #include "framework/runtime.h"
 #include "framework/logging/log.h"
 #include "framework/mesh/cell/cell.h"
+#include "framework/utils/caliper_scopes.h"
 #include "framework/utils/error.h"
 #include <memory>
 
@@ -44,6 +45,9 @@ MeshGenerator::GenerateUnpartitionedMesh(std::shared_ptr<UnpartitionedMesh> inpu
 std::shared_ptr<MeshContinuum>
 MeshGenerator::Execute()
 {
+  CaliperPhaseScope cali_setup_phase("Setup", CaliperSetupPhaseDepth());
+  CaliperRegionScope cali_meshgen_scope("MeshGeneration", CaliperMeshGenerationScopeDepth());
+
   // Execute all input generators
   // Note these could be empty
   std::shared_ptr<UnpartitionedMesh> current_umesh = nullptr;
@@ -96,6 +100,8 @@ MeshGenerator::Execute()
 std::vector<int>
 MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh, const int num_partitions) const
 {
+  CaliperRegionScope cali_partitioning_scope("Partitioning", CaliperPartitioningScopeDepth());
+
   const auto& raw_cells = input_umesh.GetRawCells();
   const auto num_raw_cells = raw_cells.size();
 

--- a/framework/runtime.cc
+++ b/framework/runtime.cc
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "framework/runtime.h"
+#include "framework/logging/log.h"
 #include "framework/math/math.h"
 #include "framework/object_factory.h"
+#include "framework/utils/memory.h"
 #include "framework/utils/timer.h"
 #include "config.h"
 #include "caliper/cali.h"
@@ -47,6 +49,38 @@ Timer program_timer;
 std::filesystem::path input_path;
 unsigned int opensn_num_threads = 1;
 
+namespace
+{
+
+// Check for the necessary services to support Caliper memory usage stats
+std::string
+SanitizeMemHighwatermarkOption(const cali::ConfigManager& mgr, std::string config)
+{
+  static const std::string option = "mem.highwatermark";
+
+  const auto pos = config.find(option);
+  if (pos == std::string::npos)
+    return config; // not requested
+
+  if (mgr.check(config.c_str()).empty())
+    return config; // requested and supported on this build
+
+  auto begin = pos;
+  auto end = pos + option.size();
+  if (begin > 0 and config[begin - 1] == ',')
+    --begin;
+  else if (end < config.size() and config[end] == ',')
+    ++end;
+  config.erase(begin, end - begin);
+
+  log.Log() << "Note: \"mem.highwatermark\" was requested in the Caliper config, but is "
+               "not available in this build.";
+
+  return config;
+}
+
+} // namespace
+
 int
 Initialize()
 {
@@ -54,6 +88,7 @@ Initialize()
 
   if (use_caliper)
   {
+    cali_config = SanitizeMemHighwatermarkOption(cali_mgr, cali_config);
     cali_mgr.add(cali_config.c_str());
     cali_set_global_string_byname("opensn.version", GetVersionStr().c_str());
     cali_set_global_string_byname("opensn.input", input_path.c_str());
@@ -78,7 +113,15 @@ Finalize()
 
   opensn::mpi_comm.barrier();
 
+  // This must be set after CALI_MARK_PHASE_END to avoid spurious output in
+  // the Caliper report
   CALI_MARK_PHASE_END(opensn::program.c_str());
+
+  if (use_caliper)
+  {
+    if (const auto peak_bytes = GetPeakMemoryUsageBytes())
+      cali_set_global_uint_byname("opensn.memory.highwatermark_bytes", *peak_bytes);
+  }
 }
 
 std::string

--- a/framework/utils/caliper_scopes.h
+++ b/framework/utils/caliper_scopes.h
@@ -144,4 +144,60 @@ CaliperSweepScopeDepth()
   return depth;
 }
 
+inline int&
+CaliperMeshGenerationScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperPartitioningScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperCrossSectionReadScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperRestartIOScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperOutputScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperGPUSetupScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperGPUTransferScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
+inline int&
+CaliperUncollidedScopeDepth()
+{
+  static int depth = 0;
+  return depth;
+}
+
 } // namespace opensn

--- a/framework/utils/memory.cc
+++ b/framework/utils/memory.cc
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#include "framework/utils/memory.h"
+#include "framework/runtime.h"
+#include <sys/resource.h>
+
+namespace opensn
+{
+
+std::optional<std::uint64_t>
+GetPeakMemoryUsageBytes()
+{
+  struct rusage usage{};
+  if (getrusage(RUSAGE_SELF, &usage) != 0)
+    return std::nullopt;
+  // ru_maxrss is glibc's normal POSIX-mandated way to read this field, but some libc
+  // implementations define it via an anonymous union which can trip clang-tidy
+  const long max_rss = usage.ru_maxrss; // NOLINT(cppcoreguidelines-pro-type-union-access)
+  // A successful call with max_rss == 0 means the platform doesn't actually fill in this
+  // field rather than genuine zero peak usage
+  if (max_rss <= 0)
+    return std::nullopt;
+  // ru_maxrss is in bytes on macOS/Darwin, but kilobytes on Linux
+#ifdef __APPLE__
+  return static_cast<std::uint64_t>(max_rss);
+#else
+  return static_cast<std::uint64_t>(max_rss) * 1024;
+#endif
+}
+
+std::optional<std::uint64_t>
+GetTotalPeakMemoryUsageBytes()
+{
+  const auto local_peak = GetPeakMemoryUsageBytes();
+  const std::uint64_t local_peak_bytes = local_peak.value_or(0);
+  const int local_available = local_peak.has_value() ? 1 : 0;
+
+  std::uint64_t total_peak_bytes = 0;
+  int all_available = 0;
+  mpi_comm.all_reduce(local_peak_bytes, total_peak_bytes, mpi::op::sum<std::uint64_t>());
+  mpi_comm.all_reduce(local_available, all_available, mpi::op::min<int>());
+
+  if (!all_available)
+    return std::nullopt;
+  return total_peak_bytes;
+}
+
+} // namespace opensn

--- a/framework/utils/memory.h
+++ b/framework/utils/memory.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 The OpenSn Authors <https://open-sn.github.io/opensn/>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace opensn
+{
+
+/// Returns this process's peak (high-water-mark) resident set size, in bytes.
+std::optional<std::uint64_t> GetPeakMemoryUsageBytes();
+
+/// Returns the total physical memory usage over all MPI ranks.
+std::optional<std::uint64_t> GetTotalPeakMemoryUsageBytes();
+
+} // namespace opensn

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/boundary/discrete_ordinates_boundaries.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/boundary/discrete_ordinates_boundaries.cu
@@ -4,6 +4,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/boundary/boundary_carrier.h"
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/fluds/aahd_fluds.h"
+#include "framework/utils/caliper_scopes.h"
 
 namespace opensn
 {
@@ -13,6 +14,7 @@ DiscreteOrdinatesProblem::InitializeBoundaryCarrier()
 {
   if (not use_gpus_)
     return;
+  CaliperRegionScope cali_gpu_setup_scope("GPUSetup", CaliperGPUSetupScopeDepth());
   boundary_carrier_ = std::make_shared<BoundaryCarrier>(boundary_bank_, groupsets_);
   for (const auto& groupset : groupsets_)
     boundary_carrier_->UploadToDevice(groupset.id);
@@ -25,6 +27,7 @@ DiscreteOrdinatesProblem::TransferDeviceBoundaryData(int groupset_id,
 {
   if (not has_reflecting_boundaries_ and not force)
     return;
+  CaliperRegionScope cali_gpu_transfer_scope("GPUTransfer", CaliperGPUTransferScopeDepth());
   if (host_to_device)
     boundary_carrier_->UploadToDevice(groupset_id);
   else

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cc
@@ -453,7 +453,7 @@ DiscreteOrdinatesProblem::BuildRuntime()
 void
 DiscreteOrdinatesProblem::InitializeFCS()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeFCS");
+  CALI_CXX_MARK_SCOPE("InitializeFCS");
 
   if (uncollided_flux_file_.empty())
     return;
@@ -564,7 +564,7 @@ DiscreteOrdinatesProblem::SetSweepChunkMode(SweepChunkMode mode)
 void
 DiscreteOrdinatesProblem::InitializeSolverSchemes()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::InitializeSolverSchemes");
+  CALI_CXX_MARK_SCOPE("InitializeSolverSchemes");
   auto solver_scheme =
     BuildSolvers(*this,
                  active_set_source_function_,
@@ -871,7 +871,7 @@ DiscreteOrdinatesProblem::UpdateAngularFluxStorage()
 void
 DiscreteOrdinatesProblem::ReorientAdjointSolution()
 {
-  CALI_CXX_MARK_SCOPE("DiscreteOrdinatesProblem::ReorientAdjointSolution");
+  CALI_CXX_MARK_SCOPE("ReorientAdjointSolution");
 
   for (const auto& groupset : groupsets_)
   {

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.cu
@@ -4,6 +4,7 @@
 #include "modules/linear_boltzmann_solvers/discrete_ordinates_problem/discrete_ordinates_problem.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/device_vector_mirror.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/outflow/outflow_carrier.h"
+#include "framework/utils/caliper_scopes.h"
 
 namespace opensn
 {
@@ -13,6 +14,7 @@ DiscreteOrdinatesProblem::CopyPhiAndSrcToDevice()
 {
   if (!use_gpus_)
     return;
+  CaliperRegionScope cali_gpu_transfer_scope("GPUTransfer", CaliperGPUTransferScopeDepth());
   auto* src = GetSourceMomentsPinner();
   src->CopyToDevice();
   DeviceVectorMirror<double>* phi = GetPhiPinner();
@@ -25,6 +27,7 @@ DiscreteOrdinatesProblem::CopyPhiAndOutflowBackToHost()
 {
   if (!use_gpus_)
     return;
+  CaliperRegionScope cali_gpu_transfer_scope("GPUTransfer", CaliperGPUTransferScopeDepth());
   auto* phi = GetPhiPinner();
   phi->CopyFromDevice();
   outflow_carrier_->CopyFromDevice();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/angle_set/cbc_angle_set.cc
@@ -31,7 +31,7 @@ CBC_AngleSet::GetCommunicator()
 AngleSetStatus
 CBC_AngleSet::AngleSetAdvance(SweepChunk& sweep_chunk, AngleSetStatus permission)
 {
-  CALI_CXX_MARK_SCOPE("CBC_AngleSet::AngleSetAdvance");
+  CALI_CXX_MARK_SCOPE("AngleSetAdvance");
 
   if (executed_)
     return AngleSetStatus::FINISHED;

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/cbcd_async_comm.cu
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep/communicators/cbcd_async_comm.cu
@@ -40,7 +40,7 @@ CBCD_AsynchronousCommunicator::InitGetDownwindMessageData(int location_id,
 bool
 CBCD_AsynchronousCommunicator::SendData()
 {
-  CALI_CXX_MARK_SCOPE("CBCD_AsynchronousCommunicator::SendData");
+  CALI_CXX_MARK_SCOPE("SendData");
 
   // Batch queued face psi by destination location.
   if (not outgoing_message_queue_.empty())
@@ -105,7 +105,7 @@ CBCD_AsynchronousCommunicator::SendData()
 std::vector<std::uint64_t>
 CBCD_AsynchronousCommunicator::ReceiveData()
 {
-  CALI_CXX_MARK_SCOPE("CBCD_AsynchronousCommunicator::ReceiveData");
+  CALI_CXX_MARK_SCOPE("ReceiveData");
 
   std::vector<std::uint64_t> cells_who_received_data;
   const auto& location_dependencies = fluds_.GetSPDS().GetLocationDependencies();

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_avx_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_avx_sweep_chunk.cc
@@ -383,7 +383,7 @@ template <unsigned int NumNodes>
 void
 CBCSweepChunk::Sweep_FixedN(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunk::Sweep_FixedN");
+  CALI_CXX_MARK_SCOPE("Sweep_FixedN");
 
   CBC_Sweep_FixedN<NumNodes, false>(*this, angle_set);
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk.cc
@@ -62,7 +62,7 @@ CBCSweepChunk::CBCSweepChunk(DiscreteOrdinatesProblem& problem, LBSGroupset& gro
 void
 CBCSweepChunk::SetAngleSet(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunk::SetAngleSet");
+  CALI_CXX_MARK_SCOPE("SetAngleSet");
 
   fluds_ = &dynamic_cast<CBC_FLUDS&>(angle_set.GetFLUDS());
   async_comm_ = &dynamic_cast<CBC_AsynchronousCommunicator&>(*angle_set.GetCommunicator());
@@ -77,7 +77,7 @@ CBCSweepChunk::Sweep(AngleSet& angle_set)
 void
 CBCSweepChunk::Sweep_Generic(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunk::Sweep_Generic");
+  CALI_CXX_MARK_SCOPE("Sweep_Generic");
 
   CBC_Sweep_Generic<false>(*this, angle_set);
 }

--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk_td.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/sweep_chunks/cbc_sweep_chunk_td.cc
@@ -69,7 +69,7 @@ CBCSweepChunkTD::CBCSweepChunkTD(DiscreteOrdinatesProblem& problem, LBSGroupset&
 void
 CBCSweepChunkTD::SetAngleSet(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunkTD::SetAngleSet");
+  CALI_CXX_MARK_SCOPE("SetAngleSet");
 
   fluds_ = &dynamic_cast<CBC_FLUDS&>(angle_set.GetFLUDS());
   async_comm_ = &dynamic_cast<CBC_AsynchronousCommunicator&>(*angle_set.GetCommunicator());
@@ -84,7 +84,7 @@ CBCSweepChunkTD::Sweep(AngleSet& angle_set)
 void
 CBCSweepChunkTD::Sweep_Generic(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunkTD::Sweep_Generic");
+  CALI_CXX_MARK_SCOPE("Sweep_Generic");
 
   CBC_Sweep_Generic<true>(*this, angle_set);
 }
@@ -93,7 +93,7 @@ template <unsigned int NumNodes>
 void
 CBCSweepChunkTD::Sweep_FixedN(AngleSet& angle_set)
 {
-  CALI_CXX_MARK_SCOPE("CBCSweepChunkTD::Sweep_FixedN");
+  CALI_CXX_MARK_SCOPE("Sweep_FixedN");
 
   CBC_Sweep_FixedN<NumNodes, true>(*this, angle_set);
 }

--- a/modules/linear_boltzmann_solvers/lbs_problem/io/restart_io.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/io/restart_io.cc
@@ -7,6 +7,7 @@
 #include "framework/utils/hdf_utils.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include "framework/utils/caliper_scopes.h"
 #include <algorithm>
 #include <iostream>
 
@@ -93,6 +94,8 @@ LBSProblem::ReadRestartData(const RestartDataHook& extra_reader,
                             const std::filesystem::path& read_path,
                             bool allow_transient_initialization_from_steady)
 {
+  CaliperRegionScope cali_restart_io_scope("RestartIO", CaliperRestartIOScopeDepth());
+
   const auto& fname = read_path.empty() ? GetOptions().restart.read_path : read_path;
   OpenSnInvalidArgumentIf(fname.empty(), GetName() + ": restart read path is empty.");
 
@@ -182,6 +185,8 @@ LBSProblem::ReadRestartData(const RestartDataHook& extra_reader,
 bool
 LBSProblem::WriteRestartData(const RestartDataHook& extra_writer)
 {
+  CaliperRegionScope cali_restart_io_scope("RestartIO", CaliperRestartIOScopeDepth());
+
   const auto& fname = GetOptions().restart.write_path;
   OpenSnInvalidArgumentIf(fname.empty(), GetName() + ": restart write path is empty.");
 

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cc
@@ -782,6 +782,8 @@ LBSProblem::BuildRuntime()
 void
 LBSProblem::InitializeRuntimeCore()
 {
+  CaliperPhaseScope cali_setup_phase("Setup", CaliperSetupPhaseDepth());
+
   InitializeSpatialDiscretization();
   InitializeParrays();
   InitializeBoundaries();

--- a/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
+++ b/modules/linear_boltzmann_solvers/lbs_problem/lbs_problem.cu
@@ -7,6 +7,7 @@
 #include "modules/linear_boltzmann_solvers/lbs_problem/device/device_vector_mirror.h"
 #include "modules/linear_boltzmann_solvers/lbs_problem/outflow/outflow_carrier.h"
 #include "framework/utils/error.h"
+#include "framework/utils/caliper_scopes.h"
 
 namespace opensn
 {
@@ -19,6 +20,7 @@ LBSProblem::InitializeGPUExtras()
   {
     return;
   }
+  CaliperRegionScope cali_gpu_setup_scope("GPUSetup", CaliperGPUSetupScopeDepth());
   // initialize carriers
   total_xs_carrier_ = std::make_shared<TotalXSCarrier>(*this);
   outflow_carrier_ = std::make_shared<OutflowCarrier>(*this);

--- a/modules/linear_boltzmann_solvers/uncollided_problem/uncollided_problem.cc
+++ b/modules/linear_boltzmann_solvers/uncollided_problem/uncollided_problem.cc
@@ -173,7 +173,7 @@ UncollidedProblem::UncollidedProblem(const InputParameters& params)
 void
 UncollidedProblem::InitializeSpatialDiscretization()
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::InitializeSpatialDiscretization");
+  CALI_CXX_MARK_SCOPE("InitializeSpatialDiscretization");
 
   log.Log() << "Initializing spatial discretization.\n";
   discretization_ = PieceWiseLinearDiscontinuous::New(grid_, QuadratureOrder::FOURTH);
@@ -441,7 +441,7 @@ UncollidedProblem::PrintSimHeader()
 void
 UncollidedProblem::BuildSweepOrdering(const SourcePoint& source_point)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::BuildSweepOrdering");
+  CALI_CXX_MARK_SCOPE("BuildSweepOrdering");
 
   constexpr double tolerance = 1.0e-16;
 
@@ -593,7 +593,7 @@ UncollidedProblem::BuildSweepOrdering(const SourcePoint& source_point)
 void
 UncollidedProblem::Execute(const std::string& file_name, const unsigned int progress_interval)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::Execute");
+  CALI_CXX_MARK_SCOPE("GenerateUncollidedFlux");
 
   std::fill(phi_new_local_.begin(), phi_new_local_.end(), 0.0);
   production_ = 0.0;
@@ -942,7 +942,7 @@ UncollidedProblem::RaytraceLineInto(RayTracer& ray_tracer,
 void
 UncollidedProblem::ProjectReflectedImageSources(const unsigned int progress_interval)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::ProjectReflectedImageSources");
+  CALI_CXX_MARK_SCOPE("ProjectReflectedImageSources");
 
   const auto& sdm = *discretization_;
   const size_t num_cells = grid_->local_cells.size();
@@ -1155,7 +1155,7 @@ UncollidedProblem::ProjectReflectedImageSources(const unsigned int progress_inte
 void
 UncollidedProblem::RaytraceNearSourceRegion(const SourcePoint& source_point)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::RaytraceNearSourceRegion");
+  CALI_CXX_MARK_SCOPE("RaytraceNearSourceRegion");
   log.Log() << "\nRay-tracing near-source region.\n";
 
   const auto& sdm = *discretization_;
@@ -1499,7 +1499,7 @@ UncollidedProblem::RaytraceLine(RayTracer& ray_tracer,
 void
 UncollidedProblem::SweepBulkRegion(const SourcePoint& source_point)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::SweepBulkRegion");
+  CALI_CXX_MARK_SCOPE("SweepBulkRegion");
   log.Log() << "Sweeping bulk region.\n";
 
   const auto& sdm = *discretization_;
@@ -1732,7 +1732,7 @@ UncollidedProblem::ComputeUncollidedIntegrals(const Cell& cell, const Vector3& p
 void
 UncollidedProblem::UpdateBalance(const SourcePoint& source_point)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::UpdateBalance");
+  CALI_CXX_MARK_SCOPE("UpdateBalance");
 
   const auto& sdm = *discretization_;
 
@@ -1795,7 +1795,7 @@ UncollidedProblem::UpdateBalance(const SourcePoint& source_point)
 void
 UncollidedProblem::AccumulateMoments(const Vector3& pt_loc)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::AccumulateMoments");
+  CALI_CXX_MARK_SCOPE("AccumulateMoments");
 
   const auto& sdm = *discretization_;
   const auto swf = SpatialWeightFunction::FromCoordinateType(grid_->GetCoordinateSystem());
@@ -1860,7 +1860,7 @@ UncollidedProblem::AccumulateMoments(const Vector3& pt_loc)
 void
 UncollidedProblem::WriteFluxMoments(hid_t file)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::WriteFluxMoments");
+  CALI_CXX_MARK_SCOPE("WriteFluxMoments");
 
   OpenSnLogicalErrorIf(not H5WriteDataset1D<double>(file, "0,0", phi_new_local_),
                        GetName() + ": failed to write uncollided scalar flux.");
@@ -1873,7 +1873,7 @@ UncollidedProblem::WriteFluxMoments(hid_t file)
 void
 UncollidedProblem::FinalizeBalance(hid_t file)
 {
-  CALI_CXX_MARK_SCOPE("UncollidedProblem::FinalizeBalance");
+  CALI_CXX_MARK_SCOPE("FinalizeBalance");
 
   const double conservative_outflow = std::max(0.0, production_ - removal_);
   const double outflow_difference = conservative_outflow - out_flow_;

--- a/modules/linear_boltzmann_solvers/uncollided_problem/uncollided_solver.cc
+++ b/modules/linear_boltzmann_solvers/uncollided_problem/uncollided_solver.cc
@@ -8,6 +8,7 @@
 #include "framework/runtime.h"
 #include "framework/utils/error.h"
 #include "framework/utils/timer.h"
+#include "framework/utils/caliper_scopes.h"
 #include "caliper/cali.h"
 
 namespace opensn
@@ -53,7 +54,9 @@ UncollidedSolver::UncollidedSolver(const InputParameters& params)
 void
 UncollidedSolver::Initialize()
 {
-  CALI_CXX_MARK_SCOPE("UncollidedSolver::Initialize");
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_uncollided("Uncollided", CaliperUncollidedScopeDepth());
+  CALI_CXX_MARK_SCOPE("Initialize");
   log.Log() << program_timer.GetTimeString() << " Initializing solver " << GetName() << ".";
 
   OpenSnInvalidArgumentIf(opensn::mpi_comm.size() != 1,
@@ -68,7 +71,9 @@ UncollidedSolver::Initialize()
 void
 UncollidedSolver::Execute()
 {
-  CALI_CXX_MARK_SCOPE("UncollidedSolver::Execute");
+  CaliperPhaseScope cali_solve_phase("Solve", CaliperSolvePhaseDepth());
+  CaliperRegionScope cali_uncollided("Uncollided", CaliperUncollidedScopeDepth());
+  CALI_CXX_MARK_SCOPE("Execute");
   OpenSnLogicalErrorIf(not initialized_, GetName() + ": Initialize must be called before Execute.");
 
   log.Log() << program_timer.GetTimeString() << " Starting solver execution " << GetName() << ".";

--- a/pyopensn/py_env.cc
+++ b/pyopensn/py_env.cc
@@ -4,6 +4,7 @@
 #include "python/lib/py_env.h"
 #include "framework/logging/log.h"
 #include "framework/runtime.h"
+#include "framework/utils/memory.h"
 #include "framework/utils/timer.h"
 #include "mpi4py/mpi4py.h"
 #include "petscsys.h"
@@ -47,18 +48,26 @@ PyEnv::PyEnv()
 
 PyEnv::~PyEnv()
 {
-  // finalize the run
+  // Finalize the run
   Finalize();
   ::PetscFinalize();
-  // Print execution time
+  // Flush Caliper report
+  cali_mgr.flush();
+  // Print memory usage
+  const auto total_peak_bytes = GetTotalPeakMemoryUsageBytes();
   if (mpi_comm.rank() == 0)
   {
     std::cout << "\n";
+    if (total_peak_bytes)
+      std::cout << "Total peak host memory usage: "
+                << static_cast<double>(*total_peak_bytes) / 1.0e9 << " GB\n";
+  }
+  // Print execution time
+  if (mpi_comm.rank() == 0)
+  {
     std::cout << "Elapsed execution time: " << program_timer.GetTimeString() << "\n";
     std::cout << Timer::GetLocalDateTimeString() << " " << program << " finished execution.\n";
   }
-  // flush caliper
-  cali_mgr.flush();
 }
 
 std::unique_ptr<PyEnv> PyEnv::p_default_env{};

--- a/python/lib/py_app.cc
+++ b/python/lib/py_app.cc
@@ -6,6 +6,7 @@
 #include "python/lib/py_wrappers.h"
 #include "framework/logging/log.h"
 #include "framework/utils/utils.h"
+#include "framework/utils/memory.h"
 #include "framework/utils/timer.h"
 #include "framework/runtime.h"
 #include "cxxopts/cxxopts.h"
@@ -89,9 +90,22 @@ PyApp::Run(int argc, char** argv)
     console.ExecuteFile(opensn::input_path.string());
     opensn::Finalize();
 
+    cali_mgr.flush();
+    if (opensn::use_caliper and opensn::mpi_comm.rank() == 0)
+      std::cout << std::endl;
+
+    const auto total_peak_bytes = GetTotalPeakMemoryUsageBytes();
     if (opensn::mpi_comm.rank() == 0)
     {
-      std::cout << "\nElapsed execution time: " << program_timer.GetTimeString() << "\n"
+      std::cout << "\n";
+      if (total_peak_bytes)
+        std::cout << "Total peak host memory usage: "
+                  << static_cast<double>(*total_peak_bytes) / 1.0e9 << " GB" << std::endl;
+    }
+
+    if (opensn::mpi_comm.rank() == 0)
+    {
+      std::cout << "Elapsed execution time: " << program_timer.GetTimeString() << "\n"
                 << Timer::GetLocalDateTimeString() << " " << opensn::program
                 << " finished execution." << std::endl;
     }
@@ -99,10 +113,6 @@ PyApp::Run(int argc, char** argv)
   else
     return EXIT_FAILURE;
 
-  if (opensn::use_caliper and opensn::mpi_comm.rank() == 0)
-    std::cout << std::endl;
-
-  cali_mgr.flush();
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
With this PR, the code will print maximum memory usage summed across all ranks at the end of execution. Example:

```
Total peak host memory usage: 5.4378 GB
Elapsed execution time: 00:00:32.7
2026-08-20 23:15:16 OpenSn finished execution.
```
