### PR TITLE
Fix non-deterministic GPU sweep results with opposing reflecting boundaries

### DIFF
--- a/modules/linear_boltzmann_solvers/discrete_ordinates_problem/boundary/discrete_ordinates_boundaries.cc
+++ b/modules/linear_boltzmann_solvers/discrete_ordinates_problem/boundary/discrete_ordinates_boundaries.cc
@@ -49,12 +49,22 @@ GetGlobalUniqueBoundaryIDs(const std::shared_ptr<MeshContinuum>& grid, mpi::Comm
   return global_unique_bids_set;
 }
 
+// RecursiveAngleSort's traversal order determines, for each reflected pair of angle sets, which
+// set's angle indices get propagated to the other. With a single reflecting boundary this is
+// order-independent but with opposing reflecting boundaries, the final angle-to-angleset
+// assignment depends on visitation order. unsorted/sorted MUST order by a value stable across
+// MPI ranks and repeated runs. For this purpose, we use AngleSet::GetID().
+struct AngleSetIdLess
+{
+  bool operator()(const AngleSet* a, const AngleSet* b) const { return a->GetID() < b->GetID(); }
+};
+
 void
 RecursiveAngleSort(AngleSet* angleset,
                    AngleAggregation& angle_agg,
                    const std::vector<std::vector<std::uint32_t>>& reflected_maps,
-                   std::set<AngleSet*>& unsorted,
-                   std::set<AngleSet*>& sorted)
+                   std::set<AngleSet*, AngleSetIdLess>& unsorted,
+                   std::set<AngleSet*, AngleSetIdLess>& sorted)
 {
   sorted.insert(angleset);
   std::uint32_t angle_zero = angleset->GetAngleIndices()[0];
@@ -363,8 +373,9 @@ DiscreteOrdinatesProblem::SortAngleSetsAngleIndices()
     }
     angle_indices_list.clear();
 
-    // sort angle indices in anglesets
-    std::set<AngleSet*> sorted_anglesets, unsorted_anglesets;
+    // sort angle indices in anglesets. Ordering is by AngleSetIdLess (GetID()) so this
+    // recursion is deterministic and consistent across MPI ranks
+    std::set<AngleSet*, AngleSetIdLess> sorted_anglesets, unsorted_anglesets;
     std::transform(angle_agg.begin(),
                    angle_agg.end(),
                    std::inserter(unsorted_anglesets, unsorted_anglesets.end()),


### PR DESCRIPTION
GPU sweeps with opposing reflecting boundaries and 2+ MPI ranks could produce wrong results that vary run-to-run.

`RecursiveAngleSort` used a `std::set<AngleSet*>` ordered by raw pointer value to decide which angle set's indices get
propagated to its reflected partner. With one reflecting boundary this works fine, but with opposing boundaries, some
angle sets are constrained by two reflections simultaneously and which one wins depends on visitation order. This ordering was driven by heap addresses that vary per run and per rank. Since the GPU cross-rank sweep tags messages by angleset ID and assumes every rank agrees on the meaning, two ranks could end up disagreeing and corrupting the exchange from the first sweep onward. The fix is straightforward: order by `AngleSet::GetID()` instead of pointer address.